### PR TITLE
view:c Do not overwrite unmaximized dimensions on fullscreen

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -222,10 +222,12 @@ view_set_fullscreen(struct view *view, bool fullscreen,
 			view->toplevel_handle, fullscreen);
 	}
 	if (fullscreen) {
-		view->unmaximized_geometry.x = view->x;
-		view->unmaximized_geometry.y = view->y;
-		view->unmaximized_geometry.width = view->w;
-		view->unmaximized_geometry.height = view->h;
+		if (!view->maximized) {
+			view->unmaximized_geometry.x = view->x;
+			view->unmaximized_geometry.y = view->y;
+			view->unmaximized_geometry.width = view->w;
+			view->unmaximized_geometry.height = view->h;
+		}
 
 		if (!wlr_output) {
 			wlr_output = view_wlr_output(view);
@@ -244,7 +246,16 @@ view_set_fullscreen(struct view *view, bool fullscreen,
 		view_move_resize(view, box);
 	} else {
 		/* restore to normal */
-		view_move_resize(view, view->unmaximized_geometry);
+		if (view->maximized) {
+			view->maximized = false;
+			view->x = view->unmaximized_geometry.x;
+			view->y = view->unmaximized_geometry.y;
+			view->w = view->unmaximized_geometry.width;
+			view->h = view->unmaximized_geometry.height;
+			view_maximize(view, true);
+		} else {
+			view_move_resize(view, view->unmaximized_geometry);
+		}
 		view->fullscreen = false;
 	}
 }


### PR DESCRIPTION
Before: window -> maximize -> fullscreen -> unfullscreen would reset pre maximized state
Now: window -> maximize -> fullscreen -> unfullscreen -> unmaximize works as expected

This feels like a hack though.
I tried something like this as well:
```
view_move_resize(view, view->unmaximized_geometry);
if (view->maximized) {
    view->maximized = false;
    view_maximize(view, true);
}
```
but view->x and friends were still based on the fullscreen dimensions so it again overwrote the original premaximized state.
That would also cause a double resize which may not look that great for the user.

Maybe somebody has a better idea how to handle that (one could add something like view->unfullscreen_geometry but that feels like overkill).
