### PR TITLE
cursor: Do not clamp motion coordinates for XWayland surfaces.

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -95,8 +95,8 @@ struct seat {
 	struct wlr_layer_surface_v1 *focused_layer;
 
 	/**
-	 * pressed view/surface will usually be NULL and is only set on button
-	 * press while the mouse is over a view surface and reset to NULL on
+	 * pressed view/surface/node will usually be NULL and is only set on
+	 * button press while the mouse is over a surface and reset to NULL on
 	 * button release.
 	 * It is used to send cursor motion events to a surface even though
 	 * the cursor has left the surface in the meantime.
@@ -106,6 +106,7 @@ struct seat {
 	 */
 	struct {
 		struct view *view;
+		struct wlr_scene_node *node;
 		struct wlr_surface *surface;
 	} pressed;
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -296,8 +296,16 @@ process_cursor_motion(struct server *server, uint32_t time)
 		}
 		sx = server->seat.cursor->x - view->x;
 		sy = server->seat.cursor->y - view->y;
-		sx = sx < 0 ? 0 : (sx > view->w ? view->w : sx);
-		sy = sy < 0 ? 0 : (sy > view->h ? view->h : sy);
+		/*
+		 * X11 apps expect to be able to receive motion events outside
+		 * the window area (this is necessary for client-side move/resize
+		 * handles to work properly).  So do not clamp the motion
+		 * coordinates for XWayland surfaces.
+		 */
+		if (view->type == LAB_XDG_SHELL_VIEW) {
+			sx = sx < 0 ? 0 : (sx > view->w ? view->w : sx);
+			sy = sy < 0 ? 0 : (sy > view->h ? view->h : sy);
+		}
 		if (view->type == LAB_XDG_SHELL_VIEW && view->xdg_surface) {
 			/* Take into account invisible CSD borders */
 			struct wlr_box geo;

--- a/src/layers.c
+++ b/src/layers.c
@@ -145,6 +145,10 @@ unmap(struct lab_layer_surface *layer)
 	if (seat->focused_layer == layer->scene_layer_surface->layer_surface) {
 		seat_set_focus_layer(seat, NULL);
 	}
+	if (seat->pressed.surface == layer->scene_layer_surface->layer_surface->surface) {
+		seat->pressed.node = NULL;
+		seat->pressed.surface = NULL;
+	}
 }
 
 static void


### PR DESCRIPTION
This is a follow-on to #453 and continues the effort to make
client-side move/resize of XWayland apps work properly.

X11 apps expect to be able to receive motion events outside
the window area; therefore, for XWayland surfaces, we should
not "clamp" the motion coordinates to within the surface.

Before this change, attempting to enlarge an XWayland window
using a client-side resize handle resulted in the window size
lagging behind the mouse cursor quite severely, since each
motion event was in effect allowed to expand the window by
only a few pixels.  The closer the initial button-press was
to the edge of the window, the worse the lag would be.

The discussion in #483 seems related, but centers around
native Wayland clients, with which I am less familiar.  For
XWayland surfaces, I believe the problem and solution are
pretty clear and simple.