### PR TITLE
Implement Resize as an action

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -470,7 +470,8 @@ void server_init(struct server *server);
 void server_start(struct server *server);
 void server_finish(struct server *server);
 
-void action(struct server *server, const char *action, const char *command);
+void action(struct server *server, const char *action, const char *command,
+	uint32_t resize_edges);
 
 /* update onscreen display 'alt-tab' texture */
 void osd_update(struct server *server);

--- a/src/action.c
+++ b/src/action.c
@@ -20,7 +20,7 @@ show_menu(struct server *server, const char *menu)
 }
 
 void
-action(struct server *server, const char *action, const char *command)
+action(struct server *server, const char *action, const char *command, uint32_t resize_edges)
 {
 	if (!action)
 		return;
@@ -76,6 +76,11 @@ action(struct server *server, const char *action, const char *command)
 		struct view *view = desktop_view_at_cursor(server);
 		if (view) {
 			interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
+		}
+	} else if (!strcasecmp(action, "Resize")) {
+		struct view *view = desktop_view_at_cursor(server);
+		if (view) {
+			interactive_begin(view, LAB_INPUT_STATE_RESIZE, resize_edges);
 		}
 	} else {
 		wlr_log(WLR_ERROR, "action (%s) not supported", action);

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -65,7 +65,7 @@ handle_keybinding(struct server *server, uint32_t modifiers, xkb_keysym_t sym)
 		for (size_t i = 0; i < keybind->keysyms_len; i++) {
 			if (xkb_keysym_to_lower(sym) == keybind->keysyms[i]) {
 				action(server, keybind->action,
-				       keybind->command);
+				       keybind->command, 0);
 				return true;
 			}
 		}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -416,7 +416,7 @@ menu_action_selected(struct server *server, struct menu *menu)
 	struct menuitem *menuitem;
 	wl_list_for_each (menuitem, &menu->menuitems, link) {
 		if (menuitem->selected && !menuitem->submenu) {
-			action(server, menuitem->action, menuitem->command);
+			action(server, menuitem->action, menuitem->command, 0);
 			break;
 		}
 		if (menuitem->submenu) {


### PR DESCRIPTION
This requires `action()` to know the resize edges to use, so thread them through.