### PR TITLE
v0.5 backport: build: set 'check: false' on run_command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ add_project_arguments(cc.get_supported_arguments(
 version='"@0@"'.format(meson.project_version())
 git = find_program('git', native: true, required: false)
 if git.found()
-  git_commit = run_command([git, 'describe', '--dirty'])
+  git_commit = run_command([git, 'describe', '--dirty'], check: false)
   if git_commit.returncode() == 0
     version = '"@0@"'.format(git_commit.stdout().strip())
   endif


### PR DESCRIPTION
Future meson releases will change the default, so we explicitly set
check: false to maintain behaviour