### PR TITLE
Feature/graphic helpers

### DIFF
--- a/include/common/graphic-helpers.h
+++ b/include/common/graphic-helpers.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+struct wlr_scene_tree;
+struct wlr_scene_rect;
+struct wl_listener;
+
+struct multi_rect {
+	struct wlr_scene_tree *tree;
+	int line_width; /* read-only */
+
+	/* Private */
+	struct wlr_scene_rect *top[3];
+	struct wlr_scene_rect *bottom[3];
+	struct wlr_scene_rect *left[3];
+	struct wlr_scene_rect *right[3];
+	struct wl_listener destroy;
+};
+
+/**
+ * Create a new multi_rect.
+ * A multi_rect consists of 3 nested rectangular outlines.
+ * Each of the rectangular outlines is using the same @line_width
+ * but its own color based on the @colors argument.
+ *
+ * The multi-rect can be positioned by positioning multi_rect->tree->node.
+ *
+ * It can be destroyed by destroying its tree node (or one of its
+ * parent nodes). Once the tree node has been destroyed the struct
+ * will be free'd automatically.
+ */
+struct multi_rect *multi_rect_create(struct wlr_scene_tree *parent,
+		float *colors[3], int line_width);
+
+void multi_rect_set_size(struct multi_rect *rect, int width, int height);

--- a/include/common/graphic-helpers.h
+++ b/include/common/graphic-helpers.h
@@ -32,3 +32,13 @@ struct multi_rect *multi_rect_create(struct wlr_scene_tree *parent,
 		float *colors[3], int line_width);
 
 void multi_rect_set_size(struct multi_rect *rect, int width, int height);
+
+/**
+ * Sets the cairo color.
+ * Splits a float[4] single color array into its own arguments
+ */
+void set_cairo_color(cairo_t *cairo, float *color);
+
+/* Draws a border with a specified line width */
+void draw_cairo_border(cairo_t *cairo, double width, double height,
+		double line_width);

--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <assert.h>
+#include <cairo.h>
 #include <stdlib.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/graphic-helpers.h"
@@ -57,4 +58,29 @@ multi_rect_set_size(struct multi_rect *rect, int width, int height)
 		wlr_scene_rect_set_size(rect->right[i],
 			line_width, height - i * line_width * 2);
 	}
+}
+
+/* Draws a border with a specified line width */
+void
+draw_cairo_border(cairo_t *cairo, double width, double height, double line_width)
+{
+	cairo_save(cairo);
+
+	double x, y, w, h;
+	/* The anchor point of a line is in the center */
+	x = y = line_width / 2;
+	w = width - line_width;
+	h = height - line_width;
+	cairo_set_line_width(cairo, line_width);
+	cairo_rectangle(cairo, x, y, w, h);
+	cairo_stroke(cairo);
+
+	cairo_restore(cairo);
+}
+
+/* Sets the cairo color. Splits the single color channels */
+void
+set_cairo_color(cairo_t *cairo, float *c)
+{
+	cairo_set_source_rgba(cairo, c[0], c[1], c[2], c[3]);
 }

--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_scene.h>
+#include "common/graphic-helpers.h"
+
+static void
+multi_rect_destroy_notify(struct wl_listener *listener, void *data)
+{
+	struct multi_rect *rect = wl_container_of(listener, rect, destroy);
+	free(rect);
+}
+
+struct multi_rect *
+multi_rect_create(struct wlr_scene_tree *parent, float *colors[3], int line_width)
+{
+	struct multi_rect *rect = calloc(1, sizeof(*rect));
+	rect->line_width = line_width;
+	rect->tree = wlr_scene_tree_create(parent);
+	rect->destroy.notify = multi_rect_destroy_notify;
+	wl_signal_add(&rect->tree->node.events.destroy, &rect->destroy);
+	for (size_t i = 0; i < 3; i++) {
+		rect->top[i] = wlr_scene_rect_create(rect->tree, 0, 0, colors[i]);
+		rect->right[i] = wlr_scene_rect_create(rect->tree, 0, 0, colors[i]);
+		rect->bottom[i] = wlr_scene_rect_create(rect->tree, 0, 0, colors[i]);
+		rect->left[i] = wlr_scene_rect_create(rect->tree, 0, 0, colors[i]);
+		wlr_scene_node_set_position(&rect->top[i]->node,
+			i * line_width, i * line_width);
+		wlr_scene_node_set_position(&rect->left[i]->node,
+			i * line_width, i * line_width);
+	}
+	return rect;
+}
+
+void
+multi_rect_set_size(struct multi_rect *rect, int width, int height)
+{
+	assert(rect);
+	int line_width = rect->line_width;
+
+	for (size_t i = 0; i < 3; i++) {
+
+		/* Reposition, top and left don't ever change */
+		wlr_scene_node_set_position(&rect->right[i]->node,
+			width - (i + 1) * line_width, i * line_width);
+		wlr_scene_node_set_position(&rect->bottom[i]->node,
+			i * line_width, height - (i + 1) * line_width);
+
+		/* Update sizes */
+		wlr_scene_rect_set_size(rect->top[i],
+			width - i * line_width * 2, line_width);
+		wlr_scene_rect_set_size(rect->bottom[i],
+			width - i * line_width * 2, line_width);
+		wlr_scene_rect_set_size(rect->left[i],
+			line_width, height - i * line_width * 2);
+		wlr_scene_rect_set_size(rect->right[i],
+			line_width, height - i * line_width * 2);
+	}
+}

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -4,6 +4,7 @@ labwc_sources += files(
   'fd_util.c',
   'font.c',
   'grab-file.c',
+  'graphic-helpers.c',
   'nodename.c',
   'scaled_font_buffer.c',
   'scaled_scene_buffer.c',

--- a/src/osd.c
+++ b/src/osd.c
@@ -7,6 +7,7 @@
 #include "buffer.h"
 #include "common/buf.h"
 #include "common/font.h"
+#include "common/graphic-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "theme.h"
@@ -19,30 +20,6 @@
 #define OSD_BORDER_WIDTH (6)
 #define OSD_TAB1 (120)
 #define OSD_TAB2 (300)
-
-static void
-set_source(cairo_t *cairo, float *c)
-{
-	cairo_set_source_rgba(cairo, c[0], c[1], c[2], c[3]);
-}
-
-/* Draws a border with a specified line width */
-static void
-draw_border(cairo_t *cairo, double width, double height, double line_width)
-{
-	cairo_save(cairo);
-
-	double x, y, w, h;
-	/* The anchor point of a line is in the center */
-	x = y = line_width / 2;
-	w = width - line_width;
-	h = height - line_width;
-	cairo_set_line_width(cairo, line_width);
-	cairo_rectangle(cairo, x, y, w, h);
-	cairo_stroke(cairo);
-
-	cairo_restore(cairo);
-}
 
 /* is title different from app_id/class? */
 static int
@@ -155,13 +132,13 @@ osd_update(struct server *server)
 		cairo_surface_t *surf = cairo_get_target(cairo);
 
 		/* background */
-		set_source(cairo, theme->osd_bg_color);
+		set_cairo_color(cairo, theme->osd_bg_color);
 		cairo_rectangle(cairo, 0, 0, w, h);
 		cairo_fill(cairo);
 
 		/* Border */
-		set_source(cairo, theme->osd_border_color);
-		draw_border(cairo, w, h, theme->osd_border_width);
+		set_cairo_color(cairo, theme->osd_border_color);
+		draw_cairo_border(cairo, w, h, theme->osd_border_width);
 
 		int y = OSD_BORDER_WIDTH;
 
@@ -177,7 +154,7 @@ osd_update(struct server *server)
 				continue;
 			}
 			if (view == server->cycle_view) {
-				set_source(cairo, theme->osd_label_text_color);
+				set_cairo_color(cairo, theme->osd_label_text_color);
 				cairo_rectangle(cairo, OSD_BORDER_WIDTH, y,
 					OSD_ITEM_WIDTH, OSD_ITEM_HEIGHT);
 				cairo_stroke(cairo);
@@ -187,7 +164,7 @@ osd_update(struct server *server)
 		}
 
 		/* text */
-		set_source(cairo, theme->osd_label_text_color);
+		set_cairo_color(cairo, theme->osd_label_text_color);
 		PangoLayout *layout = pango_cairo_create_layout(cairo);
 		pango_layout_set_width(layout,
 			(OSD_ITEM_WIDTH - 2 * OSD_ITEM_PADDING) * PANGO_SCALE);

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -9,6 +9,7 @@
 #include <strings.h>
 #include "labwc.h"
 #include "common/font.h"
+#include "common/graphic-helpers.h"
 #include "common/zfree.h"
 #include "workspaces.h"
 
@@ -43,33 +44,6 @@ parse_workspace_index(const char *name)
 		return 0;
 	}
 	return index;
-}
-
-/*
- * TODO: set_source and draw_border are straight up copies from src/osd.c
- * find some proper place for them instead of duplicating stuff.
- */
-static void
-set_source(cairo_t *cairo, float *c)
-{
-	cairo_set_source_rgba(cairo, c[0], c[1], c[2], c[3]);
-}
-
-static void
-draw_border(cairo_t *cairo, double width, double height, double line_width)
-{
-	cairo_save(cairo);
-
-	double x, y, w, h;
-	/* The anchor point of a line is in the center */
-	x = y = line_width / 2;
-	w = width - line_width;
-	h = height - line_width;
-	cairo_set_line_width(cairo, line_width);
-	cairo_rectangle(cairo, x, y, w, h);
-	cairo_stroke(cairo);
-
-	cairo_restore(cairo);
 }
 
 static void
@@ -110,18 +84,18 @@ _osd_update(struct server *server)
 		cairo = buffer->cairo;
 
 		/* Background */
-		set_source(cairo, theme->osd_bg_color);
+		set_cairo_color(cairo, theme->osd_bg_color);
 		cairo_rectangle(cairo, 0, 0, width, height);
 		cairo_fill(cairo);
 
 		/* Border */
-		set_source(cairo, theme->osd_border_color);
-		draw_border(cairo, width, height, theme->osd_border_width);
+		set_cairo_color(cairo, theme->osd_border_color);
+		draw_cairo_border(cairo, width, height, theme->osd_border_width);
 
 		uint16_t x = (width - marker_width) / 2;
 		wl_list_for_each(workspace, &server->workspaces, link) {
 			bool active =  workspace == server->workspace_current;
-			set_source(cairo, server->theme->osd_label_text_color);
+			set_cairo_color(cairo, server->theme->osd_label_text_color);
 			cairo_rectangle(cairo, x, margin,
 				rect_width - padding, rect_height);
 			cairo_stroke(cairo);
@@ -134,7 +108,7 @@ _osd_update(struct server *server)
 		}
 
 		/* Text */
-		set_source(cairo, server->theme->osd_label_text_color);
+		set_cairo_color(cairo, server->theme->osd_label_text_color);
 		PangoLayout *layout = pango_cairo_create_layout(cairo);
 		pango_layout_set_width(layout, (width - 2 * margin) * PANGO_SCALE);
 		pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);


### PR DESCRIPTION
Move some graphic helpers into a shared file so we don't have to have copies of those around.
Also adds a multi-color `multi_rect` for future use in `A-Tab` preview outlines / region indicators.