### PR TITLE
Reduce damage on cursor_move

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -43,6 +43,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include "config/keybind.h"
 #include "config/rcxml.h"
+#include "ssd.h"
 
 #define XCURSOR_DEFAULT "left_ptr"
 #define XCURSOR_SIZE 24
@@ -448,7 +449,7 @@ bool isfocusable(struct view *view);
  */
 struct view *desktop_surface_and_view_at(struct server *server, double lx,
 	double ly, struct wlr_surface **surface, double *sx, double *sy,
-	int *view_area);
+	enum ssd_part_type *view_area);
 
 struct view *desktop_view_at_cursor(struct server *server);
 

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -69,5 +69,6 @@ void ssd_create(struct view *view);
 void ssd_destroy(struct view *view);
 void ssd_update_geometry(struct view *view, bool force);
 bool ssd_part_contains(enum ssd_part_type whole, enum ssd_part_type candidate);
+bool ssd_is_button(enum ssd_part_type type);
 
 #endif /* __LABWC_SSD_H */

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -2,8 +2,6 @@
 #ifndef __LABWC_SSD_H
 #define __LABWC_SSD_H
 
-#include "labwc.h"
-
 /*
  * Sequence these according to the order they should be processed for
  * press and hover events. Bear in mind that some of their respective
@@ -30,6 +28,13 @@ enum ssd_part_type {
 	LAB_SSD_ROOT,
 	LAB_SSD_END_MARKER
 };
+
+/*
+ * Defer including labwc.h because it is using enum ssd_part_type.
+ * This is an issue for headers like mousebind.h which only includes
+ * ssd.h but does not include labwc.h.
+ */
+#include "labwc.h"
 
 struct ssd_part {
 	struct wlr_box box;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -17,7 +17,7 @@ cursor_rebase(struct seat *seat, uint32_t time_msec)
 {
 	double sx, sy;
 	struct wlr_surface *surface;
-	int view_area = LAB_SSD_NONE;
+	enum ssd_part_type view_area = LAB_SSD_NONE;
 
 	desktop_surface_and_view_at(seat->server, seat->cursor->x,
 		seat->cursor->y, &surface, &sx, &sy, &view_area);
@@ -201,7 +201,7 @@ process_cursor_motion(struct server *server, uint32_t time)
 	double sx, sy;
 	struct wlr_seat *wlr_seat = server->seat.seat;
 	struct wlr_surface *surface = NULL;
-	int view_area = LAB_SSD_NONE;
+	enum ssd_part_type view_area = LAB_SSD_NONE;
 	struct view *view = desktop_surface_and_view_at(server,
 		server->seat.cursor->x, server->seat.cursor->y, &surface,
 		&sx, &sy, &view_area);
@@ -583,7 +583,7 @@ cursor_button(struct wl_listener *listener, void *data)
 
 	double sx, sy;
 	struct wlr_surface *surface;
-	int view_area = LAB_SSD_NONE;
+	enum ssd_part_type view_area = LAB_SSD_NONE;
 	uint32_t resize_edges;
 
 	/* bindings to the Frame context swallow mouse events if activated */

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -343,7 +343,7 @@ layer_surface_popup_at(struct output *output, struct wl_list *layer,
 struct view *
 desktop_surface_and_view_at(struct server *server, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy,
-		int *view_area)
+		enum ssd_part_type *view_area)
 {
 	struct wlr_output *wlr_output = wlr_output_layout_output_at(
 			server->output_layout, lx, ly);
@@ -435,7 +435,7 @@ desktop_view_at_cursor(struct server *server)
 {
 	double sx, sy;
 	struct wlr_surface *surface;
-	int view_area = LAB_SSD_NONE;
+	enum ssd_part_type view_area = LAB_SSD_NONE;
 
 	return desktop_surface_and_view_at(server,
 			server->seat.cursor->x, server->seat.cursor->y,

--- a/src/output.c
+++ b/src/output.c
@@ -544,15 +544,6 @@ render_osd(struct output *output, pixman_region32_t *damage,
 	}
 }
 
-static bool
-isbutton(enum ssd_part_type type)
-{
-	return type == LAB_SSD_BUTTON_CLOSE ||
-	       type == LAB_SSD_BUTTON_MAXIMIZE ||
-	       type == LAB_SSD_BUTTON_ICONIFY ||
-	       type == LAB_SSD_BUTTON_WINDOW_MENU;
-}
-
 static void
 render_deco(struct view *view, struct output *output,
 		pixman_region32_t *output_damage)
@@ -585,7 +576,7 @@ render_deco(struct view *view, struct output *output,
 	struct wlr_cursor *cur = view->server->seat.cursor;
 	enum ssd_part_type type = ssd_at(view, cur->x, cur->y);
 	struct wlr_box box = ssd_visible_box(view, type);
-	if (isbutton(type) &&
+	if (ssd_is_button(type) &&
 			wlr_box_contains_point(&box, cur->x, cur->y)) {
 		float *color = (float[4]) { 0.5, 0.5, 0.5, 0.5 };
 		render_rect(output, output_damage, &box, color);

--- a/src/ssd.c
+++ b/src/ssd.c
@@ -186,6 +186,15 @@ justify_right(struct view *view, struct wlr_box *box,
 	box->x = view->x + (box->width - texture->width);
 }
 
+bool
+ssd_is_button(enum ssd_part_type type)
+{
+	return type == LAB_SSD_BUTTON_CLOSE ||
+	       type == LAB_SSD_BUTTON_MAXIMIZE ||
+	       type == LAB_SSD_BUTTON_ICONIFY ||
+	       type == LAB_SSD_BUTTON_WINDOW_MENU;
+}
+
 struct wlr_box
 ssd_visible_box(struct view *view, enum ssd_part_type type)
 {


### PR DESCRIPTION
Part two of #222:
- Detect button enter/leave events and only damage the current output if happened
- Use proper `enum ssd_part_type` for `desktop_surface_and_view_at()`
- Move `is_button()` from `src/output.c` into `src/ssd.c` and make it public

This could be further optimized by damaging only the old/new button regions on button enter/leave.

By the way, thanks for this comment:
`/* Required for iconify/maximize/close button mouse-over deco */`
This made it really easy to figure out what was going on and - way more important - why it has been going on.