### PR TITLE
[wip] Preliminary support for overwriting subpixel rendering

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -11,6 +11,7 @@
     <decoration>server</decoration>
     <gap>0</gap>
     <adaptiveSync>no</adaptiveSync>
+    <subpixel>0</subpixel>
     <cycleViewPreview>no</cycleViewPreview>
     <cycleViewOutlines>yes</cycleViewOutlines>
   </core>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <wayland-server-core.h>
+#include <wayland-server-protocol.h>
 
 #include "common/buf.h"
 #include "config/libinput.h"
@@ -17,6 +18,7 @@ struct rcxml {
 	bool xdg_shell_server_side_deco;
 	int gap;
 	bool adaptive_sync;
+	enum wl_output_subpixel subpixel;
 
 	/* focus */
 	bool focus_follow_mouse;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -360,6 +360,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.gap = atoi(content);
 	} else if (!strcasecmp(nodename, "adaptiveSync.core")) {
 		rc.adaptive_sync = get_bool(content);
+	} else if (!strcasecmp(nodename, "subpixel.core")) {
+		rc.subpixel = atoi(content);
 	} else if (!strcmp(nodename, "name.theme")) {
 		rc.theme_name = strdup(content);
 	} else if (!strcmp(nodename, "cornerradius.theme")) {
@@ -490,6 +492,7 @@ rcxml_init()
 	wl_list_init(&rc.mousebinds);
 	wl_list_init(&rc.libinput_categories);
 	rc.xdg_shell_server_side_deco = true;
+	rc.subpixel = WL_OUTPUT_SUBPIXEL_UNKNOWN;
 	rc.corner_radius = 8;
 	rc.font_size_activewindow = 10;
 	rc.font_size_menuitem = 10;

--- a/src/output.c
+++ b/src/output.c
@@ -9,6 +9,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include "config.h"
 #include <assert.h>
+#include <wayland-server-protocol.h>
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_output.h>
@@ -16,6 +17,7 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/region.h>
 #include <wlr/util/log.h>
+
 #include "buffer.h"
 #include "labwc.h"
 #include "layers.h"
@@ -105,6 +107,15 @@ new_output_notify(struct wl_listener *listener, void *data)
 	struct wlr_output_mode *preferred_mode =
 		wlr_output_preferred_mode(wlr_output);
 	wlr_output_set_mode(wlr_output, preferred_mode);
+
+	/* Allow to overwrite subpixel rendering */
+	if (rc.subpixel != WL_OUTPUT_SUBPIXEL_UNKNOWN
+			&& rc.subpixel != wlr_output->subpixel) {
+		wlr_log(WLR_ERROR,
+			"changing configured output subpixel rendering from %u to %u",
+			wlr_output->subpixel, rc.subpixel);
+		wlr_output_set_subpixel(wlr_output, rc.subpixel);
+	}
 
 	/*
 	 * Sometimes the preferred mode is not available due to hardware


### PR DESCRIPTION
Reported-by: @acoolstraw

Missing:
- [ ] docs
- [ ] use actual subpixel rendering names for the config instead of using raw enum based integers
- [ ] use a better config option name, "subpixel" doesn't really say all that much
- [ ] turn log message into debug
- [ ] create a copy of the enum so we don't have to depend on wayland-protocols
- [ ] wire up for `Reconfigure`