### PR TITLE
Implement cursor input for overlay popups

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -357,9 +357,37 @@ desktop_surface_and_view_at(struct server *server, double lx, double ly,
 	wlr_output_layout_output_coords(output->server->output_layout,
 		wlr_output, &ox, &oy);
 
+	/* Overlay-layer popups */
+	*surface = layer_surface_popup_at(output,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
+			ox, oy, sx, sy);
+	if (*surface) {
+		return NULL;
+	}
+
 	/* Overlay-layer */
 	*surface = layer_surface_at(
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
+			ox, oy, sx, sy);
+	if (*surface) {
+		return NULL;
+	}
+
+	/* Check for other layer popups */
+	*surface = layer_surface_popup_at(output,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
+			ox, oy, sx, sy);
+	if (*surface) {
+		return NULL;
+	}
+	*surface = layer_surface_popup_at(output,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM],
+			ox, oy, sx, sy);
+	if (*surface) {
+		return NULL;
+	}
+	*surface = layer_surface_popup_at(output,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND],
 			ox, oy, sx, sy);
 	if (*surface) {
 		return NULL;
@@ -381,26 +409,6 @@ desktop_surface_and_view_at(struct server *server, double lx, double ly,
 	}
 #endif
 
-	/* Check all layer popups */
-	*surface = layer_surface_popup_at(output,
-			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
-			ox, oy, sx, sy);
-	if (*surface) {
-		return NULL;
-	}
-	*surface = layer_surface_popup_at(output,
-			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM],
-			ox, oy, sx, sy);
-	if (*surface) {
-		return NULL;
-	}
-	*surface = layer_surface_popup_at(output,
-			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND],
-			ox, oy, sx, sy);
-	if (*surface) {
-		return NULL;
-	}
-
 	/* Top-layer */
 	*surface = layer_surface_at(
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
@@ -409,6 +417,7 @@ desktop_surface_and_view_at(struct server *server, double lx, double ly,
 		return NULL;
 	}
 
+	/* Usual views */
 	struct view *view;
 	wl_list_for_each (view, &server->views, link) {
 		if (!view->mapped) {
@@ -431,6 +440,7 @@ desktop_surface_and_view_at(struct server *server, double lx, double ly,
 		}
 	}
 
+	/* Bottom and Background layers */
 	*surface = layer_surface_at(
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM],
 			ox, oy, sx, sy);


### PR DESCRIPTION
\+ Move check for unmanaged X11 surfaces down a bit so we now check for:
- overlay popups
- overlay layer
- other layer popups
- unmanaged X11 surfaces
- top layer
- usual views
- bottom layer
- background layer

Should finally fix #226 when using a wayland native dbus notification daemon.