### PR TITLE
menu: do not require label attribute for highest level menu definition

### DIFF
--- a/docs/labwc-menu.5.scd
+++ b/docs/labwc-menu.5.scd
@@ -15,7 +15,7 @@ A menu file must be entirely enclosed within <openbox_menu> and
 </openbox_menu> tags.  Inside these tags, menus are specified as follows:
 
 ```
-<menu id="" label="">
+<menu id="">
 
   <!-- A menu entry with an action, for example to execute an application -->
   <item label="">

--- a/docs/menu.xml
+++ b/docs/menu.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <openbox_menu>
-<menu id="client-menu" label="ClientMenu">
+
+<menu id="client-menu">
 	<item label="Minimize">
 		<action name="Iconify" />
 	</item>
@@ -31,7 +32,8 @@
 		<action name="Close" />
 	</item>
 </menu>
-<menu id="root-menu" label="">
+
+<menu id="root-menu">
   <item label="Web browser">
     <action name="Execute"><command>firefox</command></action>
   </item>


### PR DESCRIPTION
Allow highest level menu definitions - typically used for root-menu and
client-menu - to be defined like this:

    <openbox_menu>
      <menu id="">
      </menu>
    </openbox>

Previously this required a label attribute (which was not used for
anything and could be an empty string) as show below:

    <openbox_menu>
      <menu id="" label="">
      </menu>
    </openbox>

Closes issue #472