### PR TITLE
src/xwayland.c: keep SSD state on unmap/map cycle

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -308,13 +308,13 @@ map(struct view *view)
 		}
 	}
 
-	view->ssd.enabled = want_deco(view);
-
-	if (view->ssd.enabled) {
-		view->margin = ssd_thickness(view);
-	}
-
 	if (!view->been_mapped) {
+
+		view->ssd.enabled = want_deco(view);
+		if (view->ssd.enabled) {
+			view->margin = ssd_thickness(view);
+		}
+
 		foreign_toplevel_handle_create(view);
 
 		if (!view->maximized && !view->fullscreen) {
@@ -326,12 +326,12 @@ map(struct view *view)
 		}
 
 		view_discover_output(view);
-		view->been_mapped = true;
-	}
 
-	if (view->ssd.enabled) {
-		/* Create ssd after view_disover_output() had been called */
-		ssd_create(view);
+		if (view->ssd.enabled) {
+			/* Create ssd after view_disover_output() had been called */
+			ssd_create(view);
+		}
+		view->been_mapped = true;
 	}
 
 	if (view->ssd.enabled && !view->fullscreen && !view->maximized) {


### PR DESCRIPTION
Move SSD related `map()` work into the `!view->been_mapped` branch, similar to `src/xdg.c`.

Without this patch following series of events restores the initial state of the SSD when activating the view:
- spawn xcalc (or some other X11 application)
- observe it shows the SSD
- toggleDecorations to hide the SSD (via keybinding or window menu)
- minimize xcalc (via some panel or `A-Space`)
- activate xcalc (via some panel or `A-Tab`)
- observe the SSD is back visible