### PR TITLE
cursor: Update focus when unmanaged surfaces are mapped/unmapped

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -522,14 +522,6 @@ struct view *desktop_node_and_view_at(struct server *server, double lx,
 struct view *desktop_view_at_cursor(struct server *server);
 
 /**
- * cursor_rebase - set cursor icon for and send motion-event to surface below it
- * @seat - current seat
- * @time_msec - time now
- * @force - disable check for skipping already focused surface
- */
-void cursor_rebase(struct seat *seat, uint32_t time_msec, bool force);
-
-/**
  * cursor_set - set cursor icon
  * @seat - current seat
  * @cursor_name - name of cursor, for example "left_ptr" or "grab"
@@ -537,7 +529,7 @@ void cursor_rebase(struct seat *seat, uint32_t time_msec, bool force);
 void cursor_set(struct seat *seat, const char *cursor_name);
 
 /**
- * cursor_update_focus - update cursor focus
+ * cursor_update_focus - update cursor focus, may update the cursor icon
  * @server - server
  * Use it to force an update of the cursor icon and to send an enter event
  * to the surface below the cursor.

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -27,6 +27,11 @@ is_surface(enum ssd_part_type view_area)
 void
 cursor_rebase(struct seat *seat, uint32_t time_msec, bool force)
 {
+	if (seat->pressed.surface) {
+		/* Don't leave surface while a button is pressed */
+		return;
+	}
+
 	double sx, sy;
 	struct wlr_scene_node *node;
 	enum ssd_part_type view_area = LAB_SSD_NONE;
@@ -41,7 +46,7 @@ cursor_rebase(struct seat *seat, uint32_t time_msec, bool force)
 	if (surface) {
 		if (!force && surface == seat->seat->pointer_state.focused_surface) {
 			/*
-			 * Usually we prevent re-entering an already focued surface
+			 * Usually we prevent re-entering an already focused surface
 			 * because it sends useless leave and enter events.
 			 *
 			 * They may also seriously confuse clients if sent between

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -847,6 +847,9 @@ cursor_axis(struct wl_listener *listener, void *data)
 	struct wlr_pointer_axis_event *event = data;
 	wlr_idle_notify_activity(seat->wlr_idle, seat->seat);
 
+	/* Make sure we are sending the events to the surface under the cursor */
+	cursor_update_focus(seat->server);
+
 	/* Notify the client with pointer focus of the axis event. */
 	wlr_seat_pointer_notify_axis(seat->seat, event->time_msec,
 		event->orientation, event->delta, event->delta_discrete,

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -43,6 +43,8 @@ cursor_rebase(struct seat *seat, uint32_t time_msec, bool force)
 		surface = lab_wlr_surface_from_node(node);
 	}
 
+	ssd_update_button_hover(node, &seat->server->ssd_hover_state);
+
 	if (surface) {
 		if (!force && surface == seat->seat->pointer_state.focused_surface) {
 			/*

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -27,11 +27,6 @@ is_surface(enum ssd_part_type view_area)
 void
 cursor_rebase(struct seat *seat, uint32_t time_msec, bool force)
 {
-	if (seat->pressed.surface) {
-		/* Don't leave surface while a button is pressed */
-		return;
-	}
-
 	double sx, sy;
 	struct wlr_scene_node *node;
 	enum ssd_part_type view_area = LAB_SSD_NONE;
@@ -44,6 +39,10 @@ cursor_rebase(struct seat *seat, uint32_t time_msec, bool force)
 	}
 
 	ssd_update_button_hover(node, &seat->server->ssd_hover_state);
+	if (seat->pressed.surface && surface != seat->pressed.surface) {
+		/* Don't leave surface when a button was pressed over another surface */
+		return;
+	}
 
 	if (surface) {
 		if (!force && surface == seat->seat->pointer_state.focused_surface) {

--- a/src/view.c
+++ b/src/view.c
@@ -149,6 +149,7 @@ view_moved(struct view *view)
 	wlr_scene_node_set_position(&view->scene_tree->node, view->x, view->y);
 	view_discover_output(view);
 	ssd_update_geometry(view);
+	cursor_update_focus(view->server);
 }
 
 /* N.B. Use view_move() if not resizing. */

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -40,16 +40,23 @@ handle_commit(struct wl_listener *listener, void *data)
 	struct wlr_box size;
 	wlr_xdg_surface_get_geometry(view->xdg_surface, &size);
 
-	view->w = size.width;
-	view->h = size.height;
+	bool update_required = false;
+
+	if (view->w != size.width || view->h != size.height) {
+		update_required = true;
+		view->w = size.width;
+		view->h = size.height;
+	}
 
 	uint32_t serial = view->pending_move_resize.configure_serial;
 	if (serial > 0 && serial >= view->xdg_surface->current.configure_serial) {
 		if (view->pending_move_resize.update_x) {
+			update_required = true;
 			view->x = view->pending_move_resize.x +
 				view->pending_move_resize.width - size.width;
 		}
 		if (view->pending_move_resize.update_y) {
+			update_required = true;
 			view->y = view->pending_move_resize.y +
 				view->pending_move_resize.height - size.height;
 		}
@@ -57,7 +64,9 @@ handle_commit(struct wl_listener *listener, void *data)
 			view->pending_move_resize.configure_serial = 0;
 		}
 	}
-	view_moved(view);
+	if (update_required) {
+		view_moved(view);
+	}
 }
 
 static void

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -11,6 +11,7 @@ unmanaged_handle_request_configure(struct wl_listener *listener, void *data)
 	wlr_xwayland_surface_configure(xsurface, ev->x, ev->y, ev->width, ev->height);
 	if (unmanaged->node) {
 		wlr_scene_node_set_position(unmanaged->node, ev->x, ev->y);
+		cursor_update_focus(unmanaged->server);
 	}
 }
 
@@ -22,6 +23,7 @@ unmanaged_handle_set_geometry(struct wl_listener *listener, void *data)
 	struct wlr_xwayland_surface *xsurface = unmanaged->xwayland_surface;
 	if (unmanaged->node) {
 		wlr_scene_node_set_position(unmanaged->node, xsurface->x, xsurface->y);
+		cursor_update_focus(unmanaged->server);
 	}
 }
 
@@ -49,6 +51,7 @@ unmanaged_handle_map(struct wl_listener *listener, void *data)
 			unmanaged->server->unmanaged_tree,
 			xsurface->surface)->buffer->node;
 	wlr_scene_node_set_position(unmanaged->node, xsurface->x, xsurface->y);
+	cursor_update_focus(unmanaged->server);
 }
 
 static void
@@ -102,6 +105,7 @@ unmanaged_handle_unmap(struct wl_listener *listener, void *data)
 		seat_reset_pressed(seat);
 	}
 	unmanaged->node = NULL;
+	cursor_update_focus(unmanaged->server);
 
 	if (seat->seat->keyboard_state.focused_surface == xsurface->surface) {
 		focus_next_surface(unmanaged->server, xsurface);


### PR DESCRIPTION
Update cursor focus when unmanaged XWayland surfaces are mapped/unmapped, unless an out-of-surface drag is in progress.

Fixes: #522