### PR TITLE
cursor: add cursor_update_focus()

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -467,6 +467,14 @@ void cursor_rebase(struct seat *seat, uint32_t time_msec);
  */
 void cursor_set(struct seat *seat, const char *cursor_name);
 
+/**
+ * cursor_update_focus - update cursor focus
+ * @server - server
+ * Use it to force an update of the cursor icon and to send an enter event
+ * to the surface below the cursor.
+ */
+void cursor_update_focus(struct server *server);
+
 void cursor_init(struct seat *seat);
 void cursor_finish(struct seat *seat);
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -316,6 +316,20 @@ process_cursor_motion(struct server *server, uint32_t time)
 	}
 }
 
+static uint32_t
+msec(const struct timespec *t)
+{
+	return t->tv_sec * 1000 + t->tv_nsec / 1000000;
+}
+
+void
+cursor_update_focus(struct server *server)
+{
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	cursor_rebase(&server->seat, msec(&now));
+}
+
 void
 start_drag(struct wl_listener *listener, void *data)
 {
@@ -737,7 +751,6 @@ cursor_axis(struct wl_listener *listener, void *data)
 	wlr_idle_notify_activity(seat->wlr_idle, seat->seat);
 
 	/* Notify the client with pointer focus of the axis event. */
-	cursor_rebase(seat, event->time_msec);
 	wlr_seat_pointer_notify_axis(seat->seat, event->time_msec,
 		event->orientation, event->delta, event->delta_discrete,
 		event->source);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -61,6 +61,7 @@ desktop_move_to_front(struct view *view)
 #if HAVE_XWAYLAND
 	move_xwayland_sub_views_to_front(view);
 #endif
+	cursor_update_focus(view->server);
 }
 
 static void


### PR DESCRIPTION
...and call it from desktop_move_to_front() in order force an enter event
on the surface below the cursor when cycling views.

Fixes #162 and #225
Inspired by PR #164 - just restructured it a bit.

Third time is a charm. See https://github.com/labwc/labwc/issues/162#issuecomment-1051570900 for context.

If the PR is accepted I'll cherry-pick it for scene-graph as well (applies cleanly).