### PR TITLE
Feature/tab preview: restore functionality after the move to scene-graph

### DIFF
--- a/include/common/scene-helpers.h
+++ b/include/common/scene-helpers.h
@@ -1,7 +1,17 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <wlr/types/wlr_scene.h>
+struct wlr_scene_node;
+struct wlr_scene_rect;
+struct wlr_scene_tree;
+struct wlr_surface;
 
 struct wlr_scene_rect *lab_wlr_scene_get_rect(struct wlr_scene_node *node);
 struct wlr_scene_tree *lab_scene_tree_from_node(struct wlr_scene_node *node);
 struct wlr_surface *lab_wlr_surface_from_node(struct wlr_scene_node *node);
+
+/**
+ * lab_get_prev_node - return previous (sibling) node
+ * @node: node to find the previous node from
+ * Return NULL if previous link is list-head which means node is bottom-most
+ */
+struct wlr_scene_node *lab_wlr_scene_get_prev_node(struct wlr_scene_node *node);

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -583,6 +583,8 @@ void osd_update(struct server *server);
 void osd_finish(struct server *server);
 /* Moves preview views back into their original stacking order and state */
 void osd_preview_restore(struct server *server);
+/* Notify OSD about a destroying view */
+void osd_on_view_destroy(struct view *view);
 
 /*
  * wlroots "input inhibitor" extension (required for swaylock) blocks

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -202,8 +202,6 @@ struct server {
 	/* Tree for built in menu */
 	struct wlr_scene_tree *menu_tree;
 
-	struct multi_rect *osd_preview_outline;
-
 	/* Workspaces */
 	struct wl_list workspaces;  /* struct workspace.link */
 	struct workspace *workspace_current;
@@ -236,6 +234,7 @@ struct server {
 		bool preview_was_enabled;
 		struct wlr_scene_node *preview_node;
 		struct wlr_scene_node *preview_anchor;
+		struct multi_rect *preview_outline;
 	} osd_state;
 
 	struct theme *theme;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -233,6 +233,7 @@ struct server {
 	/* Set when in cycle (alt-tab) mode */
 	struct osd_state {
 		struct view *cycle_view;
+		bool preview_was_enabled;
 		struct wlr_scene_node *preview_node;
 		struct wlr_scene_node *preview_anchor;
 	} osd_state;
@@ -577,9 +578,12 @@ void server_init(struct server *server);
 void server_start(struct server *server);
 void server_finish(struct server *server);
 
-/* update onscreen display 'alt-tab' buffer */
-void osd_finish(struct server *server);
+/* Updates onscreen display 'alt-tab' buffer */
 void osd_update(struct server *server);
+/* Closes the OSD */
+void osd_finish(struct server *server);
+/* Moves preview views back into their original stacking order and state */
+void osd_preview_restore(struct server *server);
 
 /*
  * wlroots "input inhibitor" extension (required for swaylock) blocks

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -231,7 +231,11 @@ struct server {
 	struct wl_listener new_constraint;
 
 	/* Set when in cycle (alt-tab) mode */
-	struct view *cycle_view;
+	struct osd_state {
+		struct view *cycle_view;
+		struct wlr_scene_node *preview_node;
+		struct wlr_scene_node *preview_anchor;
+	} osd_state;
 
 	struct theme *theme;
 

--- a/src/action.c
+++ b/src/action.c
@@ -235,13 +235,13 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_NEXT_WINDOW:
-			server->cycle_view = desktop_cycle_view(server,
-				server->cycle_view, LAB_CYCLE_DIR_FORWARD);
+			server->osd_state.cycle_view = desktop_cycle_view(server,
+				server->osd_state.cycle_view, LAB_CYCLE_DIR_FORWARD);
 			osd_update(server);
 			break;
 		case ACTION_TYPE_PREVIOUS_WINDOW:
-			server->cycle_view = desktop_cycle_view(server,
-				server->cycle_view, LAB_CYCLE_DIR_BACKWARD);
+			server->osd_state.cycle_view = desktop_cycle_view(server,
+				server->osd_state.cycle_view, LAB_CYCLE_DIR_BACKWARD);
 			osd_update(server);
 			break;
 		case ACTION_TYPE_RECONFIGURE:

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -32,3 +32,15 @@ lab_wlr_surface_from_node(struct wlr_scene_node *node)
 	}
 	return NULL;
 }
+
+struct wlr_scene_node *
+lab_wlr_scene_get_prev_node(struct wlr_scene_node *node)
+{
+	assert(node);
+	struct wlr_scene_node *prev;
+	prev = wl_container_of(node->link.prev, node, link);
+	if (&prev->link == &node->parent->children) {
+		return NULL;
+	}
+	return prev;
+}

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -203,6 +203,9 @@ desktop_cycle_view(struct server *server, struct view *start_view,
 	/* Scene nodes are ordered like last node == displayed topmost */
 	iter = dir == LAB_CYCLE_DIR_FORWARD ? get_prev_item : get_next_item;
 
+	/* Make sure to have all nodes in their actual ordering */
+	osd_preview_restore(server);
+
 	do {
 		list_item = iter(list_item);
 		if (list_item == list_head) {

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -150,6 +150,7 @@ handle_compositor_keybindings(struct wl_listener *listener,
 			for (int i = 0; i < nsyms; i++) {
 				if (syms[i] == XKB_KEY_Escape) {
 					/* cancel */
+					osd_preview_restore(server);
 					/* osd_finish() additionally resets cycle_view to NULL */
 					osd_finish(server);
 					return true;

--- a/src/osd.c
+++ b/src/osd.c
@@ -109,6 +109,8 @@ osd_update_preview_outlines(struct view *view)
 void
 osd_finish(struct server *server)
 {
+	server->osd_state.cycle_view = NULL;
+
 	struct output *output;
 	wl_list_for_each(output, &server->outputs, link) {
 		destroy_osd_nodes(output);
@@ -185,7 +187,7 @@ osd_update(struct server *server)
 			if (!isfocusable(view)) {
 				continue;
 			}
-			if (view == server->cycle_view) {
+			if (view == server->osd_state.cycle_view) {
 				set_cairo_color(cairo, theme->osd_label_text_color);
 				cairo_rectangle(cairo, OSD_BORDER_WIDTH, y,
 					OSD_ITEM_WIDTH, OSD_ITEM_HEIGHT);

--- a/src/osd.c
+++ b/src/osd.c
@@ -90,7 +90,7 @@ osd_update_preview_outlines(struct view *view)
 {
 	/* Create / Update preview outline tree */
 	struct server *server = view->server;
-	struct multi_rect *rect = view->server->osd_preview_outline;
+	struct multi_rect *rect = view->server->osd_state.preview_outline;
 	if (!rect) {
 		int line_width = server->theme->osd_border_width;
 		float *colors[] = {
@@ -100,7 +100,7 @@ osd_update_preview_outlines(struct view *view)
 		};
 		rect = multi_rect_create(&server->scene->tree, colors, line_width);
 		wlr_scene_node_place_above(&rect->tree->node, &server->menu_tree->node);
-		server->osd_preview_outline = rect;
+		server->osd_state.preview_outline = rect;
 	}
 
 	struct wlr_box geo = ssd_max_extents(view);
@@ -120,10 +120,10 @@ osd_finish(struct server *server)
 		destroy_osd_nodes(output);
 		wlr_scene_node_set_enabled(&output->osd_tree->node, false);
 	}
-	if (server->osd_preview_outline) {
+	if (server->osd_state.preview_outline) {
 		/* Destroy the whole multi_rect so we can easily react to new themes */
-		wlr_scene_node_destroy(&server->osd_preview_outline->tree->node);
-		server->osd_preview_outline = NULL;
+		wlr_scene_node_destroy(&server->osd_state.preview_outline->tree->node);
+		server->osd_state.preview_outline = NULL;
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -809,41 +809,11 @@ view_destroy(struct view *view)
 		server->focused_view = NULL;
 	}
 
-	struct osd_state *osd_state = &view->server->osd_state;
-	if (osd_state->cycle_view == view) {
-		/*
-		 * If we are the current OSD selected view, cycle
-		 * to the next because we are dying.
-		 */
-		osd_state->cycle_view = desktop_cycle_view(server,
-			osd_state->cycle_view, LAB_CYCLE_DIR_BACKWARD);
-
-		/*
-		 * If we cycled back to ourselves, then we have no windows.
-		 * just remove it and close the OSD for good.
-		 */
-		if (osd_state->cycle_view == view || !osd_state->cycle_view) {
-			/* osd_finish() additionally resets cycle_view to NULL */
-			osd_finish(server);
-		}
-	}
-
-	if (osd_state->cycle_view) {
-		/* Update the OSD to reflect the view has now gone. */
-		osd_update(server);
-	}
+	osd_on_view_destroy(view);
 
 	if (view->scene_tree) {
-		struct wlr_scene_node *node = &view->scene_tree->node;
-		if (osd_state->preview_anchor == node) {
-			/*
-			 * If we are the anchor for the current OSD selected view,
-			 * replace the anchor with the node before us.
-			 */
-			osd_state->preview_anchor = lab_wlr_scene_get_prev_node(node);
-		}
 		ssd_destroy(view);
-		wlr_scene_node_destroy(node);
+		wlr_scene_node_destroy(&view->scene_tree->node);
 		view->scene_tree = NULL;
 	}
 

--- a/src/view.c
+++ b/src/view.c
@@ -808,25 +808,26 @@ view_destroy(struct view *view)
 		server->focused_view = NULL;
 	}
 
-	if (server->cycle_view == view) {
+	struct osd_state *osd_state = &view->server->osd_state;
+	if (osd_state->cycle_view == view) {
 		/*
 		 * If we are the current OSD selected view, cycle
 		 * to the next because we are dying.
 		 */
-		server->cycle_view = desktop_cycle_view(server,
-			server->cycle_view, LAB_CYCLE_DIR_BACKWARD);
+		osd_state->cycle_view = desktop_cycle_view(server,
+			osd_state->cycle_view, LAB_CYCLE_DIR_BACKWARD);
 
 		/*
 		 * If we cycled back to ourselves, then we have no windows.
 		 * just remove it and close the OSD for good.
 		 */
-		if (server->cycle_view == view || !server->cycle_view) {
-			server->cycle_view = NULL;
+		if (osd_state->cycle_view == view || !osd_state->cycle_view) {
+			/* osd_finish() additionally resets cycle_view to NULL */
 			osd_finish(server);
 		}
 	}
 
-	if (server->cycle_view) {
+	if (osd_state->cycle_view) {
 		/* Update the OSD to reflect the view has now gone. */
 		osd_update(server);
 	}

--- a/src/view.c
+++ b/src/view.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <strings.h>
 #include <xcb/xcb_icccm.h>
+#include "common/scene-helpers.h"
 #include "labwc.h"
 #include "ssd.h"
 #include "menu/menu.h"
@@ -833,8 +834,16 @@ view_destroy(struct view *view)
 	}
 
 	if (view->scene_tree) {
+		struct wlr_scene_node *node = &view->scene_tree->node;
+		if (osd_state->preview_anchor == node) {
+			/*
+			 * If we are the anchor for the current OSD selected view,
+			 * replace the anchor with the node before us.
+			 */
+			osd_state->preview_anchor = lab_wlr_scene_get_prev_node(node);
+		}
 		ssd_destroy(view);
-		wlr_scene_node_destroy(&view->scene_tree->node);
+		wlr_scene_node_destroy(node);
 		view->scene_tree = NULL;
 	}
 


### PR DESCRIPTION
~~I am still not 100% satisfied with the implementation.~~
First commit basically just replaces `server->cycle_view` with `server->osd_state.cycle_view` so can be skipped for review.

What I don't really like:
- `view_destroy()` starts to look like a OSD clean up routine, maybe we should have an additional `osd_view_destroyed()` handler or something like that that we can call from `view_destroy()` (similar to `ssd_destroy()`)?

What is missing: 
- [x] some kind of marker for the currently selected window (see #430)
- [x] minimized views wouldn't have any preview because their scene_node is disabled (fixed)
- [x] refactor `view_destroy()` to call some `osd_view_destroy()`
- [x] refactor to `prev_node()` as suggested by @johanmalm
- [x] respect the existing config option to enable / disable the preview
- [x] document in header file what `osd_preview_restore()` does

All in all this is one of the very few things that actually got harder by the move to the scene-graph API.