### PR TITLE
Implement foreign toplevel close

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -268,6 +268,7 @@ struct view {
 	struct wl_listener toplevel_handle_request_minimize;
 	struct wl_listener toplevel_handle_request_fullscreen;
 	struct wl_listener toplevel_handle_request_activate;
+	struct wl_listener toplevel_handle_request_close;
 
 	struct wl_listener map;
 	struct wl_listener unmap;
@@ -353,6 +354,7 @@ void view_child_finish(struct view_child *child);
 void view_subsurface_create(struct view *view, struct wlr_subsurface *wlr_subsurface);
 
 void view_set_activated(struct view *view, bool activated);
+void view_close(struct view *view);
 struct border view_border(struct view *view);
 void view_move_resize(struct view *view, struct wlr_box geo);
 void view_move(struct view *view, double x, double y);

--- a/src/action.c
+++ b/src/action.c
@@ -33,7 +33,7 @@ action(struct view *activator, struct server *server, const char *action, const 
 	if (!strcasecmp(action, "Close")) {
 		struct view *view = activator_or_focused_view(activator, server);
 		if (view) {
-			view->impl->close(view);
+			view_close(view);
 		}
 	} else if (!strcasecmp(action, "Debug")) {
 		/* nothing */

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -39,6 +39,14 @@ handle_toplevel_handle_request_activate(struct wl_listener *listener, void *data
 	desktop_move_to_front(view);
 }
 
+static void
+handle_toplevel_handle_request_close(struct wl_listener *listener, void *data)
+{
+	struct view *view = wl_container_of(listener, view,
+		toplevel_handle_request_close);
+	view_close(view);
+}
+
 void
 foreign_toplevel_handle_create(struct view *view)
 {
@@ -78,5 +86,11 @@ foreign_toplevel_handle_create(struct view *view)
 		handle_toplevel_handle_request_activate;
 	wl_signal_add(&view->toplevel_handle->events.request_activate,
 		&view->toplevel_handle_request_activate);
-	/* TODO: hook up remaining signals (close, destroy) */
+
+	view->toplevel_handle_request_close.notify =
+		handle_toplevel_handle_request_close;
+	wl_signal_add(&view->toplevel_handle->events.request_close,
+		&view->toplevel_handle_request_close);
+
+	/* TODO: hook up remaining signals (destroy) */
 }

--- a/src/view.c
+++ b/src/view.c
@@ -17,6 +17,14 @@ view_set_activated(struct view *view, bool activated)
 }
 
 void
+view_close(struct view *view)
+{
+	if (view->impl->close) {
+		view->impl->close(view);
+	}
+}
+
+void
 view_move_resize(struct view *view, struct wlr_box geo)
 {
 	if (view->impl->configure) {


### PR DESCRIPTION
I've basically copied #140 + the action handler for Close.

While doing that I also wrapped view->impl->close(view) in a view_close(view) function which AFAIU seems to be the desired design. The action handler for Close now uses view_close(view) as well.

I've only tested the PR using mate-panel (including context menu PR) but it should work with any foreign-toplevel client.