### PR TITLE
(Partly) fix handling of client-initiated configure requests

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -365,6 +365,7 @@ struct view {
 struct xwayland_unmanaged {
 	struct server *server;
 	struct wlr_xwayland_surface *xwayland_surface;
+	struct wlr_scene_node *node;
 	struct wl_list link;
 	int lx, ly;
 

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -20,6 +20,8 @@ unmanaged_handle_commit(struct wl_listener *listener, void *data)
 	struct wlr_xwayland_surface *xsurface = unmanaged->xwayland_surface;
 	unmanaged->lx = xsurface->x;
 	unmanaged->ly = xsurface->y;
+	wlr_scene_node_set_position(unmanaged->node,
+		unmanaged->lx, unmanaged->ly);
 }
 
 static void
@@ -59,10 +61,11 @@ unmanaged_handle_map(struct wl_listener *listener, void *data)
 	}
 
 	/* node will be destroyed automatically once surface is destroyed */
-	struct wlr_scene_node *node = &wlr_scene_surface_create(
+	unmanaged->node = &wlr_scene_surface_create(
 			unmanaged->server->unmanaged_tree,
 			xsurface->surface)->buffer->node;
-	wlr_scene_node_set_position(node, unmanaged->lx, unmanaged->ly);
+	wlr_scene_node_set_position(unmanaged->node,
+		unmanaged->lx, unmanaged->ly);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -144,6 +144,13 @@ handle_request_configure(struct wl_listener *listener, void *data)
 	int height = event->height;
 	view_adjust_size(view, &width, &height);
 
+	view->pending_move_resize.update_x = event->x != view->x;
+	view->pending_move_resize.update_y = event->y != view->y;
+	view->pending_move_resize.x = event->x;
+	view->pending_move_resize.y = event->y;
+	view->pending_move_resize.width = width;
+	view->pending_move_resize.height = height;
+
 	wlr_xwayland_surface_configure(view->xwayland_surface,
 		event->x, event->y, width, height);
 }
@@ -216,6 +223,13 @@ move(struct view *view, double x, double y)
 {
 	view->x = x;
 	view->y = y;
+
+	/* override any previous pending move */
+	view->pending_move_resize.update_x = false;
+	view->pending_move_resize.update_y = false;
+	view->pending_move_resize.x = x;
+	view->pending_move_resize.y = y;
+
 	struct wlr_xwayland_surface *s = view->xwayland_surface;
 	wlr_xwayland_surface_configure(s, (int16_t)x, (int16_t)y,
 		(uint16_t)s->width, (uint16_t)s->height);


### PR DESCRIPTION
- Add missing call to wlr_scene_node_set_position() in
  unmanaged_handle_commit() -- this fixes moving unmanaged XWayland
  windows.

- Update view->pending_move_resize when we receive a configure request
  for a managed XWayland surface -- this fixes moving managed but
  undecorated XWayland windows.

- Also update view->pending_move_resize when we move a surface while a
  configure request is already pending -- this fixes a discrepancy
  between displayed and actual position for XWayland windows that try to
  set their own initial position, but then get overridden by labwc's
  positioning.

Moving undecorated XWayland windows is still really glitchy -- it appears
that an XWayland window gets sent incorrect mouse motion coordinates when
there is a pending configure request moving the window itself.

Fixes #418 