### PR TITLE
Allow mouse movements to trigger SnapToEdge

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -30,6 +30,14 @@
   </focus>
 
   <!--
+    Set range to 0 to disable window snapping completely
+  -->
+  <snapping>
+    <range>1</range>
+    <topMaximize>yes</topMaximize>
+  </snapping>
+
+  <!--
     Keybind actions are specified in labwc-actions(5)
     The following keybind modifiers are supported:
       W - window/super/logo

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -44,6 +44,10 @@ struct rcxml {
 
 	/* resistance */
 	int screen_edge_strength;
+
+	/* window snapping */
+	int snap_edge_range;
+	bool snap_top_maximize;
 };
 
 extern struct rcxml rc;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -374,6 +374,10 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.repeat_delay = atoi(content);
 	} else if (!strcasecmp(nodename, "screenEdgeStrength.resistance")) {
 		rc.screen_edge_strength = atoi(content);
+	} else if (!strcasecmp(nodename, "range.snapping")) {
+		rc.snap_edge_range = atoi(content);
+	} else if (!strcasecmp(nodename, "topMaximize.snapping")) {
+		rc.snap_top_maximize = get_bool(content);
 	}
 }
 
@@ -470,6 +474,8 @@ rcxml_init()
 	rc.repeat_rate = 25;
 	rc.repeat_delay = 600;
 	rc.screen_edge_strength = 20;
+	rc.snap_edge_range = 1;
+	rc.snap_top_maximize = true;
 }
 
 static struct {

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -597,8 +597,12 @@ cursor_button(struct wl_listener *listener, void *data)
 		damage_all_outputs(server);
 		if (server->input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
 			/* Exit interactive move/resize/menu mode. */
-			server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
-			server->grabbed_view = NULL;
+			if (server->grabbed_view == view) {
+				interactive_end(view);
+			} else {
+				server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
+				server->grabbed_view = NULL;
+			}
 			cursor_rebase(&server->seat, event->time_msec);
 		}
 


### PR DESCRIPTION
Basic support for window snapping by "throwing" the window onto an edge.
See #122 for context.

rc.xml.all got two new options:
```
<snapping>
  <range>1</range>
  <TopMaximize>yes</TopMaximize>
</snapping>
```
Whenever a move ends within `range` of `usable_area`, `view_snap_to_edge()`  for the given edge is called (or `view_maximize()` if we are dealing with the top edge and TopMaximize setting is set to true) .
A range of 0 ~~(or not setting the new config at all)~~ disables the feature.

~~Warning: only tested using a single screen.~~