### PR TITLE
[bugfix] Query passed prop, not 'title'

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -517,7 +517,7 @@ const char *
 view_get_string_prop(struct view *view, const char *prop)
 {
 	if (view->impl->get_string_prop) {
-		return view->impl->get_string_prop(view, "title");
+		return view->impl->get_string_prop(view, prop);
 	}
 	return "";
 }


### PR DESCRIPTION
This was causing (among other issues) windows from foot, chromium, and other programs that change their titles to lose their window icons when minimized and reactivated using waybar.