### PR TITLE
Fix stuck mouse drags when maximizing a window

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -542,7 +542,13 @@ handle_press_mousebinding(struct view *view, struct server *server,
 			switch (mousebind->mouse_event) {
 			case MOUSE_ACTION_DRAG: /* FALLTHROUGH */
 			case MOUSE_ACTION_CLICK:
-				mousebind->pressed_in_context = true;
+				/*
+				 * DRAG and CLICK actions will be processed on
+				 * the release event, unless the press event is
+				 * counted as a DOUBLECLICK.
+				 */
+				if (!double_click)
+					mousebind->pressed_in_context = true;
 				continue;
 			case MOUSE_ACTION_DOUBLECLICK:
 				if (!double_click)

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -481,10 +481,8 @@ handle_release_mousebinding(struct view *view, struct server *server,
 			case MOUSE_ACTION_RELEASE:
 				break;
 			case MOUSE_ACTION_CLICK:
-				if (mousebind->pressed_in_context) {
-					mousebind->pressed_in_context = false;
+				if (mousebind->pressed_in_context)
 					break;
-				}
 				continue;
 			default:
 				continue;
@@ -493,8 +491,14 @@ handle_release_mousebinding(struct view *view, struct server *server,
 			activated_any_frame |= mousebind->context == LAB_SSD_FRAME;
 			action(view, server, &mousebind->actions, resize_edges);
 		}
-		/* For the drag events */
-		mousebind->pressed_in_context = false;
+	}
+	/*
+	 * Clear "pressed" status for all bindings of this mouse button,
+	 * regardless of whether activated or not
+	 */
+	wl_list_for_each(mousebind, &rc.mousebinds, link) {
+		if (mousebind->button == button)
+			mousebind->pressed_in_context = false;
 	}
 	return activated_any && activated_any_frame;
 }


### PR DESCRIPTION
Fix two separate bugs that predate, but were exposed by, ae43d4b9d1c8fb1a758fa9f212f629a72e6d7c27 ("Unmaximize on Move"):

1. Double-clicking on the titlebar and then moving the mouse (while still held after the second press) would trigger both a DOUBLECLICK and then also a DRAG binding, resulting in the window maximizing and then immediately unmaximizing.
2. Clicking on the maximize button would trigger a CLICK binding but also leave a DRAG binding active, resulting in the window unmaximizing and moving as soon as the mouse moved, even though the mouse button was no longer held.

More details in the commit messages.