### PR TITLE
Unhardcode defaults

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -67,6 +67,12 @@ action(struct server *server, const char *action, const char *command, uint32_t 
 		if (view) {
 			view_toggle_decorations(view);
 		}
+	} else if (!strcasecmp(action, "Focus")) {
+		struct view *view = desktop_view_at_cursor(server);
+		if (view) {
+			desktop_focus_and_activate_view(&server->seat, view);
+			damage_all_outputs(server);
+		}
 	} else if (!strcasecmp(action, "Iconify")) {
 		struct view *view = desktop_focused_view(server);
 		if (view) {
@@ -76,6 +82,12 @@ action(struct server *server, const char *action, const char *command, uint32_t 
 		struct view *view = desktop_view_at_cursor(server);
 		if (view) {
 			interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
+		}
+	} else if (!strcasecmp(action, "Raise")) {
+		struct view *view = desktop_focused_view(server);
+		if (view) {
+			desktop_raise_view(view);
+			damage_all_outputs(server);
 		}
 	} else if (!strcasecmp(action, "Resize")) {
 		struct view *view = desktop_view_at_cursor(server);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -475,6 +475,10 @@ static struct {
 	{ "Root", "Left", "Press", "ShowMenu", "root-menu"},
 	{ "Root", "Right", "Press", "ShowMenu", "root-menu"},
 	{ "Root", "Middle", "Press", "ShowMenu", "root-menu"},
+	{ "Client", "Left", "Press", "Focus", NULL},
+	{ "Client", "Left", "Press", "Raise", NULL},
+	{ "Titlebar", "Left", "Press", "Focus", NULL},
+	{ "Titlebar", "Left", "Press", "Raise", NULL},
 	{ NULL, NULL, NULL, NULL, NULL },
 };
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -472,6 +472,9 @@ static struct {
 	{ "Close", "Left", "Click", "Close", NULL },
 	{ "Iconify", "Left", "Click", "Iconify", NULL},
 	{ "Maximize", "Left", "Click", "ToggleMaximize", NULL},
+	{ "Root", "Left", "Press", "ShowMenu", "root-menu"},
+	{ "Root", "Right", "Press", "ShowMenu", "root-menu"},
+	{ "Root", "Middle", "Press", "ShowMenu", "root-menu"},
 	{ NULL, NULL, NULL, NULL, NULL },
 };
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -581,7 +581,7 @@ cursor_button(struct wl_listener *listener, void *data)
 
 	/* Handle _press_ on root window */
 	if (!view) {
-		action(server, "ShowMenu", "root-menu", 0);
+		handle_press_mousebinding(server, event->button, modifiers, LAB_SSD_ROOT, 0);
 		return;
 	}
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -585,11 +585,6 @@ cursor_button(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	/* Handle _press_ on view */
-	desktop_focus_and_activate_view(&server->seat, view);
-	desktop_raise_view(view);
-	damage_all_outputs(server);
-
 	/* Resize if SSD resize edge is clicked */
 	resize_edges = ssd_resize_edges(view_area);
 	if (resize_edges) {


### PR DESCRIPTION
Now that we have more flexible event handling, we can move a fair amount of logic to default configuration.

This should be carefully tested to make sure that behavior is identical, but I haven't been able to detect a difference. Remember to test with `labwc -c /dev/null` or similar so that the default config is used.