### PR TITLE
xwayland: Implement activate and minimize

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -277,6 +277,7 @@ struct view {
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_configure;	/* xwayland only */
+	struct wl_listener request_activate;
 	struct wl_listener request_minimize;
 	struct wl_listener request_maximize;
 	struct wl_listener request_fullscreen;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -277,6 +277,7 @@ struct view {
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_configure;	/* xwayland only */
+	struct wl_listener request_minimize;
 	struct wl_listener request_maximize;
 	struct wl_listener request_fullscreen;
 	struct wl_listener set_title;

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -102,7 +102,8 @@ desktop_focus_and_activate_view(struct seat *seat, struct view *view)
 		seat_focus_surface(seat, NULL);
 		return;
 	}
-	if (input_inhibit_blocks_surface(seat, view->surface->resource)) {
+
+	if (view->surface && input_inhibit_blocks_surface(seat, view->surface->resource)) {
 		return;
 	}
 
@@ -114,7 +115,8 @@ desktop_focus_and_activate_view(struct seat *seat, struct view *view)
 		view_minimize(view, false);
 		return;
 	}
-	if (!view->mapped) {
+
+	if (!view->mapped || !view->surface) {
 		return;
 	}
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -426,8 +426,7 @@ xdg_surface_new(struct wl_listener *listener, void *data)
 	view->request_maximize.notify = handle_request_maximize;
 	wl_signal_add(&toplevel->events.request_maximize, &view->request_maximize);
 	view->request_fullscreen.notify = handle_request_fullscreen;
-	wl_signal_add(&toplevel->events.request_fullscreen,
-		&view->request_fullscreen);
+	wl_signal_add(&toplevel->events.request_fullscreen, &view->request_fullscreen);
 
 	view->set_title.notify = handle_set_title;
 	wl_signal_add(&toplevel->events.set_title, &view->set_title);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -136,6 +136,16 @@ handle_request_resize(struct wl_listener *listener, void *data)
 }
 
 static void
+handle_request_minimize(struct wl_listener *listener, void *data)
+{
+	struct view *view = wl_container_of(listener, view, request_minimize);
+	struct wlr_xdg_surface *surface = data;
+	if (view) {
+		view_minimize(view, surface->toplevel->requested.minimized);
+	}
+}
+
+static void
 handle_request_maximize(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, request_maximize);
@@ -423,6 +433,8 @@ xdg_surface_new(struct wl_listener *listener, void *data)
 	wl_signal_add(&toplevel->events.request_move, &view->request_move);
 	view->request_resize.notify = handle_request_resize;
 	wl_signal_add(&toplevel->events.request_resize, &view->request_resize);
+	view->request_minimize.notify = handle_request_minimize;
+	wl_signal_add(&toplevel->events.request_minimize, &view->request_minimize);
 	view->request_maximize.notify = handle_request_maximize;
 	wl_signal_add(&toplevel->events.request_maximize, &view->request_maximize);
 	view->request_fullscreen.notify = handle_request_fullscreen;

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -358,19 +358,15 @@ xwayland_surface_new(struct wl_listener *listener, void *data)
 	view->destroy.notify = handle_destroy;
 	wl_signal_add(&xsurface->events.destroy, &view->destroy);
 	view->request_configure.notify = handle_request_configure;
-	wl_signal_add(&xsurface->events.request_configure,
-		      &view->request_configure);
+	wl_signal_add(&xsurface->events.request_configure, &view->request_configure);
 	view->request_maximize.notify = handle_request_maximize;
 	wl_signal_add(&xsurface->events.request_maximize, &view->request_maximize);
 	view->request_fullscreen.notify = handle_request_fullscreen;
-	wl_signal_add(&xsurface->events.request_fullscreen,
-		&view->request_fullscreen);
+	wl_signal_add(&xsurface->events.request_fullscreen, &view->request_fullscreen);
 	view->request_move.notify = handle_request_move;
-	wl_signal_add(&xsurface->events.request_move,
-		&view->request_move);
+	wl_signal_add(&xsurface->events.request_move, &view->request_move);
 	view->request_resize.notify = handle_request_resize;
-	wl_signal_add(&xsurface->events.request_resize,
-		&view->request_resize);
+	wl_signal_add(&xsurface->events.request_resize, &view->request_resize);
 
 	view->set_title.notify = handle_set_title;
 	wl_signal_add(&xsurface->events.set_title, &view->set_title);

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -112,6 +112,15 @@ handle_request_configure(struct wl_listener *listener, void *data)
 #undef MAX
 
 static void
+handle_request_activate(struct wl_listener *listener, void *data)
+{
+	struct view *view = wl_container_of(listener, view, request_activate);
+	assert(view);
+	desktop_focus_and_activate_view(&view->server->seat, view);
+	desktop_move_to_front(view);
+}
+
+static void
 handle_request_minimize(struct wl_listener *listener, void *data)
 {
 	struct wlr_xwayland_minimize_event *event = data;
@@ -368,6 +377,8 @@ xwayland_surface_new(struct wl_listener *listener, void *data)
 	wl_signal_add(&xsurface->events.destroy, &view->destroy);
 	view->request_configure.notify = handle_request_configure;
 	wl_signal_add(&xsurface->events.request_configure, &view->request_configure);
+	view->request_activate.notify = handle_request_activate;
+	wl_signal_add(&xsurface->events.request_activate, &view->request_activate);
 	view->request_minimize.notify = handle_request_minimize;
 	wl_signal_add(&xsurface->events.request_minimize, &view->request_minimize);
 	view->request_maximize.notify = handle_request_maximize;

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -112,6 +112,15 @@ handle_request_configure(struct wl_listener *listener, void *data)
 #undef MAX
 
 static void
+handle_request_minimize(struct wl_listener *listener, void *data)
+{
+	struct wlr_xwayland_minimize_event *event = data;
+	struct view *view = wl_container_of(listener, view, request_minimize);
+	assert(view);
+	view_minimize(view, event->minimize);
+}
+
+static void
 handle_request_maximize(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, request_maximize);
@@ -359,6 +368,8 @@ xwayland_surface_new(struct wl_listener *listener, void *data)
 	wl_signal_add(&xsurface->events.destroy, &view->destroy);
 	view->request_configure.notify = handle_request_configure;
 	wl_signal_add(&xsurface->events.request_configure, &view->request_configure);
+	view->request_minimize.notify = handle_request_minimize;
+	wl_signal_add(&xsurface->events.request_minimize, &view->request_minimize);
 	view->request_maximize.notify = handle_request_maximize;
 	wl_signal_add(&xsurface->events.request_maximize, &view->request_maximize);
 	view->request_fullscreen.notify = handle_request_fullscreen;


### PR DESCRIPTION
Activate is used by Steam for bringing up/focusing the chat windows, and minimize is used on the CSD by Steam and many apps.