### PR TITLE
Add workspaces

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -66,6 +66,14 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="ToggleAlwaysOnTop">*
 	Toggle always-on-top of focused window.
 
+*<action name="GoToDesktop"><to>*
+	Switch to workspace. Supported values are "left", "right" or the full
+	name of a workspace or its index (starting at 1) as configured in rc.xml.
+
+*<action name="SendToDesktop"><to>*
+	Send active window to workspace.
+	Supported values are the same as for GoToDesktop.
+
 # SEE ALSO
 
 labwc(1), labwc-config(5), labwc-theme(5)

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -88,6 +88,7 @@ The rest of this man page describes configuration options.
 	Raise window to top when focused. Default is no.
 
 ## WINDOW SNAPPING
+
 *<snapping><range>*
 	The distance in pixels from the edge of an ouput for window Move
 	operations to trigger SnapToEdge. A range of 0 disables window snapping.
@@ -95,6 +96,18 @@ The rest of this man page describes configuration options.
 
 *<snapping><topMaximize>* [yes|no]
 	Maximize window if Move operation ends on the top edge. Default is yes.
+
+## WORKSPACES
+
+*<desktops><names><name>*
+	Define workspaces. A workspace covers all outputs. The OSD only shows
+	windows on the current workspace. Workspaces can be switched to with
+	GoToDesktop and windows can be moved with SendToDesktop. See
+	labwc-actions(5) for more information about their arguments.
+
+*<desktops><popupTime>*
+	Define the timeout after which to hide the workspace OSD.
+	A setting of 0 disables the OSD. Default is 1000 ms.
 
 ## THEME
 

--- a/docs/menu.xml
+++ b/docs/menu.xml
@@ -17,6 +17,16 @@
 	<item label="AlwaysOnTop">
 		<action name="ToggleAlwaysOnTop" />
 	</item>
+	<menu id="workspaces" label="Workspace">
+		<item label="Move left">
+			<action name="SendToDesktop" to="left" />
+			<action name="GoToDesktop" to="left" />
+		</item>
+		<item label="Move right">
+			<action name="SendToDesktop" to="right" />
+			<action name="GoToDesktop" to="right" />
+		</item>
+	</menu>
 	<item label="Close">
 		<action name="Close" />
 	</item>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -40,6 +40,32 @@
   </snapping>
 
   <!--
+    Use GoToDesktop left | right to switch workspaces.
+    Use SendToDesktop left | right to move windows.
+    See man labwc-actions for futher information.
+
+    Workspaces can be configured like this:
+    <desktops>
+      <popupTime>1000</popupTime>
+      <names>
+        <name>Workspace 1</name>
+        <name>Workspace 2</name>
+        <name>Workspace 3</name>
+      </names>
+    </desktops>
+  -->
+  <desktops>
+    <!--
+      popupTime defaults to 1000 so could be left out.
+      Set to 0 to completely disable the workspace OSD.
+    -->
+    <popupTime>1000</popupTime>
+    <names>
+      <name>Default</name>
+    </names>
+  </desktops>
+
+  <!--
     Keybind actions are specified in labwc-actions(5)
     The following keybind modifiers are supported:
       W - window/super/logo

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -55,6 +55,11 @@ struct rcxml {
 
 	/* cycle view (alt+tab) */
 	bool cycle_preview_contents;
+
+	struct {
+		int popuptime;
+		struct wl_list workspaces;  /* struct workspace.link */
+	} workspace_config;
 };
 
 extern struct rcxml rc;

--- a/include/workspaces.h
+++ b/include/workspaces.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LABWC_WORKSPACES_H
+#define __LABWC_WORKSPACES_H
+
+struct seat;
+struct view;
+struct server;
+struct wl_list;
+
+/* Double use: as config in config/rcxml.c and as instance in workspaces.c */
+struct workspace {
+	struct wl_list link; /* struct server.workspaces
+	                        struct rcxml.workspace_config.workspaces */
+	struct server *server;
+
+	char *name;
+	struct wlr_scene_tree *tree;
+};
+
+
+void workspaces_init(struct server *server);
+void workspaces_switch_to(struct workspace *target);
+void workspaces_send_to(struct view *view, struct workspace *target);
+void workspaces_destroy(struct server *server);
+void workspaces_osd_hide(struct seat *seat);
+struct workspace * workspaces_find(struct workspace *anchor, const char *name);
+
+#endif /* __LABWC_WORKSPACES_H */

--- a/src/action.c
+++ b/src/action.c
@@ -9,6 +9,7 @@
 #include "menu/menu.h"
 #include "ssd.h"
 #include "action.h"
+#include "workspaces.h"
 
 enum action_type {
 	ACTION_TYPE_NONE = 0,
@@ -31,6 +32,8 @@ enum action_type {
 	ACTION_TYPE_MOVE,
 	ACTION_TYPE_RAISE,
 	ACTION_TYPE_RESIZE,
+	ACTION_TYPE_GO_TO_DESKTOP,
+	ACTION_TYPE_SEND_TO_DESKTOP,
 };
 
 const char *action_names[] = {
@@ -54,6 +57,8 @@ const char *action_names[] = {
 	"Move",
 	"Raise",
 	"Resize",
+	"GoToDesktop",
+	"SendToDesktop",
 	NULL
 };
 
@@ -253,6 +258,24 @@ actions_run(struct view *activator, struct server *server,
 			if (view) {
 				interactive_begin(view, LAB_INPUT_STATE_RESIZE,
 					resize_edges);
+			}
+			break;
+		case ACTION_TYPE_GO_TO_DESKTOP:
+			{
+				struct workspace *target;
+				target = workspaces_find(server->workspace_current, action->arg);
+				if (target) {
+					workspaces_switch_to(target);
+				}
+			}
+			break;
+		case ACTION_TYPE_SEND_TO_DESKTOP:
+			if (view) {
+				struct workspace *target;
+				target = workspaces_find(view->workspace, action->arg);
+				if (target) {
+					workspaces_send_to(view, target);
+				}
 			}
 			break;
 		case ACTION_TYPE_NONE:

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -75,10 +75,16 @@ fill_keybind(char *nodename, char *content)
 		wlr_log(WLR_ERROR, "Action argument already set: %s",
 			current_keybind_action->arg);
 	} else if (!strcmp(nodename, "command.action")) {
+		/* Execute */
 		current_keybind_action->arg = strdup(content);
 	} else if (!strcmp(nodename, "direction.action")) {
+		/* MoveToEdge, SnapToEdge */
 		current_keybind_action->arg = strdup(content);
 	} else if (!strcmp(nodename, "menu.action")) {
+		/* ShowMenu */
+		current_keybind_action->arg = strdup(content);
+	} else if (!strcmp(nodename, "to.action")) {
+		/* GoToDesktop, SendToDesktop */
 		current_keybind_action->arg = strdup(content);
 	}
 }

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -21,6 +21,7 @@
 #include "config/libinput.h"
 #include "config/mousebind.h"
 #include "config/rcxml.h"
+#include "workspaces.h"
 
 static bool in_keybind;
 static bool in_mousebind;
@@ -387,6 +388,12 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.snap_top_maximize = get_bool(content);
 	} else if (!strcasecmp(nodename, "cycleViewPreview.core")) {
 		rc.cycle_preview_contents = get_bool(content);
+	} else if (!strcasecmp(nodename, "name.names.desktops")) {
+		struct workspace *workspace = calloc(1, sizeof(struct workspace));
+		workspace->name = strdup(content);
+		wl_list_insert(rc.workspace_config.workspaces.prev, &workspace->link);
+	} else if (!strcasecmp(nodename, "popupTime.desktops")) {
+		rc.workspace_config.popuptime = atoi(content);
 	}
 }
 
@@ -486,6 +493,8 @@ rcxml_init()
 	rc.snap_edge_range = 1;
 	rc.snap_top_maximize = true;
 	rc.cycle_preview_contents = false;
+	rc.workspace_config.popuptime = INT_MIN;
+	wl_list_init(&rc.workspace_config.workspaces);
 }
 
 static struct {
@@ -620,6 +629,14 @@ post_processing(void)
 		struct libinput_category *l = libinput_category_create();
 		l->type = TOUCH_DEVICE;
 	}
+	if (!wl_list_length(&rc.workspace_config.workspaces)) {
+		struct workspace *workspace = calloc(1, sizeof(struct workspace));
+		workspace->name = strdup("Default");
+		wl_list_insert(rc.workspace_config.workspaces.prev, &workspace->link);
+	}
+	if (rc.workspace_config.popuptime == INT_MIN) {
+		rc.workspace_config.popuptime = 1000;
+	}
 }
 
 static void
@@ -716,6 +733,13 @@ rcxml_finish(void)
 		wl_list_remove(&l->link);
 		zfree(l->name);
 		zfree(l);
+	}
+
+	struct workspace *w, *w_tmp;
+	wl_list_for_each_safe(w, w_tmp, &rc.workspace_config.workspaces, link) {
+		wl_list_remove(&w->link);
+		zfree(w->name);
+		zfree(w);
 	}
 
 	/* Reset state vars for starting fresh when Reload is triggered */

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "labwc.h"
+#include "workspaces.h"
 
 static void
 handle_toplevel_handle_request_minimize(struct wl_listener *listener, void *data)
@@ -42,6 +43,9 @@ handle_toplevel_handle_request_activate(struct wl_listener *listener, void *data
 	// struct wlr_foreign_toplevel_handle_v1_activated_event *event = data;
 	/* In a multi-seat world we would select seat based on event->seat here. */
 	if (view) {
+		if (view->workspace != view->server->workspace_current) {
+			workspaces_switch_to(view->workspace);
+		}
 		desktop_focus_and_activate_view(&view->server->seat, view);
 		desktop_move_to_front(view);
 	}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -489,6 +489,22 @@ menu_init_windowmenu(struct server *server)
 		fill_item("name.action", "ToggleDecorations");
 		current_item = item_create(menu, _("AlwaysOnTop"));
 		fill_item("name.action", "ToggleAlwaysOnTop");
+
+		/* Workspace sub-menu */
+		struct menu *workspace_menu = menu_create(server, "workspaces", "");
+		current_item = item_create(workspace_menu, _("Move left"));
+		fill_item("name.action", "SendToDesktop");
+		fill_item("to.action", "left");
+		fill_item("name.action", "GoToDesktop");
+		fill_item("to.action", "left");
+		current_item = item_create(workspace_menu, _("Move right"));
+		fill_item("name.action", "SendToDesktop");
+		fill_item("to.action", "right");
+		fill_item("name.action", "GoToDesktop");
+		fill_item("to.action", "right");
+		current_item = item_create(menu, _("Workspace"));
+		current_item->submenu = workspace_menu;
+
 		current_item = item_create(menu, _("Close"));
 		fill_item("name.action", "Close");
 	}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -203,6 +203,8 @@ fill_item(char *nodename, char *content)
 		 * compatibility with old openbox-menu generators
 		 */
 		current_item_action->arg = strdup(content);
+	} else if (!strcmp(nodename, "to.action")) {
+		current_item_action->arg = strdup(content);
 	}
 }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ labwc_sources = files(
   'theme.c',
   'view.c',
   'view-impl.c',
+  'workspaces.c',
   'xdg.c',
   'xdg-deco.c',
   'xdg-popup.c',

--- a/src/server.c
+++ b/src/server.c
@@ -18,6 +18,7 @@
 #include "menu/menu.h"
 #include "ssd.h"
 #include "theme.h"
+#include "workspaces.h"
 
 #define LAB_XDG_SHELL_VERSION (2)
 
@@ -181,6 +182,7 @@ server_init(struct server *server)
 		event_loop, SIGINT, handle_sigterm, server->wl_display);
 	sigterm_source = wl_event_loop_add_signal(
 		event_loop, SIGTERM, handle_sigterm, server->wl_display);
+	server->wl_event_loop = event_loop;
 
 	/*
 	 * The backend is a feature which abstracts the underlying input and
@@ -244,6 +246,8 @@ server_init(struct server *server)
 	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->tree);
 #endif
 	server->menu_tree = wlr_scene_tree_create(&server->scene->tree);
+
+	workspaces_init(server);
 
 	output_init(server);
 
@@ -452,7 +456,7 @@ server_start(struct server *server)
 void
 server_finish(struct server *server)
 {
-/* TODO: clean up various scene_tree nodes */
+
 #if HAVE_XWAYLAND
 	wlr_xwayland_destroy(server->xwayland);
 #endif
@@ -465,4 +469,7 @@ server_finish(struct server *server)
 	wlr_output_layout_destroy(server->output_layout);
 
 	wl_display_destroy(server->wl_display);
+
+	/* TODO: clean up various scene_tree nodes */
+	workspaces_destroy(server);
 }

--- a/src/view.c
+++ b/src/view.c
@@ -6,6 +6,7 @@
 #include "labwc.h"
 #include "ssd.h"
 #include "menu/menu.h"
+#include "workspaces.h"
 
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
@@ -336,8 +337,8 @@ void
 view_toggle_always_on_top(struct view *view)
 {
 	if (is_always_on_top(view)) {
-		wlr_scene_node_reparent(&view->scene_tree->node,
-			view->server->view_tree);
+		view->workspace = view->server->workspace_current;
+		wlr_scene_node_reparent(&view->scene_tree->node, view->workspace->tree);
 	} else {
 		wlr_scene_node_reparent(&view->scene_tree->node,
 			view->server->view_tree_always_on_top);

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <cairo.h>
+#include <pango/pangocairo.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include "labwc.h"
+#include "common/font.h"
+#include "common/zfree.h"
+#include "workspaces.h"
+
+/* Internal helpers */
+static size_t
+parse_workspace_index(const char *name)
+{
+	/*
+	 * We only want to get positive numbers which span the whole string.
+	 *
+	 * More detailed requirement:
+	 *  .---------------.--------------.
+	 *  |     Input     | Return value |
+	 *  |---------------+--------------|
+	 *  | "2nd desktop" |      0       |
+	 *  |    "-50"      |      0       |
+	 *  |     "0"       |      0       |
+	 *  |    "124"      |     124      |
+	 *  |    "1.24"     |      0       |
+	 *  `------------------------------´
+	 *
+	 * As atoi() happily parses any numbers until it hits a non-number we
+	 * can't really use it for this case. Instead, we use strtol() combined
+	 * with further checks for the endptr (remaining non-number characters)
+	 * and returned negative numbers.
+	 */
+	long index;
+	char *endptr;
+	errno = 0;
+	index = strtol(name, &endptr, 10);
+	if (errno || *endptr != '\0' || index < 0) {
+		return 0;
+	}
+	return index;
+}
+
+/*
+ * TODO: set_source and draw_border are straight up copies from src/osd.c
+ * find some proper place for them instead of duplicating stuff.
+ */
+static void
+set_source(cairo_t *cairo, float *c)
+{
+	cairo_set_source_rgba(cairo, c[0], c[1], c[2], c[3]);
+}
+
+static void
+draw_border(cairo_t *cairo, double width, double height, double line_width)
+{
+	cairo_save(cairo);
+
+	double x, y, w, h;
+	/* The anchor point of a line is in the center */
+	x = y = line_width / 2;
+	w = width - line_width;
+	h = height - line_width;
+	cairo_set_line_width(cairo, line_width);
+	cairo_rectangle(cairo, x, y, w, h);
+	cairo_stroke(cairo);
+
+	cairo_restore(cairo);
+}
+
+static void
+_osd_update(struct server *server)
+{
+
+	struct theme *theme = server->theme;
+
+	/* Settings */
+	uint16_t margin = 10;
+	uint16_t padding = 2;
+	uint16_t rect_height = 20;
+	uint16_t rect_width = 20;
+	struct font font = {
+		.name = rc.font_name_osd,
+		.size = rc.font_size_osd,
+	};
+
+	/* Dimensions */
+	size_t workspace_count = wl_list_length(&server->workspaces);
+	uint16_t marker_width = workspace_count * (rect_width + padding) - padding;
+	uint16_t width = margin * 2 + (marker_width < 200 ? 200 : marker_width);
+	uint16_t height = margin * 3 + rect_height + font_height(&font);
+
+	cairo_t *cairo;
+	cairo_surface_t *surface;
+	struct workspace *workspace;
+
+	struct output *output;
+	wl_list_for_each(output, &server->outputs, link) {
+		struct lab_data_buffer *buffer = buffer_create_cairo(width, height,
+			output->wlr_output->scale, true);
+		if (!buffer) {
+			wlr_log(WLR_ERROR, "Failed to allocate buffer for workspace OSD");
+			continue;
+		}
+
+		cairo = buffer->cairo;
+
+		/* Background */
+		set_source(cairo, theme->osd_bg_color);
+		cairo_rectangle(cairo, 0, 0, width, height);
+		cairo_fill(cairo);
+
+		/* Border */
+		set_source(cairo, theme->osd_border_color);
+		draw_border(cairo, width, height, theme->osd_border_width);
+
+		uint16_t x = (width - marker_width) / 2;
+		wl_list_for_each(workspace, &server->workspaces, link) {
+			bool active =  workspace == server->workspace_current;
+			set_source(cairo, server->theme->osd_label_text_color);
+			cairo_rectangle(cairo, x, margin,
+				rect_width - padding, rect_height);
+			cairo_stroke(cairo);
+			if (active) {
+				cairo_rectangle(cairo, x, margin,
+					rect_width - padding, rect_height);
+				cairo_fill(cairo);
+			}
+			x += rect_width + padding;
+		}
+
+		/* Text */
+		set_source(cairo, server->theme->osd_label_text_color);
+		PangoLayout *layout = pango_cairo_create_layout(cairo);
+		pango_layout_set_width(layout, (width - 2 * margin) * PANGO_SCALE);
+		pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
+
+		PangoFontDescription *desc = pango_font_description_new();
+		pango_font_description_set_family(desc, font.name);
+		pango_font_description_set_size(desc, font.size * PANGO_SCALE);
+		pango_layout_set_font_description(layout, desc);
+
+		/* Center workspace indicator on the x axis */
+		x = font_width(&font, server->workspace_current->name);
+		x = (width - x) / 2;
+		cairo_move_to(cairo, x, margin * 2 + rect_height);
+		//pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
+		pango_layout_set_font_description(layout, desc);
+		pango_font_description_free(desc);
+		pango_layout_set_text(layout, server->workspace_current->name, -1);
+		pango_cairo_show_layout(cairo, layout);
+
+		g_object_unref(layout);
+		surface = cairo_get_target(cairo);
+		cairo_surface_flush(surface);
+
+		if (!output->workspace_osd) {
+			output->workspace_osd = wlr_scene_buffer_create(
+				&server->scene->tree, NULL);
+		}
+		/* Position the whole thing */
+		struct wlr_box output_box;
+		wlr_output_layout_get_box(output->server->output_layout,
+			output->wlr_output, &output_box);
+		int lx = output->usable_area.x
+			+ (output->usable_area.width - width) / 2
+			+ output_box.x;
+		int ly = output->usable_area.y
+			+ (output->usable_area.height - height ) / 2
+			+ output_box.y;
+		wlr_scene_node_set_position(&output->workspace_osd->node, lx, ly);
+		wlr_scene_buffer_set_buffer(output->workspace_osd, &buffer->base);
+		wlr_scene_buffer_set_dest_size(output->workspace_osd,
+			buffer->unscaled_width, buffer->unscaled_height);
+
+		/* And finally drop the buffer so it will get destroyed on OSD hide */
+		wlr_buffer_drop(&buffer->base);
+	}
+}
+
+/* Internal API */
+static void
+add_workspace(struct server *server, const char *name)
+{
+	struct workspace *workspace = calloc(1, sizeof(struct workspace));
+	workspace->server = server;
+	workspace->name = strdup(name);
+	workspace->tree = wlr_scene_tree_create(server->view_tree);
+	wl_list_insert(server->workspaces.prev, &workspace->link);
+	if (!server->workspace_current) {
+		server->workspace_current = workspace;
+	} else {
+		wlr_scene_node_set_enabled(&workspace->tree->node, false);
+	}
+}
+
+static struct workspace *
+get_prev(struct workspace *current, struct wl_list *workspaces)
+{
+	struct wl_list *target_link = current->link.prev;
+	if (target_link == workspaces) {
+		/* Current workspace is the first one, roll over */
+		target_link = target_link->prev;
+	}
+	return wl_container_of(target_link, current, link);
+}
+
+static struct workspace *
+get_next(struct workspace *current, struct wl_list *workspaces)
+{
+	struct wl_list *target_link = current->link.next;
+	if (target_link == workspaces) {
+		/* Current workspace is the last one, roll over */
+		target_link = target_link->next;
+	}
+	return wl_container_of(target_link, current, link);
+}
+
+static int
+_osd_handle_timeout(void *data)
+{
+	struct seat *seat = data;
+	workspaces_osd_hide(seat);
+	/* Don't re-check */
+	return 0;
+}
+
+static void
+_osd_show(struct server *server)
+{
+	if (!rc.workspace_config.popuptime) {
+		return;
+	}
+
+	_osd_update(server);
+	struct output *output;
+	wl_list_for_each(output, &server->outputs, link) {
+		wlr_scene_node_set_enabled(&output->workspace_osd->node, true);
+	}
+	struct wlr_keyboard *keyboard = &server->seat.keyboard_group->keyboard;
+	if (keyboard_any_modifiers_pressed(keyboard)) {
+		/* Hidden by release of all modifiers */
+		server->seat.workspace_osd_shown_by_modifier = true;
+	} else {
+		/* Hidden by timer */
+		if (!server->seat.workspace_osd_timer) {
+			server->seat.workspace_osd_timer = wl_event_loop_add_timer(
+				server->wl_event_loop, _osd_handle_timeout, &server->seat);
+		}
+		wl_event_source_timer_update(server->seat.workspace_osd_timer,
+			rc.workspace_config.popuptime);
+	}
+}
+
+/* Public API */
+void
+workspaces_init(struct server *server)
+{
+	wl_list_init(&server->workspaces);
+
+	struct workspace *conf;
+	wl_list_for_each(conf, &rc.workspace_config.workspaces, link) {
+		add_workspace(server, conf->name);
+	}
+}
+
+void
+workspaces_switch_to(struct workspace *target)
+{
+	assert(target);
+	if (target == target->server->workspace_current) {
+		return;
+	}
+
+	/* Disable the old workspace */
+	wlr_scene_node_set_enabled(
+		&target->server->workspace_current->tree->node, false);
+
+	/* Enable the new workspace */
+	wlr_scene_node_set_enabled(&target->tree->node, true);
+
+	/* Make sure new views will spawn on the new workspace */
+	target->server->workspace_current = target;
+
+	/**
+	 * Make sure we are focusing what the user sees.
+	 *
+	 * TODO: This is an issue for always-on-top views as they will
+	 * loose keyboard focus once switching to another workspace.
+	 */
+	desktop_focus_topmost_mapped_view(target->server);
+
+	/* And finally show the OSD */
+	_osd_show(target->server);
+}
+
+void
+workspaces_send_to(struct view *view, struct workspace *target)
+{
+	assert(view);
+	assert(target);
+	if (view->workspace == target) {
+		return;
+	}
+	wlr_scene_node_reparent(&view->scene_tree->node, target->tree);
+	view->workspace = target;
+}
+
+
+void
+workspaces_osd_hide(struct seat *seat)
+{
+	assert(seat);
+	struct output *output;
+	struct server *server = seat->server;
+	wl_list_for_each(output, &server->outputs, link) {
+		wlr_scene_node_set_enabled(&output->workspace_osd->node, false);
+		wlr_scene_buffer_set_buffer(output->workspace_osd, NULL);
+	}
+	seat->workspace_osd_shown_by_modifier = false;
+}
+
+struct workspace *
+workspaces_find(struct workspace *anchor, const char *name)
+{
+	assert(anchor);
+	if (!name) {
+		return NULL;
+	}
+	size_t index = 0;
+	struct workspace *target;
+	size_t wants_index = parse_workspace_index(name);
+	struct wl_list *workspaces = &anchor->server->workspaces;
+
+	if (wants_index) {
+		wl_list_for_each(target, workspaces, link) {
+			if (wants_index == ++index) {
+				return target;
+			}
+		}
+	} else if (!strcasecmp(name, "left")) {
+		return get_prev(anchor, workspaces);
+	} else if (!strcasecmp(name, "right")) {
+		return get_next(anchor, workspaces);
+	} else {
+		wl_list_for_each(target, workspaces, link) {
+			if (!strcasecmp(target->name, name)) {
+				return target;
+			}
+		}
+	}
+	wlr_log(WLR_ERROR, "Workspace '%s' not found", name);
+	return NULL;
+}
+
+void
+workspaces_destroy(struct server *server)
+{
+	struct workspace *workspace, *tmp;
+	wl_list_for_each_safe(workspace, tmp, &server->workspaces, link) {
+		wlr_scene_node_destroy(&workspace->tree->node);
+		zfree(workspace->name);
+		wl_list_remove(&workspace->link);
+		free(workspace);
+	}
+	assert(wl_list_empty(&server->workspaces));
+}

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -3,6 +3,7 @@
 #include "labwc.h"
 #include "node.h"
 #include "ssd.h"
+#include "workspaces.h"
 
 static void
 handle_new_xdg_popup(struct wl_listener *listener, void *data)
@@ -374,7 +375,8 @@ xdg_surface_new(struct wl_listener *listener, void *data)
 	view->impl = &xdg_toplevel_view_impl;
 	view->xdg_surface = xdg_surface;
 
-	view->scene_tree = wlr_scene_tree_create(view->server->view_tree);
+	view->workspace = server->workspace_current;
+	view->scene_tree = wlr_scene_tree_create(view->workspace->tree);
 	wlr_scene_node_set_enabled(&view->scene_tree->node, false);
 
 	struct wlr_scene_tree *tree = wlr_scene_xdg_surface_create(

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -3,6 +3,7 @@
 #include "labwc.h"
 #include "node.h"
 #include "ssd.h"
+#include "workspaces.h"
 
 static void
 handle_commit(struct wl_listener *listener, void *data)
@@ -434,7 +435,8 @@ xwayland_surface_new(struct wl_listener *listener, void *data)
 	view->impl = &xwl_view_impl;
 	view->xwayland_surface = xsurface;
 
-	view->scene_tree = wlr_scene_tree_create(view->server->view_tree);
+	view->workspace = server->workspace_current;
+	view->scene_tree = wlr_scene_tree_create(view->workspace->tree);
 	node_descriptor_create(&view->scene_tree->node,
 		LAB_NODE_DESC_VIEW, view);
 	xsurface->data = view;


### PR DESCRIPTION
This ~~is just a simple test implementation for workspaces~~ implements workspaces.
I'd welcome some more testing and review.

### Config
2 new actions:
- `SendToDesktop` `target` (move current view to workspace `target`, also available via window menu)
- `GoToDesktop` `target` (change active workspace to `target`)

Workspaces have to be defined in `rc.xml`. Example:
```xml
  <desktops>
    <popupTime>1000</popupTime>
    <names>
      <name>Workspace a</name>
      <name>Workspace b</name>
      <name>Workspace c</name>
    </names>
  </desktops>
```
Actions have to use `to` for their `target` argument, a `target` can be defined as:
- `left` / `right`
- the workspace index, beginning from 1
- the full name of the workspace

Example:
```xml
    <keybind key="W-Left">
      <action name="GoToDesktop" to="left" />
    </keybind>

    <keybind key="W-S-Left">
      <action name="SendToDesktop" to="left" />
      <action name="GoToDesktop" to="left" />
    </keybind>

    <keybind key="W-1">
      <action name="GoToDesktop" to="Workspace a" />
    </keybind>

    <keybind key="W-2">
      <action name="GoToDesktop" to="2" />
    </keybind>
```

### OSD
When switching to a different workspace, a non-interactive workspace OSD pops up.
If the workspace switch had been initiated using a modifier keybinding the OSD will close when all modifiers are released. If the workspace switch instead had been initiated using some other action like using the window menu the OSD will close after `popupTime` ms. A `popupTime` of `0` disables both variants.

### Nested window menu
By default the `client-menu` (also known as window menu) has a new nested menu with id `workspaces` which has two entries `Move left` and `Move right`. That menu can be removed or redefined as usual via a custom `menu.xml`.
If there is only a single workspace, all menu items pointing to a menu with id `workspaces` will be removed automatically.

### Other

As this started as simple test implementation I chose the most simple design:
- A workspace covers all outputs
- The `A-Tab` OSD only shows windows from the active workspace
- A window can only be in a single workspace at any given point in time (no tags)
- External panels will show all windows. When activating a window which is on a different workspace labwc will switch to that workspace automatically

Whatever we decide to do (or not to do), using external panels to switch / manage workspaces or move windows into workspaces seems a looong time away:
https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/40
https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/59
https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/60