### PR TITLE
action: Select resize edges for Resize triggered by keybind

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -545,6 +545,9 @@ struct cursor_context get_cursor_context(struct server *server);
  */
 void cursor_set(struct seat *seat, const char *cursor_name);
 
+uint32_t cursor_get_resize_edges(struct wlr_cursor *cursor,
+	struct cursor_context *ctx);
+
 /**
  * cursor_update_focus - update cursor focus, may update the cursor icon
  * @server - server

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -378,8 +378,8 @@ cursor_update_common(struct server *server, struct cursor_context *ctx,
 	}
 }
 
-static uint32_t
-determine_resize_edges(struct wlr_cursor *cursor, struct cursor_context *ctx)
+uint32_t
+cursor_get_resize_edges(struct wlr_cursor *cursor, struct cursor_context *ctx)
 {
 	uint32_t resize_edges = ssd_resize_edges(ctx->type);
 	if (ctx->view && !resize_edges) {
@@ -783,7 +783,7 @@ cursor_button_press(struct seat *seat, struct wlr_pointer_button_event *event)
 	struct cursor_context ctx = get_cursor_context(server);
 
 	/* Determine closest resize edges in case action is Resize */
-	uint32_t resize_edges = determine_resize_edges(seat->cursor, &ctx);
+	uint32_t resize_edges = cursor_get_resize_edges(seat->cursor, &ctx);
 
 	if (ctx.view || ctx.surface) {
 		/* Store resize edges for later action processing */


### PR DESCRIPTION
@Consolatis noticed in https://github.com/labwc/labwc/pull/544#discussion_r971306613 that `Resize` does not work when triggered from a keybind.  This fixes the issue by making `cursor_get_resize_edges()` public and calling from the keybind path also.

An alternative would be always to use a fixed value of `resize_edges` (e.g. `BOTTOM | RIGHT`) for the keybind case, rather than querying the cursor.

There is a very minor merge conflict with #545, due to renaming `determine_resize_edges()`.