### PR TITLE
Alt-Tab switcher improvements

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -52,7 +52,7 @@ action(struct view *activator, struct server *server, const char *action, const 
 		view_snap_to_edge(activator_or_focused_view(activator, server), command);
 	} else if (!strcasecmp(action, "NextWindow")) {
 		server->cycle_view =
-			desktop_cycle_view(server, server->cycle_view, LAB_CYCLE_DIR_NONE);
+			desktop_cycle_view(server, server->cycle_view, LAB_CYCLE_DIR_FORWARD);
 		osd_update(server);
 	} else if (!strcasecmp(action, "Reconfigure")) {
 		spawn_async_no_shell("killall -SIGHUP labwc");

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -140,7 +140,6 @@ handle_compositor_keybindings(struct wl_listener *listener,
 					desktop_cycle_view(server, server->cycle_view,
 						backwards ? LAB_CYCLE_DIR_BACKWARD : LAB_CYCLE_DIR_FORWARD);
 				osd_update(server);
-				damage_all_outputs(server);
 			}
 		}
 		/* don't send any key events to clients when osd onscreen */

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -119,6 +119,14 @@ handle_compositor_keybindings(struct wl_listener *listener,
 	if (server->cycle_view) {
 		damage_all_outputs(server);
 		if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
+			for (int i = 0; i < nsyms; i++) {
+				if (syms[i] == XKB_KEY_Escape) {
+					/* cancel */
+					server->cycle_view = NULL;
+					return true;
+				}
+			}
+
 			/* cycle to next */
 			bool backwards = modifiers & WLR_MODIFIER_SHIFT;
 			/* ignore if this is a modifier key being pressed */


### PR DESCRIPTION
A couple of improvements to the Alt-Tab window switcher:

- Pressing Alt-Tab a single time should switch to the next window
- Pressing Escape should cancel the window switcher

These changes both make `labwc` work more like OpenBox and other stacking WMs.

Thanks!