### PR TITLE
docs/rc.xml.all: Add focus + raise to TitleBar movement / maximize

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -121,8 +121,6 @@
         <action name="Raise"/>
         <action name="Move"/>
       </mousebind>
-    </context>
-    <context name="Frame">
       <mousebind button="A-Right" action="Press">
         <action name="Focus"/>
         <action name="Raise"/>
@@ -132,22 +130,31 @@
 
     <context name="TitleBar">
       <mousebind button="Left" action="Press">
+        <action name="Focus"/>
+        <action name="Raise"/>
         <action name="Move"/>
       </mousebind>
       <mousebind button="Left" action="DoubleClick">
+        <action name="Focus"/>
+        <action name="Raise"/>
         <action name="ToggleMaximize"/>
       </mousebind>
     </context>
+
     <context name="Maximize">
       <mousebind button="Left" action="Click">
+        <action name="Focus"/>
+        <action name="Raise"/>
         <action name="ToggleMaximize"/>
       </mousebind>
     </context>
+
     <context name="Iconify">
       <mousebind button="left" action="Click">
         <action name="Iconify"/>
       </mousebind>
     </context>
+
     <context name="Close">
       <mousebind button="Left" action="Click">
         <action name="Close"/>


### PR DESCRIPTION
This makes labwc feel way more intuitive when using the default rc.xml config.

Might be something for an issue instead:
Repeating Focus/Raise everywhere we interact with a Frame points to labwc missing a context or similar.

Something along the lines of
```
<context name="Frame" filter="unfocused" passthrough="yes">
    <mousebind button="Any" action="Press">
        <action name="Focus">
    </mousebind>
</context>

<context name="Frame" filter="unraised" passthrough="yes">
    <mousebind button="Any" action="Press">
        <action name="Raise">
    </mousebind>
</context>
```

Or as alternative:  
- restore raiseOnFocus to work without force-enabling followMouse
- a new dynamic context called FrameUnfocused which passes events to Frame/Client but allows to `mousebind` so it can be focused on Press which then in turn causes the raise because the toplevel is now focused