### PR TITLE
Honor XWayland client window positions

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -307,7 +307,7 @@ xdg_toplevel_view_map(struct view *view)
 			view_maximize(view, true);
 		}
 
-		view_discover_output(view);
+		view_moved(view);
 		view->been_mapped = true;
 	}
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -340,7 +340,7 @@ map(struct view *view)
 			view_center(view);
 		}
 
-		view_discover_output(view);
+		view_moved(view);
 		view->been_mapped = true;
 	}
 


### PR DESCRIPTION
Currently all XWayland views are centered, regardless of whether the application requested a specific window position. This breaks applications that save and restore their own window positions, and is particularly bad for usability when the application displays multiple windows (e.g. Audacious in Winamp mode), since they all get stacked on top of each other.

Two changes here:
- Honor the ICCCM window position hints
- Fix a bug where `wlr_scene_node_set_position()` might never be called

v2: Use `view_adjust_for_layout_change()` to make sure the window is still on-screen.