### PR TITLE
Adjust views to account for output layout changes

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -370,6 +370,7 @@ void view_toggle_maximize(struct view *view);
 void view_toggle_decorations(struct view *view);
 void view_set_decorations(struct view *view, bool decorations);
 void view_toggle_fullscreen(struct view *view);
+void view_adjust_for_layout_change(struct view *view);
 void view_for_each_surface(struct view *view,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 void view_for_each_popup_surface(struct view *view,


### PR DESCRIPTION
labwc currently doesn't handle output layout changes very well:

 - Windows can end up "lost" completely offscreen
 - Maximized/fullscreen windows can end up spanning multiple outputs

Currently, `new_output_notify()` and `output_destroy_notify()` contain logic
to update the cursor and force a repaint when outputs are added or
removed.  This logic in fact needs to run on any output layout change,
so consolidate it into a new function, `output_update_for_layout_change()`.

Then add a second new function, `view_adjust_for_layout_change()`, which
adjusts window placement to account for the new layout.

The behavior is roughly as follows:

 - Normal windows that end up offscreen are centered on the closest
   output (making use of the existing `view_center()` logic)
 - Maximized windows are re-maximized on the closest output.  Logic is
   also added to the unmaximize step to check that the original
   unmaximized position is still on-screen.
 - Fullscreen windows are re-fullscreened on the same output if
   possible; otherwise they are un-fullscreened.

Minimized windows don't require any special handling.  Their placement
is adjusted just the same, but invisible to the user until they are
later unminimized.

There is some positioning glitch still with un-fullscreening a window
whose output has been disconnected/disabled; it can end up in an
unexpected position (but at least has the correct size and decoration).
I don't think this is due to a bug in my change per se, but perhaps the
change has exposed a bug elsewhere.

Fixes: #177