### PR TITLE
Add autoscaling font buffer

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -37,6 +37,8 @@ struct lab_data_buffer {
 	uint32_t format;
 	size_t stride;
 	bool free_on_destroy;
+	uint32_t unscaled_width;
+	uint32_t unscaled_height;
 };
 
 /* Create a buffer which creates a new cairo CAIRO_FORMAT_ARGB32 surface */

--- a/include/common/font.h
+++ b/include/common/font.h
@@ -24,7 +24,7 @@ int font_height(struct font *font);
  * @color: foreground color in rgba format
  */
 void font_buffer_create(struct lab_data_buffer **buffer, int max_width,
-	const char *text, struct font *font, float *color);
+	const char *text, struct font *font, float *color, double scale);
 
 /**
  * font_buffer_update - Wrapper around font_buffer_create
@@ -32,7 +32,7 @@ void font_buffer_create(struct lab_data_buffer **buffer, int max_width,
  * wlr_buffer_drop() will be called on the buffer.
  */
 void font_buffer_update(struct lab_data_buffer **buffer, int max_width,
-	const char *text, struct font *font, float *color);
+	const char *text, struct font *font, float *color, double scale);
 
 /**
  * font_finish - free some font related resources

--- a/include/common/scaled_font_buffer.h
+++ b/include/common/scaled_font_buffer.h
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LAB_COMMON_SCALED_FONT_BUFFER_H
+#define __LAB_COMMON_SCALED_FONT_BUFFER_H
+
+struct font;
+struct wlr_scene_tree;
+struct wlr_scene_buffer;
+struct scaled_scene_buffere;
+
+struct scaled_font_buffer {
+	struct wlr_scene_buffer *scene_buffer;
+	int width;   /* unscaled, read only */
+	int height;  /* unscaled, read only */
+
+	/* Private */
+	char *text;
+	int max_width;
+	float color[4];
+	struct font font;
+	struct scaled_scene_buffer *scaled_buffer;
+};
+
+/**
+ * Create an auto scaling font buffer, providing a wlr_scene_buffer node for
+ * display. It gets destroyed automatically when the backing scaled_scene_buffer
+ * is being destoyed which in turn happens automatically when the backing
+ * wlr_scene_buffer (or one of its parents) is being destroyed.
+ *
+ * To actually show some text, scaled_font_buffer_update() has to be called.
+ *
+ */
+struct scaled_font_buffer *scaled_font_buffer_create(struct wlr_scene_tree *parent);
+
+/**
+ * Update an existing auto scaling font buffer.
+ *
+ * No steps are taken to detect if its actually required to render a new buffer.
+ * This should be done by the caller to prevent useless recreation of the same
+ * buffer in case nothing actually changed.
+ *
+ * Some basic checks could be something like
+ * - truncated = buffer->width == max_width
+ * - text_changed = strcmp(old_text, new_text)
+ * - font and color the same
+ */
+void scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
+	int max_width, struct font *font, float *color);
+
+#endif /* __LAB_COMMON_SCALED_FONT_BUFFER_H */

--- a/include/common/scaled_scene_buffer.h
+++ b/include/common/scaled_scene_buffer.h
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LAB_COMMON_SCALED_SCENE_BUFFER_H
+#define __LAB_COMMON_SCALED_SCENE_BUFFER_H
+
+#define LAB_SCALED_BUFFER_MAX_CACHE 2
+
+struct wl_list;
+struct wlr_buffer;
+struct wl_listener;
+struct wlr_scene_tree;
+struct lab_data_buffer;
+struct scaled_scene_buffer;
+
+struct scaled_scene_buffer_impl {
+	/* Return a new buffer optimized for the new scale */
+	struct lab_data_buffer *(*create_buffer)
+		(struct scaled_scene_buffer *scaled_buffer, double scale);
+	/* Might be NULL or used for cleaning up */
+	void (*destroy)(struct scaled_scene_buffer *scaled_buffer);
+};
+
+struct scaled_scene_buffer {
+	struct wlr_scene_buffer *scene_buffer;
+	int width;   /* unscaled, read only */
+	int height;  /* unscaled, read only */
+	void *data;  /* opaque user data */
+
+	/* Private */
+	double active_scale;
+	struct wl_list cache;  /* struct scaled_buffer_cache_entry.link */
+	struct wl_listener destroy;
+	struct wl_listener output_enter;
+	struct wl_listener output_leave;
+	const struct scaled_scene_buffer_impl *impl;
+};
+
+/**
+ * Create an auto scaling buffer that creates a wlr_scene_buffer
+ * and subscribes to its output_enter and output_leave signals.
+ *
+ * If the maximal scale changes, it either sets an already existing buffer
+ * that was rendered for the current scale or - if there is none - calls
+ * implementation->create_buffer(self, scale) to get a new lab_data_buffer
+ * optimized for the new scale.
+ *
+ * Up to LAB_SCALED_BUFFER_MAX_CACHE (2) buffers are cached in an LRU fashion
+ * to handle the majority of use cases where a view is moved between no more
+ * than two different scales.
+ *
+ * scaled_scene_buffer will clean up automatically once the internal
+ * wlr_scene_buffer is being destroyed. If implementation->destroy is set
+ * it will also get called so a consumer of this API may clean up its own
+ * allocations.
+ */
+struct scaled_scene_buffer *scaled_scene_buffer_create(
+	struct wlr_scene_tree *parent,
+	const struct scaled_scene_buffer_impl *implementation);
+
+/* Clear the cache of existing buffers, useful in case the content changes */
+void scaled_scene_buffer_invalidate_cache(struct scaled_scene_buffer *self);
+
+
+/* Private */
+struct scaled_scene_buffer_cache_entry {
+	struct wl_list link;   /* struct scaled_scene_buffer.cache */
+	struct wlr_buffer *buffer;
+	double scale;
+};
+
+#endif /* __LAB_COMMON_SCALED_SCENE_BUFFER_H */

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -8,9 +8,9 @@
 struct view;
 struct server;
 struct wl_list;
-struct lab_data_buffer;
 struct wlr_scene_tree;
 struct wlr_scene_node;
+struct scaled_font_buffer;
 
 enum menu_align {
 	LAB_MENU_OPEN_AUTO   = 0,
@@ -22,9 +22,9 @@ enum menu_align {
 
 struct menu_scene {
 	struct wlr_scene_tree *tree;
-	struct lab_data_buffer *buffer;
 	struct wlr_scene_node *text;
 	struct wlr_scene_node *background;
+	struct scaled_font_buffer *buffer;
 };
 
 struct menuitem {

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -53,6 +53,7 @@ struct view;
 struct wl_list;
 struct wlr_box;
 struct wlr_scene_tree;
+struct scaled_font_buffer;
 
 struct ssd_button {
 	struct view *view;
@@ -115,7 +116,7 @@ struct ssd_part {
 	enum ssd_part_type type;
 
 	/* Buffer pointer. May be NULL */
-	struct lab_data_buffer *buffer;
+	struct scaled_font_buffer *buffer;
 
 	/* This part represented in scene graph */
 	struct wlr_scene_node *node;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -92,10 +92,23 @@ buffer_create_cairo(uint32_t width, uint32_t height, float scale,
 	if (!buffer) {
 		return NULL;
 	}
-	wlr_buffer_init(&buffer->base, &data_buffer_impl, width, height);
+	buffer->unscaled_width = width;
+	buffer->unscaled_height = height;
+	width *= scale;
+	height *= scale;
 
+	/* Allocate the buffer with the scaled size */
+	wlr_buffer_init(&buffer->base, &data_buffer_impl, width, height);
 	cairo_surface_t *surf =
 		cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+
+	/**
+	 * Tell cairo about the device scale so we can keep drawing in unscaled
+	 * coordinate space. Pango will automatically use the cairo scale attribute
+	 * as well when creating text on this surface.
+	 *
+	 * For a more complete explanation see PR #389
+	 */
 	cairo_surface_set_device_scale(surf, scale, scale);
 
 	buffer->cairo = cairo_create(surf);

--- a/src/common/font.c
+++ b/src/common/font.c
@@ -51,18 +51,18 @@ font_height(struct font *font)
 
 void
 font_buffer_update(struct lab_data_buffer **buffer, int max_width,
-	const char *text, struct font *font, float *color)
+	const char *text, struct font *font, float *color, double scale)
 {
 	if (*buffer) {
 		wlr_buffer_drop(&(*buffer)->base);
 		*buffer = NULL;
 	}
-	font_buffer_create(buffer, max_width, text, font, color);
+	font_buffer_create(buffer, max_width, text, font, color, scale);
 }
 
 void
 font_buffer_create(struct lab_data_buffer **buffer, int max_width,
-	const char *text, struct font *font, float *color)
+	const char *text, struct font *font, float *color, double scale)
 {
 	if (!text || !*text) {
 		return;
@@ -72,8 +72,7 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	if (max_width && rect.width > max_width) {
 		rect.width = max_width;
 	}
-	/* TODO: scale */
-	*buffer = buffer_create_cairo(rect.width, rect.height, 1, true);
+	*buffer = buffer_create_cairo(rect.width, rect.height, scale, true);
 	if (!*buffer) {
 		wlr_log(WLR_ERROR, "Failed to create font buffer of size %dx%d",
 			rect.width, rect.height);

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -4,6 +4,7 @@ labwc_sources += files(
   'font.c',
   'grab-file.c',
   'nodename.c',
+  'scaled_scene_buffer.c',
   'scene-helpers.c',
   'spawn.c',
   'string-helpers.c',

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -4,6 +4,7 @@ labwc_sources += files(
   'font.c',
   'grab-file.c',
   'nodename.c',
+  'scaled_font_buffer.c',
   'scaled_scene_buffer.c',
   'scene-helpers.c',
   'spawn.c',

--- a/src/common/scaled_font_buffer.c
+++ b/src/common/scaled_font_buffer.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wayland-server-core.h>
+#include <wlr/util/log.h>
+#include "buffer.h"
+#include "common/font.h"
+#include "common/scaled_scene_buffer.h"
+#include "common/scaled_font_buffer.h"
+#include "common/zfree.h"
+
+static struct lab_data_buffer *
+_create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
+{
+	struct lab_data_buffer *buffer;
+	struct scaled_font_buffer *self = scaled_buffer->data;
+
+	/* Buffer gets free'd automatically along the backing wlr_buffer */
+	font_buffer_create(&buffer, self->max_width, self->text,
+		&self->font, self->color, scale);
+
+	self->width = buffer ? buffer->unscaled_width : 0;
+	self->height = buffer ? buffer->unscaled_height : 0;
+	return buffer;
+}
+
+static void
+_destroy(struct scaled_scene_buffer *scaled_buffer)
+{
+	struct scaled_font_buffer *self = scaled_buffer->data;
+	if (self->text) {
+		zfree(self->text);
+	}
+	if (self->font.name) {
+		zfree(self->font.name);
+	}
+	zfree(scaled_buffer->data);
+}
+
+static const struct scaled_scene_buffer_impl impl = {
+	.create_buffer = _create_buffer,
+	.destroy = _destroy
+};
+
+/* Public API */
+struct scaled_font_buffer *
+scaled_font_buffer_create(struct wlr_scene_tree *parent)
+{
+	assert(parent);
+	struct scaled_font_buffer *self = calloc(1, sizeof(*self));
+	if (!self) {
+		return NULL;
+	}
+
+	struct scaled_scene_buffer *scaled_buffer
+		= scaled_scene_buffer_create(parent, &impl);
+	if (!scaled_buffer) {
+		free(self);
+		return NULL;
+	}
+
+	scaled_buffer->data = self;
+	self->scaled_buffer = scaled_buffer;
+	self->scene_buffer = scaled_buffer->scene_buffer;
+	return self;
+}
+
+void
+scaled_font_buffer_update(struct scaled_font_buffer *self,
+		const char *text, int max_width, struct font *font, float *color)
+{
+	assert(self);
+	assert(text);
+	assert(font);
+	assert(color);
+
+	/* Clean up old internal state */
+	if (self->text) {
+		zfree(self->text);
+	}
+	if (self->font.name) {
+		zfree(self->font.name);
+	}
+
+	/* Update internal state */
+	self->text = strdup(text);
+	self->max_width = max_width;
+	if (font->name) {
+		self->font.name = strdup(font->name);
+	}
+	self->font.size = font->size;
+	memcpy(self->color, color, sizeof(self->color));
+
+	/* Invalidate cache and force a new render */
+	scaled_scene_buffer_invalidate_cache(self->scaled_buffer);
+}

--- a/src/common/scaled_scene_buffer.c
+++ b/src/common/scaled_scene_buffer.c
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <stdlib.h>
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_buffer.h>
+#include <wlr/types/wlr_scene.h>
+#include <wlr/util/log.h>
+#include "buffer.h"
+#include "common/scaled_scene_buffer.h"
+
+/**
+ * TODO
+ *
+ * This implementation does not react to output scale changes itself but only
+ * to movement of scene nodes to different outputs. To also handle output scale
+ * changes we'd need to keep a list of struct wlr_outputs * in sync and listen
+ * to their commit signals.
+ *
+ * The detection of the max output scale is also not 100% robust for all use
+ * cases as on output_enter we only compare the new output scale with the
+ * primary_output scale. In specific conditions the primary output may be the
+ * same as the new output even though a smaller part of the buffer node is
+ * still visible on an output with a bigger scale. This could be solved the
+ * same way as the previous point in keeping a list of outputs in sync.
+ *
+ * Most of this would be easier when wlroots would instead provide a
+ * max_scale_changed event because it already touches all the relevant parts
+ * when calculating the primary_output and inform wlr_scene_buffers about
+ * output changes.
+ *
+ * See wlroots/types/scene/wlr_scene.c scene_buffer_update_outputs()
+ */
+
+/* Internal API */
+static void
+_cache_entry_destroy(struct scaled_scene_buffer_cache_entry *cache_entry)
+{
+	wl_list_remove(&cache_entry->link);
+	if (cache_entry->buffer) {
+		wlr_buffer_drop(cache_entry->buffer);
+	}
+	free(cache_entry);
+}
+
+static void
+_update_buffer(struct scaled_scene_buffer *self, double scale)
+{
+	self->active_scale = scale;
+
+	/* Search for cached buffer of specified scale */
+	struct scaled_scene_buffer_cache_entry *cache_entry, *cache_entry_tmp;
+	wl_list_for_each_safe(cache_entry, cache_entry_tmp, &self->cache, link) {
+		if (cache_entry->scale == scale) {
+			/* LRU cache, recently used in front */
+			wl_list_remove(&cache_entry->link);
+			wl_list_insert(&self->cache, &cache_entry->link);
+			wlr_scene_buffer_set_buffer(self->scene_buffer, cache_entry->buffer);
+			return;
+		}
+	}
+
+	/* Create new buffer, will get destroyed along the backing wlr_buffer */
+	struct lab_data_buffer *buffer = self->impl->create_buffer(self, scale);
+	self->width = buffer ? buffer->unscaled_width : 0;
+	self->height = buffer ? buffer->unscaled_height : 0;
+
+	/* Create or reuse cache entry */
+	if (wl_list_length(&self->cache) < LAB_SCALED_BUFFER_MAX_CACHE) {
+		cache_entry = calloc(1, sizeof(*cache_entry));
+	} else {
+		cache_entry = wl_container_of(self->cache.prev, cache_entry, link);
+		if (cache_entry->buffer) {
+			wlr_buffer_drop(cache_entry->buffer);
+		}
+		wl_list_remove(&cache_entry->link);
+	}
+
+	/* Update the cache entry */
+	cache_entry->scale = scale;
+	cache_entry->buffer = buffer ? &buffer->base : NULL;
+	wl_list_insert(&self->cache, &cache_entry->link);
+
+	/* And finally update the wlr_scene_buffer itself */
+	wlr_scene_buffer_set_buffer(self->scene_buffer, cache_entry->buffer);
+	wlr_scene_buffer_set_dest_size(self->scene_buffer, self->width, self->height);
+}
+
+/* Internal event handlers */
+static void
+_handle_node_destroy(struct wl_listener *listener, void *data)
+{
+	struct scaled_scene_buffer_cache_entry *cache_entry, *cache_entry_tmp;
+	struct scaled_scene_buffer *self = wl_container_of(listener, self, destroy);
+
+	wl_list_remove(&self->destroy.link);
+	wl_list_remove(&self->output_enter.link);
+	wl_list_remove(&self->output_leave.link);
+
+	wl_list_for_each_safe(cache_entry, cache_entry_tmp, &self->cache, link) {
+		_cache_entry_destroy(cache_entry);
+	}
+	assert(wl_list_empty(&self->cache));
+
+	if (self->impl->destroy) {
+		self->impl->destroy(self);
+	}
+	free(self);
+}
+
+static void
+_handle_output_enter(struct wl_listener *listener, void *data)
+{
+	struct scaled_scene_buffer *self
+		= wl_container_of(listener, self, output_enter);
+	/* primary_output is the output most of the node area is in */
+	struct wlr_scene_output *primary = self->scene_buffer->primary_output;
+	/* scene_output is the output we just entered */
+	struct wlr_scene_output *scene_output = data;
+	double max_scale = scene_output->output->scale;
+
+	if (primary && primary->output->scale > max_scale) {
+		max_scale = primary->output->scale;
+	}
+
+	if (self->active_scale != max_scale) {
+		_update_buffer(self, max_scale);
+	}
+}
+
+static void
+_handle_output_leave(struct wl_listener *listener, void *data)
+{
+	struct scaled_scene_buffer *self
+		= wl_container_of(listener, self, output_leave);
+	/* primary_output is the output most of the node area is in */
+	struct wlr_scene_output *primary = self->scene_buffer->primary_output;
+
+	if (primary && primary->output->scale != self->active_scale) {
+		_update_buffer(self, primary->output->scale);
+	}
+}
+
+/* Public API */
+struct scaled_scene_buffer *
+scaled_scene_buffer_create(struct wlr_scene_tree *parent,
+		const struct scaled_scene_buffer_impl *impl)
+{
+	assert(parent);
+	assert(impl);
+	assert(impl->create_buffer);
+
+	struct scaled_scene_buffer *self = calloc(1, sizeof(*self));
+	if (!self) {
+		return NULL;
+	}
+
+	self->scene_buffer = wlr_scene_buffer_create(parent, NULL);
+	if (!self->scene_buffer) {
+		wlr_log(WLR_ERROR, "Failed to create scene buffer");
+		free(self);
+		return NULL;
+	}
+
+	self->impl = impl;
+	self->active_scale = 1;
+	wl_list_init(&self->cache);
+
+	/* Listen to output enter/leave so we get notified about scale changes */
+	self->output_enter.notify = _handle_output_enter;
+	wl_signal_add(&self->scene_buffer->events.output_enter, &self->output_enter);
+	self->output_leave.notify = _handle_output_leave;
+	wl_signal_add(&self->scene_buffer->events.output_leave, &self->output_leave);
+
+	/* Let it destroy automatically when the scene node destroys */
+	self->destroy.notify = _handle_node_destroy;
+	wl_signal_add(&self->scene_buffer->node.events.destroy, &self->destroy);
+
+	return self;
+}
+
+void
+scaled_scene_buffer_invalidate_cache(struct scaled_scene_buffer *self)
+{
+	assert(self);
+	struct scaled_scene_buffer_cache_entry *cache_entry, *cache_entry_tmp;
+	wl_list_for_each_safe(cache_entry, cache_entry_tmp, &self->cache, link) {
+		_cache_entry_destroy(cache_entry);
+	}
+	assert(wl_list_empty(&self->cache));
+	_update_buffer(self, self->active_scale);
+}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -268,7 +268,11 @@ handle_menu_element(xmlNode *n, struct server *server)
 			 * create an item pointing to the new submenu
 			 */
 			current_item = item_create(current_menu, label);
-			submenu = &current_item->submenu;
+			if (current_item) {
+				submenu = &current_item->submenu;
+			} else {
+				submenu = NULL;
+			}
 		}
 		++menu_level;
 		current_menu = menu_create(server, id, label);
@@ -282,7 +286,9 @@ handle_menu_element(xmlNode *n, struct server *server)
 		struct menu *menu = menu_get_by_id(id);
 		if (menu) {
 			current_item = item_create(current_menu, menu->label);
-			current_item->submenu = menu;
+			if (current_item) {
+				current_item->submenu = menu;
+			}
 		} else {
 			wlr_log(WLR_ERROR, "no menu with id '%s'", id);
 		}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -99,9 +99,9 @@ item_create(struct menu *menu, const char *text)
 
 	/* Font buffer */
 	font_buffer_create(&menuitem->normal.buffer, item_max_width,
-		text, &font, theme->menu_items_text_color);
+		text, &font, theme->menu_items_text_color, 1);
 	font_buffer_create(&menuitem->selected.buffer, item_max_width,
-		text, &font, theme->menu_items_active_text_color);
+		text, &font, theme->menu_items_active_text_color, 1);
 	if (!menuitem->normal.buffer || !menuitem->selected.buffer) {
 		wlr_log(WLR_ERROR, "Failed to create menu item '%s'", text);
 		if (menuitem->normal.buffer) {

--- a/src/osd.c
+++ b/src/osd.c
@@ -129,13 +129,11 @@ osd_update(struct server *server)
 		float scale = output->wlr_output->scale;
 		int w = (OSD_ITEM_WIDTH + (2 * OSD_BORDER_WIDTH));
 		int h = get_osd_height(&server->views);
-		int scaled_w = w * scale;
-		int scaled_h = h * scale;
 
 		if (output->osd_buffer) {
 			wlr_buffer_drop(&output->osd_buffer->base);
 		}
-		output->osd_buffer = buffer_create_cairo(scaled_w, scaled_h, scale, true);
+		output->osd_buffer = buffer_create_cairo(w, h, scale, true);
 
 		cairo_t *cairo = output->osd_buffer->cairo;
 		cairo_surface_t *surf = cairo_get_target(cairo);

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -4,6 +4,7 @@
 #include "labwc.h"
 #include "ssd.h"
 #include "node.h"
+#include "common/font.h"
 
 /* Internal helpers */
 static void
@@ -165,10 +166,8 @@ ssd_destroy_parts(struct wl_list *list)
 			wlr_scene_node_destroy(part->node);
 			part->node = NULL;
 		}
-		if (part->buffer) {
-			wlr_buffer_drop(&part->buffer->base);
-			part->buffer = NULL;
-		}
+		/* part->buffer will free itself along the scene_buffer node */
+		part->buffer = NULL;
 		if (part->geometry) {
 			free(part->geometry);
 			part->geometry = NULL;

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -247,7 +247,8 @@ ssd_update_title(struct view *view)
 		}
 
 		/* Generate and update the lab_data_buffer, drops the old buffer */
-		font_buffer_update(&part->buffer, title_bg_width, title, &font, text_color);
+		font_buffer_update(&part->buffer, title_bg_width, title, &font,
+			text_color, 1);
 		if (!part->buffer) {
 			/* This can happen for example by defining a font size of 0 */
 			wlr_log(WLR_ERROR, "Failed to create title buffer");


### PR DESCRIPTION
This adds an auto scaling font buffer to labwc and converts menu and ssd_titlebar to use it.
I tried to put everything into small and digestible commits.

First three commits could likely be split out of this PR.

![auto_scale_buffer](https://user-images.githubusercontent.com/35009135/173250501-ce0800b1-f986-4203-aef5-baf9100f25e1.png)

I am mostly satisfied with the auto scale buffer state for now, I'd just need to remove the debug logs.

Something that might be interesting for the future is to generalize this some more and instead of having an scale adapting font buffer we'd have an abstract scale adapting 'thing' that gets a config struct when initialized containing callbacks that will get called whenever a new buffer needs to be rendered. The 'thing'  would then only be responsible for setting the appropriate scaled buffer on output_enter/leave events and request new buffers if the node had been moved to an unknown (or already evicted) scale. The first user of that 'thing' would then be a `autoscaling_font_buffer`.
Somewhat similar in design to `wlr_buffer` <--> `lab_data_buffer`.

Edit: did that ^. [Abstract](https://github.com/labwc/labwc/blob/dfd33dc721754629e8fb1e123b4421163861e36c/include/common/scaled_scene_buffer.h) & [Font buffer](https://github.com/labwc/labwc/blob/dfd33dc721754629e8fb1e123b4421163861e36c/include/common/scaled_font_buffer.h)


Related to
- #348
- #389