### PR TITLE
[scene] Various checkpatch fixups

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -14,7 +14,7 @@ struct action {
 struct action *action_create(const char *action_name);
 void action_list_free(struct wl_list *action_list);
 
-void action(struct view *activator, struct server *server,
+void actions_run(struct view *activator, struct server *server,
 	struct wl_list *actions, uint32_t resize_edges);
 
 #endif

--- a/src/action.c
+++ b/src/action.c
@@ -129,7 +129,8 @@ activator_or_focused_view(struct view *activator, struct server *server)
 }
 
 void
-action(struct view *activator, struct server *server, struct wl_list *actions, uint32_t resize_edges)
+actions_run(struct view *activator, struct server *server,
+	struct wl_list *actions, uint32_t resize_edges)
 {
 	if (!actions) {
 		wlr_log(WLR_ERROR, "empty actions");

--- a/src/action.c
+++ b/src/action.c
@@ -79,7 +79,8 @@ action_create(const char *action_name)
 	return action;
 }
 
-void action_list_free(struct wl_list *action_list) {
+void action_list_free(struct wl_list *action_list)
+{
 	struct action *action, *action_tmp;
 	wl_list_for_each_safe(action, action_tmp, action_list, link) {
 		wl_list_remove(&action->link);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -261,7 +261,7 @@ process_cursor_motion(struct server *server, uint32_t time)
 			}
 
 			mousebind->pressed_in_context = false;
-			action(NULL, server, &mousebind->actions, resize_edges);
+			actions_run(NULL, server, &mousebind->actions, resize_edges);
 		}
 	}
 
@@ -517,7 +517,7 @@ handle_release_mousebinding(struct view *view, struct server *server,
 			}
 			activated_any = true;
 			activated_any_frame |= mousebind->context == LAB_SSD_FRAME;
-			action(view, server, &mousebind->actions, resize_edges);
+			actions_run(view, server, &mousebind->actions, resize_edges);
 		}
 	}
 	/*
@@ -599,7 +599,7 @@ handle_press_mousebinding(struct view *view, struct server *server,
 			}
 			activated_any = true;
 			activated_any_frame |= mousebind->context == LAB_SSD_FRAME;
-			action(view, server, &mousebind->actions, resize_edges);
+			actions_run(view, server, &mousebind->actions, resize_edges);
 		}
 	}
 	return activated_any && activated_any_frame;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -70,7 +70,7 @@ handle_keybinding(struct server *server, uint32_t modifiers, xkb_keysym_t sym)
 		for (size_t i = 0; i < keybind->keysyms_len; i++) {
 			if (xkb_keysym_to_lower(sym) == keybind->keysyms[i]) {
 				wlr_keyboard_set_repeat_info(kb, 0, 0);
-				action(NULL, server, &keybind->actions, 0);
+				actions_run(NULL, server, &keybind->actions, 0);
 				return true;
 			}
 		}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -574,7 +574,7 @@ menu_call_actions(struct menu *menu, struct wlr_scene_node *node)
 			/* ..but it just opens a submenu */
 			return false;
 		}
-		action(NULL, menu->server, &menu->selection.item->actions, 0);
+		actions_run(NULL, menu->server, &menu->selection.item->actions, 0);
 		menu_close(menu->server->menu_current);
 		menu->server->menu_current = NULL;
 		return true;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -519,7 +519,7 @@ void
 menu_process_cursor_motion(struct menu *menu, struct wlr_scene_node *node)
 {
 	if (!node) {
-		wlr_log(WLR_ERROR, "menu_process_cursor_motion() node == NULL");
+		wlr_log(WLR_ERROR, "%s() node == NULL", __func__);
 		return;
 	}
 	assert(menu);


### PR DESCRIPTION
- rename `action()` to ~~`call_actions()`~~ `actions_run()`
- fix open brace after function definition (another. yay.)
- use `__func__` in log message
- break long lines (using tabwidth 4, tabwidth 8 yields yet another 158 lines that are > 80 columns)

For some of the long line fixes I am not sure if it actually helps readability to split them.
So If you prefer to not fix the long lines for now I can drop the last patch from the PR.

`layer.c` has been ignored (3 lines > 80, nothing else).

Other than `layer.c` and the `#define FOR_EACH_END }` "macro" the checkpatch.pl output is now empty for all of the `include/` and `src/` trees.

Edit:
Removed the break-long-lines patch bc40d60e75c255374727bf35387071370db61815 from the PR.
I think it makes various things harder to understand than just being slightly > 80 columns.