### PR TITLE
cursor: Handle missing cursor theme

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -79,6 +79,7 @@ struct seat {
 	struct server *server;
 	struct wlr_keyboard_group *keyboard_group;
 
+	bool cursor_requires_fallback;
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;
 

--- a/src/server.c
+++ b/src/server.c
@@ -423,13 +423,7 @@ server_init(struct server *server)
 		wlr_log(WLR_DEBUG, "xwayland is running on display %s",
 			server->xwayland->display_name);
 	}
-#endif
 
-	if (!wlr_xcursor_manager_load(server->seat.xcursor_manager, 1)) {
-		wlr_log(WLR_ERROR, "cannot load xcursor theme");
-	}
-
-#if HAVE_XWAYLAND
 	struct wlr_xcursor *xcursor;
 	xcursor = wlr_xcursor_manager_get_xcursor(server->seat.xcursor_manager,
 						  XCURSOR_DEFAULT, 1);


### PR DESCRIPTION
Temporary fix for #246

This should be reverted once wlroots MR !3651 is merged.

Can be tested nested with `XCURSOR_PATH=/tmp/  labwc` and observing the cursor when moving or resizing a window.

~~This PR is based on top of #535, will rebase once that one is merged.~~