### PR TITLE
Chase wlroots: Culling

### DIFF
--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = c20468cfa292e99357fd504fc5b5884f6078ca96
+revision = fa7d2cb8d60ed48c44c707106c03682056ddfaca
 
 [provide]
 dependency_names = wlroots


### PR DESCRIPTION
To update the wlroots subproject use
meson subprojects update wlroots

Chases wlroots fa7d2cb8d60ed48c44c707106c03682056ddfaca
wlr_scene: Only consider visible parts of the node when culling background

Fixes #501