### PR TITLE
view: view_move() s/double/int/ for x and y

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -272,7 +272,7 @@ struct view_impl {
 	void (*close)(struct view *view);
 	const char *(*get_string_prop)(struct view *view, const char *prop);
 	void (*map)(struct view *view);
-	void (*move)(struct view *view, double x, double y);
+	void (*move)(struct view *view, int x, int y);
 	void (*set_activated)(struct view *view, bool activated);
 	void (*set_fullscreen)(struct view *view, bool fullscreen);
 	void (*unmap)(struct view *view);
@@ -326,7 +326,7 @@ struct view {
 
 	struct view_pending_move_resize {
 		bool update_x, update_y;
-		double x, y;
+		int x, y;
 		uint32_t width, height;
 		uint32_t configure_serial;
 	} pending_move_resize;
@@ -418,7 +418,7 @@ void view_close(struct view *view);
  * For move only, use view_move()
  */
 void view_move_resize(struct view *view, struct wlr_box geo);
-void view_move(struct view *view, double x, double y);
+void view_move(struct view *view, int x, int y);
 void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
 /* view_wlr_output - return the output that a view is mostly on */

--- a/src/view.c
+++ b/src/view.c
@@ -119,7 +119,7 @@ view_close(struct view *view)
 }
 
 void
-view_move(struct view *view, double x, double y)
+view_move(struct view *view, int x, int y)
 {
 	if (view->impl->move) {
 		view->impl->move(view, x, y);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -186,7 +186,7 @@ xdg_toplevel_view_configure(struct view *view, struct wlr_box geo)
 }
 
 static void
-xdg_toplevel_view_move(struct view *view, double x, double y)
+xdg_toplevel_view_move(struct view *view, int x, int y)
 {
 	view->x = x;
 	view->y = y;

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -204,7 +204,7 @@ handle_set_class(struct wl_listener *listener, void *data)
 }
 
 static void
-move(struct view *view, double x, double y)
+move(struct view *view, int x, int y)
 {
 	assert(view->xwayland_surface);
 


### PR DESCRIPTION
@Consolatis @jlindgren90 Can you think of any reasons why we should stick with `double`? Everything else related seems to be int. Even `struct wlr_xwayland_surface_configure_event` uses `int16_t` for x and y.
