### PR TITLE
[v0.5] Backport - add support for wlr-output-power-management

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -26,6 +26,7 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_output_management_v1.h>
+#include <wlr/types/wlr_output_power_management_v1.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_pointer.h>
@@ -170,6 +171,9 @@ struct server {
 	struct wlr_output_configuration_v1 *pending_output_config;
 
 	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
+
+	struct wlr_output_power_manager_v1 *output_power_manager_v1;
+	struct wl_listener output_power_manager_set_mode;
 
 	struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
 	struct wlr_pointer_constraints_v1 *constraints;
@@ -520,6 +524,8 @@ struct output *output_from_wlr_output(struct server *server,
 	struct wlr_output *wlr_output);
 struct wlr_box output_usable_area_in_layout_coords(struct output *output);
 struct wlr_box output_usable_area_from_cursor_coords(struct server *server);
+void handle_output_power_manager_set_mode(struct wl_listener *listener,
+	void *data);
 
 void damage_all_outputs(struct server *server);
 void damage_view_whole(struct view *view);

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -18,6 +18,7 @@ server_protocols = [
 	[wl_protocol_dir, 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml'],
 	['wlr-layer-shell-unstable-v1.xml'],
 	['wlr-input-inhibitor-unstable-v1.xml'],
+	['wlr-output-power-management-unstable-v1.xml'],
 ]
 
 server_protos_src = []

--- a/protocols/wlr-output-power-management-unstable-v1.xml
+++ b/protocols/wlr-output-power-management-unstable-v1.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_power_management_unstable_v1">
+  <copyright>
+    Copyright © 2019 Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Control power management modes of outputs">
+    This protocol allows clients to control power management modes
+    of outputs that are currently part of the compositor space. The
+    intent is to allow special clients like desktop shells to power
+    down outputs when the system is idle.
+
+    To modify outputs not currently part of the compositor space see
+    wlr-output-management.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_output_power_manager_v1" version="1">
+    <description summary="manager to create per-output power management">
+      This interface is a manager that allows creating per-output power
+      management mode controls.
+    </description>
+
+    <request name="get_output_power">
+      <description summary="get a power management for an output">
+        Create an output power management mode control that can be used to
+        adjust the power management mode for a given output.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_power_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_power_v1" version="1">
+    <description summary="adjust power management mode for an output">
+      This object offers requests to set the power management mode of
+      an output.
+    </description>
+
+    <enum name="mode">
+      <entry name="off" value="0"
+             summary="Output is turned off."/>
+      <entry name="on" value="1"
+             summary="Output is turned on, no power saving"/>
+    </enum>
+
+    <enum name="error">
+      <entry name="invalid_mode" value="1" summary="nonexistent power save mode"/>
+    </enum>
+
+    <request name="set_mode">
+      <description summary="Set an outputs power save mode">
+        Set an output's power save mode to the given mode. The mode change
+        is effective immediately. If the output does not support the given
+        mode a failed event is sent.
+      </description>
+      <arg name="mode" type="uint" enum="mode" summary="the power save mode to set"/>
+    </request>
+
+    <event name="mode">
+      <description summary="Report a power management mode change">
+        Report the power management mode change of an output.
+
+        The mode event is sent after an output changed its power
+        management mode. The reason can be a client using set_mode or the
+        compositor deciding to change an output's mode.
+        This event is also sent immediately when the object is created
+        so the client is informed about the current power management mode.
+      </description>
+      <arg name="mode" type="uint" enum="mode"
+           summary="the output's new power management mode"/>
+    </event>
+
+    <event name="failed">
+      <description summary="object no longer valid">
+        This event indicates that the output power management mode control
+        is no longer valid. This can happen for a number of reasons,
+        including:
+        - The output doesn't support power management
+        - Another client already has exclusive power management mode control
+          for this output
+        - The output disappeared
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this power management">
+        Destroys the output power management mode control object.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/src/output.c
+++ b/src/output.c
@@ -9,6 +9,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include "config.h"
 #include <assert.h>
+#include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/util/region.h>
@@ -1299,7 +1300,9 @@ handle_output_power_manager_set_mode(struct wl_listener *listener, void *data)
 		break;
 	case ZWLR_OUTPUT_POWER_V1_MODE_ON:
 		wlr_output_enable(event->output, true);
-		output_ensure_buffer(event->output);
+		if (!wlr_output_test(event->output)) {
+			wlr_output_rollback(event->output);
+		}
 		wlr_output_commit(event->output);
 		break;
 	}

--- a/src/output.c
+++ b/src/output.c
@@ -1291,6 +1291,8 @@ output_usable_area_from_cursor_coords(struct server *server)
 void
 handle_output_power_manager_set_mode(struct wl_listener *listener, void *data)
 {
+	struct server *server
+		= wl_container_of(listener, server, output_power_manager_set_mode);
 	struct wlr_output_power_v1_set_mode_event *event = data;
 
 	switch (event->mode) {
@@ -1306,4 +1308,5 @@ handle_output_power_manager_set_mode(struct wl_listener *listener, void *data)
 		wlr_output_commit(event->output);
 		break;
 	}
+	damage_all_outputs(server);
 }

--- a/src/output.c
+++ b/src/output.c
@@ -1286,3 +1286,21 @@ output_usable_area_from_cursor_coords(struct server *server)
 	struct output *output = output_from_wlr_output(server, wlr_output);
 	return output_usable_area_in_layout_coords(output);
 }
+
+void
+handle_output_power_manager_set_mode(struct wl_listener *listener, void *data)
+{
+	struct wlr_output_power_v1_set_mode_event *event = data;
+
+	switch (event->mode) {
+	case ZWLR_OUTPUT_POWER_V1_MODE_OFF:
+		wlr_output_enable(event->output, false);
+		wlr_output_commit(event->output);
+		break;
+	case ZWLR_OUTPUT_POWER_V1_MODE_ON:
+		wlr_output_enable(event->output, true);
+		output_ensure_buffer(event->output);
+		wlr_output_commit(event->output);
+		break;
+	}
+}

--- a/src/server.c
+++ b/src/server.c
@@ -317,6 +317,13 @@ server_init(struct server *server)
 	server->foreign_toplevel_manager =
 		wlr_foreign_toplevel_manager_v1_create(server->wl_display);
 
+	server->output_power_manager_v1 =
+		wlr_output_power_manager_v1_create(server->wl_display);
+	server->output_power_manager_set_mode.notify =
+		handle_output_power_manager_set_mode;
+	wl_signal_add(&server->output_power_manager_v1->events.set_mode,
+		&server->output_power_manager_set_mode);
+
 	layers_init(server);
 
 #if HAVE_XWAYLAND


### PR DESCRIPTION
Since someone on IRC noticed wlopm wasn't working for 0.5.2 I tried to add the relevant commits to it:

https://github.com/labwc/labwc/commit/5fd5024ca655d07d04cfb3e9c829c1764dd8ee01
https://github.com/labwc/labwc/commit/748b3d38e7ff8aee926f6ea4679b15a9265ea10d
https://github.com/labwc/labwc/commit/c23397f362930e97e616a75590c4111558891381