### PR TITLE
Restore original window geometry after tiling

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -306,6 +306,7 @@ struct view {
 	bool been_mapped;
 	bool minimized;
 	bool maximized;
+	bool is_tiled;
 	struct wlr_output *fullscreen;
 
 	/* geometry of the wlr_surface contained within the view */
@@ -313,6 +314,9 @@ struct view {
 
 	/* geometry before maximize */
 	struct wlr_box unmaximized_geometry;
+
+	/* geometry before tiling */
+	struct wlr_box untiled_geometry;
 
 	/*
 	 * margin refers to the space between the extremities of the

--- a/src/view.c
+++ b/src/view.c
@@ -668,6 +668,23 @@ view_snap_to_edge(struct view *view, const char *direction)
 			view_edge_invert(edge));
 	}
 
+	/* Remember old geometry */
+	if (!view->is_tiled) {
+		if (!view->maximized) {
+			/* Store current geometry */
+			view->untiled_geometry.x = view->x;
+			view->untiled_geometry.y = view->y;
+			view->untiled_geometry.width = view->w;
+			view->untiled_geometry.height = view->h;
+		} else {
+			/* Reuse unmaximized geometry */
+			memcpy(&view->untiled_geometry, &view->unmaximized_geometry,
+				sizeof(view->untiled_geometry));
+		}
+		view->is_tiled = true;
+	}
+	view->maximized = false;
+
 	if (view->w == dst.width && view->h == dst.height) {
 		/* move horizontally/vertically without changing size */
 		view_move(view, dst.x, dst.y);


### PR DESCRIPTION
This could need some testing, especially in combination with (un)maximizing or fullscreen (fullscreen not actually tested \*at all\*)

Fixes #391