### PR TITLE
v0.5-backport: meson: use proper dependency fallback for wlroots

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,22 +37,14 @@ if git.found()
 endif
 add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 
-wlroots_version = ['>=0.15.0', '<0.16.0']
-wlroots_proj = subproject(
+wlroots = dependency(
   'wlroots',
   default_options: ['default_library=static', 'examples=false'],
-  required: false,
-  version: wlroots_version,
+  version: ['>=0.15.0', '<0.16.0'],
 )
 
-if wlroots_proj.found()
-  wlroots = wlroots_proj.get_variable('wlroots')
-  wlroots_conf = wlroots_proj.get_variable('conf_data')
-  wlroots_has_xwayland = wlroots_conf.get('WLR_HAS_XWAYLAND') == 1
-else
-  wlroots = dependency('wlroots', version: wlroots_version)
-  wlroots_has_xwayland = cc.get_define('WLR_HAS_XWAYLAND', prefix: '#include <wlr/config.h>', dependencies: wlroots) == '1'
-endif
+wlroots_has_xwayland = wlroots.get_variable('have_xwayland') == 'true'
+
 wayland_server = dependency('wayland-server', version: '>=1.19.0')
 wayland_protos = dependency('wayland-protocols')
 xkbcommon = dependency('xkbcommon')

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,3 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
 revision = 0.15.1
+
+[provide]
+dependency_names = wlroots


### PR DESCRIPTION
Make the subproject wrap file declare the dependencies it provides.

Remove the manual subproject invocation and allow Meson to select
whichever wlroots it finds which satisfies the version requirement --
either a system one via pkg-config, or the subproject fallback.

Use a dependency-generic method of acquiring wlroots configuration info
-- enabled features are present in the pkg-config file and additionally
exported as declare_dependency() variables, so there is no need to do C
preprocessor checks for it.

This ensures that Meson best practices are followed, and also...

Fixes #318

Backport of 2656cf525f677c59549ee42b966f542a13be19e8 (PR #321) to v0.5