### PR TITLE
[scene] xwayland.c: Fix positioning with multiple queued configure events

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -274,7 +274,7 @@ struct view {
 	 */
 	struct border padding;
 
-	struct {
+	struct view_pending_move_resize {
 		bool update_x, update_y;
 		double x, y;
 		uint32_t width, height;


### PR DESCRIPTION
Prevents a single action like ToggleDecorations + ToggleMaximize to
position the view somewhere with negative coordinates when unmaximizing.

It may still position the view on negative coordinates but later commit
events will fix the position. This issue only exists on xwayland because
there are no configure serials which we could use to ignore all
repositioning until we are at the latest desired state.