### PR TITLE
Avoid breaking double-click selection in foot on v0.5 branch

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -23,6 +23,16 @@ cursor_rebase(struct seat *seat, uint32_t time_msec)
 		seat->cursor->y, &surface, &sx, &sy, &view_area);
 
 	if (surface) {
+		struct view *focused_view = desktop_focused_view(seat->server);
+		struct wlr_surface* focused_surface = focused_view
+			? focused_view->surface
+			: NULL;
+
+		/* do not notify unless rebasing changes which surface has focus */
+		if (surface == focused_surface) {
+			return;
+		}
+
 		wlr_seat_pointer_notify_clear_focus(seat->seat);
 		wlr_seat_pointer_notify_enter(seat->seat, surface, sx, sy);
 		wlr_seat_pointer_notify_motion(seat->seat, time_msec, sx, sy);


### PR DESCRIPTION
This regressed in ce38d2d; basically, we shouldn't clear and set focus again if the same surface is focused before and after cursor rebase.

`WAYLAND_DEBUG=1` output of double-clicking on foot looks like the below:

master:
```
[41.928] wl_pointer@19.button(7086, 77762627, 272, 1)
[41.947] wl_pointer@19.frame()
```

v0.5:
```
[41.856] wl_pointer@19.leave(7084, wl_surface@3)
[41.902] wl_pointer@19.frame()
[41.908] wl_pointer@19.enter(7085, wl_surface@3, 48.48437500, 11.87500000)
[41.924] wl_pointer@19.frame()
[41.928] wl_pointer@19.button(7086, 77762627, 272, 1)
[41.947] wl_pointer@19.frame()
```

And looks just like master again after this fix.