### PR TITLE
src/output.c: fix debug flag for full frame damage

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -860,7 +860,7 @@ renderer_end:
 	wlr_region_transform(&frame_damage, &output->damage->current,
 		transform, output_width, output_height);
 
-#ifdef DEBUG
+#if DEBUG
 	pixman_region32_union_rect(&frame_damage, &frame_damage, 0, 0,
 		output_width, output_height);
 #endif


### PR DESCRIPTION
I am still on my quest to use an old tablet as secondary screen (and possibly as second input as well).
After getting [wayvnc](https://github.com/any1/wayvnc) to work [without virtual pointer and keyboard protocols](https://github.com/any1/wayvnc/pull/126) for now, I discovered it was really spiking the labwc CPU time.
I've seen this before, its listed in my random todo list as 'wdisplays using 200% CPU'.

So I got into debugging the screencopy implementation and found two issues:
- one is an outdated `#ifdef DEBUG` statement which is actually always defined on the top of `src/output.c` and causes full damage on each frame. Thus the screencopy protocol will always send the frame, even though nothing has actually changed
- the other is that moving the cursor in the main screen somehow gets the second 'headless' screen damaged as well, even though the mouse cursor never actually shows up there. It seems to happen with both, software and hardware cursors.

The first issue was easy to fix after recognizing it which is what this PR does.
For the second issue, I still don't really know what may be causing it. Maybe something on the `cursor_motion()` path calls `damage_all_outputs()`.

If you want to give wayvnc a try (even though without a secondary 'headless' output but that is [really easy to add](https://github.com/labwc/labwc/issues/203) or use `WLR_{X11,WL}_OUTPUTS=2` when running nested):
`build/wayvnc --disable-input --output HEADLESS-1 --render-cursor --max-fps 120 --show-performance 0.0.0.0`
and connect with some VNC client to 127.0.0.1 or your LAN IP.

Obviously replace `--output` with whatever wlr-randr has to say about your outputs.
