### PR TITLE
theme: fix parsing inactive label colors

### DIFF
--- a/src/theme.c
+++ b/src/theme.c
@@ -161,7 +161,7 @@ entry(struct theme *theme, const char *key, const char *value)
 	if (match(key, "window.active.label.text.color")) {
 		parse_hexstr(value, theme->window_active_label_text_color);
 	}
-	if (match(key, "window.inactive.lable.text.color")) {
+	if (match(key, "window.inactive.label.text.color")) {
 		parse_hexstr(value, theme->window_inactive_label_text_color);
 	}
 


### PR DESCRIPTION
There was a typo here which meant these never got parsed and always appeared as black.

Signed-off-by: Joshua Ashton <joshua@froggi.es>