### PR TITLE
src/view.c: Fix minimizing the last window

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -217,6 +217,18 @@ view_minimize(struct view *view, bool minimized)
 	if (minimized) {
 		view->impl->unmap(view);
 		desktop_move_to_back(view);
+		_view_set_activated(view, false);
+		if (view == view->server->focused_view) {
+			/*
+			 * Prevents clearing the active view when
+			 * we don't actually have keyboard focus.
+			 *
+			 * This may happen when using a custom mouse
+			 * focus configuration or by using the foreign
+			 * toplevel protocol via some panel.
+			 */
+			view->server->focused_view = NULL;
+		}
 	} else {
 		view->impl->map(view);
 	}


### PR DESCRIPTION
Before this patch, minimizing the last un-minimized window would
not cause it to be set to inactive. This in turn would confuse panels
which depend on the 'active' flag to decide when to either activate or
minimize the clicked on window.

Reported-by: @Flrian
Predicted-by: @johanmalm