### PR TITLE
desktop_node_and_view_at(): handle layer surfaces

### DIFF
--- a/include/node.h
+++ b/include/node.h
@@ -29,10 +29,10 @@ struct node_descriptor {
  * @scene_node: wlr_scene_node to attached node_descriptor to
  * @type: node descriptor type
  * @data: struct to point to as follows:
- *   - LAB_NODE_DESC_VIEW		struct view
- *   - LAB_NODE_DESC_XDG_POPUP		struct view
- *   - LAB_NODE_DESC_LAYER_SURFACE	struct lab_layer_surface
- *   - LAB_NODE_DESC_LAYER_POPUP	struct lab_layer_popup
+ *   - LAB_NODE_DESC_VIEW           struct view
+ *   - LAB_NODE_DESC_XDG_POPUP      struct view
+ *   - LAB_NODE_DESC_LAYER_SURFACE  struct lab_layer_surface
+ *   - LAB_NODE_DESC_LAYER_POPUP    struct lab_layer_popup
  */
 void node_descriptor_create(struct wlr_scene_node *scene_node,
 	enum node_descriptor_type type, void *data);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -294,6 +294,11 @@ desktop_node_and_view_at(struct server *server, double lx, double ly,
 			if (desc->type == LAB_NODE_DESC_XDG_POPUP) {
 				goto has_view_data;
 			}
+			if (desc->type == LAB_NODE_DESC_LAYER_SURFACE) {
+				/* FIXME: we shouldn't have to set *view_area */
+				*view_area = LAB_SSD_CLIENT;
+				return NULL;
+			}
 			if (desc->type == LAB_NODE_DESC_LAYER_POPUP) {
 				/* FIXME: we shouldn't have to set *view_area */
 				*view_area = LAB_SSD_CLIENT;


### PR DESCRIPTION
\+ Replace some tabs with spaces in `include/node.h`

Fixes: #278

Only tested with `gtk-layer-demo` but that turned from not-working into working so I expect `wapanel` to be fixed as well.


This PR uncovered two more issues with the previous cursor fix:
- with this PR we now have a (layer) surface without view which segfaults when doing the out-of-surface-thingie with a layer surface (as we are using the `view` geometry)
- when out-of-surface, we don't actually send the button release event to the correct surface which in case of the gtk-layer-demo causes the respective button to trigger continuously

For this reason I'll put the PR into draft mode until the two new issues are fixed.
