### PR TITLE
view/ssd: Handle view_set_activated(false) case correctly

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -188,7 +188,7 @@ struct server {
 	uint32_t resize_edges;
 
 	/* SSD state */
-	struct view *ssd_focused_view;
+	struct view *focused_view;
 	struct ssd_hover_state ssd_hover_state;
 
 	/* Tree for all non-layer xdg/xwayland-shell surfaces */
@@ -408,7 +408,7 @@ struct xwayland_unmanaged *xwayland_unmanaged_create(struct server *server,
 void unmanaged_handle_map(struct wl_listener *listener, void *data);
 #endif
 
-void view_set_activated(struct view *view, bool activated);
+void view_set_activated(struct view *view);
 void view_close(struct view *view);
 
 /**

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -134,7 +134,7 @@ struct ssd_hover_state {
 
 /* Public SSD API */
 void ssd_create(struct view *view);
-void ssd_set_active(struct view *view);
+void ssd_set_active(struct view *view, bool active);
 void ssd_update_title(struct view *view);
 void ssd_update_geometry(struct view *view);
 void ssd_reload(struct view *view);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -87,18 +87,6 @@ desktop_move_to_back(struct view *view)
 	wl_list_insert_tail(&view->server->views, &view->link);
 }
 
-static void
-deactivate_all_views(struct server *server)
-{
-	struct view *view;
-	wl_list_for_each (view, &server->views, link) {
-		if (!view->mapped) {
-			continue;
-		}
-		view_set_activated(view, false);
-	}
-}
-
 void
 desktop_arrange_all_views(struct server *server)
 {
@@ -151,8 +139,7 @@ desktop_focus_and_activate_view(struct seat *seat, struct view *view)
 		return;
 	}
 
-	deactivate_all_views(view->server);
-	view_set_activated(view, true);
+	view_set_activated(view);
 	seat_focus_surface(seat, view->surface);
 }
 


### PR DESCRIPTION
`view_set_activated()` takes a Boolean parameter `activated`.
`ssd_set_active()` needs a Boolean parameter as well, otherwise `view_set_activated(false)` results in calling `_ssd_set_active(true)`.

Partially fixes #494.