### PR TITLE
Allow leasing desktop displays

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -240,6 +240,8 @@ struct output {
 
 	struct wl_listener destroy;
 	struct wl_listener frame;
+
+	bool leased;
 };
 
 #undef LAB_NR_LAYERS

--- a/src/output.c
+++ b/src/output.c
@@ -59,16 +59,22 @@ new_output_notify(struct wl_listener *listener, void *data)
 	struct wlr_output *wlr_output = data;
 
 	/*
-	 * If this is a non-desktop output, offer it for leasing.
-	 * We may want to do more logic here in future, if we choose
-	 * to offer non-desktop outputs.
+	 * We offer any display as available for lease, some apps like
+	 * gamescope, want to take ownership of a display when they can
+	 * to use planes and present directly.
+	 * This is also useful for debugging the DRM parts of
+	 * another compositor.
+	 */
+	if (server->drm_lease_manager) {
+		wlr_drm_lease_v1_manager_offer_output(
+			server->drm_lease_manager, wlr_output);
+	}
+
+	/*
+	 * Don't configure any non-desktop displays, such as VR headsets;
 	 */
 	if (wlr_output->non_desktop) {
 		wlr_log(WLR_DEBUG, "Not configuring non-desktop output");
-		if (server->drm_lease_manager) {
-			wlr_drm_lease_v1_manager_offer_output(
-				server->drm_lease_manager, wlr_output);
-		}
 		return;
 	}
 
@@ -231,11 +237,12 @@ output_config_apply(struct server *server,
 	wl_list_for_each(head, &config->heads, link) {
 		struct wlr_output *o = head->state.output;
 		struct output *output = output_from_wlr_output(server, o);
-		bool need_to_add = head->state.enabled && !o->enabled;
-		bool need_to_remove = !head->state.enabled && o->enabled;
+		bool output_enabled = head->state.enabled && !output->leased;
+		bool need_to_add = output_enabled && !o->enabled;
+		bool need_to_remove = !output_enabled && o->enabled;
 
-		wlr_output_enable(o, head->state.enabled);
-		if (head->state.enabled) {
+		wlr_output_enable(o, output_enabled);
+		if (output_enabled) {
 			/* Output specifc actions only */
 			if (head->state.mode) {
 				wlr_output_set_mode(o, head->state.mode);
@@ -261,7 +268,7 @@ output_config_apply(struct server *server,
 			assert(output->scene_output);
 		}
 
-		if (head->state.enabled) {
+		if (output_enabled) {
 			wlr_output_layout_move(server->output_layout, o,
 				head->state.x, head->state.y);
 		}


### PR DESCRIPTION
Apps such as Gamescope eventually want to offer a DRM lease option to use planes and handle all of getting to the screen themselves.

This implements logic to allow leasing of desktop displays