### PR TITLE
Output.c: fix include

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -9,7 +9,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include "config.h"
 #include <assert.h>
-#include <types/wlr_output.h>
+#include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
 #include <wlr/types/wlr_output_damage.h>


### PR DESCRIPTION
Closes #273

_____________
Fixes at least the problem with the header not found.
But currently looking into the following linker failure:
```sh
/usr/bin/ld: /tmp/ccu6sWgC.ltrans0.ltrans.o: in function `handle_output_power_manager_set_mode':
<artificial>:(.text+0x27ed): undefined reference to `output_ensure_buffer'
```

Edit:
```sh
../labwc/src/output.c:415:17: Warning: Implicit declaration of function »output_ensure_buffer« [-Wimplicit-function-declaration]
  415 |                 output_ensure_buffer(event->output);
      |                 ^~~~~~~~~~~~~~~~~~~~
```
Will try to add a fix for this in this PR