### PR TITLE
Resolve focus change theme color transition error

### DIFF
--- a/include/ssd.h
+++ b/include/ssd.h
@@ -135,7 +135,7 @@ struct ssd_hover_state {
 /* Public SSD API */
 void ssd_create(struct view *view);
 void ssd_hide(struct view *view);
-void ssd_set_active(struct view *view);
+void ssd_set_active(struct view *view, bool activated);
 void ssd_update_title(struct view *view);
 void ssd_update_geometry(struct view *view);
 void ssd_reload(struct view *view);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -285,19 +285,11 @@ ssd_part_contains(enum ssd_part_type whole, enum ssd_part_type candidate)
 }
 
 void
-ssd_set_active(struct view *view)
+ssd_set_active(struct view *view, bool activated)
 {
 	if (!view->ssd.tree) {
 		return;
 	}
-
-	struct view *last = view->server->ssd_focused_view;
-	if (last == view) {
-		return;
-	}
-	if (last && last->ssd.tree) {
-		_ssd_set_active(&last->ssd, false);
-	}
-	_ssd_set_active(&view->ssd, true);
+	_ssd_set_active(&view->ssd, activated);
 	view->server->ssd_focused_view = view;
 }

--- a/src/view.c
+++ b/src/view.c
@@ -14,7 +14,7 @@ void
 view_set_activated(struct view *view, bool activated)
 {
 	if (view->ssd.enabled) {
-		ssd_set_active(view);
+		ssd_set_active(view, activated);
 	}
 	if (view->impl->set_activated) {
 		view->impl->set_activated(view, activated);


### PR DESCRIPTION
When using the server decoration, the focus shifts to the client decorated with the client, and the theme color will not become inactive.
