### PR TITLE
xwayland: (Re)set seat when xwayland is ready

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -165,6 +165,7 @@ struct server {
 	struct wl_listener xdg_toplevel_decoration;
 #if HAVE_XWAYLAND
 	struct wlr_xwayland *xwayland;
+	struct wl_listener xwayland_ready;
 	struct wl_listener new_xwayland_surface;
 #endif
 


### PR DESCRIPTION
For some reason wlroots will reset the seat assigned to xwayland
to `NULL` whenever Xwayland terminates. This patch restores the seat
whenever Xwayland is ready again.

Fixes
- #166
- #444

Thanks @droc12345 for figuring out the actual issue.

Testing welcome.