### PR TITLE
xwayland: handle set_override_redirect events

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -333,6 +333,7 @@ struct view {
 	struct wl_listener set_title;
 	struct wl_listener set_app_id;		/* class on xwayland */
 	struct wl_listener set_decorations;	/* xwayland only */
+	struct wl_listener override_redirect;	/* xwayland only */
 	struct wl_listener new_popup;		/* xdg-shell only */
 };
 
@@ -371,8 +372,9 @@ void xdg_surface_new(struct wl_listener *listener, void *data);
 
 #if HAVE_XWAYLAND
 void xwayland_surface_new(struct wl_listener *listener, void *data);
-void xwayland_unmanaged_create(struct server *server,
+struct xwayland_unmanaged *xwayland_unmanaged_create(struct server *server,
 	struct wlr_xwayland_surface *xsurface);
+void unmanaged_handle_map(struct wl_listener *listener, void *data);
 #endif
 
 void view_set_activated(struct view *view, bool activated);

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -38,7 +38,7 @@ parent_view(struct server *server, struct wlr_xwayland_surface *surface)
 	return NULL;
 }
 
-static void
+void
 unmanaged_handle_map(struct wl_listener *listener, void *data)
 {
 	struct xwayland_unmanaged *unmanaged =
@@ -108,7 +108,7 @@ unmanaged_handle_destroy(struct wl_listener *listener, void *data)
 	free(unmanaged);
 }
 
-void
+struct xwayland_unmanaged *
 xwayland_unmanaged_create(struct server *server,
 			  struct wlr_xwayland_surface *xsurface)
 {
@@ -126,4 +126,5 @@ xwayland_unmanaged_create(struct server *server,
 	unmanaged->unmap.notify = unmanaged_handle_unmap;
 	wl_signal_add(&xsurface->events.destroy, &unmanaged->destroy);
 	unmanaged->destroy.notify = unmanaged_handle_destroy;
+	return unmanaged;
 }


### PR DESCRIPTION
This is needed to allow X11 applications to create surfaces as
non-override_redirect and then change them to override_redirect later

Without this gitk-menus and rofi are treated as xwayland-views with
associated server-side-decoration and forced positioning.