### PR TITLE
Check the return value of wlr_output_layout_get() for NULL

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -526,6 +526,10 @@ render_osd(struct output *output, pixman_region32_t *damage,
 	struct wlr_output_layout_output *ol_output;
 	wl_list_for_each(o, &server->outputs, link) {
 		ol_output = wlr_output_layout_get(layout, o->wlr_output);
+		if (!ol_output) {
+			continue;
+		}
+
 		struct wlr_box box = {
 			.x = ol_output->x + o->wlr_output->width
 				/ o->wlr_output->scale / 2,

--- a/src/view.c
+++ b/src/view.c
@@ -125,6 +125,10 @@ view_center(struct view *view)
 	struct wlr_output_layout *layout = view->server->output_layout;
 	struct wlr_output_layout_output *ol_output =
 		wlr_output_layout_get(layout, wlr_output);
+	if (!ol_output) {
+		return;
+	}
+
 	int center_x = ol_output->x + wlr_output->width / wlr_output->scale / 2;
 	int center_y = ol_output->y + wlr_output->height / wlr_output->scale / 2;
 	view_move(view, center_x - view->w / 2, center_y - view->h / 2);


### PR DESCRIPTION
`wlr_output_layout_get()` seems to return `NULL` for disabled outputs.

Fixes: #174