### PR TITLE
cursor: Fix crash when creating a cursor constraint and there is no c…

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -410,7 +410,7 @@ create_constraint(struct wl_listener *listener, void *data)
 	wl_signal_add(&wlr_constraint->events.destroy, &constraint->destroy);
 
 	view = desktop_focused_view(server);
-	if (view->surface == wlr_constraint->surface) {
+	if (view && view->surface == wlr_constraint->surface) {
 		constrain_cursor(server, wlr_constraint);
 	}
 }


### PR DESCRIPTION
…urrently focused view

Fixes a crash starting Warhammer 40,000: Dawn of War II (15620)