### PR TITLE
cursor: Fix GTK3 menus in native Wayland mode

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -152,6 +152,7 @@ struct seat {
 	struct wl_listener destroy_drag;
 	struct wl_listener constraint_commit;
 	struct wl_listener idle_inhibitor_create;
+	struct wl_listener pressed_surface_destroy;
 };
 
 struct lab_data_buffer;
@@ -561,6 +562,8 @@ void seat_finish(struct server *server);
 void seat_reconfigure(struct server *server);
 void seat_focus_surface(struct seat *seat, struct wlr_surface *surface);
 void seat_set_focus_layer(struct seat *seat, struct wlr_layer_surface_v1 *layer);
+void seat_set_pressed(struct seat *seat, struct view *view,
+	struct wlr_scene_node *node, struct wlr_surface *surface);
 void seat_reset_pressed(struct seat *seat);
 
 void interactive_begin(struct view *view, enum input_mode mode,

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -115,6 +115,7 @@ struct seat {
 		struct view *view;
 		struct wlr_scene_node *node;
 		struct wlr_surface *surface;
+		struct wlr_surface *toplevel;
 	} pressed;
 
 	struct wl_client *active_client_while_inhibited;
@@ -563,7 +564,8 @@ void seat_reconfigure(struct server *server);
 void seat_focus_surface(struct seat *seat, struct wlr_surface *surface);
 void seat_set_focus_layer(struct seat *seat, struct wlr_layer_surface_v1 *layer);
 void seat_set_pressed(struct seat *seat, struct view *view,
-	struct wlr_scene_node *node, struct wlr_surface *surface);
+	struct wlr_scene_node *node, struct wlr_surface *surface,
+	struct wlr_surface *toplevel);
 void seat_reset_pressed(struct seat *seat);
 
 void interactive_begin(struct view *view, enum input_mode mode,

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -814,9 +814,7 @@ cursor_button(struct wl_listener *listener, void *data)
 
 	/* Handle _press */
 	if (surface) {
-		seat->pressed.view = view;
-		seat->pressed.node = node;
-		seat->pressed.surface = surface;
+		seat_set_pressed(seat, view, node, surface);
 	}
 
 	if (server->input_mode == LAB_INPUT_STATE_MENU) {

--- a/src/layers.c
+++ b/src/layers.c
@@ -145,9 +145,6 @@ unmap(struct lab_layer_surface *layer)
 	if (seat->focused_layer == layer->scene_layer_surface->layer_surface) {
 		seat_set_focus_layer(seat, NULL);
 	}
-	if (seat->pressed.surface == layer->scene_layer_surface->layer_surface->surface) {
-		seat_reset_pressed(seat);
-	}
 }
 
 static void

--- a/src/seat.c
+++ b/src/seat.c
@@ -383,7 +383,8 @@ pressed_surface_destroy(struct wl_listener *listener, void *data)
 
 void
 seat_set_pressed(struct seat *seat, struct view *view,
-	struct wlr_scene_node *node, struct wlr_surface *surface)
+	struct wlr_scene_node *node, struct wlr_surface *surface,
+	struct wlr_surface *toplevel)
 {
 	assert(surface);
 	seat_reset_pressed(seat);
@@ -391,6 +392,7 @@ seat_set_pressed(struct seat *seat, struct view *view,
 	seat->pressed.view = view;
 	seat->pressed.node = node;
 	seat->pressed.surface = surface;
+	seat->pressed.toplevel = toplevel;
 	seat->pressed_surface_destroy.notify = pressed_surface_destroy;
 	wl_signal_add(&surface->events.destroy, &seat->pressed_surface_destroy);
 }
@@ -402,6 +404,7 @@ seat_reset_pressed(struct seat *seat)
 		seat->pressed.view = NULL;
 		seat->pressed.node = NULL;
 		seat->pressed.surface = NULL;
+		seat->pressed.toplevel = NULL;
 		wl_list_remove(&seat->pressed_surface_destroy.link);
 	}
 }

--- a/src/seat.c
+++ b/src/seat.c
@@ -370,10 +370,38 @@ seat_set_focus_layer(struct seat *seat, struct wlr_layer_surface_v1 *layer)
 	}
 }
 
+static void
+pressed_surface_destroy(struct wl_listener *listener, void *data)
+{
+	struct wlr_surface *surface = data;
+	struct seat *seat = wl_container_of(listener, seat,
+		pressed_surface_destroy);
+
+	assert(surface == seat->pressed.surface);
+	seat_reset_pressed(seat);
+}
+
+void
+seat_set_pressed(struct seat *seat, struct view *view,
+	struct wlr_scene_node *node, struct wlr_surface *surface)
+{
+	assert(surface);
+	seat_reset_pressed(seat);
+
+	seat->pressed.view = view;
+	seat->pressed.node = node;
+	seat->pressed.surface = surface;
+	seat->pressed_surface_destroy.notify = pressed_surface_destroy;
+	wl_signal_add(&surface->events.destroy, &seat->pressed_surface_destroy);
+}
+
 void
 seat_reset_pressed(struct seat *seat)
 {
-	seat->pressed.view = NULL;
-	seat->pressed.node = NULL;
-	seat->pressed.surface = NULL;
+	if (seat->pressed.surface) {
+		seat->pressed.view = NULL;
+		seat->pressed.node = NULL;
+		seat->pressed.surface = NULL;
+		wl_list_remove(&seat->pressed_surface_destroy.link);
+	}
 }

--- a/src/view.c
+++ b/src/view.c
@@ -815,11 +815,6 @@ view_destroy(struct view *view)
 		need_cursor_update = true;
 	}
 
-	if (server->seat.pressed.view == view) {
-		/* Mouse was pressed on surface and is still pressed */
-		seat_reset_pressed(&server->seat);
-	}
-
 	if (server->focused_view == view) {
 		server->focused_view = NULL;
 		need_cursor_update = true;

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -101,9 +101,6 @@ unmanaged_handle_unmap(struct wl_listener *listener, void *data)
 	 * Mark the node as gone so a racing configure event
 	 * won't try to reposition the node while unmapped.
 	 */
-	if (unmanaged->node && seat->pressed.node == unmanaged->node) {
-		seat_reset_pressed(seat);
-	}
 	unmanaged->node = NULL;
 	cursor_update_focus(unmanaged->server);
 


### PR DESCRIPTION
**Problem description**

Drop-down menus in GTK3 (native Wayland) applications are not working correctly:

1. Press and hold left mouse button over e.g. "File" in the menu bar
2. While holding the button, move the mouse down into the menu that appears
3. Let up the mouse button over the menu item you want to activate (e.g. "Open File")

With GTK3 apps in native Wayland mode, none of the menu items are highlighted while moving the mouse over them, and the menu simply closes when releasing the button (no menu item is activated).

I tested various GTK3 apps (Geany, Thunar, xfce4-terminal): all have the same issue.

**Other observations**

- The same issue occurs under both Sway and KWin.
- The issue does not occur under Weston.
- The issue does not occur with `GDK_BACKEND=X11`.
- Qt 5 menus don't suffer from the same issue.

There was a bug report of a similar issue at https://gitlab.gnome.org/GNOME/gtk/-/issues/3662 but it's supposedly fixed. There was apparently a change needed in Mutter as well.

**Analysis and fix/workaround**

Using `WAYLAND_DEBUG=1`, I found that Weston is sending leave/enter events when the mouse pointer enters the menu (XDG popup).  Labwc currently doesn't send any leave/enter events at this point due to our `seat.pressed` logic in `cursor.c`.  We can't just rip out that logic either, without breaking things in other scenarios.

It's tempting to just call this a bug in GTK3, especially given that it occurs under KWin as well.  But I'm not hopeful about our chances trying to get the GTK developers to share that perspective.

A workaround we could use (and what I've implemented in this pull request) is to add a special case (ugh) and send the leave/enter events when the pointer is moved between XDG surfaces owned by the same client.  There's some precedent for this, looking at how `wlroots` handles popup grabs (see `xdg_pointer_grab_enter()` in `wlr_xdg_popup.c`):
```
	if (wl_resource_get_client(surface->resource) == popup_grab->client) {
		wlr_seat_pointer_enter(grab->seat, surface, sx, sy);
	} else {
		wlr_seat_pointer_clear_focus(grab->seat);
	}
```

I'd appreciate some other ideas and lots of testing on this, to make sure it doesn't break other things.