### PR TITLE
cursor.c: Do not segfault on missing drag icon

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -365,6 +365,11 @@ start_drag(struct wl_listener *listener, void *data)
 	struct wlr_drag *wlr_drag = data;
 	seat->active_view = NULL;
 	seat->drag_icon = wlr_drag->icon;
+	if (!seat->drag_icon) {
+		wlr_log(WLR_ERROR,
+			"Started drag but application did not set a drag icon");
+		return;
+	}
 	wl_signal_add(&seat->drag_icon->events.destroy, &seat->destroy_drag);
 }
 


### PR DESCRIPTION
Observed by moving tabs in Chromium 98 wayland native
(started with --ozone-platform-hint=wayland).

I am not sure how to deal with this situation properly so this commit just stops segfaulting the whole compositor for now.
Moving tabs with Firefox wayland native (MOZ_ENABLE_WAYLAND=1) works.