### PR TITLE
cursor: Add struct cursor_context and clean up code

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -499,37 +499,41 @@ struct view *desktop_focused_view(struct server *server);
 void desktop_focus_topmost_mapped_view(struct server *server);
 bool isfocusable(struct view *view);
 
+struct cursor_context {
+	struct view *view;
+	struct wlr_scene_node *node;
+	struct wlr_surface *surface;
+	enum ssd_part_type type;
+	double sx, sy;
+};
+
 /**
- * desktop_node_and_view_at - find view and scene_node at (lx, ly)
+ * get_cursor_context - find view and scene_node at cursor
  *
  * Behavior if node points to a surface:
- *  - If surface is a layer-surface, *view_area will be
+ *  - If surface is a layer-surface, type will be
  *    set to LAB_SSD_LAYER_SURFACE and view will be NULL.
  *
  *  - If surface is a 'lost' unmanaged xsurface (one
- *    with a never-mapped parent view), *view_area will
+ *    with a never-mapped parent view), type will
  *    be set to LAB_SSD_UNMANAGED and view will be NULL.
  *
  *    'Lost' unmanaged xsurfaces are usually caused by
  *    X11 applications opening popups without setting
  *    the main window as parent. Example: VLC submenus.
  *
- *  - Any other surface will cause *view_area be set to
+ *  - Any other surface will cause type to be set to
  *    LAB_SSD_CLIENT and return the attached view.
  *
  * Behavior if node points to internal elements:
- *  - *view_area will be set to the appropiate enum value
+ *  - type will be set to the appropriate enum value
  *    and view will be NULL if the node is not part of the SSD.
  *
  * If no node is found for the given layout coordinates,
- * *view_area will be set to LAB_SSD_ROOT and view will be NULL.
+ * type will be set to LAB_SSD_ROOT and view will be NULL.
  *
  */
-struct view *desktop_node_and_view_at(struct server *server, double lx,
-	double ly, struct wlr_scene_node **scene_node, double *sx, double *sy,
-	enum ssd_part_type *view_area);
-
-struct view *desktop_view_at_cursor(struct server *server);
+struct cursor_context get_cursor_context(struct server *server);
 
 /**
  * cursor_set - set cursor icon

--- a/src/action.c
+++ b/src/action.c
@@ -275,7 +275,7 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_FOCUS:
-			view = desktop_view_at_cursor(server);
+			view = get_cursor_context(server).view;
 			if (view) {
 				desktop_focus_and_activate_view(&server->seat, view);
 			}
@@ -286,7 +286,7 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_MOVE:
-			view = desktop_view_at_cursor(server);
+			view = get_cursor_context(server).view;
 			if (view) {
 				interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
 			}
@@ -297,7 +297,7 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_RESIZE:
-			view = desktop_view_at_cursor(server);
+			view = get_cursor_context(server).view;
 			if (view) {
 				interactive_begin(view, LAB_INPUT_STATE_RESIZE,
 					resize_edges);


### PR DESCRIPTION
The `desktop_node_and_view_at()` function is quite cumbersome to use, because of all the "out" parameters.  It seems like a great candidate to return a `struct` containing all the related information.

Since `desktop_node_and_view_at()` is always used to find the view, node, `ssd_part_type` etc. around the mouse cursor, let's call the new struct `cursor_context` and rename the function to `get_cursor_context()`.  The `cursor_context` struct is also very useful for passing around as a single parameter inside `cursor.c`.

No functional change.