### PR TITLE
src/config/rcxml.c: Add support for <devault /> mousebinds

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -219,6 +219,13 @@ The rest of this man page describes configuration options.
 	- DoubleClick: Two presses within the doubleClickTime.
 	- Drag: Pressing the button within the context, then moving the cursor
 
+*<mouse><default />*
+	Load default mousebinds. This is an addition to the openbox
+	specification and provides a way to keep config files simpler whilst
+	allowing user specific binds.  Note that if no rc.xml is found, or if no
+	<mouse><mousebind> entries exist, the same default mousebinds will be
+	loaded even if the <default /> element is not provided.
+
 ## LIBINPUT
 
 *<libinput><device category="">*

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -111,7 +111,7 @@ mousebind_create(const char *context)
 	struct mousebind *m = calloc(1, sizeof(struct mousebind));
 	m->context = context_from_str(context);
 	if (m->context != LAB_SSD_NONE) {
-		wl_list_insert(&rc.mousebinds, &m->link);
+		wl_list_insert(rc.mousebinds.prev, &m->link);
 	}
 	wl_list_init(&m->actions);
 	return m;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -545,7 +545,7 @@ load_default_key_bindings(void)
 	}
 }
 
-static struct {
+static struct mouse_combos {
 	const char *context, *button, *event, *action, *command;
 } mouse_combos[] = {
 	{ "Left", "Left", "Drag", "Resize", NULL},
@@ -590,17 +590,26 @@ load_default_mouse_bindings(void)
 {
 	struct mousebind *m;
 	struct action *action;
+	struct mouse_combos *current;
 	for (int i = 0; mouse_combos[i].context; i++) {
-		m = mousebind_create(mouse_combos[i].context);
-		m->button = mousebind_button_from_str(mouse_combos[i].button,
-			&m->modifiers);
-		m->mouse_event = mousebind_event_from_str(mouse_combos[i].event);
+		current = &mouse_combos[i];
+		if (i == 0
+				|| strcmp(current->context, mouse_combos[i - 1].context)
+				|| strcmp(current->button, mouse_combos[i - 1].button)
+				|| strcmp(current->event, mouse_combos[i - 1].event)) {
 
-		action = action_create(mouse_combos[i].action);
+			/* Create new mousebind */
+			m = mousebind_create(current->context);
+			m->button = mousebind_button_from_str(current->button,
+				&m->modifiers);
+			m->mouse_event = mousebind_event_from_str(current->event);
+		}
+
+		action = action_create(current->action);
 		wl_list_insert(m->actions.prev, &action->link);
 
-		if (mouse_combos[i].command) {
-			action_arg_add_str(action, NULL, mouse_combos[i].command);
+		if (current->command) {
+			action_arg_add_str(action, NULL, current->command);
 		}
 	}
 }

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -42,6 +42,7 @@ enum font_place {
 };
 
 static void load_default_key_bindings(void);
+static void load_default_mouse_bindings(void);
 
 static void
 fill_keybind(char *nodename, char *content)
@@ -333,6 +334,11 @@ entry(xmlNode *node, char *nodename, char *content)
 	/* handle nodes without content, e.g. <keyboard><default /> */
 	if (!strcmp(nodename, "default.keyboard")) {
 		load_default_key_bindings();
+		return;
+	}
+	if (!strcmp(nodename, "devault.mouse")
+			|| !strcmp(nodename, "default.mouse")) {
+		load_default_mouse_bindings();
 		return;
 	}
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -547,7 +547,7 @@ handle_release_mousebinding(struct view *view, struct server *server,
 	bool activated_any = false;
 	bool activated_any_frame = false;
 
-	wl_list_for_each_reverse(mousebind, &rc.mousebinds, link) {
+	wl_list_for_each(mousebind, &rc.mousebinds, link) {
 		if (ssd_part_contains(mousebind->context, view_area)
 				&& mousebind->button == button
 				&& modifiers == mousebind->modifiers) {
@@ -629,7 +629,7 @@ handle_press_mousebinding(struct view *view, struct server *server,
 	bool activated_any = false;
 	bool activated_any_frame = false;
 
-	wl_list_for_each_reverse(mousebind, &rc.mousebinds, link) {
+	wl_list_for_each(mousebind, &rc.mousebinds, link) {
 		if (ssd_part_contains(mousebind->context, view_area)
 				&& mousebind->button == button
 				&& modifiers == mousebind->modifiers) {


### PR DESCRIPTION
This loads default mousebinds and provides a way to keep config files
simpler whilst allowing user specific binds.

Note that if no rc.xml is found, or if no <mouse><mousebind> entries
exist, the same default mousebinds will be loaded even if the <devault />
element is not provided.

Example usage (with a slight spelling error):
```xml
  <mouse>
    <default />
    <context name="Root">
      <mousebind button="Right" action="Press">
        <action name="ShowMenu" menu="desktop-menu" />
      </mousebind>
    </context>
  </mouse>
```
Co-Authored-By: @johanmalm