### PR TITLE
Changes to get screen cast portals working

### DIFF
--- a/docs/labwc.desktop
+++ b/docs/labwc.desktop
@@ -3,4 +3,4 @@ Name=labwc
 Comment=A wayland stacking compositor
 Exec=labwc
 Type=Application
-
+DesktopNames=wlroots

--- a/src/main.c
+++ b/src/main.c
@@ -92,6 +92,15 @@ main(int argc, char *argv[])
 	server_init(&server);
 	server_start(&server);
 
+	/* Initialize systemd and dbus with our relevant variables
+	 * which are needed for some desktop portal use.
+	 *
+	 * This fixes things such as OBS screen casting not working.
+	 * In the worst case, on non-systemd/dbus systems, this will just not do anything.
+	 */
+	system("systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP");
+	system("dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP");
+
 	struct theme theme = { 0 };
 	theme_init(&theme, rc.theme_name);
 	rc.theme = &theme;


### PR DESCRIPTION
Sets the desktop name for the session and initializes some variables dbus/systemd need to call the right things.

With these changes, I can successfully screencast with OBS Studio, previously it would ask the global portal interface and there would be none.

It doesn't find portals itself to talk to like some other applications do.