### PR TITLE
Fix use-after-free errors detected by valgrind

### DIFF
--- a/src/seat.c
+++ b/src/seat.c
@@ -10,6 +10,7 @@ input_device_destroy(struct wl_listener *listener, void *data)
 {
 	struct input *input = wl_container_of(listener, input, destroy);
 	wl_list_remove(&input->link);
+	wl_list_remove(&input->destroy.link);
 	free(input);
 }
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -97,6 +97,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 	}
 	interactive_end(view);
 	wl_list_remove(&view->link);
+	wl_list_remove(&view->destroy.link);
 	ssd_destroy(view);
 	free(view);
 }


### PR DESCRIPTION
Handlers for the "destroy" signal need to unregister themselves from the signal (using `wl_list_remove()`) before invoking `free()`.

    Invalid write of size 8
       at 0x487DF27: wl_list_remove (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x4906FF0: wlr_signal_emit_safe (signal.c:32)
       by 0x48EA304: reset_xdg_surface (wlr_xdg_surface.c:430)
       by 0x48EA3D6: UnknownInlinedFun (wlr_xdg_surface.c:464)
       by 0x48EA3D6: xdg_surface_handle_resource_destroy (wlr_xdg_surface.c:282)
       by 0x4877899: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x487DEBF: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x487E3DF: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x487830D: wl_client_destroy (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x48783F6: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x487B1C9: wl_event_loop_dispatch (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x4878D36: wl_display_run (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x110DAC: main (main.c:81)
     Address 0xc3213d8 is 424 bytes inside a block of size 704 free'd
       at 0x484118B: free (vg_replace_malloc.c:755)
       by 0x4906FDD: wlr_signal_emit_safe (signal.c:29)
       by 0x48EA304: reset_xdg_surface (wlr_xdg_surface.c:430)
       by 0x48EA3D6: UnknownInlinedFun (wlr_xdg_surface.c:464)
       by 0x48EA3D6: xdg_surface_handle_resource_destroy (wlr_xdg_surface.c:282)
       by 0x4877899: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x487DEBF: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x487E3DF: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x487830D: wl_client_destroy (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x48783F6: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x487B1C9: wl_event_loop_dispatch (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x4878D36: wl_display_run (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x110DAC: main (main.c:81)
     Block was alloc'd at
       at 0x48435FF: calloc (vg_replace_malloc.c:1117)
       by 0x113E22: xdg_surface_new (xdg.c:401)
       by 0x4906FDD: wlr_signal_emit_safe (signal.c:29)
       by 0x48EABE7: handle_xdg_surface_commit (wlr_xdg_surface.c:331)
       by 0x4908FE7: surface_commit_state (wlr_surface.c:457)
       by 0x524DD49: ??? (in /usr/lib/libffi.so.8.1.0)
       by 0x524D266: ??? (in /usr/lib/libffi.so.8.1.0)
       by 0x487D322: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x48785CB: ??? (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x487B1C9: wl_event_loop_dispatch (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x4878D36: wl_display_run (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x110DAC: main (main.c:81)

    Invalid write of size 8
       at 0x487DF27: wl_list_remove (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x4906FF0: wlr_signal_emit_safe (signal.c:32)
       by 0x48F5529: UnknownInlinedFun (wlr_input_device.c:34)
       by 0x48F5529: wlr_input_device_destroy (wlr_input_device.c:29)
       by 0x48CE4B5: backend_destroy.part.0.lto_priv.0 (backend.c:148)
       by 0x48D2D55: multi_backend_destroy (backend.c:59)
       by 0x48788FE: wl_display_destroy (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x110E71: UnknownInlinedFun (server.c:406)
       by 0x110E71: main (main.c:83)
     Address 0xc466568 is 24 bytes inside a block of size 56 free'd
       at 0x484118B: free (vg_replace_malloc.c:755)
       by 0x4906FDD: wlr_signal_emit_safe (signal.c:29)
       by 0x48F5529: UnknownInlinedFun (wlr_input_device.c:34)
       by 0x48F5529: wlr_input_device_destroy (wlr_input_device.c:29)
       by 0x48CE4B5: backend_destroy.part.0.lto_priv.0 (backend.c:148)
       by 0x48D2D55: multi_backend_destroy (backend.c:59)
       by 0x48788FE: wl_display_destroy (in /usr/lib/libwayland-server.so.0.20.0)
       by 0x110E71: UnknownInlinedFun (server.c:406)
       by 0x110E71: main (main.c:83)
     Block was alloc'd at
       at 0x48435FF: calloc (vg_replace_malloc.c:1117)
       by 0x11590F: new_input_notify (seat.c:137)
       by 0x4906FDD: wlr_signal_emit_safe (signal.c:29)
       by 0x4906FDD: wlr_signal_emit_safe (signal.c:29)
       by 0x48CDCEE: UnknownInlinedFun (events.c:109)
       by 0x48CDCEE: UnknownInlinedFun (events.c:242)
       by 0x48CDCEE: UnknownInlinedFun (backend.c:58)
       by 0x48CDCEE: handle_libinput_readable (backend.c:48)
       by 0x48CE1BE: backend_start.lto_priv.0 (backend.c:114)
       by 0x48D2CE5: multi_backend_start (backend.c:33)
       by 0x110C45: UnknownInlinedFun (server.c:375)
       by 0x110C45: main (main.c:68)