### PR TITLE
Use "bemenu-run -n" for the A-F3 default keybind to be on top of panels

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -92,7 +92,7 @@
       <action name="Execute"><command>alacritty</command></action>
     </keybind>
     <keybind key="A-F3">
-      <action name="Execute"><command>bemenu-run</command></action>
+      <action name="Execute"><command>bemenu-run -n</command></action>
     </keybind>
     <keybind key="A-F4">
       <action name="Close" />

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -503,7 +503,7 @@ static struct {
 	{ "A-Tab", "NextWindow", NULL },
 	{ "A-Escape", "Exit", NULL },
 	{ "W-Return", "Execute", "alacritty" },
-	{ "A-F3", "Execute", "bemenu-run" },
+	{ "A-F3", "Execute", "bemenu-run -n" },
 	{ "A-F4", "Close", NULL },
 	{ "W-a", "ToggleMaximize", NULL },
 	{ "A-Left", "MoveToEdge", "left" },


### PR DESCRIPTION
Fixes
- #474

I can't test this as I don't even have bemenu installed but the [man page](https://github.com/Cloudef/bemenu/blob/master/man/bemenu.1.scd.in#L103) for `-n` made sense.