### PR TITLE
xwayland: Process unmanaged client configure requests more quickly

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -368,12 +368,10 @@ struct xwayland_unmanaged {
 	struct wlr_xwayland_surface *xwayland_surface;
 	struct wlr_scene_node *node;
 	struct wl_list link;
-	int lx, ly;
 
 	struct wl_listener request_activate;
 	struct wl_listener request_configure;
 /*	struct wl_listener request_fullscreen; */
-	struct wl_listener commit;
 	struct wl_listener set_geometry;
 	struct wl_listener map;
 	struct wl_listener unmap;


### PR DESCRIPTION
This is a similar fix to 065c37d3f5ee but for unmanaged windows.  The issue
could be seen for example when moving the undocked Search Tool window in
Audacious.  For unmanaged windows, we don't track any pending move/resizes,
so just process all client configure requests immediately.

Video of the issue:
https://user-images.githubusercontent.com/1244737/180612621-461f4503-faa3-4a00-ab4b-411929985478.mp4
