### PR TITLE
view: Refactor view destruction some more

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -404,7 +404,7 @@ void view_update_app_id(struct view *view);
 void view_impl_map(struct view *view);
 void view_adjust_size(struct view *view, int *w, int *h);
 
-void view_handle_destroy(struct view *view);
+void view_destroy(struct view *view);
 
 void foreign_toplevel_handle_create(struct view *view);
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -78,7 +78,16 @@ static void
 handle_destroy(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, destroy);
-	view_handle_destroy(view);
+	assert(view->type == LAB_XDG_SHELL_VIEW);
+
+	/* Reset XDG specific surface for good measure */
+	view->xdg_surface = NULL;
+
+	/* Remove XDG specific handlers */
+	wl_list_remove(&view->destroy.link);
+
+	/* And finally destroy / free the view */
+	view_destroy(view);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -96,7 +96,21 @@ static void
 handle_destroy(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, destroy);
-	view_handle_destroy(view);
+	assert(view->type == LAB_XWAYLAND_VIEW);
+
+	/* Reset XWayland specific surface for good measure */
+	view->xwayland_surface = NULL;
+
+	/* Remove XWayland specific handlers */
+	wl_list_remove(&view->map.link);
+	wl_list_remove(&view->unmap.link);
+	wl_list_remove(&view->request_configure.link);
+	wl_list_remove(&view->request_maximize.link);
+	wl_list_remove(&view->request_fullscreen.link);
+	wl_list_remove(&view->destroy.link);
+
+	/* And finally destroy / free the view */
+	view_destroy(view);
 }
 
 static void


### PR DESCRIPTION
As a follow up to #299:
- Move XDG / XWayland specific cleanups back into their own files
- Update the OSD when the destroyed view was the currently selected one
- Handle NULL return from `desktop_cycle_view()`
- Rename `view_handle_destroy()` to `view_destroy()` (it actually frees the view)

Open questions:
- Maybe I am lost here but it seems we are cleaning up some random subset of event listeners for XDG / XWayland. Shouldn't we either clean up all of them or none of them?
- @johanmalm are you fine with having the generic `view_destroy()` in `src/view.c` or should we move it somewhere else?