### PR TITLE
nls: add native language support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,12 @@ line with wlroots.
 With the introduction of the scene-graph API, some wlroots functions also use
 node coordinates (nx, ny) but we prefer (sx, sy) where possible.
 
+## Native Language Support
+
+Translators can add their `MY_LOCALE.po` files to the `po` directory
+based on `po/labwc.pot` and issue a pull request.
+
 
 [coding style]: https://git.sr.ht/~sircmpwn/cstyle
 [commit messages]: https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/CONTRIBUTING.md#commit-messages 
 [checkpatch.pl]: https://github.com/johanmalm/checkpatch.pl
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,8 @@ that branch.
 This release contains significant refactoring to use the wlroots
 scene-graph API, particularly src/output.c, server-side-decoration
 and the layer-shell implementation. Many thanks to @Consolatis for some
-heavy lifting with this.
+heavy lifting with this. Native language support has been added by
+@01micko.
 
 ### Added
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -48,6 +48,13 @@
 #include "config/keybind.h"
 #include "config/rcxml.h"
 #include "ssd.h"
+#if HAVE_NLS
+#include <libintl.h>
+#include <locale.h>
+#define _ gettext
+#else
+#define _(s) (s)
+#endif
 
 #define XCURSOR_DEFAULT "left_ptr"
 #define XCURSOR_SIZE 24

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,15 @@ have_xwayland = xcb.found() and wlroots_has_xwayland
 conf_data = configuration_data()
 conf_data.set10('HAVE_XWAYLAND', have_xwayland)
 
+msgfmt = find_program('msgfmt', required: get_option('nls'))
+if msgfmt.found()
+  source_root = meson.current_source_dir()
+  conf_data.set('HAVE_NLS', 1)
+  subdir('po')
+else
+  conf_data.set('HAVE_NLS', 0)
+endif
+
 labwc_inc = include_directories('include')
 
 subdir('protocols')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
+option('nls', type: 'feature', value: 'auto', description: 'Enable native language support')

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,0 +1,1 @@
+de es it sv

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,0 +1,1 @@
+src/menu/menu.c

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,50 @@
+# Labwc pot file
+# Copyright (C) 2022
+# This file is distributed under the same license as the labwc package.
+# FIRST AUTHOR <https://github.com/Consolatis>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: labwc\n"
+"Report-Msgid-Bugs-To: https://github.com/labwc/labwc/issues\n"
+"POT-Creation-Date: 2022-04-30 16:43+1000\n"
+"PO-Revision-Date: 2022-04-30 16:50+1000\n"
+"Last-Translator: Consolatis <https://github.com/Consolatis>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: German\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/menu/menu.c:428
+msgid "Reconfigure"
+msgstr "Rekonfigurieren"
+
+#: src/menu/menu.c:430
+msgid "Exit"
+msgstr "Beenden"
+
+#: src/menu/menu.c:446
+msgid "Minimize"
+msgstr "Minimieren"
+
+#: src/menu/menu.c:448
+msgid "Maximize"
+msgstr "Maximieren"
+
+#: src/menu/menu.c:450
+msgid "Fullscreen"
+msgstr "Vollbild"
+
+#: src/menu/menu.c:452
+msgid "Decorations"
+msgstr "Dekorationen"
+
+#: src/menu/menu.c:454
+msgid "AlwaysOnTop"
+msgstr "Immer im Vordergrund"
+
+#: src/menu/menu.c:456
+msgid "Close"
+msgstr "Schließen"

--- a/po/es.po
+++ b/po/es.po
@@ -1,0 +1,50 @@
+# Labwc pot file
+# Copyright (C) 2022
+# This file is distributed under the same license as the labwc package.
+# FIRST AUTHOR <01micko@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: labwc\n"
+"Report-Msgid-Bugs-To: https://github.com/labwc/labwc/issues\n"
+"POT-Creation-Date: 2022-04-30 16:43+1000\n"
+"PO-Revision-Date: 2022-04-30 16:50+1000\n"
+"Last-Translator: Mick Amadio <01micko@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: Spanish\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/menu/menu.c:428
+msgid "Reconfigure"
+msgstr "Reconfigurar"
+
+#: src/menu/menu.c:430
+msgid "Exit"
+msgstr "Salir"
+
+#: src/menu/menu.c:446
+msgid "Minimize"
+msgstr "Minimizar"
+
+#: src/menu/menu.c:448
+msgid "Maximize"
+msgstr "Maximizar"
+
+#: src/menu/menu.c:450
+msgid "Fullscreen"
+msgstr "Pantalla completa"
+
+#: src/menu/menu.c:452
+msgid "Decorations"
+msgstr "Decoraciones"
+
+#: src/menu/menu.c:454
+msgid "AlwaysOnTop"
+msgstr "Siempre encima"
+
+#: src/menu/menu.c:456
+msgid "Close"
+msgstr "Cerrar"

--- a/po/it.po
+++ b/po/it.po
@@ -1,0 +1,50 @@
+# Labwc pot file
+# Copyright (C) 2022
+# This file is distributed under the same license as the labwc package.
+# FIRST AUTHOR <01micko@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: labwc\n"
+"Report-Msgid-Bugs-To: https://github.com/labwc/labwc/issues\n"
+"POT-Creation-Date: 2022-04-30 16:43+1000\n"
+"PO-Revision-Date: 2022-04-30 16:50+1000\n"
+"Last-Translator: Mick Amadio <01micko@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: Italian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/menu/menu.c:428
+msgid "Reconfigure"
+msgstr "Riconfigurare"
+
+#: src/menu/menu.c:430
+msgid "Exit"
+msgstr "Uscita"
+
+#: src/menu/menu.c:446
+msgid "Minimize"
+msgstr "Riduci"
+
+#: src/menu/menu.c:448
+msgid "Maximize"
+msgstr "Ingrandisci"
+
+#: src/menu/menu.c:450
+msgid "Fullscreen"
+msgstr "Schermo intero"
+
+#: src/menu/menu.c:452
+msgid "Decorations"
+msgstr "Decorazioni"
+
+#: src/menu/menu.c:454
+msgid "AlwaysOnTop"
+msgstr "Sempre sopra"
+
+#: src/menu/menu.c:456
+msgid "Close"
+msgstr "Chiudi"

--- a/po/labwc.pot
+++ b/po/labwc.pot
@@ -1,0 +1,50 @@
+# Labwc pot file
+# Copyright (C) 2022
+# This file is distributed under the same license as the labwc package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: labwc\n"
+"Report-Msgid-Bugs-To: https://github.com/labwc/labwc/issues\n"
+"POT-Creation-Date: 2022-04-30 16:43+1000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/menu/menu.c:428
+msgid "Reconfigure"
+msgstr ""
+
+#: src/menu/menu.c:430
+msgid "Exit"
+msgstr ""
+
+#: src/menu/menu.c:446
+msgid "Minimize"
+msgstr ""
+
+#: src/menu/menu.c:448
+msgid "Maximize"
+msgstr ""
+
+#: src/menu/menu.c:450
+msgid "Fullscreen"
+msgstr ""
+
+#: src/menu/menu.c:452
+msgid "Decorations"
+msgstr ""
+
+#: src/menu/menu.c:454
+msgid "AlwaysOnTop"
+msgstr ""
+
+#: src/menu/menu.c:456
+msgid "Close"
+msgstr ""

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,12 @@
+i18n = import('i18n')
+add_project_arguments('-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
+  '-DLOCALEDIR="' + get_option('prefix') / get_option('localedir') + '"',
+  language:'c')
+i18n.gettext(meson.project_name(),
+  args: ['--directory=' + source_root,
+    '--add-comments=TRANSLATORS',
+    '--no-location',
+    '--keyword=_',
+    '--msgid-bugs=https://github.com/labwc/labwc/issues'],
+    preset: 'glib'
+)

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,0 +1,50 @@
+# Labwc pot file
+# Copyright (C) 2022
+# This file is distributed under the same license as the labwc package.
+# FIRST AUTHOR <jgm323@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: labwc\n"
+"Report-Msgid-Bugs-To: https://github.com/labwc/labwc/issues\n"
+"POT-Creation-Date: 2022-04-30 16:43+1000\n"
+"PO-Revision-Date: 2022-04-30 16:50+1000\n"
+"Last-Translator: Johan Malm <jgm323@gmail.com\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: Swedish\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/menu/menu.c:428
+msgid "Reconfigure"
+msgstr "Konfigurera om"
+
+#: src/menu/menu.c:430
+msgid "Exit"
+msgstr "Utgång"
+
+#: src/menu/menu.c:446
+msgid "Minimize"
+msgstr "Minimera"
+
+#: src/menu/menu.c:448
+msgid "Maximize"
+msgstr "Maximera"
+
+#: src/menu/menu.c:450
+msgid "Fullscreen"
+msgstr "Fullskärm"
+
+#: src/menu/menu.c:452
+msgid "Decorations"
+msgstr "Dekorationer"
+
+#: src/menu/menu.c:454
+msgid "AlwaysOnTop"
+msgstr "Alltid överst"
+
+#: src/menu/menu.c:456
+msgid "Close"
+msgstr "Stäng"

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,11 @@ usage(void)
 int
 main(int argc, char *argv[])
 {
+#if HAVE_NLS
+	setlocale(LC_ALL, "");
+	bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
+	textdomain(GETTEXT_PACKAGE);
+#endif
 	char *startup_cmd = NULL;
 	char *config_file = NULL;
 	enum wlr_log_importance verbosity = WLR_ERROR;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -425,9 +425,9 @@ menu_init_rootmenu(struct server *server)
 		menu = menu_create(server, "root-menu", "");
 	}
 	if (wl_list_empty(&menu->menuitems)) {
-		current_item = item_create(menu, "Reconfigure");
+		current_item = item_create(menu, _("Reconfigure"));
 		fill_item("name.action", "Reconfigure");
-		current_item = item_create(menu, "Exit");
+		current_item = item_create(menu, _("Exit"));
 		fill_item("name.action", "Exit");
 	}
 }
@@ -443,17 +443,17 @@ menu_init_windowmenu(struct server *server)
 		menu = menu_create(server, "client-menu", "");
 	}
 	if (wl_list_empty(&menu->menuitems)) {
-		current_item = item_create(menu, "Minimize");
+		current_item = item_create(menu, _("Minimize"));
 		fill_item("name.action", "Iconify");
-		current_item = item_create(menu, "Maximize");
+		current_item = item_create(menu, _("Maximize"));
 		fill_item("name.action", "ToggleMaximize");
-		current_item = item_create(menu, "Fullscreen");
+		current_item = item_create(menu, _("Fullscreen"));
 		fill_item("name.action", "ToggleFullscreen");
-		current_item = item_create(menu, "Decorations");
+		current_item = item_create(menu, _("Decorations"));
 		fill_item("name.action", "ToggleDecorations");
-		current_item = item_create(menu, "AlwaysOnTop");
+		current_item = item_create(menu, _("AlwaysOnTop"));
 		fill_item("name.action", "ToggleAlwaysOnTop");
-		current_item = item_create(menu, "Close");
+		current_item = item_create(menu, _("Close"));
 		fill_item("name.action", "Close");
 	}
 }


### PR DESCRIPTION
- adds labwc.pot and po files for de, es, it and sv
- added notes in NEWS.md and CONTRIBUTING.md
- addresses #269
- conditional upon `msgfmt` being installed
- can be disabled at build time