### PR TITLE
src/xwayland-unmanaged.c: Give keyboard focus back to topmost mapped view

### DIFF
--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -88,6 +88,12 @@ unmanaged_handle_unmap(struct wl_listener *listener, void *data)
 			return;
 		}
 	}
+	/*
+	 * If we don't find a surface to focus fall back
+	 * to the topmost mapped view. This fixes dmenu
+	 * not giving focus back when closed with ESC.
+	 */
+	desktop_focus_topmost_mapped_view(unmanaged->server);
 }
 
 static void


### PR DESCRIPTION
Previously, when unmapping and not finding another unmanaged surface
to give keyboard focus to we were not doing anything. With this patch
we will give focus to the topmost mapped view which is the same
behavior that also happens when an usual X11 surface unmaps.

This fixes dmenu when being exited with ESC.

Reported-by: @Flrian