### PR TITLE
Parse menu names from Menu mouse-bindings

### DIFF
--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -98,6 +98,8 @@ fill_mousebind(char *nodename, char *content)
 		current_mousebind->action = strdup(content);
 	} else if (!strcmp(nodename, "command.action")) {
 		current_mousebind->command = strdup(content);
+	} else if (!strcmp(nodename, "menu.action")) {
+		current_mousebind->command = strdup(content);
 	}
 }
 


### PR DESCRIPTION
These were being ignored before. The only menu currently supported by labwc (from what I could tell) is "root-menu", but even that cannot be triggered by mouse bindings without this fix.