### PR TITLE
theme: Implement window.label.text.justify

### DIFF
--- a/include/theme.h
+++ b/include/theme.h
@@ -10,6 +10,12 @@
 #include <stdio.h>
 #include <wlr/render/wlr_renderer.h>
 
+enum lab_justification {
+	LAB_JUSTIFY_LEFT,
+	LAB_JUSTIFY_CENTER,
+	LAB_JUSTIFY_RIGHT,
+};
+
 struct theme {
 	int border_width;
 	int padding_height;
@@ -22,6 +28,7 @@ struct theme {
 
 	float window_active_label_text_color[4];
 	float window_inactive_label_text_color[4];
+	enum lab_justification window_label_text_justify;
 
 	/* buttons */
 	float window_active_button_iconify_unpressed_image_color[4];

--- a/src/ssd.c
+++ b/src/ssd.c
@@ -148,8 +148,24 @@ center_vertically(struct wlr_box *box, struct wlr_texture *texture)
 		return;
 	}
 	box->y += (box->height - texture->height) / 2;
-	box->width = texture->width;
-	box->height = texture->height;
+}
+
+static void
+center_horizontally(struct view *view, struct wlr_box *box, struct wlr_texture *texture)
+{
+	if (!texture) {
+		return;
+	}
+	box->x = view->x + (view->w - texture->width) / 2;
+}
+
+static void
+justify_right(struct view *view, struct wlr_box *box, struct wlr_texture *texture)
+{
+	if (!texture) {
+		return;
+	}
+	box->x = view->x + (box->width - texture->width);
 }
 
 struct wlr_box
@@ -175,6 +191,15 @@ ssd_visible_box(struct view *view, enum ssd_part_type type)
 	case LAB_SSD_PART_TITLE:
 		box = ssd_box(view, type);
 		center_vertically(&box, view->title.active);
+		if (theme->window_label_text_justify == LAB_JUSTIFY_CENTER) {
+			center_horizontally(view, &box, view->title.active);
+		} else if (theme->window_label_text_justify == LAB_JUSTIFY_RIGHT) {	
+			justify_right(view, &box, view->title.active);
+		}
+		if (view->title.active) {
+			box.width = view->title.active->width;
+			box.height = view->title.active->height;
+		}
 		break;
 	case LAB_SSD_PART_CORNER_TOP_LEFT:
 		box = ssd_box(view, type);

--- a/src/theme.c
+++ b/src/theme.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
+#include <strings.h>
 #include "common/dir.h"
 #include "common/font.h"
 #include "common/string-helpers.h"
@@ -61,6 +62,18 @@ parse_hexstr(const char *hex, float *rgba)
 	}
 }
 
+static enum lab_justification
+parse_justification(const char *str)
+{
+	if (!strcasecmp(str, "Center")) {
+		return LAB_JUSTIFY_CENTER;
+	} else if (!strcasecmp(str, "Right")) {
+		return LAB_JUSTIFY_RIGHT;
+	} else {
+		return LAB_JUSTIFY_LEFT;
+	}
+}
+
 /*
  * We generally use Openbox defaults, but if no theme file can be found it's
  * better to populate the theme variables with some sane values as no-one
@@ -87,6 +100,7 @@ theme_builtin(struct theme *theme)
 
 	parse_hexstr("#000000", theme->window_active_label_text_color);
 	parse_hexstr("#000000", theme->window_inactive_label_text_color);
+	theme->window_label_text_justify = parse_justification("Left");
 
 	parse_hexstr("#000000",
 		theme->window_active_button_iconify_unpressed_image_color);
@@ -163,6 +177,9 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match(key, "window.inactive.label.text.color")) {
 		parse_hexstr(value, theme->window_inactive_label_text_color);
+	}
+	if (match(key, "window.label.text.justify")) {
+		theme->window_label_text_justify = parse_justification(value);
 	}
 
 	/* universal button */


### PR DESCRIPTION
Crosses off 6.12.1

Signed-off-by: Joshua Ashton <joshua@froggi.es>

### Left

![20211017_19h15m36s_grim](https://user-images.githubusercontent.com/21316711/137641646-3edf04b7-05ee-4dbd-a54f-698cf48fbf17.png)

### Center

![20211017_19h16m01s_grim](https://user-images.githubusercontent.com/21316711/137641660-cb4142d0-3f9a-4d91-b353-361c542c63f8.png)

### Right

![20211017_19h16m26s_grim](https://user-images.githubusercontent.com/21316711/137641669-18b6ac00-5ef2-420a-bffc-9272a8705f17.png)


