### PR TITLE
main: Increase FD limit

### DIFF
--- a/include/common/fd_util.h
+++ b/include/common/fd_util.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LABWC_FD_UTIL_H
+#define __LABWC_FD_UTIL_H
+
+void increase_nofile_limit(void);
+void restore_nofile_limit(void);
+
+#endif /* __LABWC_FD_UTIL_H */

--- a/src/common/fd_util.c
+++ b/src/common/fd_util.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+
+#include <sys/resource.h>
+#include <wlr/util/log.h>
+
+#include "common/fd_util.h"
+
+static struct rlimit original_nofile_rlimit = {0};
+
+void
+increase_nofile_limit(void)
+{
+	if (getrlimit(RLIMIT_NOFILE, &original_nofile_rlimit) != 0) {
+		wlr_log_errno(WLR_ERROR, "Failed to bump max open files limit: getrlimit(NOFILE) failed");
+		return;
+	}
+
+	struct rlimit new_rlimit = original_nofile_rlimit;
+	new_rlimit.rlim_cur = new_rlimit.rlim_max;
+	if (setrlimit(RLIMIT_NOFILE, &new_rlimit) != 0) {
+		wlr_log_errno(WLR_ERROR, "Failed to bump max open files limit: setrlimit(NOFILE) failed");
+
+		wlr_log(WLR_INFO, "Running with %d max open files",
+            (int)original_nofile_rlimit.rlim_cur);
+	}
+}
+
+void
+restore_nofile_limit(void)
+{
+	if (original_nofile_rlimit.rlim_cur == 0) {
+		return;
+	}
+
+	if (setrlimit(RLIMIT_NOFILE, &original_nofile_rlimit) != 0) {
+		wlr_log_errno(WLR_ERROR, "Failed to restore max open files limit: setrlimit(NOFILE) failed");
+	}
+}

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -1,6 +1,7 @@
 labwc_sources += files(
   'buf.c',
   'dir.c',
+  'fd_util.c',
   'font.c',
   'grab-file.c',
   'nodename.c',

--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <wlr/util/log.h>
 #include "common/spawn.h"
+#include "common/fd_util.h"
 
 void
 spawn_async_no_shell(char const *command)
@@ -39,6 +40,8 @@ spawn_async_no_shell(char const *command)
 		wlr_log(WLR_ERROR, "unable to fork()");
 		goto out;
 	case 0:
+		restore_nofile_limit();
+
 		setsid();
 		sigset_t set;
 		sigemptyset(&set);

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include "theme.h"
 #include "xbm/xbm.h"
 #include "menu/menu.h"
+#include "common/fd_util.h"
 
 struct rcxml rc = { 0 };
 
@@ -84,6 +85,8 @@ main(int argc, char *argv[])
 		wlr_log(WLR_ERROR, "XDG_RUNTIME_DIR is unset");
 		exit(EXIT_FAILURE);
 	}
+
+	increase_nofile_limit();
 
 	struct server server = { 0 };
 	server_init(&server);


### PR DESCRIPTION
This defaults to 1024, which is tiny, but is a requirement
for processes using the deprecated `select` function.

We must reset this back whenever we fork to start a new process,
as this is inherited, and breaks applications using `select` otherwise.