### PR TITLE
Force repaint after window title changes

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -158,6 +158,7 @@ handle_set_title(struct wl_listener *listener, void *data)
 	struct view *view = wl_container_of(listener, view, set_title);
 	assert(view);
 	view_update_title(view);
+	damage_all_outputs(view->server);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -132,6 +132,7 @@ handle_set_title(struct wl_listener *listener, void *data)
 	struct view *view = wl_container_of(listener, view, set_title);
 	assert(view);
 	view_update_title(view);
+	damage_all_outputs(view->server);
 }
 
 static void


### PR DESCRIPTION
When a window title changed dynamically (for example when running
"cd" within an xfce4-terminal), the titlebar did not immediately
update to show the new title.  (The titlebar would update as soon
as the mouse cursor moved.)

Calling `damage_all_outputs()` might not be the most optimal fix,
but it at least seems to work.