### PR TITLE
Basic support for Drag/Move action

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -430,6 +430,8 @@ struct view *desktop_surface_and_view_at(struct server *server, double lx,
 	double ly, struct wlr_surface **surface, double *sx, double *sy,
 	int *view_area);
 
+struct view *desktop_view_at_cursor(struct server *server);
+
 void cursor_init(struct seat *seat);
 
 void keyboard_init(struct seat *seat);

--- a/src/action.c
+++ b/src/action.c
@@ -72,6 +72,11 @@ action(struct server *server, const char *action, const char *command)
 		if (view) {
 			view_minimize(view, true);
 		}
+	} else if (!strcasecmp(action, "Move")) {
+		struct view *view = desktop_view_at_cursor(server);
+		if (view) {
+			interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
+		}
 	} else {
 		wlr_log(WLR_ERROR, "action (%s) not supported", action);
 	}

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -465,6 +465,7 @@ load_default_key_bindings(void)
 static struct {
 	const char *context, *button, *event, *action, *command;
 } mouse_combos[] = {
+	{ "TitleBar", "Left", "Press", "Move", NULL },
 	{ "TitleBar", "Left", "DoubleClick", "ToggleMaximize", NULL },
 	{ "Close", "Left", "Click", "Close", NULL },
 	{ "Iconify", "Left", "Click", "Iconify", NULL},

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -574,15 +574,8 @@ cursor_button(struct wl_listener *listener, void *data)
 mousebindings:
 	if (event->state == WLR_BUTTON_RELEASED) {
 		handle_release_mousebinding(server, event->button, view_area);
-		return;
 	} else if (event->state == WLR_BUTTON_PRESSED) {
-		if (handle_press_mousebinding(server, event->button, view_area)) {
-			return;
-		}
-	}
-
-	if (view_area == LAB_SSD_PART_TITLEBAR) {
-		interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
+		handle_press_mousebinding(server, event->button, view_area);
 	}
 }
 

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -342,3 +342,14 @@ desktop_surface_and_view_at(struct server *server, double lx, double ly,
 	}
 	return NULL;
 }
+
+struct view *
+desktop_view_at_cursor(struct server *server) {
+	double sx, sy;
+	struct wlr_surface *surface;
+	int view_area = LAB_SSD_NONE;
+
+	return desktop_surface_and_view_at(server,
+			server->seat.cursor->x, server->seat.cursor->y,
+			&surface, &sx, &sy, &view_area);
+}


### PR DESCRIPTION
This makes it possible to move a window by dragging its titlebar.  Tested working with my existing Openbox config.

I'm new to the `labwc` code, so apologies if I missed anything.

Example config snippet:

    <mouse>
      <context name="Titlebar">
        <mousebind button="Left" action="Drag">
          <action name="Move"/>
        </mousebind>
      </context>
    </mouse>