### PR TITLE
Prevent missing direction arguments to segfault labwc

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -174,10 +174,18 @@ actions_run(struct view *activator, struct server *server,
 			wl_display_terminate(server->wl_display);
 			break;
 		case ACTION_TYPE_MOVE_TO_EDGE:
-			view_move_to_edge(view, action->arg);
+			if (action->arg) {
+				view_move_to_edge(view, action->arg);
+			} else {
+				wlr_log(WLR_ERROR, "Missing argument for MoveToEdge");
+			}
 			break;
 		case ACTION_TYPE_SNAP_TO_EDGE:
-			view_snap_to_edge(view, action->arg);
+			if (action->arg) {
+				view_snap_to_edge(view, action->arg);
+			} else {
+				wlr_log(WLR_ERROR, "Missing argument for SnapToEdge");
+			}
 			break;
 		case ACTION_TYPE_NEXT_WINDOW:
 			server->cycle_view = desktop_cycle_view(server,

--- a/src/view.c
+++ b/src/view.c
@@ -460,6 +460,10 @@ view_move_to_edge(struct view *view, const char *direction)
 		wlr_log(WLR_ERROR, "no output");
 		return;
 	}
+	if (!direction) {
+		wlr_log(WLR_ERROR, "invalid edge");
+		return;
+	}
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
 	if (usable.height == output->wlr_output->height
 			&& output->wlr_output->scale != 1) {
@@ -485,6 +489,9 @@ view_move_to_edge(struct view *view, const char *direction)
 		x = view->x;
 		y = usable.y + usable.height - view->h - view->margin.bottom
 			- rc.gap;
+	} else {
+		wlr_log(WLR_ERROR, "invalid edge");
+		return;
 	}
 	view_move(view, x, y);
 }
@@ -521,6 +528,9 @@ view_edge_invert(enum view_edge edge)
 static enum view_edge
 view_edge_parse(const char *direction)
 {
+	if (!direction) {
+		return VIEW_EDGE_INVALID;
+	}
 	if (!strcasecmp(direction, "left")) {
 		return VIEW_EDGE_LEFT;
 	} else if (!strcasecmp(direction, "up")) {


### PR DESCRIPTION
Reported-by: @Flrian (thanks!)

I basically "double fixed" it by having our internal API check if the arg is `NULL` and also by having `actions.c` check it and then not even call our internal API. So we could replace the internal API checks with asserts() instead.

I am not sure about the best design / solution here.