### PR TITLE
More robust rc.xml parsing

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -116,6 +116,7 @@ fill_item(char *nodename, char *content)
 	/* <item label=""> defines the start of a new item */
 	if (!strcmp(nodename, "label")) {
 		current_item = item_create(current_menu, content);
+		current_item_action = NULL;
 	} else if (!current_item) {
 		wlr_log(WLR_ERROR, "expect <item label=\"\"> element first. "
 			"nodename: '%s' content: '%s'", nodename, content);


### PR DESCRIPTION
- Reset `current_mousebind` when assigning a new `current_mouse_context`
- Reset `current_*_action` when creating a new `{key,mouse}bind` or `menuitem`
- Reset `current_*` in `rcxml_finish()`
- Check for `current_*` before trying to create a new action
- Check for `current_*_action` before trying to set `action->arg`
- Check for `current_mouse_context` before creating a new mousebind
- Complain to the user about most invalid config entries