### PR TITLE
OSD: Scale OSD to the largest output scale

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -154,6 +154,7 @@ struct server {
 	struct wlr_output_manager_v1 *output_manager;
 	struct wl_listener output_manager_apply;
 	struct wlr_output_configuration_v1 *pending_output_config;
+	float greatest_scale;
 
 	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -144,7 +144,6 @@ struct server {
 	double grab_x, grab_y;
 	struct wlr_box grab_box;
 	uint32_t resize_edges;
-	struct wlr_texture *osd;
 
 	struct wl_list outputs;
 	struct wl_listener new_output;
@@ -154,7 +153,6 @@ struct server {
 	struct wlr_output_manager_v1 *output_manager;
 	struct wl_listener output_manager_apply;
 	struct wlr_output_configuration_v1 *pending_output_config;
-	float greatest_scale;
 
 	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
 
@@ -177,6 +175,7 @@ struct output {
 	struct wlr_output_damage *damage;
 	struct wl_list layers[4];
 	struct wlr_box usable_area;
+	struct wlr_texture *osd;
 
 	struct wl_listener destroy;
 	struct wl_listener damage_frame;

--- a/src/osd.c
+++ b/src/osd.c
@@ -79,115 +79,118 @@ osd_update(struct server *server)
 	struct wlr_renderer *renderer = server->renderer;
 	struct theme *theme = server->theme;
 
-	float scale = server->greatest_scale;
-	int w = (OSD_ITEM_WIDTH + (2 * OSD_BORDER_WIDTH)) * scale;
-	int h = get_osd_height(&server->views) * scale;
+	struct output *output;
+	wl_list_for_each(output, &server->outputs, link) {
+		float scale = output->wlr_output->scale;
+		int w = (OSD_ITEM_WIDTH + (2 * OSD_BORDER_WIDTH)) * scale;
+		int h = get_osd_height(&server->views) * scale;
 
-	cairo_surface_t *surf =
-		cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
-	cairo_surface_set_device_scale(surf, scale, scale);
-	cairo_t *cairo = cairo_create(surf);
+		cairo_surface_t *surf =
+			cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
+		cairo_surface_set_device_scale(surf, scale, scale);
+		cairo_t *cairo = cairo_create(surf);
 
-	/* background */
-	set_source(cairo, theme->osd_bg_color);
-	cairo_rectangle(cairo, 0, 0, w, h);
-	cairo_fill(cairo);
+		/* background */
+		set_source(cairo, theme->osd_bg_color);
+		cairo_rectangle(cairo, 0, 0, w, h);
+		cairo_fill(cairo);
 
-	/* border */
-	set_source(cairo, theme->osd_label_text_color);
-	cairo_rectangle(cairo, 0, 0, w, h);
-	cairo_stroke(cairo);
+		/* border */
+		set_source(cairo, theme->osd_label_text_color);
+		cairo_rectangle(cairo, 0, 0, w, h);
+		cairo_stroke(cairo);
 
-	/* highlight current window */
-	int y = OSD_BORDER_WIDTH;
-	struct view *view;
-	wl_list_for_each(view, &server->views, link) {
-		if (!isfocusable(view)) {
-			continue;
+		/* highlight current window */
+		int y = OSD_BORDER_WIDTH;
+		struct view *view;
+		wl_list_for_each(view, &server->views, link) {
+			if (!isfocusable(view)) {
+				continue;
+			}
+			if (view == server->cycle_view) {
+				set_source(cairo, theme->osd_label_text_color);
+				cairo_rectangle(cairo, OSD_BORDER_WIDTH, y,
+					OSD_ITEM_WIDTH, OSD_ITEM_HEIGHT);
+				cairo_stroke(cairo);
+				break;
+			}
+			y += OSD_ITEM_HEIGHT;
 		}
-		if (view == server->cycle_view) {
-			set_source(cairo, theme->osd_label_text_color);
-			cairo_rectangle(cairo, OSD_BORDER_WIDTH, y,
-				OSD_ITEM_WIDTH, OSD_ITEM_HEIGHT);
-			cairo_stroke(cairo);
-			break;
-		}
-		y += OSD_ITEM_HEIGHT;
-	}
 
-	/* text */
-	set_source(cairo, theme->osd_label_text_color);
-	PangoLayout *layout = pango_cairo_create_layout(cairo);
-	pango_layout_set_width(layout, w * PANGO_SCALE);
-	pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
+		/* text */
+		set_source(cairo, theme->osd_label_text_color);
+		PangoLayout *layout = pango_cairo_create_layout(cairo);
+		pango_layout_set_width(layout, w * PANGO_SCALE);
+		pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
 
-	struct font font = {
-		.name = rc.font_name_osd,
-		.size = rc.font_size_osd,
-	};
-	PangoFontDescription *desc = pango_font_description_new();
-	pango_font_description_set_family(desc, font.name);
-	pango_font_description_set_size(desc, font.size * PANGO_SCALE);
-	pango_layout_set_font_description(layout, desc);
-	pango_font_description_free(desc);
+		struct font font = {
+			.name = rc.font_name_osd,
+			.size = rc.font_size_osd,
+		};
+		PangoFontDescription *desc = pango_font_description_new();
+		pango_font_description_set_family(desc, font.name);
+		pango_font_description_set_size(desc, font.size * PANGO_SCALE);
+		pango_layout_set_font_description(layout, desc);
+		pango_font_description_free(desc);
 
-	PangoTabArray *tabs = pango_tab_array_new_with_positions(2, TRUE,
-		PANGO_TAB_LEFT, OSD_TAB1, PANGO_TAB_LEFT, OSD_TAB2);
-	pango_layout_set_tabs(layout, tabs);
-	pango_tab_array_free(tabs);
+		PangoTabArray *tabs = pango_tab_array_new_with_positions(2, TRUE,
+			PANGO_TAB_LEFT, OSD_TAB1, PANGO_TAB_LEFT, OSD_TAB2);
+		pango_layout_set_tabs(layout, tabs);
+		pango_tab_array_free(tabs);
 
-	pango_cairo_update_layout(cairo, layout);
+		pango_cairo_update_layout(cairo, layout);
 
-	struct buf buf;
-	buf_init(&buf);
-	y = OSD_BORDER_WIDTH;
+		struct buf buf;
+		buf_init(&buf);
+		y = OSD_BORDER_WIDTH;
 
-	y += (OSD_ITEM_HEIGHT - font_height(&font)) / 2;
+		y += (OSD_ITEM_HEIGHT - font_height(&font)) / 2;
 
-	wl_list_for_each(view, &server->views, link) {
-		if (!isfocusable(view)) {
-			continue;
-		}
-		buf.len = 0;
-		cairo_move_to(cairo, OSD_BORDER_WIDTH + OSD_ITEM_PADDING, y);
+		wl_list_for_each(view, &server->views, link) {
+			if (!isfocusable(view)) {
+				continue;
+			}
+			buf.len = 0;
+			cairo_move_to(cairo, OSD_BORDER_WIDTH + OSD_ITEM_PADDING, y);
 
-		switch (view->type) {
-		case LAB_XDG_SHELL_VIEW:
-			buf_add(&buf, "[xdg-shell]\t");
-			buf_add(&buf, get_formatted_app_id(view));
-			buf_add(&buf, "\t");
-			break;
+			switch (view->type) {
+			case LAB_XDG_SHELL_VIEW:
+				buf_add(&buf, "[xdg-shell]\t");
+				buf_add(&buf, get_formatted_app_id(view));
+				buf_add(&buf, "\t");
+				break;
 #if HAVE_XWAYLAND
-		case LAB_XWAYLAND_VIEW:
-			buf_add(&buf, "[xwayland]\t");
-			buf_add(&buf, view_get_string_prop(view, "class"));
-			buf_add(&buf, "\t");
-			break;
+			case LAB_XWAYLAND_VIEW:
+				buf_add(&buf, "[xwayland]\t");
+				buf_add(&buf, view_get_string_prop(view, "class"));
+				buf_add(&buf, "\t");
+				break;
 #endif
+			}
+
+			if (is_title_different(view)) {
+				buf_add(&buf, view_get_string_prop(view, "title"));
+			}
+
+			pango_layout_set_text(layout, buf.buf, -1);
+			pango_cairo_show_layout(cairo, layout);
+			y += OSD_ITEM_HEIGHT;
 		}
 
-		if (is_title_different(view)) {
-			buf_add(&buf, view_get_string_prop(view, "title"));
+		g_object_unref(layout);
+
+		/* convert to wlr_texture */
+		cairo_surface_flush(surf);
+		unsigned char *data = cairo_image_surface_get_data(surf);
+		struct wlr_texture *texture = wlr_texture_from_pixels(renderer,
+			DRM_FORMAT_ARGB8888, cairo_image_surface_get_stride(surf),
+			w, h, data);
+
+		cairo_destroy(cairo);
+		cairo_surface_destroy(surf);
+		if (output->osd) {
+			wlr_texture_destroy(output->osd);
 		}
-
-		pango_layout_set_text(layout, buf.buf, -1);
-		pango_cairo_show_layout(cairo, layout);
-		y += OSD_ITEM_HEIGHT;
+		output->osd = texture;
 	}
-
-	g_object_unref(layout);
-
-	/* convert to wlr_texture */
-	cairo_surface_flush(surf);
-	unsigned char *data = cairo_image_surface_get_data(surf);
-	struct wlr_texture *texture = wlr_texture_from_pixels(renderer,
-		DRM_FORMAT_ARGB8888, cairo_image_surface_get_stride(surf),
-		w, h, data);
-
-	cairo_destroy(cairo);
-	cairo_surface_destroy(surf);
-	if (server->osd) {
-		wlr_texture_destroy(server->osd);
-	}
-	server->osd = texture;
 }

--- a/src/osd.c
+++ b/src/osd.c
@@ -79,11 +79,13 @@ osd_update(struct server *server)
 	struct wlr_renderer *renderer = server->renderer;
 	struct theme *theme = server->theme;
 
-	int w = OSD_ITEM_WIDTH + 2 * OSD_BORDER_WIDTH;
-	int h = get_osd_height(&server->views);
+	float scale = server->greatest_scale;
+	int w = (OSD_ITEM_WIDTH + (2 * OSD_BORDER_WIDTH)) * scale;
+	int h = get_osd_height(&server->views) * scale;
 
 	cairo_surface_t *surf =
 		cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
+	cairo_surface_set_device_scale(surf, scale, scale);
 	cairo_t *cairo = cairo_create(surf);
 
 	/* background */


### PR DESCRIPTION
I've tested this successfully with a single monitor, and two monitors with different scales. I'm still attempting to fix menu and titlebar text with multiple outputs, but I was hoping to get a little bit of feedback before I continue working on them.

By scaling the OSD using the greatest scale for all the outputs, we end up scaling down the OSD texture for outputs with any other scales. Downscaling a texture is significantly less noticeable than upscaling (which we currently do), but it is noticeable.
With my current patches, menu text would follow a similar design, so I wanted to know if anyone had any opinions on this before I continue working on it.