### PR TITLE
buf.c: fix bug in environment variable expansion

### DIFF
--- a/src/common/buf.c
+++ b/src/common/buf.c
@@ -28,7 +28,7 @@ buf_expand_shell_variables(struct buf *s)
 			environment_variable.len = 0;
 			buf_add(&environment_variable, s->buf + i + 1);
 			char *p = environment_variable.buf;
-			while (isalnum(*p) || *p == '{' || *p == '}') {
+			while (isalnum(*p) || *p == '_' || *p == '{' || *p == '}') {
 				++p;
 			}
 			*p = '\0';


### PR DESCRIPTION
Allow underscore in environment variable names.

Closes issue #439

Helped-by: @Consolatis
...who both found the bug and told us how to fix it :)