### PR TITLE
Chase wlroots xdg_shell version

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -19,6 +19,8 @@
 #include "ssd.h"
 #include "theme.h"
 
+#define LAB_XDG_SHELL_VERSION (2)
+
 static struct wlr_compositor *compositor;
 static struct wl_event_source *sighup_source;
 static struct wl_event_source *sigint_source;
@@ -282,7 +284,8 @@ server_init(struct server *server)
 	seat_init(server);
 
 	/* Init xdg-shell */
-	server->xdg_shell = wlr_xdg_shell_create(server->wl_display);
+	server->xdg_shell = wlr_xdg_shell_create(server->wl_display,
+		LAB_XDG_SHELL_VERSION);
 	if (!server->xdg_shell) {
 		wlr_log(WLR_ERROR, "unable to create the XDG shell interface");
 		exit(EXIT_FAILURE);

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 640f3b9f2156a007c5d1a36afdee570e123c95e4
+revision = 8fe3aa29da56be16faa73aca947647bd60cd4a94
 
 [provide]
 dependency_names = wlroots


### PR DESCRIPTION
To update the wlroots subproject use
`meson subprojects update wlroots`

>      xdg-shell: specify version in wlr_xdg_shell_create
>     
>     With protocol additions such as [1], compositors currently have no
>     way to opt out of the version upgrade. The protocol upgrade will
>     always be backwards-compatible but may require new compositor
>     features.
>     
>     The status quo doesn't make it possible to ship a protocol addition
>     without breaking the wlroots API. This will be an issue for API
>     stabilization [2].
>     
>     To address this, let compositors provide a maximum version in the
>     function creating the global. We need to support all previous versions
>     of the interface anyways because of older clients.
>     
>     This mechanism works the same way as Wayland clients passing a version
>     in wl_global.bind.
>     
>     [1]: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3514
>     [2]: https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/1008
>     
>     References: https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3397

Sway master uses version 2 so I simply used the same on the assumption that that was what we were implementing as well.