### PR TITLE
cursor: Use enum for server set cursor names

### DIFF
--- a/include/cursor.h
+++ b/include/cursor.h
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LABWC_CURSOR_H
+#define __LABWC_CURSOR_H
+
+#include <wlr/util/edges.h>
+#include "ssd.h"
+
+struct view;
+struct seat;
+struct server;
+struct wlr_surface;
+struct wlr_scene_node;
+
+/* Cursors used internally by labwc */
+enum lab_cursors {
+	LAB_CURSOR_CLIENT = 0,
+	LAB_CURSOR_DEFAULT,
+	LAB_CURSOR_GRAB,
+	LAB_CURSOR_RESIZE_NW,
+	LAB_CURSOR_RESIZE_N,
+	LAB_CURSOR_RESIZE_NE,
+	LAB_CURSOR_RESIZE_E,
+	LAB_CURSOR_RESIZE_SE,
+	LAB_CURSOR_RESIZE_S,
+	LAB_CURSOR_RESIZE_SW,
+	LAB_CURSOR_RESIZE_W,
+	LAB_CURSOR_COUNT
+};
+
+struct cursor_context {
+	struct view *view;
+	struct wlr_scene_node *node;
+	struct wlr_surface *surface;
+	enum ssd_part_type type;
+	double sx, sy;
+};
+
+/**
+ * get_cursor_context - find view and scene_node at cursor
+ *
+ * Behavior if node points to a surface:
+ *  - If surface is a layer-surface, type will be
+ *    set to LAB_SSD_LAYER_SURFACE and view will be NULL.
+ *
+ *  - If surface is a 'lost' unmanaged xsurface (one
+ *    with a never-mapped parent view), type will
+ *    be set to LAB_SSD_UNMANAGED and view will be NULL.
+ *
+ *    'Lost' unmanaged xsurfaces are usually caused by
+ *    X11 applications opening popups without setting
+ *    the main window as parent. Example: VLC submenus.
+ *
+ *  - Any other surface will cause type to be set to
+ *    LAB_SSD_CLIENT and return the attached view.
+ *
+ * Behavior if node points to internal elements:
+ *  - type will be set to the appropriate enum value
+ *    and view will be NULL if the node is not part of the SSD.
+ *
+ * If no node is found for the given layout coordinates,
+ * type will be set to LAB_SSD_ROOT and view will be NULL.
+ *
+ */
+struct cursor_context get_cursor_context(struct server *server);
+
+/**
+ * cursor_set - set cursor icon
+ * @seat - current seat
+ * @cursor_name - name of cursor, for example "left_ptr" or "grab"
+ */
+void cursor_set(struct seat *seat, const char *cursor_name);
+
+/**
+ * cursor_get_resize_edges - calculate resize edge based on cursor position
+ * @cursor - the current cursor (usually server->seat.cursor)
+ * @cursor_context - result of get_cursor_context()
+ *
+ * Calculates the resize edge combination that is most appropriate based
+ * on the current view and cursor position in relation to each other.
+ *
+ * This is mostly important when either resizing a window using a
+ * keyboard modifier or when using the Resize action from a keybind.
+ */
+uint32_t cursor_get_resize_edges(struct wlr_cursor *cursor,
+	struct cursor_context *ctx);
+
+/**
+ * cursor_update_focus - update cursor focus, may update the cursor icon
+ * @server - server
+ *
+ * This can be used to give the mouse focus to the surface under the cursor
+ * or to force an update of the cursor icon by sending an exit and enter
+ * event to an already focused surface.
+ */
+void cursor_update_focus(struct server *server);
+
+void cursor_init(struct seat *seat);
+void cursor_finish(struct seat *seat);
+
+#endif /* __LABWC_CURSOR_H */

--- a/include/cursor.h
+++ b/include/cursor.h
@@ -66,9 +66,9 @@ struct cursor_context get_cursor_context(struct server *server);
 /**
  * cursor_set - set cursor icon
  * @seat - current seat
- * @cursor_name - name of cursor, for example "left_ptr" or "grab"
+ * @cursor - name of cursor, for example LAB_CURSOR_DEFAULT or LAB_CURSOR_GRAB
  */
-void cursor_set(struct seat *seat, const char *cursor_name);
+void cursor_set(struct seat *seat, enum lab_cursors cursor);
 
 /**
  * cursor_get_resize_edges - calculate resize edge based on cursor position
@@ -83,6 +83,18 @@ void cursor_set(struct seat *seat, const char *cursor_name);
  */
 uint32_t cursor_get_resize_edges(struct wlr_cursor *cursor,
 	struct cursor_context *ctx);
+
+/**
+ * cursor_get_from_edge - translate wlroots edge enum to lab_cursor enum
+ * @resize_edges - WLR_EDGE_ combination like WLR_EDGE_TOP | WLR_EDGE_RIGHT
+ *
+ * Returns LAB_CURSOR_DEFAULT on WLR_EDGE_NONE
+ * Returns the appropriate lab_cursors enum if @resize_edges
+ * is one of the 4 corners or one of the 4 edges.
+ *
+ * Asserts on invalid edge combinations like WLR_EDGE_LEFT | WLR_EDGE_RIGHT
+ */
+enum lab_cursors cursor_get_from_edge(uint32_t resize_edges);
 
 /**
  * cursor_update_focus - update cursor focus, may update the cursor icon

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -45,6 +45,7 @@
 #include <wlr/xwayland.h>
 #endif
 #include <xkbcommon/xkbcommon.h>
+#include "cursor.h"
 #include "config/keybind.h"
 #include "config/rcxml.h"
 #include "ssd.h"
@@ -501,65 +502,6 @@ struct view *desktop_cycle_view(struct server *server, struct view *start_view,
 struct view *desktop_focused_view(struct server *server);
 void desktop_focus_topmost_mapped_view(struct server *server);
 bool isfocusable(struct view *view);
-
-struct cursor_context {
-	struct view *view;
-	struct wlr_scene_node *node;
-	struct wlr_surface *surface;
-	enum ssd_part_type type;
-	double sx, sy;
-};
-
-/**
- * get_cursor_context - find view and scene_node at cursor
- *
- * Behavior if node points to a surface:
- *  - If surface is a layer-surface, type will be
- *    set to LAB_SSD_LAYER_SURFACE and view will be NULL.
- *
- *  - If surface is a 'lost' unmanaged xsurface (one
- *    with a never-mapped parent view), type will
- *    be set to LAB_SSD_UNMANAGED and view will be NULL.
- *
- *    'Lost' unmanaged xsurfaces are usually caused by
- *    X11 applications opening popups without setting
- *    the main window as parent. Example: VLC submenus.
- *
- *  - Any other surface will cause type to be set to
- *    LAB_SSD_CLIENT and return the attached view.
- *
- * Behavior if node points to internal elements:
- *  - type will be set to the appropriate enum value
- *    and view will be NULL if the node is not part of the SSD.
- *
- * If no node is found for the given layout coordinates,
- * type will be set to LAB_SSD_ROOT and view will be NULL.
- *
- */
-struct cursor_context get_cursor_context(struct server *server);
-
-/**
- * cursor_set - set cursor icon
- * @seat - current seat
- * @cursor_name - name of cursor, for example "left_ptr" or "grab"
- */
-void cursor_set(struct seat *seat, const char *cursor_name);
-
-uint32_t cursor_get_resize_edges(struct wlr_cursor *cursor,
-	struct cursor_context *ctx);
-
-/**
- * cursor_update_focus - update cursor focus, may update the cursor icon
- * @server - server
- *
- * This can be used to give the mouse focus to the surface under the cursor
- * or to force an update of the cursor icon by sending an exit and enter
- * event to an already focused surface.
- */
-void cursor_update_focus(struct server *server);
-
-void cursor_init(struct seat *seat);
-void cursor_finish(struct seat *seat);
 
 void keyboard_init(struct seat *seat);
 bool keyboard_any_modifiers_pressed(struct wlr_keyboard *keyboard);

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -59,7 +59,6 @@
 
 #define XCURSOR_DEFAULT "left_ptr"
 #define XCURSOR_SIZE 24
-#define XCURSOR_MOVE "grabbing"
 
 enum input_mode {
 	LAB_INPUT_STATE_PASSTHROUGH = 0,
@@ -80,13 +79,12 @@ struct seat {
 	struct server *server;
 	struct wlr_keyboard_group *keyboard_group;
 
-	bool cursor_requires_fallback;
 	/*
-	 * Name of most recent server-side cursor image.  Set by
+	 * Enum of most recent server-side cursor image.  Set by
 	 * cursor_set().  Cleared when a client surface is entered
-	 * (in that case the client is expected to set a cursor image).
+	 * (in that case the client is expected to set its own cursor image).
 	 */
-	char *cursor_set_by_server;
+	enum lab_cursors server_cursor;
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;
 

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -84,10 +84,10 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 
 	switch (mode) {
 	case LAB_INPUT_STATE_MOVE:
-		cursor_set(&server->seat, "grab");
+		cursor_set(&server->seat, LAB_CURSOR_GRAB);
 		break;
 	case LAB_INPUT_STATE_RESIZE:
-		cursor_set(&server->seat, wlr_xcursor_get_resize_name(edges));
+		cursor_set(&server->seat, cursor_get_from_edge(edges));
 		break;
 	default:
 		break;

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -141,9 +141,8 @@ ssd_resize_edges(enum ssd_part_type type)
 	case LAB_SSD_PART_CORNER_BOTTOM_LEFT:
 		return WLR_EDGE_BOTTOM | WLR_EDGE_LEFT;
 	default:
-		break;
+		return WLR_EDGE_NONE;
 	}
-	return 0;
 }
 
 void


### PR DESCRIPTION
This mainly prevents having to use `strcmp()` on every mouse move.

Just a rough sketchup for now to gather some feedback, especially about the following:
- `static const char *cursor_{xdg,x11}[]` in a header, guarded by an additional `#ifdef`
- `static const char **cursor_names` in `src/cursor.c` which gets set in `cursor_init()`

I don't want to disturb others working on these parts of the code so I am happy to keep rebasing this if required.

Missing:
- [ ] `uint32_t` -> `enum wlr_edges`