### PR TITLE
CodeStyle

### DIFF
--- a/src/common/nodename.c
+++ b/src/common/nodename.c
@@ -22,8 +22,9 @@ nodename(xmlNode *node, char *buf, int len)
 		char c;
 		while ((c = *name++) != 0) {
 			*p++ = tolower(c);
-			if (!--len)
+			if (!--len) {
 				return buf;
+			}
 		}
 		*p = 0;
 		node = node->parent;

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -18,8 +18,9 @@ mousebind_button_from_str(const char *str, uint32_t *modifiers)
 		while (strlen(str) >= 2 && str[1] == '-') {
 			char modname[2] = {str[0], 0};
 			uint32_t parsed_modifier = parse_modifier(modname);
-			if (!parsed_modifier)
+			if (!parsed_modifier) {
 				goto invalid;
+			}
 			*modifiers |= parsed_modifier;
 			str += 2;
 		}

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -660,8 +660,9 @@ rcxml_read(const char *filename)
 	buf_init(&b);
 	while (getline(&line, &len, stream) != -1) {
 		char *p = strrchr(line, '\n');
-		if (p)
+		if (p) {
 			*p = '\0';
+		}
 		buf_add(&b, line);
 	}
 	free(line);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -481,8 +481,9 @@ handle_release_mousebinding(struct view *view, struct server *server,
 			case MOUSE_ACTION_RELEASE:
 				break;
 			case MOUSE_ACTION_CLICK:
-				if (mousebind->pressed_in_context)
+				if (mousebind->pressed_in_context) {
 					break;
+				}
 				continue;
 			default:
 				continue;
@@ -497,8 +498,9 @@ handle_release_mousebinding(struct view *view, struct server *server,
 	 * regardless of whether activated or not
 	 */
 	wl_list_for_each(mousebind, &rc.mousebinds, link) {
-		if (mousebind->button == button)
+		if (mousebind->button == button) {
 			mousebind->pressed_in_context = false;
+		}
 	}
 	return activated_any && activated_any_frame;
 }
@@ -551,12 +553,14 @@ handle_press_mousebinding(struct view *view, struct server *server,
 				 * the release event, unless the press event is
 				 * counted as a DOUBLECLICK.
 				 */
-				if (!double_click)
+				if (!double_click) {
 					mousebind->pressed_in_context = true;
+				}
 				continue;
 			case MOUSE_ACTION_DOUBLECLICK:
-				if (!double_click)
+				if (!double_click) {
 					continue;
+				}
 				break;
 			case MOUSE_ACTION_PRESS:
 				break;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -261,8 +261,9 @@ parse_xml(const char *filename, struct server *server)
 	buf_init(&b);
 	while (getline(&line, &len, stream) != -1) {
 		char *p = strrchr(line, '\n');
-		if (p)
+		if (p) {
 			*p = '\0';
+		}
 		buf_add(&b, line);
 	}
 	free(line);


### PR DESCRIPTION
Fix some new and old conditions without braces.
Found by `egrep -R -A 3 'if \(.*\)[ \t]*$' src/`