### PR TITLE
build: Relax the version constraint for wlroots to accept patch releases

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ if git.found()
 endif
 add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 
-wlroots_version = ['=0.15.0']
+wlroots_version = ['>=0.15.0', '<0.16.0']
 wlroots_proj = subproject(
   'wlroots',
   default_options: ['default_library=static', 'examples=false'],


### PR DESCRIPTION
Patch releases only contain backwards compatible changes (mainly bug
fixes) so we want to allow them. This fixes the build with the recently
released wlroots 0.15.1 and uses the same version constraints as other
projects that depend on wlroots (e.g., Sway).