### PR TITLE
action: If we have a view that is an activator, use that instead of t…

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -471,7 +471,7 @@ void server_init(struct server *server);
 void server_start(struct server *server);
 void server_finish(struct server *server);
 
-void action(struct server *server, const char *action, const char *command,
+void action(struct view *activator, struct server *server, const char *action, const char *command,
 	uint32_t resize_edges);
 
 /* update onscreen display 'alt-tab' texture */

--- a/src/action.c
+++ b/src/action.c
@@ -19,13 +19,19 @@ show_menu(struct server *server, const char *menu)
 	damage_all_outputs(server);
 }
 
+static struct view *
+activator_or_focused_view(struct view *activator, struct server *server)
+{
+	return activator ? activator : desktop_focused_view(server);
+}
+
 void
-action(struct server *server, const char *action, const char *command, uint32_t resize_edges)
+action(struct view *activator, struct server *server, const char *action, const char *command, uint32_t resize_edges)
 {
 	if (!action)
 		return;
 	if (!strcasecmp(action, "Close")) {
-		struct view *view = desktop_focused_view(server);
+		struct view *view = activator_or_focused_view(activator, server);
 		if (view) {
 			view->impl->close(view);
 		}
@@ -41,9 +47,9 @@ action(struct server *server, const char *action, const char *command, uint32_t 
 	} else if (!strcasecmp(action, "Exit")) {
 		wl_display_terminate(server->wl_display);
 	} else if (!strcasecmp(action, "MoveToEdge")) {
-		view_move_to_edge(desktop_focused_view(server), command);
+		view_move_to_edge(activator_or_focused_view(activator, server), command);
 	} else if (!strcasecmp(action, "SnapToEdge")) {
-		view_snap_to_edge(desktop_focused_view(server), command);
+		view_snap_to_edge(activator_or_focused_view(activator, server), command);
 	} else if (!strcasecmp(action, "NextWindow")) {
 		server->cycle_view =
 			desktop_cycle_view(server, server->cycle_view, LAB_CYCLE_DIR_NONE);
@@ -53,17 +59,17 @@ action(struct server *server, const char *action, const char *command, uint32_t 
 	} else if (!strcasecmp(action, "ShowMenu")) {
 		show_menu(server, command);
 	} else if (!strcasecmp(action, "ToggleMaximize")) {
-		struct view *view = desktop_focused_view(server);
+		struct view *view = activator_or_focused_view(activator, server);
 		if (view) {
 			view_toggle_maximize(view);
 		}
 	} else if (!strcasecmp(action, "ToggleFullscreen")) {
-		struct view *view = desktop_focused_view(server);
+		struct view *view = activator_or_focused_view(activator, server);
 		if (view) {
 			view_toggle_fullscreen(view);
 		}
 	} else if (!strcasecmp(action, "ToggleDecorations")) {
-		struct view *view = desktop_focused_view(server);
+		struct view *view = activator_or_focused_view(activator, server);
 		if (view) {
 			view_toggle_decorations(view);
 		}
@@ -74,7 +80,7 @@ action(struct server *server, const char *action, const char *command, uint32_t 
 			damage_all_outputs(server);
 		}
 	} else if (!strcasecmp(action, "Iconify")) {
-		struct view *view = desktop_focused_view(server);
+		struct view *view = activator_or_focused_view(activator, server);
 		if (view) {
 			view_minimize(view, true);
 		}
@@ -84,7 +90,7 @@ action(struct server *server, const char *action, const char *command, uint32_t 
 			interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
 		}
 	} else if (!strcasecmp(action, "Raise")) {
-		struct view *view = desktop_focused_view(server);
+		struct view *view = activator_or_focused_view(activator, server);
 		if (view) {
 			desktop_raise_view(view);
 			damage_all_outputs(server);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -426,7 +426,7 @@ cursor_motion_absolute(struct wl_listener *listener, void *data)
 }
 
 static bool
-handle_release_mousebinding(struct server *server, uint32_t button, uint32_t modifiers, enum ssd_part_type view_area, uint32_t resize_edges)
+handle_release_mousebinding(struct view *view, struct server *server, uint32_t button, uint32_t modifiers, enum ssd_part_type view_area, uint32_t resize_edges)
 {
 	struct mousebind *mousebind;
 	bool activated_any = false;
@@ -450,7 +450,7 @@ handle_release_mousebinding(struct server *server, uint32_t button, uint32_t mod
 			}
 			activated_any = true;
 			activated_any_frame |= mousebind->context == LAB_SSD_FRAME;
-			action(server, mousebind->action,
+			action(view, server, mousebind->action,
 				mousebind->command, resize_edges);
 		}
 	}
@@ -481,7 +481,7 @@ is_double_click(long double_click_speed, uint32_t button)
 }
 
 static bool
-handle_press_mousebinding(struct server *server, uint32_t button, uint32_t modifiers, enum ssd_part_type view_area, uint32_t resize_edges)
+handle_press_mousebinding(struct view *view, struct server *server, uint32_t button, uint32_t modifiers, enum ssd_part_type view_area, uint32_t resize_edges)
 {
 	struct mousebind *mousebind;
 	bool double_click = is_double_click(rc.doubleclick_time, button);
@@ -507,7 +507,7 @@ handle_press_mousebinding(struct server *server, uint32_t button, uint32_t modif
 			}
 			activated_any = true;
 			activated_any_frame |= mousebind->context == LAB_SSD_FRAME;
-			action(server, mousebind->action,
+			action(view, server, mousebind->action,
 				mousebind->command, resize_edges);
 		}
 	}
@@ -556,7 +556,7 @@ cursor_button(struct wl_listener *listener, void *data)
 
 		/* Handle _release_ on root window */
 		if (!view) {
-			handle_release_mousebinding(server, event->button, modifiers, LAB_SSD_ROOT, 0);
+			handle_release_mousebinding(NULL, server, event->button, modifiers, LAB_SSD_ROOT, 0);
 		}
 		goto mousebindings;
 	}
@@ -585,7 +585,7 @@ cursor_button(struct wl_listener *listener, void *data)
 
 	/* Handle _press_ on root window */
 	if (!view) {
-		handle_press_mousebinding(server, event->button, modifiers, LAB_SSD_ROOT, 0);
+		handle_press_mousebinding(NULL, server, event->button, modifiers, LAB_SSD_ROOT, 0);
 		return;
 	}
 
@@ -602,9 +602,9 @@ cursor_button(struct wl_listener *listener, void *data)
 
 mousebindings:
 	if (event->state == WLR_BUTTON_RELEASED) {
-		triggered_frame_binding |= handle_release_mousebinding(server, event->button, modifiers, view_area, resize_edges);
+		triggered_frame_binding |= handle_release_mousebinding(view, server, event->button, modifiers, view_area, resize_edges);
 	} else if (event->state == WLR_BUTTON_PRESSED) {
-		triggered_frame_binding |= handle_press_mousebinding(server, event->button, modifiers, view_area, resize_edges);
+		triggered_frame_binding |= handle_press_mousebinding(view, server, event->button, modifiers, view_area, resize_edges);
 	}
 	if (!triggered_frame_binding) {
 		/* Notify client with pointer focus of button press */

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -64,7 +64,7 @@ handle_keybinding(struct server *server, uint32_t modifiers, xkb_keysym_t sym)
 		}
 		for (size_t i = 0; i < keybind->keysyms_len; i++) {
 			if (xkb_keysym_to_lower(sym) == keybind->keysyms[i]) {
-				action(server, keybind->action,
+				action(NULL, server, keybind->action,
 				       keybind->command, 0);
 				return true;
 			}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -416,7 +416,7 @@ menu_action_selected(struct server *server, struct menu *menu)
 	struct menuitem *menuitem;
 	wl_list_for_each (menuitem, &menu->menuitems, link) {
 		if (menuitem->selected && !menuitem->submenu) {
-			action(server, menuitem->action, menuitem->command, 0);
+			action(NULL, server, menuitem->action, menuitem->command, 0);
 			break;
 		}
 		if (menuitem->submenu) {


### PR DESCRIPTION
…he current focus window

If we don't switch focus, we want the close button to close the window associated with it, not the current focus window.

Signed-off-by: Joshua Ashton <joshua@froggi.es>