### PR TITLE
out-of-surface fixes, the 187th edition

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -297,13 +297,17 @@ process_cursor_motion(struct server *server, uint32_t time)
 			server->seat.pressed.surface != surface &&
 			!server->seat.drag_icon) {
 		/*
-		 * Button has been pressed while over a view surface
+		 * Button has been pressed while over another surface
 		 * and is still held down. Just send the adjusted motion
 		 * events to the focused surface so we can keep scrolling
 		 * or selecting text even if the cursor moves outside of
 		 * the surface.
 		 */
 		view = server->seat.pressed.view;
+		if (!view) {
+			/* Button press originated on a layer surface, just ignore */
+			return;
+		}
 		sx = server->seat.cursor->x - view->x;
 		sy = server->seat.cursor->y - view->y;
 		sx = sx < 0 ? 0 : (sx > view->w ? view->w : sx);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -716,9 +716,18 @@ cursor_button(struct wl_listener *listener, void *data)
 
 	/* handle _release_ */
 	if (event->state == WLR_BUTTON_RELEASED) {
-		server->seat.pressed.view = NULL;
-		server->seat.pressed.surface = NULL;
-
+		seat->pressed.view = NULL;
+		if (seat->pressed.surface && seat->pressed.surface != surface) {
+			/*
+			 * Button released but originally pressed over a different surface.
+			 * Just send the release event to the still focused surface.
+			 */
+			wlr_seat_pointer_notify_button(seat->seat, event->time_msec,
+				event->button, event->state);
+			seat->pressed.surface = NULL;
+			return;
+		}
+		seat->pressed.surface = NULL;
 		if (server->input_mode == LAB_INPUT_STATE_MENU) {
 			if (close_menu) {
 				if (server->menu_current) {
@@ -752,7 +761,7 @@ cursor_button(struct wl_listener *listener, void *data)
 	}
 
 	/* Handle _press */
-	if (view_area == LAB_SSD_CLIENT) {
+	if (surface) {
 		server->seat.pressed.view = view;
 		server->seat.pressed.surface = surface;
 	}


### PR DESCRIPTION
- src/cursor.c: Ensure we send a release event for out-of-surface scrollng
- src/cursor.c: Ignore out-of-surface movement for surfaces without views

This is also in preparation for #342 