### PR TITLE
Restore original geometry when moving a tiled window

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -312,8 +312,8 @@ struct view {
 	/* geometry of the wlr_surface contained within the view */
 	int x, y, w, h;
 
-	/* geometry before maximize */
-	struct wlr_box unmaximized_geometry;
+	/* user defined geometry before maximize / tiling / fullscreen */
+	struct wlr_box natural_geometry;
 
 	/*
 	 * margin refers to the space between the extremities of the

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -20,11 +20,11 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 	if (view->maximized) {
 		if (mode == LAB_INPUT_STATE_MOVE) {
 			int new_x = max_move_scale(view->server->seat.cursor->x,
-				view->x, view->w, view->unmaximized_geometry.width);
+				view->x, view->w, view->natural_geometry.width);
 			int new_y = max_move_scale(view->server->seat.cursor->y,
-				view->y, view->h, view->unmaximized_geometry.height);
-			view->unmaximized_geometry.x = new_x;
-			view->unmaximized_geometry.y = new_y;
+				view->y, view->h, view->natural_geometry.height);
+			view->natural_geometry.x = new_x;
+			view->natural_geometry.y = new_y;
 			view_maximize(view, false);
 			/*
 			 * view_maximize() indirectly calls view->impl->configure
@@ -34,8 +34,8 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 			 */
 			view->x = new_x;
 			view->y = new_y;
-			view->w = view->unmaximized_geometry.width;
-			view->h = view->unmaximized_geometry.height;
+			view->w = view->natural_geometry.width;
+			view->h = view->natural_geometry.height;
 		} else {
 			return;
 		}
@@ -102,9 +102,9 @@ interactive_end(struct view *view)
 					 * When unmaximizing later on restore
 					 * original position
 					 */
-					view->unmaximized_geometry.x =
+					view->natural_geometry.x =
 						view->server->grab_box.x;
-					view->unmaximized_geometry.y =
+					view->natural_geometry.y =
 						view->server->grab_box.y;
 				} else {
 					view_snap_to_edge(view, "up");

--- a/src/view.c
+++ b/src/view.c
@@ -344,13 +344,13 @@ view_apply_maximized_geometry(struct view *view)
 static void
 set_fallback_geometry(struct view *view)
 {
-	view->unmaximized_geometry.width = LAB_FALLBACK_WIDTH;
-	view->unmaximized_geometry.height = LAB_FALLBACK_HEIGHT;
+	view->natural_geometry.width = LAB_FALLBACK_WIDTH;
+	view->natural_geometry.height = LAB_FALLBACK_HEIGHT;
 	view_compute_centered_position(view,
-		view->unmaximized_geometry.width,
-		view->unmaximized_geometry.height,
-		&view->unmaximized_geometry.x,
-		&view->unmaximized_geometry.y);
+		view->natural_geometry.width,
+		view->natural_geometry.height,
+		&view->natural_geometry.x,
+		&view->natural_geometry.y);
 }
 
 static void
@@ -361,18 +361,18 @@ view_apply_unmaximized_geometry(struct view *view)
 	 * width/height may still be zero in which case we set some fallback
 	 * values. This is the case with foot and Qt applications.
 	 */
-	if (wlr_box_empty(&view->unmaximized_geometry)) {
+	if (wlr_box_empty(&view->natural_geometry)) {
 		set_fallback_geometry(view);
 	}
 
 	struct wlr_output_layout *layout = view->server->output_layout;
 	if (wlr_output_layout_intersects(layout, NULL,
-			&view->unmaximized_geometry)) {
+			&view->natural_geometry)) {
 		/* restore to original geometry */
-		view_move_resize(view, view->unmaximized_geometry);
+		view_move_resize(view, view->natural_geometry);
 	} else {
 		/* reposition if original geometry is offscreen */
-		struct wlr_box box = view->unmaximized_geometry;
+		struct wlr_box box = view->natural_geometry;
 		if (view_compute_centered_position(view, box.width, box.height,
 				&box.x, &box.y)) {
 			view_move_resize(view, box);
@@ -398,10 +398,10 @@ view_maximize(struct view *view, bool maximize)
 	}
 	if (maximize) {
 		interactive_end(view);
-		view->unmaximized_geometry.x = view->x;
-		view->unmaximized_geometry.y = view->y;
-		view->unmaximized_geometry.width = view->w;
-		view->unmaximized_geometry.height = view->h;
+		view->natural_geometry.x = view->x;
+		view->natural_geometry.y = view->y;
+		view->natural_geometry.width = view->w;
+		view->natural_geometry.height = view->h;
 
 		view_apply_maximized_geometry(view);
 		view->maximized = true;
@@ -494,10 +494,10 @@ view_set_fullscreen(struct view *view, bool fullscreen,
 	}
 	if (fullscreen) {
 		if (!view->maximized) {
-			view->unmaximized_geometry.x = view->x;
-			view->unmaximized_geometry.y = view->y;
-			view->unmaximized_geometry.width = view->w;
-			view->unmaximized_geometry.height = view->h;
+			view->natural_geometry.x = view->x;
+			view->natural_geometry.y = view->y;
+			view->natural_geometry.width = view->w;
+			view->natural_geometry.height = view->h;
 		}
 		view->fullscreen = wlr_output;
 		view_apply_fullscreen_geometry(view, view->fullscreen);


### PR DESCRIPTION
Follow-up and depends on
- #426

Replaces
- #401

Contains all commits from #426, will rebase once that one is merged.