### PR TITLE
workspaces: Allow switching/sending to the last used workspace

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -67,8 +67,9 @@ Actions are used in menus and keyboard/mouse bindings.
 	Toggle always-on-top of focused window.
 
 *<action name="GoToDesktop"><to>*
-	Switch to workspace. Supported values are "left", "right" or the full
-	name of a workspace or its index (starting at 1) as configured in rc.xml.
+	Switch to workspace. Supported values are "last", "left", "right" or the
+	full name of a workspace or its index (starting at 1) as configured in
+	rc.xml.
 
 *<action name="SendToDesktop"><to>*
 	Send active window to workspace.

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -203,6 +203,7 @@ struct server {
 	/* Workspaces */
 	struct wl_list workspaces;  /* struct workspace.link */
 	struct workspace *workspace_current;
+	struct workspace *workspace_last;
 
 	struct wl_list outputs;
 	struct wl_listener new_output;

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -283,6 +283,9 @@ workspaces_switch_to(struct workspace *target)
 	/* Enable the new workspace */
 	wlr_scene_node_set_enabled(&target->tree->node, true);
 
+	/* Save the last visited workspace */
+	target->server->workspace_last = target->server->workspace_current;
+
 	/* Make sure new views will spawn on the new workspace */
 	target->server->workspace_current = target;
 
@@ -342,6 +345,8 @@ workspaces_find(struct workspace *anchor, const char *name)
 				return target;
 			}
 		}
+	} else if (!strcasecmp(name, "last")) {
+		return anchor->server->workspace_last;
 	} else if (!strcasecmp(name, "left")) {
 		return get_prev(anchor, workspaces);
 	} else if (!strcasecmp(name, "right")) {


### PR DESCRIPTION
Actions GoToDesktop and SendToDesktop now support the new direction
called "last" that corresponds to the last used workspace (see Openbox
help[1] for reference).

[1]: http://openbox.org/wiki/Help:Actions#GoToDesktop