### PR TITLE
action.c: use kill() instead of spawning killall

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Labwc uses the files listed below for configuration and theming.
 
 The example [rc.xml] has been kept simple. For all options and default values, see [rc.xml.all]
 
-Configuration and theme files are reloaded on receiving SIGHUP (e.g. `killall -SIGHUP labwc`)
+Configuration and theme files are reloaded on receiving SIGHUP (e.g. `killall -s SIGHUP labwc`)
 
 For keyboard settings, see [environment] and [xkeyboard-config(7)]
 

--- a/src/action.c
+++ b/src/action.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <strings.h>
 #include <wlr/util/log.h>
+#include <signal.h>
 #include "common/spawn.h"
 #include "common/zfree.h"
 #include "debug.h"
@@ -200,8 +201,7 @@ actions_run(struct view *activator, struct server *server,
 			osd_update(server);
 			break;
 		case ACTION_TYPE_RECONFIGURE:
-			/* Should be changed to signal() */
-			spawn_async_no_shell("killall -SIGHUP labwc");
+			kill(getpid(), SIGHUP);
 			break;
 		case ACTION_TYPE_SHOW_MENU:
 			show_menu(server, view, action->arg);


### PR DESCRIPTION
Also update documentation to say `killall -s SIGHUP labwc` to make
it work on Void Linux.

Fix #393