### PR TITLE
action: Fix crash in move to edge

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -212,6 +212,10 @@ view_move_to_edge(struct view *view, const char *direction)
 		return;
 	}
 	struct output *output = view_output(view);
+	if (!output) {
+		wlr_log(WLR_ERROR, "no output");
+		return;	
+	}	
 	struct border border = view_border(view);
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
 


### PR DESCRIPTION
Fixes a crash in move to edge ( #77 ) when the centre of the window is out of any display regions.

Doesn't fix the expected behaviour that it would work, but much better than the whole compositor dying.

Signed-off-by: Joshua Ashton <joshua@froggi.es>