### PR TITLE
cursor: Fix out-of-surface movement for unmanaged surfaces

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -559,6 +559,7 @@ void seat_finish(struct server *server);
 void seat_reconfigure(struct server *server);
 void seat_focus_surface(struct seat *seat, struct wlr_surface *surface);
 void seat_set_focus_layer(struct seat *seat, struct wlr_layer_surface_v1 *layer);
+void seat_reset_pressed(struct seat *seat);
 
 void interactive_begin(struct view *view, enum input_mode mode,
 		      uint32_t edges);

--- a/src/layers.c
+++ b/src/layers.c
@@ -146,8 +146,7 @@ unmap(struct lab_layer_surface *layer)
 		seat_set_focus_layer(seat, NULL);
 	}
 	if (seat->pressed.surface == layer->scene_layer_surface->layer_surface->surface) {
-		seat->pressed.node = NULL;
-		seat->pressed.surface = NULL;
+		seat_reset_pressed(seat);
 	}
 }
 

--- a/src/seat.c
+++ b/src/seat.c
@@ -369,3 +369,11 @@ seat_set_focus_layer(struct seat *seat, struct wlr_layer_surface_v1 *layer)
 		seat->focused_layer = layer;
 	}
 }
+
+void
+seat_reset_pressed(struct seat *seat)
+{
+	seat->pressed.view = NULL;
+	seat->pressed.node = NULL;
+	seat->pressed.surface = NULL;
+}

--- a/src/view.c
+++ b/src/view.c
@@ -813,8 +813,7 @@ view_destroy(struct view *view)
 
 	if (server->seat.pressed.view == view) {
 		/* Mouse was pressed on surface and is still pressed */
-		server->seat.pressed.view = NULL;
-		server->seat.pressed.surface = NULL;
+		seat_reset_pressed(&server->seat);
 	}
 
 	if (server->focused_view == view) {

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -57,6 +57,8 @@ unmanaged_handle_unmap(struct wl_listener *listener, void *data)
 	struct xwayland_unmanaged *unmanaged =
 		wl_container_of(listener, unmanaged, unmap);
 	struct wlr_xwayland_surface *xsurface = unmanaged->xwayland_surface;
+	struct seat *seat = &unmanaged->server->seat;
+
 	wl_list_remove(&unmanaged->link);
 	wl_list_remove(&unmanaged->set_geometry.link);
 
@@ -64,9 +66,11 @@ unmanaged_handle_unmap(struct wl_listener *listener, void *data)
 	 * Mark the node as gone so a racing configure event
 	 * won't try to reposition the node while unmapped.
 	 */
+	if (unmanaged->node && seat->pressed.node == unmanaged->node) {
+		seat_reset_pressed(seat);
+	}
 	unmanaged->node = NULL;
 
-	struct seat *seat = &unmanaged->server->seat;
 	if (seat->seat->keyboard_state.focused_surface == xsurface->surface) {
 		/*
 		 * Try to focus on parent surface


### PR DESCRIPTION
Fixes an issue when dragging an unmanaged XWayland surface (e.g. `kdiff3` toolbar) -- if the mouse moves outside the toolbar, the toolbar gets "stuck" and no longer follows the mouse.

The handling for unmanaged surfaces is pretty similar to what we do for layer-shell surfaces.