### PR TITLE
xwayland-unmanaged: put all surfaces under server->unmanaged_tree

### DIFF
--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -22,22 +22,6 @@ unmanaged_handle_commit(struct wl_listener *listener, void *data)
 	unmanaged->ly = xsurface->y;
 }
 
-static struct view *
-parent_view(struct server *server, struct wlr_xwayland_surface *surface)
-{
-	struct wlr_xwayland_surface *s = surface;
-	while (s->parent) {
-		s = s->parent;
-	}
-	struct view *view;
-	wl_list_for_each(view, &server->views, link) {
-		if (view->xwayland_surface == s) {
-			return view;
-		}
-	}
-	return NULL;
-}
-
 void
 unmanaged_handle_map(struct wl_listener *listener, void *data)
 {
@@ -57,20 +41,11 @@ unmanaged_handle_map(struct wl_listener *listener, void *data)
 		seat_focus_surface(&unmanaged->server->seat, xsurface->surface);
 	}
 
-	int lx = unmanaged->lx;
-	int ly = unmanaged->ly;
-	struct wlr_scene_node *parent, *node;
-	struct view *view = parent_view(unmanaged->server, xsurface);
-	if (!view || !view->scene_node) {
-		parent = &unmanaged->server->unmanaged_tree->node;
-	} else {
-		lx -= view->x;
-		ly -= view->y;
-		parent = &view->scene_tree->node;
-	}
 	/* node will be destroyed automatically once surface is destroyed */
-	node = &wlr_scene_surface_create(parent, xsurface->surface)->buffer->node;
-	wlr_scene_node_set_position(node, lx, ly);
+	struct wlr_scene_node *node = &wlr_scene_surface_create(
+			&unmanaged->server->unmanaged_tree->node,
+			xsurface->surface)->buffer->node;
+	wlr_scene_node_set_position(node, unmanaged->lx, unmanaged->ly);
 }
 
 static void


### PR DESCRIPTION
...in order to render all unmanaged surfaces above views just like sway
does it:

https://github.com/swaywm/sway/blob/e5728052b59fb5b476c78c9f18b812a85d7f4503/sway/desktop/render.c#L1148

Fixes issue #367