### PR TITLE
output: Add option to preview the contents of the current cycle_view

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -31,6 +31,10 @@ Configuration must be wrapped in a <labwc_config> root-node.
 *<core><adaptiveSync>* [yes|no]
 	Enable adaptive sync. Default is no.
 
+*<core><cycleViewPreview>* [yes|no]
+	Preview the contents of the selected window when cycling between windows.
+	Default is no.
+
 # FOCUS
 
 *<focus><followMouse>* [yes|no]

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -11,6 +11,7 @@
     <decoration>server</decoration>
     <gap>0</gap>
     <adaptiveSync>no</adaptiveSync>
+    <cycleViewPreview>no</cycleViewPreview>
   </core>
 
   <!--

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -48,6 +48,9 @@ struct rcxml {
 	/* window snapping */
 	int snap_edge_range;
 	bool snap_top_maximize;
+
+	/* cycle view (alt+tab) */
+	bool cycle_preview_contents;
 };
 
 extern struct rcxml rc;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -378,6 +378,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.snap_edge_range = atoi(content);
 	} else if (!strcasecmp(nodename, "topMaximize.snapping")) {
 		rc.snap_top_maximize = get_bool(content);
+	} else if (!strcasecmp(nodename, "cycleViewPreview.core")) {
+		rc.cycle_preview_contents = get_bool(content);
 	}
 }
 
@@ -476,6 +478,7 @@ rcxml_init()
 	rc.screen_edge_strength = 20;
 	rc.snap_edge_range = 1;
 	rc.snap_top_maximize = true;
+	rc.cycle_preview_contents = false;
 }
 
 static struct {

--- a/src/output.c
+++ b/src/output.c
@@ -802,6 +802,16 @@ output_render(struct output *output, pixman_region32_t *damage)
 
 	/* 'alt-tab' border */
 	if (output->server->cycle_view) {
+		/* If the 'cycle_preview_contents' option is set in
+		 * rc.xml, render the contents of the cycle_view over
+		 * all other views (except for the OSD)
+		 */
+		if (rc.cycle_preview_contents) {
+			render_deco(output->server->cycle_view, output, damage);
+			render_view_toplevels(output->server->cycle_view, output, damage);
+			render_view_popups(output->server->cycle_view, output, damage);
+		}
+
 		render_cycle_box(output, damage, output->server->cycle_view);
 		render_osd(output, damage, output->server);
 	}


### PR DESCRIPTION
Add the 'cycleViewPreview.core' option to rc.xml to enable previews of
the selected view when cycling between windows. Default this option to
be disabled to match current behavior.