### PR TITLE
Convert SnapToEdge to use view_apply_xxx_geometry framework

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -306,6 +306,7 @@ struct view {
 	bool been_mapped;
 	bool minimized;
 	bool maximized;
+	uint32_t tiled;  /* private, enum view_edge in src/view.c */
 	struct wlr_output *fullscreen;
 
 	/* geometry of the wlr_surface contained within the view */

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -40,6 +40,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 			return;
 		}
 	}
+	view->tiled = 0;
 
 	/*
 	 * This function sets up an interactive move or resize operation, where

--- a/src/layers.c
+++ b/src/layers.c
@@ -25,6 +25,7 @@ layers_arrange(struct output *output)
 	wlr_output_effective_resolution(output->wlr_output,
 		&full_area.width, &full_area.height);
 	struct wlr_box usable_area = full_area;
+	struct wlr_box old_usable_area = output->usable_area;
 
 	struct server *server = output->server;
 	struct wlr_scene_output *scene_output =
@@ -100,7 +101,10 @@ layers_arrange(struct output *output)
 	}
 
 	/* Finally re-arrange all views based on usable_area */
-	desktop_arrange_all_views(server);
+	if (old_usable_area.width != output->usable_area.width
+			|| old_usable_area.height != output->usable_area.height) {
+		desktop_arrange_all_views(server);
+	}
 }
 
 static void

--- a/src/view.c
+++ b/src/view.c
@@ -426,6 +426,8 @@ view_toggle_decorations(struct view *view)
 		ssd_update_geometry(view);
 		if (view->maximized) {
 			view_apply_maximized_geometry(view);
+		} else if (view->tiled) {
+			view_apply_tiled_geometry(view, NULL);
 		}
 	}
 }
@@ -457,6 +459,8 @@ view_set_decorations(struct view *view, bool decorations)
 		ssd_update_geometry(view);
 		if (view->maximized) {
 			view_apply_maximized_geometry(view);
+		} else if (view->tiled) {
+			view_apply_tiled_geometry(view, NULL);
 		}
 	}
 }

--- a/src/view.c
+++ b/src/view.c
@@ -660,6 +660,9 @@ view_snap_to_edge(struct view *view, const char *direction)
 		wlr_log(WLR_ERROR, "no view");
 		return;
 	}
+	if (view->fullscreen) {
+		return;
+	}
 	struct output *output = view_output(view);
 	if (!output) {
 		wlr_log(WLR_ERROR, "no output");

--- a/src/view.c
+++ b/src/view.c
@@ -407,7 +407,11 @@ view_maximize(struct view *view, bool maximize)
 		view->maximized = true;
 	} else {
 		/* unmaximize */
-		view_apply_unmaximized_geometry(view);
+		if (view->tiled) {
+			view_apply_tiled_geometry(view, NULL);
+		} else {
+			view_apply_unmaximized_geometry(view);
+		}
 		view->maximized = false;
 	}
 }
@@ -501,6 +505,8 @@ view_set_fullscreen(struct view *view, bool fullscreen,
 		/* restore to normal */
 		if (view->maximized) {
 			view_apply_maximized_geometry(view);
+		} else if (view->tiled) {
+			view_apply_tiled_geometry(view, NULL);
 		} else {
 			view_apply_unmaximized_geometry(view);
 		}

--- a/src/view.c
+++ b/src/view.c
@@ -709,6 +709,10 @@ view_snap_to_edge(struct view *view, const char *direction)
 		}
 	}
 
+	if (view->maximized) {
+		view_maximize(view, false);
+	}
+
 	/* TODO: store old geometry if !maximized && !fullscreen && !tiled */
 	view->tiled = edge;
 	view_apply_tiled_geometry(view, output);

--- a/src/view.c
+++ b/src/view.c
@@ -525,6 +525,9 @@ view_adjust_for_layout_change(struct view *view)
 	} else if (view->maximized) {
 		/* recompute maximized geometry */
 		view_apply_maximized_geometry(view);
+	} else if (view->tiled) {
+		/* recompute tiled geometry */
+		view_apply_tiled_geometry(view, NULL);
 	} else {
 		/* reposition view if it's offscreen */
 		struct wlr_box box = { view->x, view->y, view->w, view->h };


### PR DESCRIPTION
This looks worse than it actually is, most of the changes are just moving the existing functions up.

What actually changed:
- `struct view` got a `uint32_t tiled` member (private use in `view.c`, using internal `enum view_edge`)
- `view_snap_to_edge()` got split into two parts, the original public one mainly doing the output change logic and modifying `view->tiled`, the other internal one (`view_apply_tiled_geometry(view, output)`) just getting and applying the layout
- `view_adjust_for_layout_change()` now additionally calls `view_apply_tiled_geometry(view, NULL)`
- `view_snap_to_edge()` was modified to use `wlr_output_layout_adjacent_output()` for its output changing logic instead of working based on coordinates
- when moving or resizing a tiled window, `view->tiled` is reset, so future layout changes will not restore to tiled geometry

What is missing (somewhat unrelated to these changes but could be added to this PR with its own commits:
- [x] when maximized and then using `SnapToEdge` we first should unmaximize
- [x] same for fullscreen (or prevent `SnapToEdge` completely while in fullscreen mode)
