### PR TITLE
src/config/keybind.c: fix keybind insertion order

### DIFF
--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -59,7 +59,7 @@ keybind_create(const char *keybind)
 	if (!k) {
 		return NULL;
 	}
-	wl_list_insert(&rc.keybinds, &k->link);
+	wl_list_insert(rc.keybinds.prev, &k->link);
 	k->keysyms = malloc(k->keysyms_len * sizeof(xkb_keysym_t));
 	memcpy(k->keysyms, keysyms, k->keysyms_len * sizeof(xkb_keysym_t));
 	wl_list_init(&k->actions);


### PR DESCRIPTION
This restores the intended behavior of keybinds set by `<default />`
to be overwritten by manually configured keybinds which come later in
the config.

In `src/keyboard.c`, `handle_keybinding()` is going backwards through
the list of keybindings and breaks after the first match.

`wl_list_insert(&list_node, item)` will insert the new item \*after\* the
`list_node` so if its called multiple times with the same `list_node` as
fist argument the result will be a reversed list. Using `list_node.prev`
instead will result in a non-reversed list.