### PR TITLE
cursor: Factor out cursor_update_common() and fix some glitches

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -80,6 +80,12 @@ struct seat {
 	struct wlr_keyboard_group *keyboard_group;
 
 	bool cursor_requires_fallback;
+	/*
+	 * Name of most recent server-side cursor image.  Set by
+	 * cursor_set().  Cleared when a client surface is entered
+	 * (in that case the client is expected to set a cursor image).
+	 */
+	char *cursor_set_by_server;
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;
 
@@ -533,13 +539,12 @@ void cursor_set(struct seat *seat, const char *cursor_name);
 /**
  * cursor_update_focus - update cursor focus, may update the cursor icon
  * @server - server
- * @force_reenter - re-enter a surface if it already owns the cursor focus
  *
  * This can be used to give the mouse focus to the surface under the cursor
  * or to force an update of the cursor icon by sending an exit and enter
- * event to an already focused surface when @force_reenter is true.
+ * event to an already focused surface.
  */
-void cursor_update_focus(struct server *server, bool force_reenter);
+void cursor_update_focus(struct server *server);
 
 void cursor_init(struct seat *seat);
 void cursor_finish(struct seat *seat);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -65,7 +65,7 @@ desktop_move_to_front(struct view *view)
 #if HAVE_XWAYLAND
 	move_xwayland_sub_views_to_front(view);
 #endif
-	cursor_update_focus(view->server, false);
+	cursor_update_focus(view->server);
 }
 
 static void

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -134,14 +134,7 @@ interactive_end(struct view *view)
 				view_snap_to_edge(view, "down");
 			}
 		}
-		/*
-		 * First set the cursor image in case we moved / resized via SSD.
-		 * Then allow an application to set its own image in case there
-		 * is a surface below the cursor (e.g. moved / resized via 'Alt'
-		 * modifier). If there is no surface below the cursor the second
-		 * call is a no-op.
-		 */
-		cursor_set(&view->server->seat, XCURSOR_DEFAULT);
-		cursor_update_focus(view->server, true);
+		/* Update focus/cursor image */
+		cursor_update_focus(view->server);
 	}
 }

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -11,7 +11,7 @@ unmanaged_handle_request_configure(struct wl_listener *listener, void *data)
 	wlr_xwayland_surface_configure(xsurface, ev->x, ev->y, ev->width, ev->height);
 	if (unmanaged->node) {
 		wlr_scene_node_set_position(unmanaged->node, ev->x, ev->y);
-		cursor_update_focus(unmanaged->server, false);
+		cursor_update_focus(unmanaged->server);
 	}
 }
 
@@ -23,7 +23,7 @@ unmanaged_handle_set_geometry(struct wl_listener *listener, void *data)
 	struct wlr_xwayland_surface *xsurface = unmanaged->xwayland_surface;
 	if (unmanaged->node) {
 		wlr_scene_node_set_position(unmanaged->node, xsurface->x, xsurface->y);
-		cursor_update_focus(unmanaged->server, false);
+		cursor_update_focus(unmanaged->server);
 	}
 }
 
@@ -51,7 +51,7 @@ unmanaged_handle_map(struct wl_listener *listener, void *data)
 			unmanaged->server->unmanaged_tree,
 			xsurface->surface)->buffer->node;
 	wlr_scene_node_set_position(unmanaged->node, xsurface->x, xsurface->y);
-	cursor_update_focus(unmanaged->server, false);
+	cursor_update_focus(unmanaged->server);
 }
 
 static void
@@ -105,7 +105,7 @@ unmanaged_handle_unmap(struct wl_listener *listener, void *data)
 		seat_reset_pressed(seat);
 	}
 	unmanaged->node = NULL;
-	cursor_update_focus(unmanaged->server, false);
+	cursor_update_focus(unmanaged->server);
 
 	if (seat->seat->keyboard_state.focused_surface == xsurface->surface) {
 		focus_next_surface(unmanaged->server, xsurface);


### PR DESCRIPTION
Fix a couple of glitches seen when exiting interactive move/resize:

 - Cursor briefly set to `left_ptr` rather than the correct cursor image
 - Cursor not updated if the view being moved/resized is destroyed

Also make sure to exit interactive mode if the view is going fullscreen (labwc gets very confused otherwise).

Code changes in detail:

 - Factor out `set_server_cursor()` which will set the correct cursor image for non-client areas (either `XCURSOR_DEFAULT` or one of the resize cursors).
 - Unify the logic from `cursor_rebase()` and `process_cursor_motion()` by factoring out `cursor_update_common()`.  This corrects some logic discrepancies between the two, which should be a good thing(TM).
 - Remove the extra `cursor_set(XCURSOR_DEFAULT)` from `interactive_end()` and instead rely on `cursor_update_focus()` to do the right thing.
 - Simplify `cursor_button()` by just calling `interactive_end()` when we want to exit interactive mode.
 - Call `cursor_update_focus()` from `view_destroy()` if the view had mouse focus or was being interactively moved/resized.