### PR TITLE
Chase wlroots: upstream scene_node refactoring

### DIFF
--- a/include/common/scene-helpers.h
+++ b/include/common/scene-helpers.h
@@ -3,4 +3,5 @@
 #include <wlr/types/wlr_scene.h>
 
 struct wlr_scene_rect *lab_wlr_scene_get_rect(struct wlr_scene_node *node);
+struct wlr_scene_tree *lab_scene_tree_from_node(struct wlr_scene_node *node);
 struct wlr_surface *lab_wlr_surface_from_node(struct wlr_scene_node *node);

--- a/include/layers.h
+++ b/include/layers.h
@@ -26,7 +26,7 @@ struct lab_layer_surface {
 
 struct lab_layer_popup {
 	struct wlr_xdg_popup *wlr_popup;
-	struct wlr_scene_node *scene_node;
+	struct wlr_scene_tree *scene_tree;
 
 	/* To simplify moving popup nodes from the bottom to the top layer */
 	struct wlr_box output_toplevel_sx_box;

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -16,6 +16,7 @@ enum menu_align {
 };
 
 struct menu_scene {
+	struct wlr_scene_tree *tree;
 	struct lab_data_buffer *buffer;
 	struct wlr_scene_node *text;
 	struct wlr_scene_node *background;
@@ -25,6 +26,7 @@ struct menuitem {
 	struct wl_list actions;
 	struct menu *parent;
 	struct menu *submenu;
+	struct wlr_scene_tree *tree;
 	struct menu_scene normal;
 	struct menu_scene selected;
 	struct wl_list link; /* menu::menuitems */

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -150,18 +150,18 @@ struct ssd_part *add_scene_part(
 	struct wl_list *part_list, enum ssd_part_type type);
 struct ssd_part *add_scene_rect(
 	struct wl_list *list, enum ssd_part_type type,
-	struct wlr_scene_node *parent, int width, int height, int x, int y,
+	struct wlr_scene_tree *parent, int width, int height, int x, int y,
 	float color[4]);
 struct ssd_part *add_scene_buffer(
 	struct wl_list *list, enum ssd_part_type type,
-	struct wlr_scene_node *parent, struct wlr_buffer *buffer, int x, int y);
+	struct wlr_scene_tree *parent, struct wlr_buffer *buffer, int x, int y);
 struct ssd_part *add_scene_button(
 	struct wl_list *part_list, enum ssd_part_type type,
-	struct wlr_scene_node *parent, float *bg_color,
+	struct wlr_scene_tree *parent, float *bg_color,
 	struct wlr_buffer *icon_buffer, int x);
 struct ssd_part *add_scene_button_corner(
 	struct wl_list *part_list, enum ssd_part_type type,
-	struct wlr_scene_node *parent, struct wlr_buffer *corner_buffer,
+	struct wlr_scene_tree *parent, struct wlr_buffer *corner_buffer,
 	struct wlr_buffer *icon_buffer, int x);
 
 /* SSD internal helpers */

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -10,6 +10,13 @@ lab_wlr_scene_get_rect(struct wlr_scene_node *node)
 	return (struct wlr_scene_rect *)node;
 }
 
+struct wlr_scene_tree *
+lab_scene_tree_from_node(struct wlr_scene_node *node)
+{
+	assert(node->type == WLR_SCENE_NODE_TREE);
+	return (struct wlr_scene_tree *)node;
+}
+
 struct wlr_surface *
 lab_wlr_surface_from_node(struct wlr_scene_node *node)
 {

--- a/src/debug.c
+++ b/src/debug.c
@@ -172,10 +172,14 @@ dump_tree(struct server *server, struct wlr_scene_node *node,
 		printf("%*c%s\n", pos + 4 + INDENT_SIZE, ' ', "<skipping children>");
 		return;
 	}
-	struct wlr_scene_node *child;
-	wl_list_for_each(child, &node->children, link) {
-		dump_tree(server, child, pos + INDENT_SIZE,
-			x + child->x, y + child->y);
+
+	if (node->type == WLR_SCENE_NODE_TREE) {
+		struct wlr_scene_node *child;
+		struct wlr_scene_tree *tree = lab_scene_tree_from_node(node);
+		wl_list_for_each(child, &tree->children, link) {
+			dump_tree(server, child, pos + INDENT_SIZE,
+				x + child->x, y + child->y);
+		}
 	}
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -93,7 +93,7 @@ get_special(struct server *server, struct wlr_scene_node *node,
 	if (node == &server->menu_tree->node) {
 		return "server->menu_tree";
 	}
-	if (node->parent == &server->scene->tree.node) {
+	if (node->parent == &server->scene->tree) {
 		struct output *output;
 		wl_list_for_each(output, &server->outputs, link) {
 			if (node == &output->osd_tree->node) {
@@ -117,9 +117,8 @@ get_special(struct server *server, struct wlr_scene_node *node,
 	if (node == &server->view_tree_always_on_top->node) {
 		return "server->view_tree_always_on_top";
 	}
-	if (node->parent == &server->view_tree->node ||
-			node->parent == &server->view_tree_always_on_top->node) {
-		*last_view = node_view_from_node(node);
+	if (node->parent == server->view_tree ||
+			node->parent == server->view_tree_always_on_top) {
 		*last_view = node_view_from_node(node);
 	}
 	const char *view_part = get_view_part(*last_view, node);

--- a/src/debug.c
+++ b/src/debug.c
@@ -17,9 +17,10 @@ static const char *
 get_node_type(struct wlr_scene_node *node)
 {
 	switch (node->type) {
-	case WLR_SCENE_NODE_ROOT:
-		return "root";
 	case WLR_SCENE_NODE_TREE:
+		if (!node->parent) {
+			return "root";
+		}
 		return "tree";
 	case WLR_SCENE_NODE_RECT:
 		return "rect";
@@ -86,13 +87,13 @@ static const char *
 get_special(struct server *server, struct wlr_scene_node *node,
 	struct view **last_view)
 {
-	if (node == &server->scene->node) {
+	if (node == &server->scene->tree.node) {
 		return "server->scene";
 	}
 	if (node == &server->menu_tree->node) {
 		return "server->menu_tree";
 	}
-	if (node->parent == &server->scene->node) {
+	if (node->parent == &server->scene->tree.node) {
 		struct output *output;
 		wl_list_for_each(output, &server->outputs, link) {
 			if (node == &output->osd_tree->node) {
@@ -183,6 +184,6 @@ void
 debug_dump_scene(struct server *server)
 {
 	printf("\n");
-	dump_tree(server, &server->scene->node, 0, 0, 0);
+	dump_tree(server, &server->scene->tree.node, 0, 0, 0);
 	printf("\n");
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -173,9 +173,9 @@ dump_tree(struct server *server, struct wlr_scene_node *node,
 		return;
 	}
 	struct wlr_scene_node *child;
-	wl_list_for_each(child, &node->state.children, state.link) {
+	wl_list_for_each(child, &node->children, link) {
 		dump_tree(server, child, pos + INDENT_SIZE,
-			x + child->state.x, y + child->state.y);
+			x + child->x, y + child->y);
 	}
 }
 

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -264,7 +264,7 @@ desktop_node_and_view_at(struct server *server, double lx, double ly,
 		enum ssd_part_type *view_area)
 {
 	struct wlr_scene_node *node =
-		wlr_scene_node_at(&server->scene->node, lx, ly, sx, sy);
+		wlr_scene_node_at(&server->scene->tree.node, lx, ly, sx, sy);
 
 	*scene_node = node;
 	if (!node) {

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -278,7 +278,7 @@ desktop_node_and_view_at(struct server *server, double lx, double ly,
 			return NULL;
 		}
 #if HAVE_XWAYLAND
-		if (node->parent == &server->unmanaged_tree->node) {
+		if (node->parent == server->unmanaged_tree) {
 			*view_area = LAB_SSD_UNMANAGED;
 			return NULL;
 		}
@@ -311,7 +311,8 @@ desktop_node_and_view_at(struct server *server, double lx, double ly,
 				return NULL;
 			}
 		}
-		node = node->parent;
+		/* node->parent is always a *wlr_scene_tree */
+		node = node->parent ? &node->parent->node : NULL;
 	}
 	if (!node) {
 		wlr_log(WLR_ERROR, "Unknown node detected");

--- a/src/layers.c
+++ b/src/layers.c
@@ -230,8 +230,8 @@ move_popup_to_top_layer(struct lab_layer_surface *toplevel,
 	struct output *output = output_from_wlr_output(server, wlr_output);
 	struct wlr_box box = { 0 };
 	wlr_output_layout_get_box(server->output_layout, wlr_output, &box);
-	int lx = toplevel->scene_layer_surface->tree->node.state.x + box.x;
-	int ly = toplevel->scene_layer_surface->tree->node.state.y + box.y;
+	int lx = toplevel->scene_layer_surface->tree->node.x + box.x;
+	int ly = toplevel->scene_layer_surface->tree->node.y + box.y;
 
 	struct wlr_scene_node *node = &popup->scene_tree->node;
 	wlr_scene_node_reparent(node, output->layer_popup_tree);

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -435,7 +435,7 @@ menu_configure(struct menu *menu, int lx, int ly, enum menu_align align)
 		} else {
 			new_lx = lx;
 		}
-		rel_y = item->tree->node.state.y;
+		rel_y = item->tree->node.y;
 		new_ly = ly + rel_y - theme->menu_overlap_y;
 		menu_configure(item->submenu, new_lx, new_ly, align);
 	}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -54,7 +54,7 @@ menu_create(struct server *server, const char *id, const char *label)
 	menu->server = server;
 	menu->size.width = MENUWIDTH;
 	/* menu->size.height will be kept up to date by adding items */
-	menu->scene_tree = wlr_scene_tree_create(&server->menu_tree->node);
+	menu->scene_tree = wlr_scene_tree_create(server->menu_tree);
 	wlr_scene_node_set_enabled(&menu->scene_tree->node, false);
 	return menu;
 }
@@ -117,29 +117,29 @@ item_create(struct menu *menu, const char *text)
 	}
 
 	/* Menu item root node */
-	menuitem->tree = wlr_scene_tree_create(&menu->scene_tree->node);
+	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
 	node_descriptor_create(&menuitem->tree->node,
 		LAB_NODE_DESC_MENUITEM, menuitem);
 
 	/* Tree for each state to hold background and text buffer */
-	menuitem->normal.tree = wlr_scene_tree_create(&menuitem->tree->node);
-	menuitem->selected.tree = wlr_scene_tree_create(&menuitem->tree->node);
+	menuitem->normal.tree = wlr_scene_tree_create(menuitem->tree);
+	menuitem->selected.tree = wlr_scene_tree_create(menuitem->tree);
 
 	/* Item background nodes */
 	menuitem->normal.background = &wlr_scene_rect_create(
-		&menuitem->normal.tree->node,
+		menuitem->normal.tree,
 		MENUWIDTH, menu->item_height,
 		theme->menu_items_bg_color)->node;
 	menuitem->selected.background = &wlr_scene_rect_create(
-		&menuitem->selected.tree->node,
+		menuitem->selected.tree,
 		MENUWIDTH, menu->item_height,
 		theme->menu_items_active_bg_color)->node;
 
 	/* Font nodes */
 	menuitem->normal.text = &wlr_scene_buffer_create(
-		&menuitem->normal.tree->node, &menuitem->normal.buffer->base)->node;
+		menuitem->normal.tree, &menuitem->normal.buffer->base)->node;
 	menuitem->selected.text = &wlr_scene_buffer_create(
-		&menuitem->selected.tree->node, &menuitem->selected.buffer->base)->node;
+		menuitem->selected.tree, &menuitem->selected.buffer->base)->node;
 
 	/* Center font nodes */
 	y = (menu->item_height - menuitem->normal.buffer->base.height) / 2;

--- a/src/osd.c
+++ b/src/osd.c
@@ -96,7 +96,7 @@ static void
 destroy_osd_nodes(struct output *output)
 {
 	struct wlr_scene_node *child, *next;
-	struct wl_list *children = &output->osd_tree->node.children;
+	struct wl_list *children = &output->osd_tree->children;
 	wl_list_for_each_safe(child, next, children, link) {
 		wlr_scene_node_destroy(child);
 	}

--- a/src/osd.c
+++ b/src/osd.c
@@ -224,7 +224,7 @@ osd_update(struct server *server)
 		cairo_surface_flush(surf);
 
 		struct wlr_scene_buffer *scene_buffer = wlr_scene_buffer_create(
-			&output->osd_tree->node, &output->osd_buffer->base);
+			output->osd_tree, &output->osd_buffer->base);
 
 		/* Center OSD */
 		struct wlr_box output_box;

--- a/src/osd.c
+++ b/src/osd.c
@@ -96,8 +96,8 @@ static void
 destroy_osd_nodes(struct output *output)
 {
 	struct wlr_scene_node *child, *next;
-	struct wl_list *children = &output->osd_tree->node.state.children;
-	wl_list_for_each_safe(child, next, children, state.link) {
+	struct wl_list *children = &output->osd_tree->node.children;
+	wl_list_for_each_safe(child, next, children, link) {
 		wlr_scene_node_destroy(child);
 	}
 }

--- a/src/output.c
+++ b/src/output.c
@@ -135,14 +135,14 @@ new_output_notify(struct wl_listener *listener, void *data)
 	for (int i = 0; i < nr_layers; i++) {
 		wl_list_init(&output->layers[i]);
 		output->layer_tree[i] =
-			wlr_scene_tree_create(&server->scene->node);
+			wlr_scene_tree_create(&server->scene->tree.node);
 		node_descriptor_create(&output->layer_tree[i]->node,
 			LAB_NODE_DESC_TREE, NULL);
 	}
-	output->layer_popup_tree = wlr_scene_tree_create(&server->scene->node);
+	output->layer_popup_tree = wlr_scene_tree_create(&server->scene->tree.node);
 	node_descriptor_create(&output->layer_popup_tree->node,
 		LAB_NODE_DESC_TREE, NULL);
-	output->osd_tree = wlr_scene_tree_create(&server->scene->node);
+	output->osd_tree = wlr_scene_tree_create(&server->scene->tree.node);
 	node_descriptor_create(&output->osd_tree->node,
 		LAB_NODE_DESC_TREE, NULL);
 

--- a/src/output.c
+++ b/src/output.c
@@ -135,14 +135,14 @@ new_output_notify(struct wl_listener *listener, void *data)
 	for (int i = 0; i < nr_layers; i++) {
 		wl_list_init(&output->layers[i]);
 		output->layer_tree[i] =
-			wlr_scene_tree_create(&server->scene->tree.node);
+			wlr_scene_tree_create(&server->scene->tree);
 		node_descriptor_create(&output->layer_tree[i]->node,
 			LAB_NODE_DESC_TREE, NULL);
 	}
-	output->layer_popup_tree = wlr_scene_tree_create(&server->scene->tree.node);
+	output->layer_popup_tree = wlr_scene_tree_create(&server->scene->tree);
 	node_descriptor_create(&output->layer_popup_tree->node,
 		LAB_NODE_DESC_TREE, NULL);
-	output->osd_tree = wlr_scene_tree_create(&server->scene->tree.node);
+	output->osd_tree = wlr_scene_tree_create(&server->scene->tree);
 	node_descriptor_create(&output->osd_tree->node,
 		LAB_NODE_DESC_TREE, NULL);
 

--- a/src/server.c
+++ b/src/server.c
@@ -238,12 +238,12 @@ server_init(struct server *server)
 		wlr_log(WLR_ERROR, "unable to create scene");
 		exit(EXIT_FAILURE);
 	}
-	server->view_tree = wlr_scene_tree_create(&server->scene->node);
-	server->view_tree_always_on_top = wlr_scene_tree_create(&server->scene->node);
+	server->view_tree = wlr_scene_tree_create(&server->scene->tree.node);
+	server->view_tree_always_on_top = wlr_scene_tree_create(&server->scene->tree.node);
 #if HAVE_XWAYLAND
-	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->node);
+	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->tree.node);
 #endif
-	server->menu_tree = wlr_scene_tree_create(&server->scene->node);
+	server->menu_tree = wlr_scene_tree_create(&server->scene->tree.node);
 
 	output_init(server);
 

--- a/src/server.c
+++ b/src/server.c
@@ -238,12 +238,12 @@ server_init(struct server *server)
 		wlr_log(WLR_ERROR, "unable to create scene");
 		exit(EXIT_FAILURE);
 	}
-	server->view_tree = wlr_scene_tree_create(&server->scene->tree.node);
-	server->view_tree_always_on_top = wlr_scene_tree_create(&server->scene->tree.node);
+	server->view_tree = wlr_scene_tree_create(&server->scene->tree);
+	server->view_tree_always_on_top = wlr_scene_tree_create(&server->scene->tree);
 #if HAVE_XWAYLAND
-	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->tree.node);
+	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->tree);
 #endif
-	server->menu_tree = wlr_scene_tree_create(&server->scene->tree.node);
+	server->menu_tree = wlr_scene_tree_create(&server->scene->tree);
 
 	output_init(server);
 

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -62,31 +62,31 @@ ssd_get_part_type(struct view *view, struct wlr_scene_node *node)
 	}
 
 	struct wl_list *part_list = NULL;
-	struct wlr_scene_node *grandparent =
-		node->parent ? node->parent->parent : NULL;
+	struct wlr_scene_tree *grandparent =
+		node->parent ? node->parent->node.parent : NULL;
 
 	/* active titlebar */
-	if (node->parent == &view->ssd.titlebar.active.tree->node) {
+	if (node->parent == view->ssd.titlebar.active.tree) {
 		part_list = &view->ssd.titlebar.active.parts;
-	} else if (grandparent == &view->ssd.titlebar.active.tree->node) {
+	} else if (grandparent == view->ssd.titlebar.active.tree) {
 		part_list = &view->ssd.titlebar.active.parts;
 
 	/* extents */
-	} else if (node->parent == &view->ssd.extents.tree->node) {
+	} else if (node->parent == view->ssd.extents.tree) {
 		part_list = &view->ssd.extents.parts;
 
 	/* active border */
-	} else if (node->parent == &view->ssd.border.active.tree->node) {
+	} else if (node->parent == view->ssd.border.active.tree) {
 		part_list = &view->ssd.border.active.parts;
 
 	/* inactive titlebar */
-	} else if (node->parent == &view->ssd.titlebar.inactive.tree->node) {
+	} else if (node->parent == view->ssd.titlebar.inactive.tree) {
 		part_list = &view->ssd.titlebar.inactive.parts;
-	} else if (grandparent == &view->ssd.titlebar.inactive.tree->node) {
+	} else if (grandparent == view->ssd.titlebar.inactive.tree) {
 		part_list = &view->ssd.titlebar.inactive.parts;
 
 	/* inactive border */
-	} else if (node->parent == &view->ssd.border.inactive.tree->node) {
+	} else if (node->parent == view->ssd.border.inactive.tree) {
 		part_list = &view->ssd.border.inactive.parts;
 	}
 
@@ -154,7 +154,7 @@ ssd_create(struct view *view)
 		return;
 	}
 
-	view->ssd.tree = wlr_scene_tree_create(&view->scene_tree->node);
+	view->ssd.tree = wlr_scene_tree_create(view->scene_tree);
 	wlr_scene_node_lower_to_bottom(&view->ssd.tree->node);
 	ssd_extents_create(view);
 	ssd_border_create(view);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -106,7 +106,7 @@ ssd_at(struct view *view, double lx, double ly)
 {
 	double sx, sy;
 	struct wlr_scene_node *node = wlr_scene_node_at(
-		&view->server->scene->node, lx, ly, &sx, &sy);
+		&view->server->scene->tree.node, lx, ly, &sx, &sy);
 	return ssd_get_part_type(view, node);
 }
 

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -169,11 +169,11 @@ ssd_update_geometry(struct view *view)
 	}
 
 	if (!view->ssd.enabled) {
-		if (view->ssd.tree->node.state.enabled) {
+		if (view->ssd.tree->node.enabled) {
 			wlr_scene_node_set_enabled(&view->ssd.tree->node, false);
 		}
 		return;
-	} else if (!view->ssd.tree->node.state.enabled) {
+	} else if (!view->ssd.tree->node.enabled) {
 		wlr_scene_node_set_enabled(&view->ssd.tree->node, true);
 	}
 

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -18,18 +18,18 @@ ssd_border_create(struct view *view)
 	int full_width = width + 2 * theme->border_width;
 
 	float *color;
-	struct wlr_scene_node *parent;
+	struct wlr_scene_tree *parent;
 	struct ssd_sub_tree *subtree;
 
 	FOR_EACH_STATE(view, subtree) {
-		subtree->tree = wlr_scene_tree_create(&view->ssd.tree->node);
-		parent = &subtree->tree->node;
-		wlr_scene_node_set_position(parent, -theme->border_width, 0);
+		subtree->tree = wlr_scene_tree_create(view->ssd.tree);
+		parent = subtree->tree;
+		wlr_scene_node_set_position(&parent->node, -theme->border_width, 0);
 		if (subtree == &view->ssd.border.active) {
 			color = theme->window_active_border_color;
 		} else {
 			color = theme->window_inactive_border_color;
-			wlr_scene_node_set_enabled(parent, false);
+			wlr_scene_node_set_enabled(&parent->node, false);
 		}
 		wl_list_init(&subtree->parts);
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_LEFT, parent,

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -99,7 +99,7 @@ ssd_extents_update(struct view *view)
 		wlr_scene_node_set_enabled(&view->ssd.extents.tree->node, false);
 		return;
 	}
-	if (!view->ssd.extents.tree->node.state.enabled) {
+	if (!view->ssd.extents.tree->node.enabled) {
 		wlr_scene_node_set_enabled(&view->ssd.extents.tree->node, true);
 	}
 
@@ -177,7 +177,7 @@ ssd_extents_update(struct view *view)
 			/* Not visible */
 			wlr_scene_node_set_enabled(part->node, false);
 			continue;
-		} else if (!part->node->state.enabled) {
+		} else if (!part->node->enabled) {
 			wlr_scene_node_set_enabled(part->node, true);
 		}
 
@@ -193,8 +193,8 @@ ssd_extents_update(struct view *view)
 		}
 
 		/* Fully visible */
-		if (target->x != part->node->state.x
-				|| target->y != part->node->state.y) {
+		if (target->x != part->node->x
+				|| target->y != part->node->y) {
 			wlr_scene_node_set_position(part->node, target->x, target->y);
 		}
 		if (target->width != rect->width || target->height != rect->height) {

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -7,7 +7,7 @@
 
 static struct ssd_part *
 add_extent(struct wl_list *part_list, enum ssd_part_type type,
-		struct wlr_scene_node *parent)
+		struct wlr_scene_tree *parent)
 {
 	float invisible[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 	struct ssd_part *part = add_scene_part(part_list, type);
@@ -40,13 +40,14 @@ ssd_extents_create(struct view *view)
 	int extended_area = EXTENDED_AREA;
 	int corner_size = extended_area + theme->border_width + BUTTON_WIDTH / 2;
 
-	view->ssd.extents.tree = wlr_scene_tree_create(&view->ssd.tree->node);
-	struct wlr_scene_node *parent = &view->ssd.extents.tree->node;
+	view->ssd.extents.tree = wlr_scene_tree_create(view->ssd.tree);
+	struct wlr_scene_tree *parent = view->ssd.extents.tree;
 	if (view->maximized || view->fullscreen) {
-		wlr_scene_node_set_enabled(parent, false);
+		wlr_scene_node_set_enabled(&parent->node, false);
 	}
 	wl_list_init(&view->ssd.extents.parts);
-	wlr_scene_node_set_position(parent, -(theme->border_width + extended_area),
+	wlr_scene_node_set_position(&parent->node,
+		-(theme->border_width + extended_area),
 		-(theme->title_height + theme->border_width + extended_area));
 
 	/* Initialize parts and set constant values for targeted geometry */

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -52,22 +52,14 @@ finish_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 	float hover_bg[4] = {0.15f, 0.15f, 0.15f, 0.3f};
 
 	/* Icon */
-	int offset_y = 0;
-	int offset_x = 0;
-	if (type == LAB_SSD_BUTTON_WINDOW_MENU) {
-		offset_y = rc.theme->border_width;
-		offset_x = rc.theme->border_width;
-	} else if (type == LAB_SSD_BUTTON_CLOSE) {
-		offset_y = rc.theme->border_width;
-	}
 	add_scene_buffer(part_list, type, parent, icon_buffer,
-		offset_x + (BUTTON_WIDTH - icon_buffer->width) / 2,
-		offset_y + (rc.theme->title_height - icon_buffer->height) / 2);
+		(BUTTON_WIDTH - icon_buffer->width) / 2,
+		(rc.theme->title_height - icon_buffer->height) / 2);
 
 	/* Hover overlay */
 	struct ssd_part *hover_part;
 	hover_part = add_scene_rect(part_list, type, parent, BUTTON_WIDTH,
-		rc.theme->title_height, offset_x, offset_y, hover_bg);
+		rc.theme->title_height, 0, 0, hover_bg);
 	wlr_scene_node_set_enabled(hover_part->node, false);
 }
 
@@ -76,14 +68,28 @@ add_scene_button_corner(struct wl_list *part_list, enum ssd_part_type type,
 	struct wlr_scene_node *parent, struct wlr_buffer *corner_buffer,
 	struct wlr_buffer *icon_buffer, int x)
 {
+	struct ssd_part *button_root = add_scene_part(part_list, type);
+	parent = &wlr_scene_tree_create(parent)->node;
+	button_root->node = parent;
+	wlr_scene_node_set_position(button_root->node, x, 0);
+
+	int offset_x;
+	if (type == LAB_SSD_BUTTON_WINDOW_MENU) {
+		offset_x = rc.theme->border_width;
+	} else if (type == LAB_SSD_BUTTON_CLOSE) {
+		offset_x = 0;
+	} else {
+		assert(false && "invalid corner button type");
+	}
+
 	struct ssd_part *part;
 	/*
 	 * Background, y adjusted for border_width which is
 	 * already included in rendered theme.c / corner_buffer
 	 */
 	part = add_scene_buffer(part_list, type, parent, corner_buffer,
-		x, -rc.theme->border_width);
-	finish_scene_button(part_list, type, part->node, icon_buffer);
+		-offset_x, -rc.theme->border_width);
+	finish_scene_button(part_list, type, parent, icon_buffer);
 	return part;
 }
 
@@ -92,11 +98,16 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 	struct wlr_scene_node *parent, float *bg_color,
 	struct wlr_buffer *icon_buffer, int x)
 {
+	struct ssd_part *button_root = add_scene_part(part_list, type);
+	parent = &wlr_scene_tree_create(parent)->node;
+	button_root->node = parent;
+	wlr_scene_node_set_position(button_root->node, x, 0);
+
 	struct ssd_part *part;
 	/* Background */
 	part = add_scene_rect(part_list, type, parent,
-		BUTTON_WIDTH, rc.theme->title_height, x, 0, bg_color);
-	finish_scene_button(part_list, type, part->node, icon_buffer);
+		BUTTON_WIDTH, rc.theme->title_height, 0, 0, bg_color);
+	finish_scene_button(part_list, type, parent, icon_buffer);
 	return part;
 }
 

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -15,7 +15,7 @@ add_scene_part(struct wl_list *part_list, enum ssd_part_type type)
 
 struct ssd_part *
 add_scene_rect(struct wl_list *list, enum ssd_part_type type,
-	struct wlr_scene_node *parent, int width, int height,
+	struct wlr_scene_tree *parent, int width, int height,
 	int x, int y, float color[4])
 {
 	/*
@@ -36,7 +36,7 @@ add_scene_rect(struct wl_list *list, enum ssd_part_type type,
 
 struct ssd_part *
 add_scene_buffer(struct wl_list *list, enum ssd_part_type type,
-	struct wlr_scene_node *parent, struct wlr_buffer *buffer,
+	struct wlr_scene_tree *parent, struct wlr_buffer *buffer,
 	int x, int y)
 {
 	struct ssd_part *part = add_scene_part(list, type);
@@ -47,7 +47,7 @@ add_scene_buffer(struct wl_list *list, enum ssd_part_type type,
 
 static void
 finish_scene_button(struct wl_list *part_list, enum ssd_part_type type,
-	struct wlr_scene_node *parent, struct wlr_buffer *icon_buffer)
+	struct wlr_scene_tree *parent, struct wlr_buffer *icon_buffer)
 {
 	float hover_bg[4] = {0.15f, 0.15f, 0.15f, 0.3f};
 
@@ -65,12 +65,12 @@ finish_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 
 struct ssd_part *
 add_scene_button_corner(struct wl_list *part_list, enum ssd_part_type type,
-	struct wlr_scene_node *parent, struct wlr_buffer *corner_buffer,
+	struct wlr_scene_tree *parent, struct wlr_buffer *corner_buffer,
 	struct wlr_buffer *icon_buffer, int x)
 {
 	struct ssd_part *button_root = add_scene_part(part_list, type);
-	parent = &wlr_scene_tree_create(parent)->node;
-	button_root->node = parent;
+	parent = wlr_scene_tree_create(parent);
+	button_root->node = &parent->node;
 	wlr_scene_node_set_position(button_root->node, x, 0);
 
 	int offset_x;
@@ -95,12 +95,12 @@ add_scene_button_corner(struct wl_list *part_list, enum ssd_part_type type,
 
 struct ssd_part *
 add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
-	struct wlr_scene_node *parent, float *bg_color,
+	struct wlr_scene_tree *parent, float *bg_color,
 	struct wlr_buffer *icon_buffer, int x)
 {
 	struct ssd_part *button_root = add_scene_part(part_list, type);
-	parent = &wlr_scene_tree_create(parent)->node;
-	button_root->node = parent;
+	parent = wlr_scene_tree_create(parent);
+	button_root->node = &parent->node;
 	wlr_scene_node_set_position(button_root->node, x, 0);
 
 	struct ssd_part *part;

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -20,15 +20,15 @@ ssd_titlebar_create(struct view *view)
 	int width = view->w;
 
 	float *color;
-	struct wlr_scene_node *parent;
+	struct wlr_scene_tree *parent;
 	struct wlr_buffer *corner_top_left;
 	struct wlr_buffer *corner_top_right;
 
 	struct ssd_sub_tree *subtree;
 	FOR_EACH_STATE(view, subtree) {
-		subtree->tree = wlr_scene_tree_create(&view->ssd.tree->node);
-		parent = &subtree->tree->node;
-		wlr_scene_node_set_position(parent, 0, -theme->title_height);
+		subtree->tree = wlr_scene_tree_create(view->ssd.tree);
+		parent = subtree->tree;
+		wlr_scene_node_set_position(&parent->node, 0, -theme->title_height);
 		if (subtree == &view->ssd.titlebar.active) {
 			color = theme->window_active_title_bg_color;
 			corner_top_left = &theme->corner_top_left_active_normal->base;
@@ -37,7 +37,7 @@ ssd_titlebar_create(struct view *view)
 			color = theme->window_inactive_title_bg_color;
 			corner_top_left = &theme->corner_top_left_inactive_normal->base;
 			corner_top_right = &theme->corner_top_right_inactive_normal->base;
-			wlr_scene_node_set_enabled(parent, false);
+			wlr_scene_node_set_enabled(&parent->node, false);
 		}
 		wl_list_init(&subtree->parts);
 
@@ -65,7 +65,7 @@ ssd_titlebar_create(struct view *view)
 static bool
 is_direct_child(struct wlr_scene_node *node, struct ssd_sub_tree *subtree)
 {
-	return node->parent == &subtree->tree->node;
+	return node->parent == subtree->tree;
 }
 
 void
@@ -241,7 +241,7 @@ ssd_update_title(struct view *view)
 		if (!part) {
 			/* Initialize part and wlr_scene_buffer without attaching a buffer */
 			part = add_scene_part(&subtree->parts, LAB_SSD_PART_TITLE);
-			part->node = &wlr_scene_buffer_create(&subtree->tree->node, NULL)->node;
+			part->node = &wlr_scene_buffer_create(subtree->tree, NULL)->node;
 		}
 
 		/* Generate and update the lab_data_buffer, drops the old buffer */

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -287,14 +287,14 @@ ssd_button_hover_enable(struct view *view, enum ssd_part_type type)
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
 	FOR_EACH_STATE(view, subtree) {
-		if (subtree->tree->node.state.enabled) {
+		if (subtree->tree->node.enabled) {
 			part = ssd_get_part(&subtree->parts, type);
 			if (!part) {
 				wlr_log(WLR_ERROR, "hover enable failed to find button");
 				return NULL;
 			}
 			struct wlr_scene_node *child;
-			wl_list_for_each_reverse(child, &part->node->state.children, state.link) {
+			wl_list_for_each_reverse(child, &part->node->children, link) {
 				if (child->type == WLR_SCENE_NODE_RECT) {
 					wlr_scene_node_set_enabled(child, true);
 					return child;

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -288,13 +288,24 @@ ssd_button_hover_enable(struct view *view, enum ssd_part_type type)
 	struct ssd_sub_tree *subtree;
 	FOR_EACH_STATE(view, subtree) {
 		if (subtree->tree->node.enabled) {
+			/*
+			 * TODO: This function makes too many magic assumptions:
+			 * - It expects the returned part to be the tree for the button
+			 * - It expects the last node in that tree to be the hover overlay
+			 *
+			 * Both assumptions are valid as long as ssd_parts.c isn't changing
+			 * the way a button is created but this cries for introducing bugs
+			 * in the future if the button creation process or ssd_get_part()
+			 * lookup routine would ever change.
+			 */
 			part = ssd_get_part(&subtree->parts, type);
 			if (!part) {
 				wlr_log(WLR_ERROR, "hover enable failed to find button");
 				return NULL;
 			}
 			struct wlr_scene_node *child;
-			wl_list_for_each_reverse(child, &part->node->children, link) {
+			struct wlr_scene_tree *button = lab_scene_tree_from_node(part->node);
+			wl_list_for_each_reverse(child, &button->children, link) {
 				if (child->type == WLR_SCENE_NODE_RECT) {
 					wlr_scene_node_set_enabled(child, true);
 					return child;

--- a/src/touch.c
+++ b/src/touch.c
@@ -13,7 +13,7 @@ touch_get_coords(struct seat *seat, struct wlr_touch *touch, double x, double y,
 		x, y, &lx, &ly);
 
 	struct wlr_scene_node *node =
-		wlr_scene_node_at(&seat->server->scene->node, lx, ly, sx, sy);
+		wlr_scene_node_at(&seat->server->scene->tree.node, lx, ly, sx, sy);
 
 	/* Find the surface and return it if it accepts touch events. */
 	struct wlr_surface *surface = lab_wlr_surface_from_node(node);

--- a/src/view.c
+++ b/src/view.c
@@ -311,7 +311,7 @@ static bool
 is_always_on_top(struct view *view)
 {
 	return view->scene_tree->node.parent ==
-		&view->server->view_tree_always_on_top->node;
+		view->server->view_tree_always_on_top;
 }
 
 void
@@ -319,10 +319,10 @@ view_toggle_always_on_top(struct view *view)
 {
 	if (is_always_on_top(view)) {
 		wlr_scene_node_reparent(&view->scene_tree->node,
-			&view->server->view_tree->node);
+			view->server->view_tree);
 	} else {
 		wlr_scene_node_reparent(&view->scene_tree->node,
-			&view->server->view_tree_always_on_top->node);
+			view->server->view_tree_always_on_top);
 	}
 }
 

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -91,9 +91,9 @@ xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup)
 	}
 	struct wlr_xdg_surface *parent =
 		wlr_xdg_surface_from_wlr_surface(wlr_popup->parent);
-	struct wlr_scene_node *parent_node = parent->surface->data;
+	struct wlr_scene_tree *parent_tree = parent->surface->data;
 	wlr_popup->base->surface->data =
-		wlr_scene_xdg_surface_create(parent_node, wlr_popup->base);
+		wlr_scene_xdg_surface_create(parent_tree, wlr_popup->base);
 	node_descriptor_create(wlr_popup->base->surface->data,
 		LAB_NODE_DESC_XDG_POPUP, view);
 

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -60,7 +60,7 @@ unmanaged_handle_map(struct wl_listener *listener, void *data)
 
 	/* node will be destroyed automatically once surface is destroyed */
 	struct wlr_scene_node *node = &wlr_scene_surface_create(
-			&unmanaged->server->unmanaged_tree->node,
+			unmanaged->server->unmanaged_tree,
 			xsurface->surface)->buffer->node;
 	wlr_scene_node_set_position(node, unmanaged->lx, unmanaged->ly);
 }

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -311,13 +311,14 @@ map(struct view *view)
 
 	if (view->surface != view->xwayland_surface->surface) {
 		view->surface = view->xwayland_surface->surface;
-		view->scene_node = wlr_scene_subsurface_tree_create(
-			&view->scene_tree->node, view->surface);
-		if (!view->scene_node) {
+		struct wlr_scene_tree *tree = wlr_scene_subsurface_tree_create(
+			view->scene_tree, view->surface);
+		if (!tree) {
 			/* TODO: might need further clean up */
 			wl_resource_post_no_memory(view->surface->resource);
 			return;
 		}
+		view->scene_node = &tree->node;
 	}
 
 	if (!view->toplevel_handle) {
@@ -433,7 +434,7 @@ xwayland_surface_new(struct wl_listener *listener, void *data)
 	view->impl = &xwl_view_impl;
 	view->xwayland_surface = xsurface;
 
-	view->scene_tree = wlr_scene_tree_create(&view->server->view_tree->node);
+	view->scene_tree = wlr_scene_tree_create(view->server->view_tree);
 	node_descriptor_create(&view->scene_tree->node,
 		LAB_NODE_DESC_VIEW, view);
 	xsurface->data = view;

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 98c5f58a388926c3db5d5b4b9275645bccd54271
+revision = 9eb71146ae56c509ee33c7e8a662549592aad870
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 9eb71146ae56c509ee33c7e8a662549592aad870
+revision = ccd0f85c2a36308e35b153c7f9653abac7659af3
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = cb2dbc327e4d695c2a60a386e116a7dc20b29107
+revision = 71f8a48d380701de1e3331d53d470bd76f5f643b
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 71f8a48d380701de1e3331d53d470bd76f5f643b
+revision = bd7b42eb9f182b3eef62a59c9da0ed9f2660440a
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = ccd0f85c2a36308e35b153c7f9653abac7659af3
+revision = cb2dbc327e4d695c2a60a386e116a7dc20b29107
 
 [provide]
 dependency_names = wlroots


### PR DESCRIPTION
These are likely the biggest changes regarding the scene-graph API we had to adjust to since moving to the scene-graph API in the first place.

I split everything into their own commits, each following a upstream commit so we are able to diagnose things better if something goes wrong. I had a quick test on each step along the way but when seeing the amount of changes required I think it makes sense for others to test and/or have a look at the single commits before merging this.

As always: use `meson subprojects update wlroots` to check out the corresponding wlroots upstream commit before building.

See https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3509/commits for the upstream commits.

I will push commit by commit into this branch so the CI triggers for all of them.