### PR TITLE
osd+keyboard: Two small Alt-Tab fixes

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -151,6 +151,7 @@ handle_compositor_keybindings(struct wl_listener *listener,
 				if (syms[i] == XKB_KEY_Escape) {
 					/* cancel */
 					server->cycle_view = NULL;
+					osd_finish(server);
 					return true;
 				}
 			}

--- a/src/osd.c
+++ b/src/osd.c
@@ -146,6 +146,10 @@ osd_update(struct server *server)
 	struct wlr_scene_node *node;
 	wl_list_for_each(output, &server->outputs, link) {
 		destroy_osd_nodes(output);
+		if (!output->wlr_output->enabled) {
+			continue;
+		}
+
 		float scale = output->wlr_output->scale;
 		int w = OSD_ITEM_WIDTH + (2 * OSD_BORDER_WIDTH);
 		int h = get_osd_height(node_list);


### PR DESCRIPTION
Two separate fixes for the Alt-Tab (window switcher) OSD, short and sweet. Hopefully I didn't miss anything.

- Fix extra Alt-Tab OSD being shown if there is a disabled output (e.g. laptop display when docked)
- Fix Alt-Tab OSD remaining displayed after pressing Alt-Tab then Escape