### PR TITLE
view: Do not call ssd_set_active() for inactive views

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -98,7 +98,7 @@ view_get_edge_snap_box(struct view *view, struct output *output,
 void
 view_set_activated(struct view *view, bool activated)
 {
-	if (view->ssd.enabled) {
+	if (activated && view->ssd.enabled) {
 		ssd_set_active(view);
 	}
 	if (view->impl->set_activated) {


### PR DESCRIPTION
Partially fixes #494.

A minimally-invasive fix for the obvious logic error in `view_set_active()`.  I would request that this be merged as at least a stop-gap fix until the best long-term solution is identified (see discussion in #504).