### PR TITLE
src/osd.c: Add preview outlines

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -202,6 +202,8 @@ struct server {
 	/* Tree for built in menu */
 	struct wlr_scene_tree *menu_tree;
 
+	struct multi_rect *osd_preview_outline;
+
 	/* Workspaces */
 	struct wl_list workspaces;  /* struct workspace.link */
 	struct workspace *workspace_current;


### PR DESCRIPTION
![outlines](https://user-images.githubusercontent.com/35009135/177203074-5aec2ccd-55bb-4c2b-91e4-a9b7ce78e96e.png)

Missing:
- [x] use some theme defined color for the outlines
- [x] use some theme defined width of the outlines
- [ ] ~~use some config setting to enable / disable the outlines~~
- [x] destroy the multi_rect on `Reconfigure` (so its using the new theme when used the next time)
- [ ] extend the theme to define the 3 colors + width but keep falling back to `osd.bg` + `osd.label.text` + `osd.border.width`
- [ ] do we want this in the first place?
