### PR TITLE
xdg-shell: remove view->padding

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -297,15 +297,6 @@ struct view {
 	 */
 	struct border margin;
 
-	/*
-	 * padding refers to the space between the extremities of the
-	 * wlr_surface and the parts of the surface that is considered the
-	 * window.
-	 * This is only used for xdg-shell views with CSD where the padding
-	 * area is typically invisible except for client-side drop-shawdows.
-	 */
-	struct border padding;
-
 	struct view_pending_move_resize {
 		bool update_x, update_y;
 		double x, y;
@@ -380,7 +371,6 @@ void xwayland_unmanaged_create(struct server *server,
 
 void view_set_activated(struct view *view, bool activated);
 void view_close(struct view *view);
-struct border view_border(struct view *view);
 
 /**
  * view_move_resize - resize and move view

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -40,7 +40,7 @@ resistance_move_apply(struct view *view, double *x, double *y)
 	struct wlr_box tgeom = {.x = *x, .y = *y, .width = view->w,
 		.height = view->h};
 	struct output *output;
-	struct border border = view_border(view);
+	struct border border = view->margin;
 	struct edges view_edges; /* The edges of the current view */
 	struct edges target_edges; /* The desired edges */
 	struct edges other_edges; /* The edges of the monitor/other view */
@@ -107,7 +107,7 @@ resistance_resize_apply(struct view *view, struct wlr_box *new_view_geo)
 		.height = view->h};
 	struct wlr_box tgeom = {.x = new_view_geo->x, .y = new_view_geo->y,
 		.width = new_view_geo->width, .height = new_view_geo->height};
-	struct border border = view_border(view);
+	struct border border = view->margin;
 	struct edges view_edges; /* The edges of the current view */
 	struct edges target_edges; /* The desired edges */
 	struct edges other_edges; /* The edges of the monitor/other view */

--- a/src/view.c
+++ b/src/view.c
@@ -384,18 +384,6 @@ view_adjust_for_layout_change(struct view *view)
 	}
 }
 
-struct border
-view_border(struct view *view)
-{
-	struct border border = {
-		.left = view->margin.left - view->padding.left,
-		.top = view->margin.top - view->padding.top,
-		.right = view->margin.right + view->padding.right,
-		.bottom = view->margin.bottom + view->padding.bottom,
-	};
-	return border;
-}
-
 static void
 view_output_enter(struct view *view, struct wlr_output *wlr_output)
 {
@@ -445,7 +433,6 @@ view_move_to_edge(struct view *view, const char *direction)
 		wlr_log(WLR_ERROR, "no output");
 		return;
 	}
-	struct border border = view_border(view);
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
 	if (usable.height == output->wlr_output->height
 			&& output->wlr_output->scale != 1) {
@@ -458,17 +445,19 @@ view_move_to_edge(struct view *view, const char *direction)
 
 	int x = 0, y = 0;
 	if (!strcasecmp(direction, "left")) {
-		x = usable.x + border.left + rc.gap;
+		x = usable.x + view->margin.left + rc.gap;
 		y = view->y;
 	} else if (!strcasecmp(direction, "up")) {
 		x = view->x;
-		y = usable.y + border.top + rc.gap;
+		y = usable.y + view->margin.top + rc.gap;
 	} else if (!strcasecmp(direction, "right")) {
-		x = usable.x + usable.width - view->w - border.right - rc.gap;
+		x = usable.x + usable.width - view->w - view->margin.right
+			- rc.gap;
 		y = view->y;
 	} else if (!strcasecmp(direction, "down")) {
 		x = view->x;
-		y = usable.y + usable.height - view->h - border.bottom - rc.gap;
+		y = usable.y + usable.height - view->h - view->margin.bottom
+			- rc.gap;
 	}
 	view_move(view, x, y);
 }
@@ -524,7 +513,6 @@ static struct wlr_box
 view_get_edge_snap_box(struct view *view, struct output *output,
 		enum view_edge edge)
 {
-	struct border border = view_border(view);
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
 	if (usable.height == output->wlr_output->height
 			&& output->wlr_output->scale != 1) {
@@ -559,10 +547,10 @@ view_get_edge_snap_box(struct view *view, struct output *output,
 		break;
 	}
 	struct wlr_box dst = {
-		.x = x_offset + usable.x + border.left,
-		.y = y_offset + usable.y + border.top,
-		.width = base_width - border.left - border.right,
-		.height = base_height - border.top - border.bottom,
+		.x = x_offset + usable.x + view->margin.left,
+		.y = y_offset + usable.y + view->margin.top,
+		.width = base_width - view->margin.left - view->margin.right,
+		.height = base_height - view->margin.top - view->margin.bottom,
 	};
 
 	return dst;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -42,12 +42,6 @@ handle_commit(struct wl_listener *listener, void *data)
 	view->w = size.width;
 	view->h = size.height;
 
-	/* padding changes with maximize/unmaximize */
-	view->padding.top = size.y;
-	view->padding.bottom = size.y;
-	view->padding.left = size.x;
-	view->padding.right = size.x;
-
 	uint32_t serial = view->pending_move_resize.configure_serial;
 	if (serial > 0 && serial >= view->xdg_surface->current.configure_serial) {
 		if (view->pending_move_resize.update_x) {
@@ -212,17 +206,6 @@ xdg_toplevel_view_close(struct view *view)
 }
 
 static void
-update_padding(struct view *view)
-{
-	struct wlr_box padding;
-	wlr_xdg_surface_get_geometry(view->xdg_surface, &padding);
-	view->padding.top = padding.y;
-	view->padding.bottom = padding.y;
-	view->padding.left = padding.x;
-	view->padding.right = padding.x;
-}
-
-static void
 xdg_toplevel_view_maximize(struct view *view, bool maximized)
 {
 	wlr_xdg_toplevel_set_maximized(view->xdg_surface->toplevel, maximized);
@@ -287,8 +270,8 @@ position_xdg_toplevel_view(struct view *view)
 		view->x = center_x - view->xdg_surface->current.geometry.width / 2;
 		view->y = center_y - view->xdg_surface->current.geometry.height / 2;
 	}
-	view->x += view->margin.left - view->padding.left;
-	view->y += view->margin.top - view->padding.top;
+	view->x += view->margin.left;
+	view->y += view->margin.top;
 }
 
 static const char *
@@ -323,7 +306,6 @@ xdg_toplevel_view_map(struct view *view)
 			ssd_create(view);
 		}
 
-		update_padding(view);
 		if (!view->fullscreen && requested->fullscreen) {
 			view_set_fullscreen(view, true,
 				requested->fullscreen_output);


### PR DESCRIPTION
With the wlroots scene-graph API, the padding variable is no longer
needed for windows with Client Side Decoration (CSD).