### PR TITLE
Reload environment on SIGHUP. Partly fixes #227

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -11,6 +11,7 @@
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_viewporter.h>
 #include "config/rcxml.h"
+#include "config/session.h"
 #include "labwc.h"
 #include "layers.h"
 #include "menu/menu.h"
@@ -50,6 +51,7 @@ reload_config_and_theme(void)
 static int
 handle_sighup(int signal, void *data)
 {
+	session_environment_init();
 	reload_config_and_theme();
 	return 0;
 }


### PR DESCRIPTION
Every new application started after the SIGHUP will get the new environment. SIGHUP will not delete anything from the environment because that would require tracking every key we set (and what the original value was before we set the new one). I am not sure it is worth doing that.