### PR TITLE
src/config/session.c: Update dbus / systemd activation environment

### DIFF
--- a/docs/environment
+++ b/docs/environment
@@ -1,5 +1,8 @@
 # Example environment file
 
+# This allows xdg-desktop-portal-wlr to function (e.g. for screen-recording)
+XDG_CURRENT_DESKTOP=wlroots
+
 # Set keyboard layout to Swedish
 XKB_DEFAULT_LAYOUT=se
 

--- a/docs/labwc.desktop
+++ b/docs/labwc.desktop
@@ -3,4 +3,4 @@ Name=labwc
 Comment=A wayland stacking compositor
 Exec=labwc
 Type=Application
-
+DesktopNames=wlroots

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -79,6 +79,9 @@ build_path(const char *dir, const char *filename)
 	}
 	int len = strlen(dir) + strlen(filename) + 2;
 	char *buffer = calloc(1, len);
+	if (!buffer) {
+		return NULL;
+	}
 	strcat(buffer, dir);
 	strcat(buffer, "/");
 	strcat(buffer, filename);
@@ -101,16 +104,24 @@ update_activation_env(const char *env_keys)
 	const char *systemd = "systemctl --user import-environment ";
 
 	cmd = calloc(1, strlen(dbus) + strlen(env_keys) + 1);
-	strcat(cmd, dbus);
-	strcat(cmd, env_keys);
-	spawn_async_no_shell(cmd);
-	free(cmd);
+	if (!cmd) {
+		wlr_log(WLR_ERROR, "Failed to allocate memory for dbus env update");
+	} else {
+		strcat(cmd, dbus);
+		strcat(cmd, env_keys);
+		spawn_async_no_shell(cmd);
+		free(cmd);
+	}
 
 	cmd = calloc(1, strlen(systemd) + strlen(env_keys) + 1);
-	strcat(cmd, systemd);
-	strcat(cmd, env_keys);
-	spawn_async_no_shell(cmd);
-	free(cmd);
+	if (!cmd) {
+		wlr_log(WLR_ERROR, "Failed to allocate memory for systemd env update");
+	} else {
+		strcat(cmd, systemd);
+		strcat(cmd, env_keys);
+		spawn_async_no_shell(cmd);
+		free(cmd);
+	}
 }
 
 void
@@ -148,6 +159,10 @@ session_autostart_init(const char *dir)
 	wlr_log(WLR_INFO, "run autostart file %s", autostart);
 	int len = strlen(autostart) + 4;
 	char *cmd = calloc(1, len);
+	if (!cmd) {
+		wlr_log(WLR_ERROR, "Failed to allocate memory for autostart command");
+		goto out;
+	}
 	strcat(cmd, "sh ");
 	strcat(cmd, autostart);
 	spawn_async_no_shell(cmd);


### PR DESCRIPTION
This allows xdg-desktop-portal-wlr to work out of the box for screen-recording.
If systemd or dbus is not available the environment update will fail gracefully.

This patch will set `XDG_CURRENT_DESKTOP=wlroots` but a user may change this by
either having the environment variable set before starting labwc or by having
a different value set in `~/.config/labwc/environment`.

Based on PR #461 by @Joshua-Ashton