### PR TITLE
Centralize freeing of action lists

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -12,6 +12,7 @@ struct action {
 };
 
 struct action *action_create(const char *action_name);
+void action_list_free(struct wl_list *action_list);
 
 void action(struct view *activator, struct server *server,
 	struct wl_list *actions, uint32_t resize_edges);

--- a/src/action.c
+++ b/src/action.c
@@ -2,6 +2,7 @@
 #include <strings.h>
 #include <wlr/util/log.h>
 #include "common/spawn.h"
+#include "common/zfree.h"
 #include "labwc.h"
 #include "menu/menu.h"
 #include "action.h"
@@ -74,6 +75,15 @@ action_create(const char *action_name)
 	struct action *action = calloc(1, sizeof(struct action));
 	action->type = action_type_from_str(action_name);
 	return action;
+}
+
+void action_list_free(struct wl_list *action_list) {
+	struct action *action, *action_tmp;
+	wl_list_for_each_safe(action, action_tmp, action_list, link) {
+		wl_list_remove(&action->link);
+		zfree(action->arg);
+		zfree(action);
+	}
 }
 
 static void

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -676,7 +676,6 @@ no_config:
 void
 rcxml_finish(void)
 {
-	struct action *action, *action_tmp;
 
 	zfree(rc.font_name_activewindow);
 	zfree(rc.font_name_menuitem);
@@ -686,11 +685,7 @@ rcxml_finish(void)
 	struct keybind *k, *k_tmp;
 	wl_list_for_each_safe(k, k_tmp, &rc.keybinds, link) {
 		wl_list_remove(&k->link);
-		wl_list_for_each_safe(action, action_tmp, &k->actions, link) {
-			wl_list_remove(&action->link);
-			zfree(action->arg);
-			zfree(action);
-		}
+		action_list_free(&k->actions);
 		zfree(k->keysyms);
 		zfree(k);
 	}
@@ -698,11 +693,7 @@ rcxml_finish(void)
 	struct mousebind *m, *m_tmp;
 	wl_list_for_each_safe(m, m_tmp, &rc.mousebinds, link) {
 		wl_list_remove(&m->link);
-		wl_list_for_each_safe(action, action_tmp, &m->actions, link) {
-			wl_list_remove(&action->link);
-			zfree(action->arg);
-			zfree(action);
-		}
+		action_list_free(&m->actions);
 		zfree(m);
 	}
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -330,17 +330,12 @@ void
 menu_finish(void)
 {
 	struct menu *menu;
-	struct action *action, *action_tmp;
 	for (int i = 0; i < nr_menus; ++i) {
 		menu = menus + i;
 		struct menuitem *item, *next;
 		wl_list_for_each_safe(item, next, &menu->menuitems, link) {
 			wl_list_remove(&item->link);
-			wl_list_for_each_safe(action, action_tmp, &item->actions, link) {
-				wl_list_remove(&action->link);
-				zfree(action->arg);
-				zfree(action);
-			}
+			action_list_free(&item->actions);
 			free(item);
 		}
 	}


### PR DESCRIPTION
Removes some code duplication and makes it easier to extend `struct action` by adding further arguments.