### PR TITLE
config/rcxml: Allow multiple <action>s inside of a <mousebind>

### DIFF
--- a/include/config/mousebind.h
+++ b/include/config/mousebind.h
@@ -34,5 +34,6 @@ struct mousebind {
 enum mouse_event mousebind_event_from_str(const char *str);
 uint32_t mousebind_button_from_str(const char *str, uint32_t *modifiers);
 struct mousebind *mousebind_create(const char *context);
+struct mousebind *mousebind_create_from(struct mousebind *from, const char *context);
 
 #endif /* __LABWC_MOUSEBIND_H */

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -92,3 +92,17 @@ mousebind_create(const char *context)
 	}
 	return m;
 }
+
+struct mousebind *
+mousebind_create_from(struct mousebind *from, const char *context)
+{
+	if (!from) {
+		wlr_log(WLR_ERROR, "invalid mousebind instance specified");
+		return NULL;
+	}
+	struct mousebind *m = mousebind_create(context);
+	m->button = from->button;
+	m->modifiers = from->modifiers;
+	m->mouse_event = from->mouse_event;
+	return m;
+}

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -75,6 +75,8 @@ fill_mousebind(char *nodename, char *content)
 	/*
 	 * Example of what we are parsing:
 	 * <mousebind button="Left" action="DoubleClick">
+	 *   <action name="Focus"/>
+	 *   <action name="Raise"/>
 	 *   <action name="ToggleMaximize"/>
 	 * </mousebind>
 	 */
@@ -97,6 +99,10 @@ fill_mousebind(char *nodename, char *content)
 		current_mousebind->mouse_event =
 			mousebind_event_from_str(content);
 	} else if (!strcmp(nodename, "name.action")) {
+		if (current_mousebind->action) {
+			current_mousebind = mousebind_create_from(current_mousebind,
+				current_mouse_context);
+		}
 		current_mousebind->action = strdup(content);
 	} else if (!strcmp(nodename, "command.action")) {
 		current_mousebind->command = strdup(content);


### PR DESCRIPTION
Issue arises when using the default config from docs/rc.xml.all.
Without this patch only the last action defined inside a `<mousebind>` will have an effect.

Without a config or when defining the same `<mousebind>` multiple times with each containing only a single `<action>` the issue does not exist.