### PR TITLE
Allow multiple actions at once

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LABWC_ACTION_H
+#define __LABWC_ACTION_H
+
+struct action {
+	uint32_t type;
+	char *arg;
+	struct wl_list link;
+};
+
+struct action *action_create(const char *action_str);
+
+#endif

--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -11,8 +11,7 @@ struct keybind {
 	uint32_t modifiers;
 	xkb_keysym_t *keysyms;
 	size_t keysyms_len;
-	char *action;
-	char *command;
+	struct wl_list actions;
 	struct wl_list link;
 };
 

--- a/include/config/mousebind.h
+++ b/include/config/mousebind.h
@@ -24,8 +24,7 @@ struct mousebind {
 
 	/* ex: doubleclick, press, drag */
 	enum mouse_event mouse_event;
-	const char *action;
-	const char *command;
+	struct wl_list actions;
 
 	struct wl_list link; /* rcxml::mousebinds */
 	bool pressed_in_context; /* used in click events */
@@ -34,6 +33,5 @@ struct mousebind {
 enum mouse_event mousebind_event_from_str(const char *str);
 uint32_t mousebind_button_from_str(const char *str, uint32_t *modifiers);
 struct mousebind *mousebind_create(const char *context);
-struct mousebind *mousebind_create_from(struct mousebind *from, const char *context);
 
 #endif /* __LABWC_MOUSEBIND_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -500,8 +500,8 @@ void server_init(struct server *server);
 void server_start(struct server *server);
 void server_finish(struct server *server);
 
-void action(struct view *activator, struct server *server, const char *action,
-	const char *command, uint32_t resize_edges);
+void action(struct view *activator, struct server *server,
+	struct wl_list *actions, uint32_t resize_edges);
 
 /* update onscreen display 'alt-tab' texture */
 void osd_update(struct server *server);

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -6,8 +6,7 @@
 #include <wlr/render/wlr_renderer.h>
 
 struct menuitem {
-	char *action;
-	char *command;
+	struct wl_list actions;
 	struct menu *submenu;
 	struct wlr_box box;
 	struct {

--- a/src/action.c
+++ b/src/action.c
@@ -4,6 +4,78 @@
 #include "common/spawn.h"
 #include "labwc.h"
 #include "menu/menu.h"
+#include "action.h"
+
+enum action_type {
+	ACTION_TYPE_NONE = 0,
+	ACTION_TYPE_CLOSE,
+	ACTION_TYPE_DEBUG,
+	ACTION_TYPE_EXECUTE,
+	ACTION_TYPE_EXIT,
+	ACTION_TYPE_MOVE_TO_EDGE,
+	ACTION_TYPE_SNAP_TO_EDGE,
+	ACTION_TYPE_NEXT_WINDOW,
+	ACTION_TYPE_PREVIOUS_WINDOW,
+	ACTION_TYPE_RECONFIGURE,
+	ACTION_TYPE_SHOW_MENU,
+	ACTION_TYPE_TOGGLE_MAXIMIZE,
+	ACTION_TYPE_TOGGLE_FULLSCREEN,
+	ACTION_TYPE_TOGGLE_DECORATIONS,
+	ACTION_TYPE_FOCUS,
+	ACTION_TYPE_ICONIFY,
+	ACTION_TYPE_MOVE,
+	ACTION_TYPE_RAISE,
+	ACTION_TYPE_RESIZE,
+};
+
+const char *action_names[] = {
+	"NoOp",
+	"Close",
+	"Debug",
+	"Execute",
+	"Exit",
+	"MoveToEdge",
+	"SnapToEdge",
+	"NextWindow",
+	"PreviousWindow",
+	"Reconfigure",
+	"ShowMenu",
+	"ToggleMaximize",
+	"ToggleFullscreen",
+	"ToggleDecorations",
+	"Focus",
+	"Iconify",
+	"Move",
+	"Raise",
+	"Resize",
+	NULL
+};
+
+
+static enum action_type
+action_type_from_str(const char *action_name)
+{
+	for (size_t i=1; action_names[i] != NULL; i++) {
+		if (!strcasecmp(action_name, action_names[i])) {
+			return i;
+		}
+	}
+	wlr_log(WLR_ERROR, "Invalid action: %s", action_name);
+	return ACTION_TYPE_NONE;
+}
+
+struct action *
+action_create(const char *action_name)
+{
+	if (!action_name) {
+		wlr_log(WLR_ERROR, "action name not specified");
+		return NULL;
+	}
+	struct action *action = calloc(1, sizeof(struct action));
+	action->type = action_type_from_str(action_name);
+	return action;
+}
+
 
 static void
 show_menu(struct server *server, const char *menu)
@@ -26,85 +98,123 @@ activator_or_focused_view(struct view *activator, struct server *server)
 }
 
 void
-action(struct view *activator, struct server *server, const char *action, const char *command, uint32_t resize_edges)
+action(struct view *activator, struct server *server, struct wl_list *actions, uint32_t resize_edges)
 {
-	if (!action)
+	if (!actions) {
+		wlr_log(WLR_ERROR, "empty actions");
 		return;
-	if (!strcasecmp(action, "Close")) {
-		struct view *view = activator_or_focused_view(activator, server);
-		if (view) {
-			view_close(view);
+	}
+
+	struct view *view;
+	struct action *action;
+	wl_list_for_each(action, actions, link) {
+		wlr_log(WLR_DEBUG, "Handling action %s (%u) with arg %s",
+			 action_names[action->type], action->type, action->arg);
+
+		/* Refetch view because it may have been changed due to the previous action */
+		view = activator_or_focused_view(activator, server);
+
+		switch(action->type) {
+		case ACTION_TYPE_CLOSE:;
+			if (view) {
+				view_close(view);
+			}
+			break;
+		case ACTION_TYPE_DEBUG:;
+			/* nothing */
+			break;
+		case ACTION_TYPE_EXECUTE:;
+			{
+				struct buf cmd;
+				buf_init(&cmd);
+				buf_add(&cmd, action->arg);
+				buf_expand_shell_variables(&cmd);
+				spawn_async_no_shell(cmd.buf);
+				free(cmd.buf);
+			}
+			break;
+		case ACTION_TYPE_EXIT:;
+			wl_display_terminate(server->wl_display);
+			break;
+		case ACTION_TYPE_MOVE_TO_EDGE:;
+			view_move_to_edge(view, action->arg);
+			break;
+		case ACTION_TYPE_SNAP_TO_EDGE:;
+			view_snap_to_edge(view, action->arg);
+			break;
+		case ACTION_TYPE_NEXT_WINDOW:;
+			server->cycle_view =
+				desktop_cycle_view(server, server->cycle_view, LAB_CYCLE_DIR_FORWARD);
+			osd_update(server);
+			break;
+		case ACTION_TYPE_PREVIOUS_WINDOW:;
+			server->cycle_view =
+				desktop_cycle_view(server, server->cycle_view, LAB_CYCLE_DIR_BACKWARD);
+			osd_update(server);
+			break;
+		case ACTION_TYPE_RECONFIGURE:;
+			/* Should be changed to signal() */
+			spawn_async_no_shell("killall -SIGHUP labwc");
+			break;
+		case ACTION_TYPE_SHOW_MENU:;
+			show_menu(server, action->arg);
+			break;
+		case ACTION_TYPE_TOGGLE_MAXIMIZE:;
+			if (view) {
+				view_toggle_maximize(view);
+			}
+			break;
+		case ACTION_TYPE_TOGGLE_FULLSCREEN:;
+			if (view) {
+				view_toggle_fullscreen(view);
+			}
+			break;
+		case ACTION_TYPE_TOGGLE_DECORATIONS:;
+			if (view) {
+				view_toggle_decorations(view);
+			}
+			break;
+		case ACTION_TYPE_FOCUS:;
+			view = desktop_view_at_cursor(server);
+			if (view) {
+				desktop_focus_and_activate_view(&server->seat, view);
+				damage_all_outputs(server);
+			}
+			break;
+		case ACTION_TYPE_ICONIFY:;
+			if (view) {
+				view_minimize(view, true);
+			}
+			break;
+		case ACTION_TYPE_MOVE:;
+			view = desktop_view_at_cursor(server);
+			if (view) {
+				interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
+			}
+			break;
+		case ACTION_TYPE_RAISE:;
+			if (view) {
+				desktop_move_to_front(view);
+				damage_all_outputs(server);
+			}
+			break;
+		case ACTION_TYPE_RESIZE:;
+			view = desktop_view_at_cursor(server);
+			if (view) {
+				interactive_begin(view, LAB_INPUT_STATE_RESIZE, resize_edges);
+			}
+			break;
+		case ACTION_TYPE_NONE:;
+			wlr_log(WLR_ERROR, "Not executing unknown action with arg %s", action->arg);
+			break;
+		default:;
+			/*
+			 * If we get here it must be a BUG caused most likely by
+			 * action_names and action_type being out of sync or by
+			 * adding a new action without installing a handler here.
+			 */
+			wlr_log(WLR_ERROR, "Not executing invalid action (%u) with arg %s"
+				"This is a BUG. Please report.", action->type, action->arg);
 		}
-	} else if (!strcasecmp(action, "Debug")) {
-		/* nothing */
-	} else if (!strcasecmp(action, "Execute")) {
-		struct buf cmd;
-		buf_init(&cmd);
-		buf_add(&cmd, command);
-		buf_expand_shell_variables(&cmd);
-		spawn_async_no_shell(cmd.buf);
-		free(cmd.buf);
-	} else if (!strcasecmp(action, "Exit")) {
-		wl_display_terminate(server->wl_display);
-	} else if (!strcasecmp(action, "MoveToEdge")) {
-		view_move_to_edge(activator_or_focused_view(activator, server), command);
-	} else if (!strcasecmp(action, "SnapToEdge")) {
-		view_snap_to_edge(activator_or_focused_view(activator, server), command);
-	} else if (!strcasecmp(action, "NextWindow")) {
-		server->cycle_view =
-			desktop_cycle_view(server, server->cycle_view, LAB_CYCLE_DIR_FORWARD);
-		osd_update(server);
-	} else if (!strcasecmp(action, "PreviousWindow")) {
-		server->cycle_view =
-			desktop_cycle_view(server, server->cycle_view, LAB_CYCLE_DIR_BACKWARD);
-		osd_update(server);
-	} else if (!strcasecmp(action, "Reconfigure")) {
-		spawn_async_no_shell("killall -SIGHUP labwc");
-	} else if (!strcasecmp(action, "ShowMenu")) {
-		show_menu(server, command);
-	} else if (!strcasecmp(action, "ToggleMaximize")) {
-		struct view *view = activator_or_focused_view(activator, server);
-		if (view) {
-			view_toggle_maximize(view);
-		}
-	} else if (!strcasecmp(action, "ToggleFullscreen")) {
-		struct view *view = activator_or_focused_view(activator, server);
-		if (view) {
-			view_toggle_fullscreen(view);
-		}
-	} else if (!strcasecmp(action, "ToggleDecorations")) {
-		struct view *view = activator_or_focused_view(activator, server);
-		if (view) {
-			view_toggle_decorations(view);
-		}
-	} else if (!strcasecmp(action, "Focus")) {
-		struct view *view = desktop_view_at_cursor(server);
-		if (view) {
-			desktop_focus_and_activate_view(&server->seat, view);
-			damage_all_outputs(server);
-		}
-	} else if (!strcasecmp(action, "Iconify")) {
-		struct view *view = activator_or_focused_view(activator, server);
-		if (view) {
-			view_minimize(view, true);
-		}
-	} else if (!strcasecmp(action, "Move")) {
-		struct view *view = desktop_view_at_cursor(server);
-		if (view) {
-			interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
-		}
-	} else if (!strcasecmp(action, "Raise")) {
-		struct view *view = activator_or_focused_view(activator, server);
-		if (view) {
-			desktop_move_to_front(view);
-			damage_all_outputs(server);
-		}
-	} else if (!strcasecmp(action, "Resize")) {
-		struct view *view = desktop_view_at_cursor(server);
-		if (view) {
-			interactive_begin(view, LAB_INPUT_STATE_RESIZE, resize_edges);
-		}
-	} else {
-		wlr_log(WLR_ERROR, "(%s) not supported", action);
 	}
 }

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -61,5 +61,6 @@ keybind_create(const char *keybind)
 	wl_list_insert(&rc.keybinds, &k->link);
 	k->keysyms = malloc(k->keysyms_len * sizeof(xkb_keysym_t));
 	memcpy(k->keysyms, keysyms, k->keysyms_len * sizeof(xkb_keysym_t));
+	wl_list_init(&k->actions);
 	return k;
 }

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -108,19 +108,6 @@ mousebind_create(const char *context)
 	if (m->context != LAB_SSD_NONE) {
 		wl_list_insert(&rc.mousebinds, &m->link);
 	}
-	return m;
-}
-
-struct mousebind *
-mousebind_create_from(struct mousebind *from, const char *context)
-{
-	if (!from) {
-		wlr_log(WLR_ERROR, "invalid mousebind instance specified");
-		return NULL;
-	}
-	struct mousebind *m = mousebind_create(context);
-	m->button = from->button;
-	m->modifiers = from->modifiers;
-	m->mouse_event = from->mouse_event;
+	wl_list_init(&m->actions);
 	return m;
 }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -470,8 +470,7 @@ handle_release_mousebinding(struct view *view, struct server *server,
 			}
 			activated_any = true;
 			activated_any_frame |= mousebind->context == LAB_SSD_FRAME;
-			action(view, server, mousebind->action,
-				mousebind->command, resize_edges);
+			action(view, server, &mousebind->actions, resize_edges);
 		}
 	}
 	return activated_any && activated_any_frame;
@@ -532,8 +531,7 @@ handle_press_mousebinding(struct view *view, struct server *server,
 			}
 			activated_any = true;
 			activated_any_frame |= mousebind->context == LAB_SSD_FRAME;
-			action(view, server, mousebind->action,
-				mousebind->command, resize_edges);
+			action(view, server, &mousebind->actions, resize_edges);
 		}
 	}
 	return activated_any && activated_any_frame;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -67,8 +67,7 @@ handle_keybinding(struct server *server, uint32_t modifiers, xkb_keysym_t sym)
 		for (size_t i = 0; i < keybind->keysyms_len; i++) {
 			if (xkb_keysym_to_lower(sym) == keybind->keysyms[i]) {
 				wlr_keyboard_set_repeat_info(kb, 0, 0);
-				action(NULL, server, keybind->action,
-				       keybind->command, 0);
+				action(NULL, server, &keybind->actions, 0);
 				return true;
 			}
 		}


### PR DESCRIPTION
I converted all actions to a `wl_list` containing `struct action`. That is: keybindings, mousebindings and menus.
Seems to work so far. For example this now works:
```
<keybind key="A-1">
	<action name=ToggleDecorations" />
	<action name=ToggleMaximize" />
</keybind>
```
Struct currently looks like this:
```
struct action {
	uint32_t type;
	char *arg;
	struct wl_list link;
};
```
~~Open questions:~~
~~- Should `action_create(action_str)` get a `wl_list` pointer as second argument and add itself to that list?~~
~~Currently it is the responsibility of the caller to add the created action to its list.~~

~~Do not merge the PR as is, it contains debug statements in action.c and changed the global loglevel to INFO.~~

Is the approach generally usable or should it be changed in design or implementation?