### PR TITLE
src/action.c: Fix includes for kill() and getpid()

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
-#include <strings.h>
-#include <wlr/util/log.h>
+#define _POSIX_C_SOURCE 200809L
 #include <signal.h>
+#include <strings.h>
+#include <unistd.h>
+#include <wlr/util/log.h>
 #include "common/spawn.h"
 #include "common/zfree.h"
 #include "labwc.h"


### PR DESCRIPTION
Fixes #410

Backport of c49f4e735d98fbb942db2acc834a9173e2e6bdca