### PR TITLE
ssd: some small rework

### DIFF
--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -8,6 +8,7 @@
 
 #include "common/buf.h"
 #include "config/libinput.h"
+#include "theme.h"
 
 struct rcxml {
 
@@ -29,6 +30,8 @@ struct rcxml {
 	int font_size_activewindow;
 	int font_size_menuitem;
 	int font_size_osd;
+	/* Pointer to current theme */
+	struct theme *theme;
 
 	/* keyboard */
 	int repeat_rate;

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -5,7 +5,6 @@
 #include "buffer.h"
 #include <wlr/util/box.h>
 
-#define SSD_HEIGHT 26    /* TODO: use theme->title_height */
 #define BUTTON_COUNT 4
 #define BUTTON_WIDTH 26
 #define EXTENDED_AREA 8

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -74,6 +74,8 @@ struct ssd {
 	 * don't update things we don't have to.
 	 */
 	struct {
+		int x;
+		int y;
 		int width;
 		int height;
 		struct ssd_state_title {
@@ -109,6 +111,9 @@ struct ssd_part {
 
 	/* This part represented in scene graph */
 	struct wlr_scene_node *node;
+
+	/* Targeted geometry. May be NULL */
+	struct wlr_box *geometry;
 
 	struct wl_list link;
 };

--- a/src/main.c
+++ b/src/main.c
@@ -69,6 +69,7 @@ main(int argc, char *argv[])
 
 	struct theme theme = { 0 };
 	theme_init(&theme, rc.theme_name);
+	rc.theme = &theme;
 	server.theme = &theme;
 
 	menu_init_rootmenu(&server);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -18,7 +18,7 @@ ssd_thickness(struct view *view)
 {
 	struct theme *theme = view->server->theme;
 	struct border border = {
-		.top = theme->title_height,
+		.top = theme->title_height + theme->border_width,
 		.bottom = theme->border_width,
 		.left = theme->border_width,
 		.right = theme->border_width,

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -13,13 +13,12 @@
 #include "theme.h"
 #include "ssd.h"
 
-/* TODO: use theme->title_height instead of SSD_HEIGHT */
 struct border
 ssd_thickness(struct view *view)
 {
 	struct theme *theme = view->server->theme;
 	struct border border = {
-		.top = SSD_HEIGHT,
+		.top = theme->title_height,
 		.bottom = theme->border_width,
 		.left = theme->border_width,
 		.right = theme->border_width,

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -42,7 +42,7 @@ ssd_border_create(struct view *view)
 			0, height, color);
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_TOP, parent,
 			full_width - 2 * BUTTON_WIDTH, theme->border_width,
-			BUTTON_WIDTH, -SSD_HEIGHT, color);
+			BUTTON_WIDTH, -theme->title_height, color);
 	} FOR_EACH_END
 }
 
@@ -79,7 +79,7 @@ ssd_border_update(struct view *view)
 					full_width - 2 * BUTTON_WIDTH,
 					theme->border_width);
 				wlr_scene_node_set_position(part->node,
-					BUTTON_WIDTH, -SSD_HEIGHT);
+					BUTTON_WIDTH, -theme->title_height);
 				continue;
 			default:
 				continue;

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -38,11 +38,11 @@ ssd_border_create(struct view *view)
 			theme->border_width, height,
 			theme->border_width + width, 0, color);
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_BOTTOM, parent,
-			full_width, theme->border_width,
-			0, height, color);
+			full_width, theme->border_width, 0, height, color);
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_TOP, parent,
-			full_width - 2 * BUTTON_WIDTH, theme->border_width,
-			BUTTON_WIDTH, -theme->title_height, color);
+			width - 2 * BUTTON_WIDTH, theme->border_width,
+			theme->border_width + BUTTON_WIDTH,
+			-(theme->title_height + theme->border_width), color);
 	} FOR_EACH_END
 }
 
@@ -76,10 +76,7 @@ ssd_border_update(struct view *view)
 				continue;
 			case LAB_SSD_PART_TOP:
 				wlr_scene_rect_set_size(rect,
-					full_width - 2 * BUTTON_WIDTH,
-					theme->border_width);
-				wlr_scene_node_set_position(part->node,
-					BUTTON_WIDTH, -theme->title_height);
+					width - 2 * BUTTON_WIDTH, theme->border_width);
 				continue;
 			default:
 				continue;

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -13,8 +13,8 @@ ssd_extents_create(struct view *view)
 	struct wl_list *part_list = &view->ssd.extents.parts;
 	int width = view->w;
 	int height = view->h;
-	int full_height = height + theme->border_width + theme->title_height;
-	int full_width = width + 2 * theme->border_width;
+	int full_height = height + theme->border_width * 2 + theme->title_height;
+	int full_width = width + theme->border_width * 2;
 	int extended_area = EXTENDED_AREA;
 	int corner_size = extended_area + theme->border_width + BUTTON_WIDTH / 2;
 	int side_width = full_width + extended_area * 2 - corner_size * 2;
@@ -27,7 +27,7 @@ ssd_extents_create(struct view *view)
 	}
 	wl_list_init(&view->ssd.extents.parts);
 	wlr_scene_node_set_position(parent, -(theme->border_width + extended_area),
-		-(theme->title_height + extended_area));
+		-(theme->title_height + theme->border_width + extended_area));
 
 	/* Top */
 	add_scene_rect(part_list, LAB_SSD_PART_CORNER_TOP_LEFT, parent,
@@ -54,7 +54,7 @@ ssd_extents_create(struct view *view)
 		0, corner_size + side_height, invisible);
 	add_scene_rect(part_list, LAB_SSD_PART_BOTTOM, parent,
 		side_width, extended_area,
-		extended_area, extended_area + full_height, invisible);
+		corner_size, extended_area + full_height, invisible);
 	add_scene_rect(part_list, LAB_SSD_PART_CORNER_BOTTOM_RIGHT, parent,
 		corner_size, corner_size,
 		corner_size + side_width, corner_size + side_height, invisible);
@@ -75,7 +75,7 @@ ssd_extents_update(struct view *view)
 
 	int width = view->w;
 	int height = view->h;
-	int full_height = height + theme->border_width + theme->title_height;
+	int full_height = height + theme->border_width * 2 + theme->title_height;
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = EXTENDED_AREA;
 	int corner_size = extended_area + theme->border_width + BUTTON_WIDTH / 2;

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -16,6 +16,9 @@ ssd_extents_create(struct view *view)
 	int full_height = height + theme->border_width + SSD_HEIGHT;
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = EXTENDED_AREA;
+	int corner_size = extended_area + theme->border_width + BUTTON_WIDTH / 2;
+	int side_width = full_width + extended_area * 2 - corner_size * 2;
+	int side_height = full_height + extended_area * 2 - corner_size * 2;
 
 	view->ssd.extents.tree = wlr_scene_tree_create(&view->ssd.tree->node);
 	struct wlr_scene_node *parent = &view->ssd.extents.tree->node;
@@ -28,33 +31,33 @@ ssd_extents_create(struct view *view)
 
 	/* Top */
 	add_scene_rect(part_list, LAB_SSD_PART_CORNER_TOP_LEFT, parent,
-		extended_area, extended_area,
+		corner_size, corner_size,
 		0, 0, invisible);
 	add_scene_rect(part_list, LAB_SSD_PART_TOP, parent,
-		full_width, extended_area,
-		extended_area, 0, invisible);
+		side_width, extended_area,
+		corner_size, 0, invisible);
 	add_scene_rect(part_list, LAB_SSD_PART_CORNER_TOP_RIGHT, parent,
-		extended_area, extended_area,
-		extended_area + full_width, 0, invisible);
+		corner_size, corner_size,
+		corner_size + side_width, 0, invisible);
 
 	/* Sides */
 	add_scene_rect(part_list, LAB_SSD_PART_LEFT, parent,
-		extended_area, full_height,
-		0, extended_area, invisible);
+		extended_area, side_height,
+		0, corner_size, invisible);
 	add_scene_rect(part_list, LAB_SSD_PART_RIGHT, parent,
-		extended_area, full_height,
-		extended_area + full_width, extended_area, invisible);
+		extended_area, side_height,
+		corner_size + side_width, corner_size, invisible);
 
 	/* Bottom */
 	add_scene_rect(part_list, LAB_SSD_PART_CORNER_BOTTOM_LEFT, parent,
-		extended_area, extended_area,
-		0, extended_area + full_height, invisible);
+		corner_size, corner_size,
+		0, corner_size + side_height, invisible);
 	add_scene_rect(part_list, LAB_SSD_PART_BOTTOM, parent,
-		full_width, extended_area,
+		side_width, extended_area,
 		extended_area, extended_area + full_height, invisible);
 	add_scene_rect(part_list, LAB_SSD_PART_CORNER_BOTTOM_RIGHT, parent,
-		extended_area, extended_area,
-		extended_area + full_width, extended_area + full_height, invisible);
+		corner_size, corner_size,
+		corner_size + side_width, corner_size + side_height, invisible);
 }
 
 void
@@ -75,6 +78,9 @@ ssd_extents_update(struct view *view)
 	int full_height = height + theme->border_width + SSD_HEIGHT;
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = EXTENDED_AREA;
+	int corner_size = extended_area + theme->border_width + BUTTON_WIDTH / 2;
+	int side_width = full_width + extended_area * 2 - corner_size * 2;
+	int side_height = full_height + extended_area * 2 - corner_size * 2;
 
 	struct ssd_part *part;
 	struct wlr_scene_rect *rect;
@@ -82,32 +88,32 @@ ssd_extents_update(struct view *view)
 		rect = lab_wlr_scene_get_rect(part->node);
 		switch (part->type) {
 		case LAB_SSD_PART_TOP:
-			wlr_scene_rect_set_size(rect, full_width, extended_area);
+			wlr_scene_rect_set_size(rect, side_width, extended_area);
 			continue;
 		case LAB_SSD_PART_CORNER_TOP_RIGHT:
 			wlr_scene_node_set_position(
-				part->node, extended_area + full_width, 0);
+				part->node, corner_size + side_width, 0);
 			continue;
 		case LAB_SSD_PART_LEFT:
-			wlr_scene_rect_set_size(rect, extended_area, full_height);
+			wlr_scene_rect_set_size(rect, extended_area, side_height);
 			continue;
 		case LAB_SSD_PART_RIGHT:
-			wlr_scene_rect_set_size(rect, extended_area, full_height);
+			wlr_scene_rect_set_size(rect, extended_area, side_height);
 			wlr_scene_node_set_position(
-				part->node, extended_area + full_width, extended_area);
+				part->node, extended_area + full_width, corner_size);
 			continue;
 		case LAB_SSD_PART_CORNER_BOTTOM_LEFT:
 			wlr_scene_node_set_position(
-				part->node, 0, extended_area + full_height);
+				part->node, 0, corner_size + side_height);
 			continue;
 		case LAB_SSD_PART_BOTTOM:
-			wlr_scene_rect_set_size(rect, full_width, extended_area);
+			wlr_scene_rect_set_size(rect, side_width, extended_area);
 			wlr_scene_node_set_position(
-				part->node, extended_area, extended_area + full_height);
+				part->node, corner_size, extended_area + full_height);
 			continue;
 		case LAB_SSD_PART_CORNER_BOTTOM_RIGHT:
 			wlr_scene_node_set_position(part->node,
-				extended_area + full_width, extended_area + full_height);
+				corner_size + side_width, corner_size + side_height);
 			continue;
 		default:
 			continue;

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -13,7 +13,7 @@ ssd_extents_create(struct view *view)
 	struct wl_list *part_list = &view->ssd.extents.parts;
 	int width = view->w;
 	int height = view->h;
-	int full_height = height + theme->border_width + SSD_HEIGHT;
+	int full_height = height + theme->border_width + theme->title_height;
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = EXTENDED_AREA;
 	int corner_size = extended_area + theme->border_width + BUTTON_WIDTH / 2;
@@ -26,8 +26,8 @@ ssd_extents_create(struct view *view)
 		wlr_scene_node_set_enabled(parent, false);
 	}
 	wl_list_init(&view->ssd.extents.parts);
-	wlr_scene_node_set_position(parent,
-		-(theme->border_width + extended_area), -(SSD_HEIGHT + extended_area));
+	wlr_scene_node_set_position(parent, -(theme->border_width + extended_area),
+		-(theme->title_height + extended_area));
 
 	/* Top */
 	add_scene_rect(part_list, LAB_SSD_PART_CORNER_TOP_LEFT, parent,
@@ -75,7 +75,7 @@ ssd_extents_update(struct view *view)
 
 	int width = view->w;
 	int height = view->h;
-	int full_height = height + theme->border_width + SSD_HEIGHT;
+	int full_height = height + theme->border_width + theme->title_height;
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = EXTENDED_AREA;
 	int corner_size = extended_area + theme->border_width + BUTTON_WIDTH / 2;

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -86,6 +86,9 @@ ssd_extents_create(struct view *view)
 	p = add_extent(part_list, LAB_SSD_PART_CORNER_BOTTOM_RIGHT, parent);
 	p->geometry->width = corner_size;
 	p->geometry->height = corner_size;
+
+	/* Initial manual update to keep X11 applications happy */
+	ssd_extents_update(view);
 }
 
 void

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -5,20 +5,40 @@
 #include "theme.h"
 #include "common/scene-helpers.h"
 
+static struct ssd_part *
+add_extent(struct wl_list *part_list, enum ssd_part_type type,
+		struct wlr_scene_node *parent)
+{
+	float invisible[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+	struct ssd_part *part = add_scene_part(part_list, type);
+	/*
+	 * Extents need additional geometry to enable dynamic
+	 * resize based on position and output->usable_area.
+	 *
+	 * part->geometry will get free'd automatically in ssd_destroy_parts().
+	 */
+	part->node = &wlr_scene_rect_create(parent, 0, 0, invisible)->node;
+	part->geometry = calloc(1, sizeof(struct wlr_box));
+	return part;
+}
+
+static void
+lab_wlr_output_layout_layout_coords(struct wlr_output_layout *layout,
+		struct wlr_output *output, int *x, int *y)
+{
+	struct wlr_output_layout_output *l_output;
+	l_output = wlr_output_layout_get(layout, output);
+	*x += l_output->x;
+	*y += l_output->y;
+}
+
 void
 ssd_extents_create(struct view *view)
 {
 	struct theme *theme = view->server->theme;
-	float invisible[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 	struct wl_list *part_list = &view->ssd.extents.parts;
-	int width = view->w;
-	int height = view->h;
-	int full_height = height + theme->border_width * 2 + theme->title_height;
-	int full_width = width + theme->border_width * 2;
 	int extended_area = EXTENDED_AREA;
 	int corner_size = extended_area + theme->border_width + BUTTON_WIDTH / 2;
-	int side_width = full_width + extended_area * 2 - corner_size * 2;
-	int side_height = full_height + extended_area * 2 - corner_size * 2;
 
 	view->ssd.extents.tree = wlr_scene_tree_create(&view->ssd.tree->node);
 	struct wlr_scene_node *parent = &view->ssd.extents.tree->node;
@@ -29,35 +49,43 @@ ssd_extents_create(struct view *view)
 	wlr_scene_node_set_position(parent, -(theme->border_width + extended_area),
 		-(theme->title_height + theme->border_width + extended_area));
 
+	/* Initialize parts and set constant values for targeted geometry */
+	struct ssd_part *p;
+
 	/* Top */
-	add_scene_rect(part_list, LAB_SSD_PART_CORNER_TOP_LEFT, parent,
-		corner_size, corner_size,
-		0, 0, invisible);
-	add_scene_rect(part_list, LAB_SSD_PART_TOP, parent,
-		side_width, extended_area,
-		corner_size, 0, invisible);
-	add_scene_rect(part_list, LAB_SSD_PART_CORNER_TOP_RIGHT, parent,
-		corner_size, corner_size,
-		corner_size + side_width, 0, invisible);
+	p = add_extent(part_list, LAB_SSD_PART_CORNER_TOP_LEFT, parent);
+	p->geometry->width = corner_size;
+	p->geometry->height = corner_size;
+
+	p = add_extent(part_list, LAB_SSD_PART_TOP, parent);
+	p->geometry->x = corner_size;
+	p->geometry->height = extended_area;
+
+	p = add_extent(part_list, LAB_SSD_PART_CORNER_TOP_RIGHT, parent);
+	p->geometry->width = corner_size;
+	p->geometry->height = corner_size;
 
 	/* Sides */
-	add_scene_rect(part_list, LAB_SSD_PART_LEFT, parent,
-		extended_area, side_height,
-		0, corner_size, invisible);
-	add_scene_rect(part_list, LAB_SSD_PART_RIGHT, parent,
-		extended_area, side_height,
-		corner_size + side_width, corner_size, invisible);
+	p = add_extent(part_list, LAB_SSD_PART_LEFT, parent);
+	p->geometry->y = corner_size;
+	p->geometry->width = extended_area;
+
+	p = add_extent(part_list, LAB_SSD_PART_RIGHT, parent);
+	p->geometry->y = corner_size;
+	p->geometry->width = extended_area;
 
 	/* Bottom */
-	add_scene_rect(part_list, LAB_SSD_PART_CORNER_BOTTOM_LEFT, parent,
-		corner_size, corner_size,
-		0, corner_size + side_height, invisible);
-	add_scene_rect(part_list, LAB_SSD_PART_BOTTOM, parent,
-		side_width, extended_area,
-		corner_size, extended_area + full_height, invisible);
-	add_scene_rect(part_list, LAB_SSD_PART_CORNER_BOTTOM_RIGHT, parent,
-		corner_size, corner_size,
-		corner_size + side_width, corner_size + side_height, invisible);
+	p = add_extent(part_list, LAB_SSD_PART_CORNER_BOTTOM_LEFT, parent);
+	p->geometry->width = corner_size;
+	p->geometry->height = corner_size;
+
+	p = add_extent(part_list, LAB_SSD_PART_BOTTOM, parent);
+	p->geometry->x = corner_size;
+	p->geometry->height = extended_area;
+
+	p = add_extent(part_list, LAB_SSD_PART_CORNER_BOTTOM_RIGHT, parent);
+	p->geometry->width = corner_size;
+	p->geometry->height = corner_size;
 }
 
 void
@@ -71,6 +99,10 @@ ssd_extents_update(struct view *view)
 		wlr_scene_node_set_enabled(&view->ssd.extents.tree->node, true);
 	}
 
+	if (!view->output) {
+		return;
+	}
+
 	struct theme *theme = view->server->theme;
 
 	int width = view->w;
@@ -82,41 +114,86 @@ ssd_extents_update(struct view *view)
 	int side_width = full_width + extended_area * 2 - corner_size * 2;
 	int side_height = full_height + extended_area * 2 - corner_size * 2;
 
+	struct wlr_box part_box;
+	struct wlr_box result_box;
 	struct ssd_part *part;
 	struct wlr_scene_rect *rect;
+
+	/* Convert usable area into layout coordinates */
+	struct wlr_box usable_area;
+	memcpy(&usable_area, &view->output->usable_area, sizeof(struct wlr_box));
+	lab_wlr_output_layout_layout_coords(view->server->output_layout,
+		view->output->wlr_output, &usable_area.x, &usable_area.y);
+
+	/* Remember base layout coordinates */
+	int base_x, base_y;
+	wlr_scene_node_coords(&view->ssd.extents.tree->node, &base_x, &base_y);
+
+	struct wlr_box *target;
 	wl_list_for_each(part, &view->ssd.extents.parts, link) {
 		rect = lab_wlr_scene_get_rect(part->node);
+		target = part->geometry;
 		switch (part->type) {
 		case LAB_SSD_PART_TOP:
-			wlr_scene_rect_set_size(rect, side_width, extended_area);
-			continue;
+			target->width = side_width;
+			break;
 		case LAB_SSD_PART_CORNER_TOP_RIGHT:
-			wlr_scene_node_set_position(
-				part->node, corner_size + side_width, 0);
-			continue;
+			target->x = corner_size + side_width;
+			break;
 		case LAB_SSD_PART_LEFT:
-			wlr_scene_rect_set_size(rect, extended_area, side_height);
-			continue;
+			target->height = side_height;
+			break;
 		case LAB_SSD_PART_RIGHT:
-			wlr_scene_rect_set_size(rect, extended_area, side_height);
-			wlr_scene_node_set_position(
-				part->node, extended_area + full_width, corner_size);
-			continue;
+			target->x = extended_area + full_width;
+			target->height = side_height;
+			break;
 		case LAB_SSD_PART_CORNER_BOTTOM_LEFT:
-			wlr_scene_node_set_position(
-				part->node, 0, corner_size + side_height);
-			continue;
+			target->y = corner_size + side_height;
+			break;
 		case LAB_SSD_PART_BOTTOM:
-			wlr_scene_rect_set_size(rect, side_width, extended_area);
-			wlr_scene_node_set_position(
-				part->node, corner_size, extended_area + full_height);
-			continue;
+			target->width = side_width;
+			target->y = extended_area + full_height;
+			break;
 		case LAB_SSD_PART_CORNER_BOTTOM_RIGHT:
-			wlr_scene_node_set_position(part->node,
-				corner_size + side_width, corner_size + side_height);
-			continue;
+			target->x = corner_size + side_width;
+			target->y = corner_size + side_height;
+			break;
 		default:
+			break;
+		}
+
+		/* Get layout geometry of what the part *should* be */
+		part_box.x = base_x + target->x;
+		part_box.y = base_y + target->y;
+		part_box.width = target->width;
+		part_box.height = target->height;
+
+		/* Constrain part to output->usable_area */
+		if (!wlr_box_intersection(&result_box, &part_box, &usable_area)) {
+			/* Not visible */
+			wlr_scene_node_set_enabled(part->node, false);
 			continue;
+		} else if (!part->node->state.enabled) {
+			wlr_scene_node_set_enabled(part->node, true);
+		}
+
+		if (part_box.width != result_box.width
+				|| part_box.height != result_box.height) {
+			/* Partly visible */
+			wlr_scene_rect_set_size(rect, result_box.width, result_box.height);
+			wlr_scene_node_set_position(part->node,
+				target->x + (result_box.x - part_box.x),
+				target->y + (result_box.y - part_box.y));
+			continue;
+		}
+
+		/* Fully visible */
+		if (target->x != part->node->state.x
+				|| target->y != part->node->state.y) {
+			wlr_scene_node_set_position(part->node, target->x, target->y);
+		}
+		if (target->width != rect->width || target->height != rect->height) {
+			wlr_scene_rect_set_size(rect, target->width, target->height);
 		}
 	}
 }

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -54,12 +54,12 @@ finish_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 	/* Icon */
 	add_scene_buffer(part_list, type, parent, icon_buffer,
 		(BUTTON_WIDTH - icon_buffer->width) / 2,
-		(SSD_HEIGHT - icon_buffer->height) / 2);
+		(rc.theme->title_height - icon_buffer->height) / 2);
 
 	/* Hover overlay */
 	struct ssd_part *hover_part;
 	hover_part = add_scene_rect(part_list, type, parent,
-		BUTTON_WIDTH, SSD_HEIGHT, 0, 0, hover_bg);
+		BUTTON_WIDTH, rc.theme->title_height, 0, 0, hover_bg);
 	wlr_scene_node_set_enabled(hover_part->node, false);
 }
 
@@ -83,7 +83,7 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 	struct ssd_part *part;
 	/* Background */
 	part = add_scene_rect(part_list, type, parent,
-		BUTTON_WIDTH, SSD_HEIGHT, x, 0, bg_color);
+		BUTTON_WIDTH, rc.theme->title_height, x, 0, bg_color);
 	finish_scene_button(part_list, type, part->node, icon_buffer);
 	return part;
 }

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -66,8 +66,8 @@ finish_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 
 	/* Hover overlay */
 	struct ssd_part *hover_part;
-	hover_part = add_scene_rect(part_list, type, parent,
-		BUTTON_WIDTH, rc.theme->title_height, offset_x, offset_y, hover_bg);
+	hover_part = add_scene_rect(part_list, type, parent, BUTTON_WIDTH,
+		rc.theme->title_height, offset_x, offset_y, hover_bg);
 	wlr_scene_node_set_enabled(hover_part->node, false);
 }
 
@@ -77,7 +77,10 @@ add_scene_button_corner(struct wl_list *part_list, enum ssd_part_type type,
 	struct wlr_buffer *icon_buffer, int x)
 {
 	struct ssd_part *part;
-	/* Background, y adjusted for border_width */
+	/*
+	 * Background, y adjusted for border_width which is
+	 * already included in rendered theme.c / corner_buffer
+	 */
 	part = add_scene_buffer(part_list, type, parent, corner_buffer,
 		x, -rc.theme->border_width);
 	finish_scene_button(part_list, type, part->node, icon_buffer);
@@ -116,9 +119,15 @@ ssd_destroy_parts(struct wl_list *list)
 	wl_list_for_each_reverse_safe(part, tmp, list, link) {
 		if (part->node) {
 			wlr_scene_node_destroy(part->node);
+			part->node = NULL;
 		}
 		if (part->buffer) {
 			wlr_buffer_drop(&part->buffer->base);
+			part->buffer = NULL;
+		}
+		if (part->geometry) {
+			free(part->geometry);
+			part->geometry = NULL;
 		}
 		wl_list_remove(&part->link);
 		free(part);

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -52,14 +52,22 @@ finish_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 	float hover_bg[4] = {0.15f, 0.15f, 0.15f, 0.3f};
 
 	/* Icon */
+	int offset_y = 0;
+	int offset_x = 0;
+	if (type == LAB_SSD_BUTTON_WINDOW_MENU) {
+		offset_y = rc.theme->border_width;
+		offset_x = rc.theme->border_width;
+	} else if (type == LAB_SSD_BUTTON_CLOSE) {
+		offset_y = rc.theme->border_width;
+	}
 	add_scene_buffer(part_list, type, parent, icon_buffer,
-		(BUTTON_WIDTH - icon_buffer->width) / 2,
-		(rc.theme->title_height - icon_buffer->height) / 2);
+		offset_x + (BUTTON_WIDTH - icon_buffer->width) / 2,
+		offset_y + (rc.theme->title_height - icon_buffer->height) / 2);
 
 	/* Hover overlay */
 	struct ssd_part *hover_part;
 	hover_part = add_scene_rect(part_list, type, parent,
-		BUTTON_WIDTH, rc.theme->title_height, 0, 0, hover_bg);
+		BUTTON_WIDTH, rc.theme->title_height, offset_x, offset_y, hover_bg);
 	wlr_scene_node_set_enabled(hover_part->node, false);
 }
 
@@ -69,8 +77,9 @@ add_scene_button_corner(struct wl_list *part_list, enum ssd_part_type type,
 	struct wlr_buffer *icon_buffer, int x)
 {
 	struct ssd_part *part;
-	/* Background */
-	part = add_scene_buffer(part_list, type, parent, corner_buffer, x, 0);
+	/* Background, y adjusted for border_width */
+	part = add_scene_buffer(part_list, type, parent, corner_buffer,
+		x, -rc.theme->border_width);
 	finish_scene_button(part_list, type, part->node, icon_buffer);
 	return part;
 }

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -29,7 +29,8 @@ ssd_titlebar_create(struct view *view)
 	FOR_EACH_STATE(view, subtree) {
 		subtree->tree = wlr_scene_tree_create(&view->ssd.tree->node);
 		parent = &subtree->tree->node;
-		wlr_scene_node_set_position(parent, -theme->border_width, -SSD_HEIGHT);
+		wlr_scene_node_set_position(parent,
+			-theme->border_width, -theme->title_height);
 		if (subtree == &view->ssd.titlebar.active) {
 			color = theme->window_active_title_bg_color;
 			corner_top_left = &theme->corner_top_left_active_normal->base;
@@ -44,7 +45,7 @@ ssd_titlebar_create(struct view *view)
 
 		/* Title */
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_TITLEBAR, parent,
-			full_width - BUTTON_WIDTH * BUTTON_COUNT, SSD_HEIGHT,
+			full_width - BUTTON_WIDTH * BUTTON_COUNT, theme->title_height,
 			BUTTON_WIDTH, 0, color);
 		/* Buttons */
 		add_scene_button_corner(&subtree->parts, LAB_SSD_BUTTON_WINDOW_MENU,
@@ -76,7 +77,8 @@ ssd_titlebar_update(struct view *view)
 	if (width == view->ssd.state.width) {
 		return;
 	}
-	int full_width = width + 2 * view->server->theme->border_width;
+	struct theme *theme = view->server->theme;
+	int full_width = width + 2 * theme->border_width;
 
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
@@ -85,7 +87,8 @@ ssd_titlebar_update(struct view *view)
 			switch (part->type) {
 			case LAB_SSD_PART_TITLEBAR:
 				wlr_scene_rect_set_size(lab_wlr_scene_get_rect(part->node),
-					full_width - BUTTON_WIDTH * BUTTON_COUNT, SSD_HEIGHT);
+					full_width - BUTTON_WIDTH * BUTTON_COUNT,
+					theme->title_height);
 				continue;
 			case LAB_SSD_BUTTON_ICONIFY:
 				if (is_direct_child(part->node, subtree)) {
@@ -159,7 +162,7 @@ ssd_update_title_positions(struct view *view)
 		}
 
 		x = 0;
-		y = (SSD_HEIGHT - part->buffer->base.height) / 2;
+		y = (theme->title_height - part->buffer->base.height) / 2;
 		rect = lab_wlr_scene_get_rect(part->node->parent);
 		if (rect->width <= 0) {
 			wlr_scene_node_set_position(part->node, x, y);

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -18,7 +18,6 @@ ssd_titlebar_create(struct view *view)
 {
 	struct theme *theme = view->server->theme;
 	int width = view->w;
-	int full_width = width + 2 * theme->border_width;
 
 	float *color;
 	struct wlr_scene_node *parent;
@@ -29,8 +28,7 @@ ssd_titlebar_create(struct view *view)
 	FOR_EACH_STATE(view, subtree) {
 		subtree->tree = wlr_scene_tree_create(&view->ssd.tree->node);
 		parent = &subtree->tree->node;
-		wlr_scene_node_set_position(parent,
-			-theme->border_width, -theme->title_height);
+		wlr_scene_node_set_position(parent, 0, -theme->title_height);
 		if (subtree == &view->ssd.titlebar.active) {
 			color = theme->window_active_title_bg_color;
 			corner_top_left = &theme->corner_top_left_active_normal->base;
@@ -45,21 +43,21 @@ ssd_titlebar_create(struct view *view)
 
 		/* Title */
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_TITLEBAR, parent,
-			full_width - BUTTON_WIDTH * BUTTON_COUNT, theme->title_height,
+			width - BUTTON_WIDTH * BUTTON_COUNT, theme->title_height,
 			BUTTON_WIDTH, 0, color);
 		/* Buttons */
 		add_scene_button_corner(&subtree->parts, LAB_SSD_BUTTON_WINDOW_MENU,
 			parent,	corner_top_left,
-			&theme->xbm_menu_active_unpressed->base, 0);
+			&theme->xbm_menu_active_unpressed->base, -theme->border_width);
 		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_ICONIFY, parent,
 			color, &theme->xbm_iconify_active_unpressed->base,
-			full_width - BUTTON_WIDTH * 3);
+			width - BUTTON_WIDTH * 3);
 		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE, parent,
 			color, &theme->xbm_maximize_active_unpressed->base,
-			full_width - BUTTON_WIDTH * 2);
+			width - BUTTON_WIDTH * 2);
 		add_scene_button_corner(&subtree->parts, LAB_SSD_BUTTON_CLOSE, parent,
 			corner_top_right, &theme->xbm_close_active_unpressed->base,
-			full_width - BUTTON_WIDTH * 1);
+			width - BUTTON_WIDTH * 1);
 	} FOR_EACH_END
 	ssd_update_title(view);
 }
@@ -78,7 +76,6 @@ ssd_titlebar_update(struct view *view)
 		return;
 	}
 	struct theme *theme = view->server->theme;
-	int full_width = width + 2 * theme->border_width;
 
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
@@ -87,25 +84,25 @@ ssd_titlebar_update(struct view *view)
 			switch (part->type) {
 			case LAB_SSD_PART_TITLEBAR:
 				wlr_scene_rect_set_size(lab_wlr_scene_get_rect(part->node),
-					full_width - BUTTON_WIDTH * BUTTON_COUNT,
+					width - BUTTON_WIDTH * BUTTON_COUNT,
 					theme->title_height);
 				continue;
 			case LAB_SSD_BUTTON_ICONIFY:
 				if (is_direct_child(part->node, subtree)) {
 					wlr_scene_node_set_position(part->node,
-						full_width - BUTTON_WIDTH * 3, 0);
+						width - BUTTON_WIDTH * 3, 0);
 				}
 				continue;
 			case  LAB_SSD_BUTTON_MAXIMIZE:
 				if (is_direct_child(part->node, subtree)) {
 					wlr_scene_node_set_position(part->node,
-						full_width - BUTTON_WIDTH * 2, 0);
+						width - BUTTON_WIDTH * 2, 0);
 				}
 				continue;
 			case LAB_SSD_BUTTON_CLOSE:
 				if (is_direct_child(part->node, subtree)) {
 					wlr_scene_node_set_position(part->node,
-						full_width - BUTTON_WIDTH * 1, 0);
+						width - BUTTON_WIDTH * 1, -theme->border_width);
 				}
 				continue;
 			default:

--- a/src/theme.c
+++ b/src/theme.c
@@ -421,8 +421,8 @@ create_corners(struct theme *theme)
 	struct wlr_box box = {
 		.x = 0,
 		.y = 0,
-		.width = BUTTON_WIDTH,
-		.height = theme->title_height,
+		.width = BUTTON_WIDTH + theme->border_width,
+		.height = theme->title_height + theme->border_width,
 	};
 
 	struct rounded_corner_ctx ctx = {

--- a/src/theme.c
+++ b/src/theme.c
@@ -422,7 +422,7 @@ create_corners(struct theme *theme)
 		.x = 0,
 		.y = 0,
 		.width = BUTTON_WIDTH,
-		.height = SSD_HEIGHT,
+		.height = theme->title_height,
 	};
 
 	struct rounded_corner_ctx ctx = {

--- a/src/view.c
+++ b/src/view.c
@@ -35,6 +35,7 @@ view_move(struct view *view, double x, double y)
 	}
 	view_discover_output(view);
 	wlr_scene_node_set_position(&view->scene_tree->node, view->x, view->y);
+	ssd_update_geometry(view);
 }
 
 /* N.B. Use view_move() if not resizing. */

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -290,7 +290,6 @@ map(struct view *view)
 
 	if (view->ssd.enabled) {
 		view->margin = ssd_thickness(view);
-		ssd_create(view);
 	}
 
 	if (!view->been_mapped) {
@@ -306,6 +305,11 @@ map(struct view *view)
 
 		view_discover_output(view);
 		view->been_mapped = true;
+	}
+
+	if (view->ssd.enabled) {
+		/* Create ssd after view_disover_output() had been called */
+		ssd_create(view);
 	}
 
 	if (view->ssd.enabled && !view->fullscreen && !view->maximized) {


### PR DESCRIPTION
- [x] ssd: increase resize corners
- [x] ssd: use dynamic titlebar height based on font size and padding instead of hardcoded `SSD_HEIGHT`
- [x] ssd: move top border above titlebar to fix vertical alignment
- [x] ssd: dynamically adjust resize extents based on usable_area
- [x] ssd_extents: force initial manual ssd_extents update for x11 clients

If I missed something please point it out / edit this post.

z-index / color changed for screenshots only:
![extents](https://user-images.githubusercontent.com/35009135/157351708-167dda72-e995-4e72-b461-9eed2986391b.png)
![bigfoot](https://user-images.githubusercontent.com/35009135/157402858-73e7cdff-5ac0-4f3f-9659-9c36d7b35dbc.png)
- green: resize extents (z-index changed for debugging only)
- red: cairo drawn border on corner buttons
- blue: usual scene node borders

![ssd_debug](https://user-images.githubusercontent.com/35009135/157397034-de8e31ee-2068-47fa-9297-ad6ac73c0c70.png)