### PR TITLE
Various smallish fixes

### DIFF
--- a/src/common/font.c
+++ b/src/common/font.c
@@ -74,6 +74,11 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	}
 	/* TODO: scale */
 	*buffer = buffer_create_cairo(rect.width, rect.height, 1, true);
+	if (!*buffer) {
+		wlr_log(WLR_ERROR, "Failed to create font buffer of size %dx%d",
+			rect.width, rect.height);
+		return;
+	}
 
 	cairo_t *cairo = (*buffer)->cairo;
 	cairo_surface_t *surf = cairo_get_target(cairo);

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -103,6 +103,19 @@ item_create(struct menu *menu, const char *text)
 		text, &font, theme->menu_items_text_color);
 	font_buffer_create(&menuitem->selected.buffer, item_max_width,
 		text, &font, theme->menu_items_active_text_color);
+	if (!menuitem->normal.buffer || !menuitem->selected.buffer) {
+		wlr_log(WLR_ERROR, "Failed to create menu item '%s'", text);
+		if (menuitem->normal.buffer) {
+			wlr_buffer_drop(&menuitem->normal.buffer->base);
+			menuitem->normal.buffer = NULL;
+		}
+		if (menuitem->selected.buffer) {
+			wlr_buffer_drop(&menuitem->selected.buffer->base);
+			menuitem->selected.buffer = NULL;
+		}
+		free(menuitem);
+		return NULL;
+	}
 
 	/* Item background nodes */
 	menuitem->normal.background = &wlr_scene_rect_create(parent,

--- a/src/osd.c
+++ b/src/osd.c
@@ -103,6 +103,8 @@ osd_update(struct server *server)
 
 	struct theme *theme = server->theme;
 
+	struct buf buf;
+	buf_init(&buf);
 	struct output *output;
 	wl_list_for_each(output, &server->outputs, link) {
 		destroy_osd_nodes(output);
@@ -168,10 +170,7 @@ osd_update(struct server *server)
 
 		pango_cairo_update_layout(cairo, layout);
 
-		struct buf buf;
-		buf_init(&buf);
 		y = OSD_BORDER_WIDTH;
-
 		y += (OSD_ITEM_HEIGHT - font_height(&font)) / 2;
 
 		wl_list_for_each(view, &server->views, link) {
@@ -221,4 +220,5 @@ osd_update(struct server *server)
 		wlr_scene_node_set_position(&scene_buffer->node, lx, ly);
 		wlr_scene_node_set_enabled(&output->osd_tree->node, true);
 	}
+	free(buf.buf);
 }

--- a/src/theme.c
+++ b/src/theme.c
@@ -493,5 +493,12 @@ theme_init(struct theme *theme, const char *theme_name)
 void
 theme_finish(struct theme *theme)
 {
-	; /* nothing to free */
+	wlr_buffer_drop(&theme->corner_top_left_active_normal->base);
+	wlr_buffer_drop(&theme->corner_top_left_inactive_normal->base);
+	wlr_buffer_drop(&theme->corner_top_right_active_normal->base);
+	wlr_buffer_drop(&theme->corner_top_right_inactive_normal->base);
+	theme->corner_top_left_active_normal = NULL;
+	theme->corner_top_left_inactive_normal = NULL;
+	theme->corner_top_right_active_normal = NULL;
+	theme->corner_top_right_inactive_normal = NULL;
 }


### PR DESCRIPTION
Various smallish fixes

When using a font size of 0, random stuff starts exploding so I tried to fix that in two commits:
- [[wip] deal with font_buffer creation failures](https://github.com/labwc/labwc/commit/be28373cda704e6f0e70365e3e7016f65a2f8f5e)
  This commit deals in a general way with errors from creating a font_buffer.
- [[wip] font_buffer_create: clamp size](https://github.com/labwc/labwc/commit/16bf2f85e8e1e52d36276b88bf8f48f74cce0a23)
  This commit prevents creating font_buffers with a size < 1x1 so it shouldn't actually trigger above fallback paths.

Before merging these two commits I'd welcome some second opinions.

Also: some memory leak fixes
- [src/osd.c: Free buf.buf as its malloc'd in buf_init()](https://github.com/labwc/labwc/commit/b078bc95911a77f857a3226f047e7a5345efc074)
- [src/theme.c: Clean up corner buffers on finish](https://github.com/labwc/labwc/commit/5d43a2c161337f24dcbafc049dda63cd3cd8c95e) (`wlr_log()` will be removed before merging)