### PR TITLE
Fix crash when changing TTY

### DIFF
--- a/src/seat.c
+++ b/src/seat.c
@@ -128,6 +128,7 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 static struct wlr_output *
 output_by_name(struct server *server, const char *name)
 {
+	assert(name != NULL);
 	struct output *output;
 	wl_list_for_each(output, &server->outputs, link) {
 		if (!strcasecmp(output->wlr_output->name, name)) {
@@ -150,8 +151,10 @@ new_pointer(struct seat *seat, struct input *input)
 	if (dev->type == WLR_INPUT_DEVICE_POINTER) {
 		wlr_log(WLR_INFO, "map pointer to output %s\n",
 			dev->pointer->output_name);
-		struct wlr_output *output =
-			output_by_name(seat->server, dev->pointer->output_name);
+		struct wlr_output *output = NULL;
+		if (dev->pointer->output_name != NULL) {
+			output = output_by_name(seat->server, dev->pointer->output_name);
+		}
 		wlr_cursor_map_input_to_output(seat->cursor, dev, output);
 		wlr_cursor_map_input_to_region(seat->cursor, dev, NULL);
 	}


### PR DESCRIPTION
Fixes this crash, observed when changing TTY back to labwc, running 06042337d6b746c29218268272c85a0129f9d4be:

```
Thread 1 "labwc" received signal SIGSEGV, Segmentation fault.
0x00007ffff7680e4d in __strcasecmp_l_avx () from /usr/lib/libc.so.6
#0  0x00007ffff7680e4d in __strcasecmp_l_avx () at /usr/lib/libc.so.6
#1  0x000055555557b8bc in output_by_name (server=0x7fffffffe0e0, name=0x0) at ../src/seat.c:133
        output = 0x555556134440
#2  0x000055555557b9a4 in new_pointer (seat=0x7fffffffe1b0, input=0x55555682eef0) at ../src/seat.c:154
        output = 0x0
        dev = 0x555555fe0cd0
#3  0x000055555557bad6 in new_input_notify (listener=0x7fffffffe218, data=0x555555fe0cd0) at ../src/seat.c:183
        seat = 0x7fffffffe1b0
        device = 0x555555fe0cd0
        input = 0x55555682eef0
        caps = 2
#4  0x00005555555f5b64 in wlr_signal_emit_safe (signal=0x5555556c05f8, data=0x555555fe0cd0) at ../subprojects/wlroots/util/signal.c:29
        pos = 0x7fffffffe218
        l = 0x7fffffffe218
        cursor = {link = {prev = 0x7fffffffe218, next = 0x7fffffffdce0}, notify = 0x5555555f5aae <handle_noop>}
        end = {link = {prev = 0x7fffffffdcc0, next = 0x5555556c05f8}, notify = 0x5555555f5aae <handle_noop>}
#5  0x00005555555b08ed in new_input_reemit (listener=0x555555689750, data=0x555555fe0cd0) at ../subprojects/wlroots/backend/multi/backend.c:164
        state = 0x555555689740
#6  0x00005555555f5b64 in wlr_signal_emit_safe (signal=0x5555556be978, data=0x555555fe0cd0) at ../subprojects/wlroots/util/signal.c:29
        pos = 0x555555689750
        l = 0x555555689750
        cursor = {link = {prev = 0x555555689750, next = 0x7fffffffdd80}, notify = 0x5555555f5aae <handle_noop>}
        end = {link = {prev = 0x7fffffffdd60, next = 0x5555556be978}, notify = 0x5555555f5aae <handle_noop>}
#7  0x00005555555a8ac3 in handle_device_added (backend=0x5555556be960, libinput_dev=0x55555605d540) at ../subprojects/wlroots/backend/libinput/events.c:92
        vendor = 1267
        product = 12635
        name = 0x555556022800 "<redacted>"
        dev = 0x555555fe0b40
#8  0x00005555555a8f1f in handle_libinput_event (backend=0x5555556be960, event=0x555556011330) at ../subprojects/wlroots/backend/libinput/events.c:155
        libinput_dev = 0x55555605d540
        dev = 0x0
        event_type = LIBINPUT_EVENT_DEVICE_ADDED
#9  0x00005555555a7f78 in handle_libinput_readable (fd=29, mask=1, _backend=0x5555556be960) at ../subprojects/wlroots/backend/libinput/backend.c:58
        backend = 0x5555556be960
        ret = 0
        event = 0x555556011330
#10 0x00007ffff7f991ca in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#11 0x00007ffff7f96d37 in wl_display_run () at /usr/lib/libwayland-server.so.0
#12 0x0000555555578ec5 in main (argc=1, argv=0x7fffffffe868) at ../src/main.c:83
        startup_cmd = 0x0
        config_file = 0x0
        verbosity = WLR_ERROR
        c = -1
        server = {wl_display = 0x5555556bea50, renderer = 0x555555765440, allocator = 0x555555e277b0, backend = 0x5555556c05e0, xdg_shell = 0x555555e6a7e0, layer_shell = 0x555555e826b0, new_xdg_surface = {link = {prev = 0x555555e6a828, next = 0x555555e6a828}, notify = 0x555555580c60 <xdg_surface_new>}, new_layer_surface = {link = {prev = 0x555555e826d0, next = 0x555555e826d0}, notify = 0x555555578871 <new_layer_surface_notify>}, xdg_toplevel_decoration = {link = {prev = 0x555555e83f50, next = 0x555555e83f50}, notify = 0x5555555810e8 <xdg_toplevel_decoration>}, input_inhibit = 0x555555e6aeb0, input_inhibit_activate = {link = {prev = 0x555555e6aee0, next = 0x555555e6aee0}, notify = 0x55555557c44a <handle_input_inhibit>}, input_inhibit_deactivate = {link = {prev = 0x555555e6aef0, next = 0x555555e6aef0}, notify = 0x55555557c4b3 <handle_input_disinhibit>}, views = {prev = 0x55555662ac48, next = 0x5555565c50e8}, unmanaged_surfaces = {prev = 0x7fffffffe1a0, next = 0x7fffffffe1a0}, seat = {seat = 0x555555e4be60, server = 0x7fffffffe0e0, keyboard_group = 0x555555e4c4c0, cursor = 0x555555e4c290, xcursor_manager = 0x555555e88730, drag_icon = 0x0, current_constraint = 0x0, wlr_idle = 0x555555e4c220, wlr_idle_inhibit_manager = 0x555555e3ba80, focused_layer = 0x0, active_client_while_inhibited = 0x0, inputs = {prev = 0x555555e6a508, next = 0x5555566c6a28}, new_input = {link = {prev = 0x5555556c05f8, next = 0x7fffffffdcc0}, notify = 0x55555557ba4f <new_input_notify>}, cursor_motion = {link = {prev = 0x555555e4c2a8, next = 0x555555e4c2a8}, notify = 0x555555574a42 <cursor_motion>}, cursor_motion_absolute = {link = {prev = 0x555555e4c2b8, next = 0x555555e4c2b8}, notify = 0x555555574b99 <cursor_motion_absolute>}, cursor_button = {link = {prev = 0x555555e4c2c8, next = 0x555555e4c2c8}, notify = 0x555555575146 <cursor_button>}, cursor_axis = {link = {prev = 0x555555e4c2d8, next = 0x555555e4c2d8}, notify = 0x55555557554d <cursor_axis>}, cursor_frame = {link = {prev = 0x555555e4c2e8, next = 0x555555e4c2e8}, notify = 0x5555555755de <cursor_frame>}, pointer_gestures = 0x555555e33ad0, pinch_begin = {link = {prev = 0x555555e4c328, next = 0x555555e4c328}, notify = 0x55555557560e <handle_pointer_pinch_begin>}, pinch_update = {link = {prev = 0x555555e4c338, next = 0x555555e4c338}, notify = 0x55555557565f <handle_pointer_pinch_update>}, pinch_end = {link = {prev = 0x555555e4c348, next = 0x555555e4c348}, notify = 0x5555555756e0 <handle_pointer_pinch_end>}, swipe_begin = {link = {prev = 0x555555e4c2f8, next = 0x555555e4c2f8}, notify = 0x555555575735 <handle_pointer_swipe_begin>}, swipe_update = {link = {prev = 0x555555e4c308, next = 0x555555e4c308}, notify = 0x555555575786 <handle_pointer_swipe_update>}, swipe_end = {link = {prev = 0x555555e4c318, next = 0x555555e4c318}, notify = 0x5555555757ed <handle_pointer_swipe_end>}, request_cursor = {link = {prev = 0x555555e4c148, next = 0x555555e4c148}, notify = 0x555555573c53 <request_cursor_notify>}, request_set_selection = {link = {prev = 0x555555e4c158, next = 0x555555e4c158}, notify = 0x555555573cc1 <request_set_selection_notify>}, request_set_primary_selection = {link = {prev = 0x555555e4c178, next = 0x555555e4c178}, notify = 0x555555573d0a <request_set_primary_selection_notify>}, keyboard_key = {link = {prev = 0x555555e4c600, next = 0x555555e4c600}, notify = 0x555555577aa9 <keyboard_key_notify>}, keyboard_modifiers = {link = {prev = 0x555555e4c610, next = 0x555555e4c610}, notify = 0x555555577568 <keyboard_modifiers_notify>}, request_start_drag = {link = {prev = 0x555555e4c198, next = 0x555555e4c198}, notify = 0x555555573d53 <request_start_drag_notify>}, start_drag = {link = {prev = 0x555555e4c1a8, next = 0x555555e4c1a8}, notify = 0x555555574752 <start_drag>}, destroy_drag = {link = {prev = 0x5555568a58d0, next = 0x555556441aa8}, notify = 0x555555574b4d <destroy_drag>}, constraint_commit = {link = {prev = 0x7fffffffe400, next = 0x7fffffffe400}, notify = 0x0}, idle_inhibitor_create = {link = {prev = 0x555555e3bab0, next = 0x555555e3bab0}, notify = 0x55555557bc33 <new_idle_inhibitor>}}, scene = 0x555555e4a720, input_mode = LAB_INPUT_STATE_PASSTHROUGH, grabbed_view = 0x0, grab_x = 624.15880233012376, grab_y = 579.86022107782617, grab_box = {x = 450, y = 300, width = 600, height = 400}, resize_edges = 0, ssd_focused_view = 0x0, ssd_hover_state = {view = 0x0, type = LAB_SSD_NONE, node = 0x0}, view_tree = 0x555555e37a30, menu_tree = 0x555555e3be40, osd_tree = 0x555555e3a460, outputs = {prev = 0x555556134440, next = 0x555556134440}, new_output = {link = {prev = 0x5555556c0608, next = 0x5555556c0608}, notify = 0x555555579bfe <new_output_notify>}, output_layout = 0x555555e3a530, output_layout_change = {link = {prev = 0x555555e4bd90, next = 0x555555e4c480}, notify = 0x55555557a6af <handle_output_layout_change>}, output_manager = 0x555555e4bdd0, output_manager_apply = {link = {prev = 0x555555e4be08, next = 0x555555e4be08}, notify = 0x55555557a45f <handle_output_manager_apply>}, pending_output_config = 0x0, foreign_toplevel_manager = 0x555555e6b050, output_power_manager_v1 = 0x555555e828d0, output_power_manager_set_mode = {link = {prev = 0x555555e82900, next = 0x555555e82900}, notify = 0x55555557a9ba <handle_output_power_manager_set_mode>}, relative_pointer_manager = 0x555555e82f30, constraints = 0x555555e82d10, new_constraint = {link = {prev = 0x555555e82d28, next = 0x555555e82d28}, notify = 0x5555555748b7 <create_constraint>}, cycle_view = 0x0, theme = 0x7fffffffe580, menu_current = 0x0}
        theme = {border_width = 1, padding_height = 2, menu_overlap_x = 0, menu_overlap_y = 0, window_active_border_color = {0.980392158, 0.980392158, 0.980392158, 1}, window_inactive_border_color = {0.980392158, 0.980392158, 0.980392158, 1}, window_active_title_bg_color = {0.0470588244, 0.0470588244, 0.0470588244, 1}, window_inactive_title_bg_color = {0.0470588244, 0.0470588244, 0.0470588244, 1}, window_active_label_text_color = {0.980392158, 0.980392158, 0.980392158, 1}, window_inactive_label_text_color = {0.13333334, 0.13333334, 0.13333334, 1}, window_label_text_justify = LAB_JUSTIFY_RIGHT, window_active_button_menu_unpressed_image_color = {0.423529416, 0.619607866, 0.670588255, 1}, window_active_button_iconify_unpressed_image_color = {0.423529416, 0.619607866, 0.670588255, 1}, window_active_button_max_unpressed_image_color = {0.423529416, 0.619607866, 0.670588255, 1}, window_active_button_close_unpressed_image_color = {0.423529416, 0.619607866, 0.670588255, 1}, window_inactive_button_menu_unpressed_image_color = {0.278431386, 0.286274523, 0.301960796, 1}, window_inactive_button_iconify_unpressed_image_color = {0.278431386, 0.286274523, 0.301960796, 1}, window_inactive_button_max_unpressed_image_color = {0.278431386, 0.286274523, 0.301960796, 1}, window_inactive_button_close_unpressed_image_color = {0.278431386, 0.286274523, 0.301960796, 1}, menu_items_bg_color = {0.13333334, 0.13333334, 0.13333334, 1}, menu_items_text_color = {0.980392158, 0.980392158, 0.980392158, 1}, menu_items_active_bg_color = {0.0470588244, 0.0470588244, 0.0470588244, 1}, menu_items_active_text_color = {0, 0.588235319, 0.819607854, 1}, osd_bg_color = {0.0470588244, 0.0470588244, 0.0470588244, 1}, osd_label_text_color = {0.980392158, 0.980392158, 0.980392158, 1}, xbm_close_active_unpressed = 0x5555561a5830, xbm_maximize_active_unpressed = 0x555555e98fd0, xbm_iconify_active_unpressed = 0x5555565bda00, xbm_menu_active_unpressed = 0x5555563ed6f0, xbm_close_inactive_unpressed = 0x5555564341d0, xbm_maximize_inactive_unpressed = 0x55555643de30, xbm_iconify_inactive_unpressed = 0x5555564143a0, xbm_menu_inactive_unpressed = 0x555556421350, corner_top_left_active_normal = 0x5555565753d0, corner_top_right_active_normal = 0x555556430560, corner_top_left_inactive_normal = 0x5555565882a0, corner_top_right_inactive_normal = 0x555556449b50, title_height = 17}
```