### PR TITLE
src/{common/font,theme}.c: Switch to cairo helpers

### DIFF
--- a/src/common/font.c
+++ b/src/common/font.c
@@ -7,6 +7,7 @@
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
 #include "common/font.h"
+#include "common/graphic-helpers.h"
 #include "labwc.h"
 #include "buffer.h"
 
@@ -99,7 +100,7 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	cairo_t *cairo = (*buffer)->cairo;
 	cairo_surface_t *surf = cairo_get_target(cairo);
 
-	cairo_set_source_rgba(cairo, color[0], color[1], color[2], color[3]);
+	set_cairo_color(cairo, color);
 	cairo_move_to(cairo, 0, 0);
 
 	PangoLayout *layout = pango_cairo_create_layout(cairo);

--- a/src/theme.c
+++ b/src/theme.c
@@ -20,6 +20,7 @@
 #include <strings.h>
 #include "common/dir.h"
 #include "common/font.h"
+#include "common/graphic-helpers.h"
 #include "common/string-helpers.h"
 #include "common/zfree.h"
 #include "config/rcxml.h"
@@ -358,12 +359,6 @@ struct rounded_corner_ctx {
 	} corner;
 };
 
-static void
-set_source(cairo_t *cairo, float *c)
-{
-	cairo_set_source_rgba(cairo, c[0], c[1], c[2], c[3]);
-}
-
 static struct lab_data_buffer *
 rounded_rect(struct rounded_corner_ctx *ctx)
 {
@@ -410,13 +405,13 @@ rounded_rect(struct rounded_corner_ctx *ctx)
 	}
 	cairo_close_path(cairo);
 	cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
-	set_source(cairo, ctx->fill_color);
+	set_cairo_color(cairo, ctx->fill_color);
 	cairo_fill_preserve(cairo);
 	cairo_stroke(cairo);
 
 	/* border */
 	cairo_set_line_cap(cairo, CAIRO_LINE_CAP_ROUND);
-	set_source(cairo, ctx->border_color);
+	set_cairo_color(cairo, ctx->border_color);
 	cairo_set_line_width(cairo, ctx->line_width);
 	double half_line_width = ctx->line_width / 2.0;
 	switch (ctx->corner) {


### PR DESCRIPTION
Missed these two when adding `common/graphic-helpers.c`.

The change in `common/font.c` is disputable as it adds another function call. Will revert if desired.