### PR TITLE
[scene] Convert menu to node_descriptors

### DIFF
--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -23,6 +23,7 @@ struct menu_scene {
 
 struct menuitem {
 	struct wl_list actions;
+	struct menu *parent;
 	struct menu *submenu;
 	struct menu_scene normal;
 	struct menu_scene selected;
@@ -75,15 +76,19 @@ void menu_open(struct menu *menu, int x, int y);
  * - handles hover effects
  * - may open/close submenus
  */
-void menu_process_cursor_motion(struct menu *menu, struct wlr_scene_node *node);
+void menu_process_cursor_motion(struct wlr_scene_node *node);
 
 /**
- * menu_call_actions - call actions associated with a menu entry
+ * menu_call_actions - call actions associated with a menu node
  *
- * If actions are found, server->menu_current will be closed and set to NULL
- * Returns true if handled
+ * If menuitem connected to @node does not just open a submenu:
+ * - associated actions will be called
+ * - server->menu_current will be closed
+ * - server->menu_current will be set to NULL
+ *
+ * Returns true if actions have actually been executed
  */
-bool menu_call_actions(struct menu *menu, struct wlr_scene_node *node);
+bool menu_call_actions(struct wlr_scene_node *node);
 
 /* menu_close - close menu */
 void menu_close(struct menu *menu);

--- a/include/node.h
+++ b/include/node.h
@@ -6,6 +6,7 @@
 struct view;
 struct lab_layer_surface;
 struct lab_layer_popup;
+struct menuitem;
 
 enum node_descriptor_type {
 	LAB_NODE_DESC_NODE = 0,
@@ -13,6 +14,7 @@ enum node_descriptor_type {
 	LAB_NODE_DESC_XDG_POPUP,
 	LAB_NODE_DESC_LAYER_SURFACE,
 	LAB_NODE_DESC_LAYER_POPUP,
+	LAB_NODE_DESC_MENUITEM,
 };
 
 struct node_descriptor {
@@ -52,6 +54,13 @@ struct lab_layer_surface *node_layer_surface_from_node(
  * @wlr_scene_node: wlr_scene_node from which to return data
  */
 struct lab_layer_popup *node_layer_popup_from_node(
+	struct wlr_scene_node *wlr_scene_node);
+
+/**
+ * node_menuitem_from_node - return menuitem struct from node
+ * @wlr_scene_node: wlr_scene_node from which to return data
+ */
+struct menuitem *node_menuitem_from_node(
 	struct wlr_scene_node *wlr_scene_node);
 
 #endif /* __LABWC_NODE_DESCRIPTOR_H */

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -233,7 +233,7 @@ process_cursor_motion(struct server *server, uint32_t time)
 	}
 
 	if (view_area == LAB_SSD_MENU) {
-		menu_process_cursor_motion(server->menu_current, node);
+		menu_process_cursor_motion(node);
 		return;
 	}
 
@@ -677,8 +677,8 @@ cursor_button(struct wl_listener *listener, void *data)
 		if (view_area != LAB_SSD_MENU) {
 			/* We close the menu on release so we don't leak a stray release */
 			close_menu = true;
-		} else if (menu_call_actions(server->menu_current, node)) {
-			/* Action was successfull, may fail if item contains a submenu */
+		} else if (menu_call_actions(node)) {
+			/* Action was successfull, may fail if item just opens a submenu */
 			close_menu = true;
 		}
 		return;

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -284,9 +284,9 @@ desktop_node_and_view_at(struct server *server, double lx, double ly,
 #endif
 	}
 	struct wlr_scene_node *osd = &server->osd_tree->node;
-	struct wlr_scene_node *menu = &server->menu_tree->node;
 	while (node) {
 		struct node_descriptor *desc = node->data;
+		/* TODO: convert to switch() */
 		if (desc) {
 			if (desc->type == LAB_NODE_DESC_VIEW) {
 				goto has_view_data;
@@ -299,12 +299,15 @@ desktop_node_and_view_at(struct server *server, double lx, double ly,
 				*view_area = LAB_SSD_CLIENT;
 				return NULL;
 			}
+			if (desc->type == LAB_NODE_DESC_MENUITEM) {
+				/* Always return the top scene node for menu items */
+				*scene_node = node;
+				*view_area = LAB_SSD_MENU;
+				return NULL;
+			}
 		}
 		if (node == osd) {
 			*view_area = LAB_SSD_OSD;
-			return NULL;
-		} else if (node == menu) {
-			*view_area = LAB_SSD_MENU;
 			return NULL;
 		}
 		node = node->parent;

--- a/src/node.c
+++ b/src/node.c
@@ -64,3 +64,12 @@ node_layer_popup_from_node(struct wlr_scene_node *wlr_scene_node)
 	assert(node_descriptor->type == LAB_NODE_DESC_LAYER_POPUP);
 	return (struct lab_layer_popup *)node_descriptor->data;
 }
+
+struct menuitem *
+node_menuitem_from_node(struct wlr_scene_node *wlr_scene_node)
+{
+	assert(wlr_scene_node->data);
+	struct node_descriptor *node_descriptor = wlr_scene_node->data;
+	assert(node_descriptor->type == LAB_NODE_DESC_MENUITEM);
+	return (struct menuitem *)node_descriptor->data;
+}


### PR DESCRIPTION
No loops or recursion within the menu hot path (motion / click) anymore :)
\+ `menu_call_actions()` and `menu_process_cursor_motion()` only have a single argument left: `wlr_scene_node *node`