### PR TITLE
Implement Frame, Client, and Root mouse binding contexts

### DIFF
--- a/include/ssd.h
+++ b/include/ssd.h
@@ -5,7 +5,7 @@
 #include "labwc.h"
 
 /*
- * Sequence these according to the order they should be processes for
+ * Sequence these according to the order they should be processed for
  * press and hover events. Bear in mind that some of their respective
  * interactive areas overlap, so for example buttons need to come before title.
  */
@@ -24,6 +24,9 @@ enum ssd_part_type {
 	LAB_SSD_PART_RIGHT,
 	LAB_SSD_PART_BOTTOM,
 	LAB_SSD_PART_LEFT,
+	LAB_SSD_CLIENT,
+	LAB_SSD_FRAME,
+	LAB_SSD_ROOT,
 	LAB_SSD_END_MARKER
 };
 

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -67,5 +67,6 @@ void ssd_update_title(struct view *view);
 void ssd_create(struct view *view);
 void ssd_destroy(struct view *view);
 void ssd_update_geometry(struct view *view, bool force);
+bool ssd_part_contains(enum ssd_part_type whole, enum ssd_part_type candidate);
 
 #endif /* __LABWC_SSD_H */

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -87,6 +87,8 @@ mousebind_create(const char *context)
 	}
 	struct mousebind *m = calloc(1, sizeof(struct mousebind));
 	m->context = context_from_str(context);
-	wl_list_insert(&rc.mousebinds, &m->link);
+	if (m->context != LAB_SSD_NONE) {
+		wl_list_insert(&rc.mousebinds, &m->link);
+	}
 	return m;
 }

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -65,6 +65,14 @@ context_from_str(const char *str)
 		return LAB_SSD_BUTTON_MAXIMIZE;
 	} else if (!strcasecmp(str, "Iconify")) {
 		return LAB_SSD_BUTTON_ICONIFY;
+	} else if (!strcasecmp(str, "Frame")) {
+		return LAB_SSD_FRAME;
+	} else if (!strcasecmp(str, "Client")) {
+		return LAB_SSD_CLIENT;
+	} else if (!strcasecmp(str, "Desktop")) {
+		return LAB_SSD_ROOT;
+	} else if (!strcasecmp(str, "Root")) {
+		return LAB_SSD_ROOT;
 	}
 	wlr_log(WLR_ERROR, "unknown mouse context (%s)", str);
 	return LAB_SSD_NONE;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -550,6 +550,11 @@ cursor_button(struct wl_listener *listener, void *data)
 			cursor_rebase(&server->seat, event->time_msec);
 			return;
 		}
+
+		/* Handle _release_ on root window */
+		if (!view) {
+			handle_release_mousebinding(server, event->button, modifiers, LAB_SSD_ROOT, 0);
+		}
 		goto mousebindings;
 	}
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -548,7 +548,6 @@ cursor_button(struct wl_listener *listener, void *data)
 			/* Exit interactive move/resize/menu mode. */
 			server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
 			cursor_rebase(&server->seat, event->time_msec);
-			return;
 		}
 
 		/* Handle _release_ on root window */

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -317,6 +317,7 @@ desktop_surface_and_view_at(struct server *server, double lx, double ly,
 			continue;
 		}
 		if (_view_at(view, lx, ly, surface, sx, sy)) {
+			*view_area = LAB_SSD_CLIENT;
 			return view;
 		}
 		if (!view->ssd.enabled) {

--- a/src/ssd.c
+++ b/src/ssd.c
@@ -135,6 +135,12 @@ ssd_box(struct view *view, enum ssd_part_type type)
 		box.width = theme->border_width + INVISIBLE_MARGIN;
 		box.height = view->h;
 		break;
+	case LAB_SSD_CLIENT:
+		box.x = view->x;
+		box.y = view->y;
+		box.width = view->w;
+		box.height = view->h;
+		break;
 	default:
 		break;
 	}

--- a/src/ssd.c
+++ b/src/ssd.c
@@ -415,3 +415,18 @@ ssd_update_geometry(struct view *view, bool force)
 	view->ssd.box.height = view->h;
 	damage_all_outputs(view->server);
 }
+
+bool
+ssd_part_contains(enum ssd_part_type whole, enum ssd_part_type candidate)
+{
+	if (whole == candidate) {
+		return true;
+	}
+	if (whole == LAB_SSD_PART_TITLEBAR) {
+		return candidate >= LAB_SSD_BUTTON_CLOSE && candidate <= LAB_SSD_PART_CORNER_TOP_RIGHT;
+	}
+	if (whole == LAB_SSD_FRAME) {
+		return candidate >= LAB_SSD_BUTTON_CLOSE && candidate <= LAB_SSD_CLIENT;
+	}
+	return false;
+}


### PR DESCRIPTION
This changes mouse event handling to better match Openbox (in that mouse bindings on the Frame context swallow the event while others do not) and support more mouse contexts.

After these changes, mouse bindings should be expressive enough to remove some hard-coded logic in favor of default bindings.