### PR TITLE
[v0.5] Next batch of backports 

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -8,7 +8,7 @@ labwc - actions
 
 Actions are used in keyboard bindings.
 
-*<action name="Close"><command>*
+*<action name="Close">*
 	Close top-most view.
 
 *<action name="Execute"><command>*

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -310,6 +310,7 @@ struct view {
 	struct wl_listener set_title;
 	struct wl_listener set_app_id;		/* class on xwayland */
 	struct wl_listener set_decorations;	/* xwayland only */
+	struct wl_listener override_redirect;	/* xwayland only */
 	struct wl_listener new_popup;		/* xdg-shell only */
 	struct wl_listener new_subsurface;	/* xdg-shell only */
 };
@@ -372,8 +373,9 @@ void xdg_surface_new(struct wl_listener *listener, void *data);
 
 #if HAVE_XWAYLAND
 void xwayland_surface_new(struct wl_listener *listener, void *data);
-void xwayland_unmanaged_create(struct server *server,
+struct xwayland_unmanaged *xwayland_unmanaged_create(struct server *server,
 	struct wlr_xwayland_surface *xsurface);
+void unmanaged_handle_map(struct wl_listener *listener, void *data);
 #endif
 
 void view_child_init(struct view_child *child, struct view *view,

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -56,6 +56,17 @@ unmanaged_handle_unmap(struct wl_listener *listener, void *data)
 
 	struct seat *seat = &unmanaged->server->seat;
 	if (seat->seat->keyboard_state.focused_surface == xsurface->surface) {
+		/*
+		 * Try to focus on parent surface
+		 * This seems to fix JetBrains/Intellij window focus issues
+		 */
+		if (xsurface->parent && xsurface->parent->surface
+				&& wlr_xwayland_or_surface_wants_focus(xsurface->parent)) {
+			seat_focus_surface(seat, xsurface->parent->surface);
+			return;
+		}
+
+		/* Try to focus on last created unmanaged xwayland surface */
 		struct xwayland_unmanaged *u;
 		struct wl_list *list = &unmanaged->server->unmanaged_surfaces;
 		wl_list_for_each (u, list, link) {

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -23,7 +23,7 @@ unmanaged_handle_commit(struct wl_listener *listener, void *data)
 	damage_all_outputs(unmanaged->server);
 }
 
-static void
+void
 unmanaged_handle_map(struct wl_listener *listener, void *data)
 {
 	struct xwayland_unmanaged *unmanaged =
@@ -91,7 +91,7 @@ unmanaged_handle_destroy(struct wl_listener *listener, void *data)
 	free(unmanaged);
 }
 
-void
+struct xwayland_unmanaged *
 xwayland_unmanaged_create(struct server *server,
 			  struct wlr_xwayland_surface *xsurface)
 {
@@ -109,4 +109,5 @@ xwayland_unmanaged_create(struct server *server,
 	unmanaged->unmap.notify = unmanaged_handle_unmap;
 	wl_signal_add(&xsurface->events.destroy, &unmanaged->destroy);
 	unmanaged->destroy.notify = unmanaged_handle_destroy;
+	return unmanaged;
 }

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -96,10 +96,19 @@ handle_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&view->link);
 	wl_list_remove(&view->map.link);
 	wl_list_remove(&view->unmap.link);
-	wl_list_remove(&view->destroy.link);
+	wl_list_remove(&view->request_move.link);
+	wl_list_remove(&view->request_resize.link);
 	wl_list_remove(&view->request_configure.link);
+	wl_list_remove(&view->request_activate.link);
+	wl_list_remove(&view->request_minimize.link);
 	wl_list_remove(&view->request_maximize.link);
 	wl_list_remove(&view->request_fullscreen.link);
+	wl_list_remove(&view->set_title.link);
+	wl_list_remove(&view->set_app_id.link);
+	wl_list_remove(&view->set_decorations.link);
+	wl_list_remove(&view->override_redirect.link);
+	wl_list_remove(&view->destroy.link);
+
 	ssd_destroy(view);
 	free(view);
 }
@@ -241,6 +250,25 @@ handle_set_decorations(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, set_decorations);
 	view_set_decorations(view, want_deco(view));
+}
+
+static void
+handle_override_redirect(struct wl_listener *listener, void *data)
+{
+	struct view *view = wl_container_of(listener, view, override_redirect);
+	struct wlr_xwayland_surface *xsurface = data;
+	struct server *server = view->server;
+	bool mapped = xsurface->mapped;
+	if (mapped) {
+		handle_unmap(&view->unmap, NULL);
+	}
+	handle_destroy(&view->destroy, view);
+	xsurface->data = NULL;
+	struct xwayland_unmanaged *unmanaged =
+		xwayland_unmanaged_create(server, xsurface);
+	if (mapped) {
+		unmanaged_handle_map(&unmanaged->map, xsurface);
+	}
 }
 
 static void
@@ -414,6 +442,10 @@ xwayland_surface_new(struct wl_listener *listener, void *data)
 	view->set_decorations.notify = handle_set_decorations;
 	wl_signal_add(&xsurface->events.set_decorations,
 			&view->set_decorations);
+
+	view->override_redirect.notify = handle_override_redirect;
+	wl_signal_add(&xsurface->events.set_override_redirect,
+			&view->override_redirect);
 
 	wl_list_insert(&view->server->views, &view->link);
 }


### PR DESCRIPTION
Welcome back an [old friend](https://github.com/labwc/labwc/commit/ba4615d7add51e51df396f0894f4d6ab8185ae26):
![gitk](https://user-images.githubusercontent.com/35009135/171619685-32bb701a-c64e-4833-ad7f-26588dfb6404.png)

So, some more backports for 0.5:
- [xwayland-unmanaged: focus parent surface on unmap](https://github.com/labwc/labwc/commit/0c9d47e56f2412d1b3e0fdfc097856c5ccc491ce)
- [xwayland: handle set_override_redirect events](https://github.com/labwc/labwc/commit/ba4615d7add51e51df396f0894f4d6ab8185ae26)
- [labwc-action(5): remove incorrect \<command\>](https://github.com/labwc/labwc/commit/9bc92381828e8882c0a629e5cc4031bd895e8f4a)
- [xwayland: call foreign-toplevel-destroy on unmap](https://github.com/labwc/labwc/commit/ff7de832ae350e1ed019be4709220c64c16528e9)