### PR TITLE
view.c: Remove 'activated' flag when minimizing a view

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -88,6 +88,7 @@ view_minimize(struct view *view, bool minimized)
 	if (minimized) {
 		view->impl->unmap(view);
 		desktop_move_to_back(view);
+		view_set_activated(view, false);
 	} else {
 		view->impl->map(view);
 	}


### PR DESCRIPTION
Before this change a window that had been minimized showed up with states Minimized and Activated.
For foreign-toplevel clients like taskbars that could mean to handle multiple windows at once having a 'activated' state even though they were clearly minimized.

I am not 100% sure this PR won't have negative side effects as we are now additionally calling `set_activated(view, false)` in xdg.c / xwayland.c. To fix the issue at hand it would have been enough to call `wlr_foreign_toplevel_handle_v1_set_activated(handle, false)` in view.c but that seemed like a half fix where other parts of the code would still think this window is actually active. So I chose the generic `view_set_activated(view, false)` (which calls into `view->impl->set_activated(view, false)`) instead.

There may be a better place to call the foreign_toplevel_handler.