### PR TITLE
[bugfix] Don't crash when a minimized window closes

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -364,11 +364,13 @@ xdg_toplevel_view_map(struct view *view)
 static void
 xdg_toplevel_view_unmap(struct view *view)
 {
-	view->mapped = false;
-	damage_all_outputs(view->server);
-	wl_list_remove(&view->commit.link);
-	wl_list_remove(&view->new_subsurface.link);
-	desktop_focus_topmost_mapped_view(view->server);
+	if (view->mapped) {
+		view->mapped = false;
+		damage_all_outputs(view->server);
+		wl_list_remove(&view->commit.link);
+		wl_list_remove(&view->new_subsurface.link);
+		desktop_focus_topmost_mapped_view(view->server);
+	}
 }
 
 static const struct view_impl xdg_toplevel_view_impl = {

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -279,10 +279,12 @@ map(struct view *view)
 static void
 unmap(struct view *view)
 {
-	view->mapped = false;
-	damage_all_outputs(view->server);
-	wl_list_remove(&view->commit.link);
-	desktop_focus_topmost_mapped_view(view->server);
+	if(view->mapped) {
+		view->mapped = false;
+		damage_all_outputs(view->server);
+		wl_list_remove(&view->commit.link);
+		desktop_focus_topmost_mapped_view(view->server);
+	}
 }
 
 static void


### PR DESCRIPTION
To reproduce, open an editor from a terminal, minimize it, then hit ^C in the terminal.

The crash can be avoided if we simply don't unmap xdg or xwayland views if they are not currently marked as mapped.