### PR TITLE
cursor.c: Keep sending adjusted motion events while button is pressed

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -79,6 +79,18 @@ struct seat {
 	/* if set, views cannot receive focus */
 	struct wlr_layer_surface_v1 *focused_layer;
 
+	/**
+	 * active_view will usually be NULL and is only set on button press
+	 * while the mouse is over a view surface and reset to NULL on button
+	 * release.
+	 * It is used to send cursor motion events to a surface even though
+	 * the cursor has left the surface in the meantime.
+	 *
+	 * This allows to keep dragging a scrollbar or selecting text even
+	 * when moving outside of the window.
+	 */
+	struct view *active_view;
+
 	struct wl_client *active_client_while_inhibited;
 	struct wl_list inputs;
 	struct wl_listener new_input;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -96,6 +96,9 @@ handle_destroy(struct wl_listener *listener, void *data)
 		wlr_foreign_toplevel_handle_v1_destroy(view->toplevel_handle);
 	}
 	interactive_end(view);
+	if (view->server->seat.active_view == view) {
+		view->server->seat.active_view = NULL;
+	}
 	wl_list_remove(&view->link);
 	wl_list_remove(&view->destroy.link);
 	ssd_destroy(view);

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -82,6 +82,9 @@ handle_destroy(struct wl_listener *listener, void *data)
 		wlr_foreign_toplevel_handle_v1_destroy(view->toplevel_handle);
 	}
 	interactive_end(view);
+	if (view->server->seat.active_view == view) {
+		view->server->seat.active_view = NULL;
+	}
 	view->xwayland_surface = NULL;
 	wl_list_remove(&view->link);
 	wl_list_remove(&view->map.link);


### PR DESCRIPTION
This allows to keep dragging a scrollbar or selecting text even when
moving outside of the window. Fixes #241

#### Potential issues

This patch is using the layer cursor coordinates and translates those into surface coordinates by simple substraction and clamping.
I am not sure if this is enough when dealing with scaled outputs.

I tried to make sure it doesn't break drag & drop and if running FireFox with `MOZ_ENABLE_WAYLAND=1` I could still move tabs between windows. However, trying the same but instead using xwayland it did not work but didn't work before the patch either. It was spamming `xcb error: op ChangeProperty` so I assume we are missing some callbacks there.

Before merging this PR I suggest to test some more drag and drop operations between different windows to make sure this patch doesn't create new issues.