### PR TITLE
Unmaximize on Move

### DIFF
--- a/src/interactive.c
+++ b/src/interactive.c
@@ -1,16 +1,49 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "labwc.h"
 
+static int
+max_move_scale(double pos_cursor, double pos_current,
+	double size_current, double size_orig)
+{
+	double anchor_frac = (pos_cursor - pos_current) / size_current;
+	int pos_new = pos_cursor - (size_orig * anchor_frac);
+	if (pos_new < pos_current) {
+		/* Clamp by using the old offsets of the maximized window */
+		pos_new = pos_current;
+	}
+	return pos_new;
+}
+
 void
 interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 {
 	if (view->maximized) {
-		return;
+		if (mode == LAB_INPUT_STATE_MOVE) {
+			int new_x = max_move_scale(view->server->seat.cursor->x,
+				view->x, view->w, view->unmaximized_geometry.width);
+			int new_y = max_move_scale(view->server->seat.cursor->y,
+				view->y, view->h, view->unmaximized_geometry.height);
+			view->unmaximized_geometry.x = new_x;
+			view->unmaximized_geometry.y = new_y;
+			view_maximize(view, false);
+			/*
+			 * view_maximize() indirectly calls view->impl->configure
+			 * which is async but we are using the current values in
+			 * server->grab_box. We pretend the configure already
+			 * happened by setting them manually.
+			 */
+			view->x = new_x;
+			view->y = new_y;
+			view->w = view->unmaximized_geometry.width;
+			view->h = view->unmaximized_geometry.height;
+		} else {
+			return;
+		}
 	}
 
 	/*
 	 * This function sets up an interactive move or resize operation, where
-	 * the compositor stops propegating pointer events to clients and
+	 * the compositor stops propagating pointer events to clients and
 	 * instead consumes them itself, to move or resize windows.
 	 */
 	struct seat *seat = &view->server->seat;


### PR DESCRIPTION
By @skyne98 in #122:
> As an additional point, I think it is important to allow users to drag the windows which were double-clicked back into their original forms (and sizes), making them not full-screen again.

I gave a try at implementing that feature.

The PR uses the fractional position of where the cursor is located related to size and position of the maximized window and scales it down to the unmaximized state.
The window will then be positioned on both axis based on the calculation and the current cursor position so it will not suddenly jump around and (at least for me) it feels natural to drag, both when moving by grabbing the title bar and when moving with `A-BTN1` or a generic `Move` keybind.

I had used `struct border` before to determine the required offsets but then it would need to consider exclusive zones and possibly other offsets in the future. That isn't required at all though because the window is already maximized and thus all those calculations had already be done and we can just use `view->x` / `view->y` to determine the correct offsets.

~~Warning: only tested using a single screen.~~