### PR TITLE
Enable new outputs (before setting mode)

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -955,6 +955,9 @@ new_output_notify(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	wlr_log(WLR_DEBUG, "enable output");
+	wlr_output_enable(wlr_output, true);
+
 	/* The mode is a tuple of (width, height, refresh rate). */
 	wlr_log(WLR_DEBUG, "set preferred mode");
 	struct wlr_output_mode *preferred_mode =


### PR DESCRIPTION
When `labwc` is started in its default configuration, all display outputs are initially disabled.  `sway` does not have the same issue.  In comparison with the `sway` code, it appears the `labwc` is missing a call to `wlr_output_enable()`.

Fixes the following error with `wlroots-git` 0.14.0.r391.g585a908a-1:

    [DEBUG] [types/output/output.c:603] Tried to modeset a disabled output