### PR TITLE
keybind: remove default alt-escape for Exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ If you have not created an rc.xml config file, default bindings will be:
 | combination              | action
 | ------------------------ | ------
 | `alt`-`tab`              | activate next window
-| `alt`-`escape`           | exit
 | `super`-`return`         | alacritty
 | `alt`-`F3`               | bemenu
 | `alt`-`F4`               | close window

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -153,7 +153,6 @@ The rest of this man page describes configuration options.
 
 ```
   A-Tab - next window
-  A-Escape - exit
   W-Return - alacritty
   A-F3 - run bemenu
   A-F4 - close window

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -82,9 +82,6 @@
   <keyboard>
     <repeatRate>25</repeatRate>
     <repeatDelay>600</repeatDelay>
-    <keybind key="A-Escape">
-      <action name="Exit" />
-    </keybind>
     <keybind key="A-Tab">
       <action name="NextWindow" />
     </keybind>

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -501,7 +501,6 @@ static struct {
 	const char *binding, *action, *command;
 } key_combos[] = {
 	{ "A-Tab", "NextWindow", NULL },
-	{ "A-Escape", "Exit", NULL },
 	{ "W-Return", "Execute", "alacritty" },
 	{ "A-F3", "Execute", "bemenu-run" },
 	{ "A-F4", "Close", NULL },


### PR DESCRIPTION
...because too many have exited the compositor by mistake trying to get
out of alt-tab cycling or similar.