### PR TITLE
src/ssd/ssd.c: Keep view->margin in sync when toggling decorations

### DIFF
--- a/include/ssd.h
+++ b/include/ssd.h
@@ -134,7 +134,6 @@ struct ssd_hover_state {
 
 /* Public SSD API */
 void ssd_create(struct view *view);
-void ssd_hide(struct view *view);
 void ssd_set_active(struct view *view);
 void ssd_update_title(struct view *view);
 void ssd_update_geometry(struct view *view);

--- a/src/server.c
+++ b/src/server.c
@@ -42,7 +42,6 @@ reload_config_and_theme(void)
 		if (!view->mapped || !view->ssd.enabled) {
 			continue;
 		}
-		view->margin = ssd_thickness(view);
 		ssd_reload(view);
 	}
 

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -17,6 +17,10 @@
 struct border
 ssd_thickness(struct view *view)
 {
+	if (!view->ssd.enabled) {
+		struct border border = { 0 };
+		return border;
+	}
 	struct theme *theme = view->server->theme;
 	struct border border = {
 		.top = theme->title_height + theme->border_width,
@@ -159,6 +163,7 @@ ssd_create(struct view *view)
 	ssd_extents_create(view);
 	ssd_border_create(view);
 	ssd_titlebar_create(view);
+	view->margin = ssd_thickness(view);
 }
 
 void
@@ -171,10 +176,12 @@ ssd_update_geometry(struct view *view)
 	if (!view->ssd.enabled) {
 		if (view->ssd.tree->node.enabled) {
 			wlr_scene_node_set_enabled(&view->ssd.tree->node, false);
+			view->margin = ssd_thickness(view);
 		}
 		return;
 	} else if (!view->ssd.tree->node.enabled) {
 		wlr_scene_node_set_enabled(&view->ssd.tree->node, true);
+		view->margin = ssd_thickness(view);
 	}
 
 	int width = view->w;
@@ -196,15 +203,6 @@ ssd_update_geometry(struct view *view)
 	view->ssd.state.height = height;
 	view->ssd.state.x = view->x;
 	view->ssd.state.y = view->y;
-}
-
-void
-ssd_hide(struct view *view)
-{
-	if (!view->ssd.tree) {
-		return;
-	}
-	wlr_scene_node_set_enabled(&view->ssd.tree->node, false);
 }
 
 void ssd_reload(struct view *view)

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -298,7 +298,6 @@ xdg_toplevel_view_map(struct view *view)
 
 		view->ssd.enabled = has_ssd(view);
 		if (view->ssd.enabled) {
-			view->margin = ssd_thickness(view);
 			ssd_create(view);
 		}
 
@@ -311,7 +310,6 @@ xdg_toplevel_view_map(struct view *view)
 		}
 
 		view_discover_output(view);
-
 		view->been_mapped = true;
 	}
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -329,7 +329,7 @@ map(struct view *view)
 	if (!view->been_mapped) {
 		view->ssd.enabled = want_deco(view);
 		if (view->ssd.enabled) {
-			view->margin = ssd_thickness(view);
+			ssd_create(view);
 		}
 
 		if (!view->maximized && !view->fullscreen) {
@@ -341,11 +341,6 @@ map(struct view *view)
 		}
 
 		view_discover_output(view);
-
-		if (view->ssd.enabled) {
-			/* Create ssd after view_disover_output() had been called */
-			ssd_create(view);
-		}
 		view->been_mapped = true;
 	}
 


### PR DESCRIPTION
- Fixes #409

I'd welcome some testing to make sure this doesn't break anything else like center positioning or starting maximized.

While testing this I discovered Wayland native applications starting in fullscreen mode like `foot -F` actually keep their SSD for unknown reasons, that appears to be the case even without this PR though so its unrelated.