### PR TITLE
Implement touch support

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -107,6 +107,11 @@ struct seat {
 	struct wl_listener keyboard_key;
 	struct wl_listener keyboard_modifiers;
 
+	struct wl_listener touch_down;
+	struct wl_listener touch_up;
+	struct wl_listener touch_motion;
+	struct wl_listener touch_frame;
+
 	struct wl_listener request_start_drag;
 	struct wl_listener start_drag;
 	struct wl_listener destroy_drag;
@@ -476,6 +481,9 @@ void cursor_finish(struct seat *seat);
 
 void keyboard_init(struct seat *seat);
 void keyboard_finish(struct seat *seat);
+
+void touch_init(struct seat *seat);
+void touch_finish(struct seat *seat);
 
 void seat_init(struct server *server);
 void seat_finish(struct server *server);

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ labwc_sources = files(
   'resistance.c',
   'seat.c',
   'server.c',
+  'touch.c',
   'theme.c',
   'view.c',
   'view-impl.c',

--- a/src/touch.c
+++ b/src/touch.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <wlr/types/wlr_touch.h>
+#include "labwc.h"
+
+static struct wlr_surface*
+touch_get_coords(struct seat *seat, struct wlr_touch* touch, double x, double y,
+	double* nx, double* ny)
+{
+	/* Convert coordinates: first [0, 1] => layout, then layout => surface */
+	double lx, ly;
+	wlr_cursor_absolute_to_layout_coords(seat->cursor, &touch->base,
+		x, y, &lx, &ly);
+
+	struct wlr_scene_node *node =
+		wlr_scene_node_at(&seat->server->scene->node, lx, ly, nx, ny);
+
+	/* Find the surface and return it if it accepts touch events. */
+	struct wlr_surface* surface = NULL;
+
+	if (node && node->type == WLR_SCENE_NODE_SURFACE) {
+		struct wlr_scene_surface *scene_surface =
+			wlr_scene_surface_from_node (node);
+		surface = scene_surface->surface;
+	}
+
+	if (surface && !wlr_surface_accepts_touch(seat->seat, surface)) {
+		surface = NULL;
+	}
+	return surface;
+}
+
+static void
+touch_motion(struct wl_listener *listener, void *data)
+{
+	struct seat *seat = wl_container_of(listener, seat, touch_motion);
+	struct wlr_touch_motion_event *event = data;
+	wlr_idle_notify_activity(seat->wlr_idle, seat->seat);
+
+	double nx, ny;
+	if (touch_get_coords(seat, event->touch, event->x, event->y, &nx, &ny)) {
+		wlr_seat_touch_notify_motion(seat->seat, event->time_msec,
+			event->touch_id, nx, ny);
+	}
+}
+
+static void
+touch_frame(struct wl_listener *listener, void *data)
+{
+	struct seat *seat = wl_container_of(listener, seat, touch_frame);
+
+	wlr_seat_touch_notify_frame(seat->seat);
+}
+
+static void
+touch_down(struct wl_listener *listener, void *data)
+{
+	struct seat *seat = wl_container_of(listener, seat, touch_down);
+	struct wlr_touch_down_event *event = data;
+
+	double nx, ny;
+	struct wlr_surface* surface =
+		touch_get_coords(seat, event->touch, event->x, event->y, &nx, &ny);
+	if (surface) {
+		wlr_seat_touch_notify_down(seat->seat, surface, event->time_msec,
+			event->touch_id, nx, ny);
+	}
+}
+
+static void
+touch_up(struct wl_listener *listener, void *data)
+{
+	struct seat *seat = wl_container_of(listener, seat, touch_up);
+	struct wlr_touch_up_event *event = data;
+
+	wlr_seat_touch_notify_up(seat->seat, event->time_msec, event->touch_id);
+}
+
+void
+touch_init(struct seat *seat)
+{
+	seat->touch_down.notify = touch_down;
+	wl_signal_add(&seat->cursor->events.touch_down, &seat->touch_down);
+	seat->touch_up.notify = touch_up;
+	wl_signal_add(&seat->cursor->events.touch_up, &seat->touch_up);
+	seat->touch_motion.notify = touch_motion;
+	wl_signal_add(&seat->cursor->events.touch_motion, &seat->touch_motion);
+	seat->touch_frame.notify = touch_frame;
+	wl_signal_add(&seat->cursor->events.touch_frame, &seat->touch_frame);
+}
+
+void
+touch_finish(struct seat *seat)
+{
+	wl_list_remove(&seat->touch_down.link);
+	wl_list_remove(&seat->touch_up.link);
+	wl_list_remove(&seat->touch_motion.link);
+	wl_list_remove(&seat->touch_frame.link);
+}


### PR DESCRIPTION
This is mostly plumbing; the most interesting logic is in `touch_get_coords`.

This introduces a bit of duplication in `seat.c` where `new_touch` is almost a copy-paste of `new_pointer`. If someone would like this factored differently just let me know.

This doesn't implement anything fancy like pointer emulation, but by my testing makes touch work in GTK3 programs including drop-down menus.