### PR TITLE
config: s/OSD/OnScreenDisplay/ in <theme><font place="OSD">

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -126,7 +126,7 @@ The rest of this man page describes configuration options.
 	Places can be any of:
 	- ActiveWindow - titlebar of active window
 	- MenuItem - menu item (currently only root menu)
-	- OSD - items in the on screen display
+	- OnScreenDisplay - items in the on screen display
 	If no place attribute is provided, the setting will be applied to all
 	places.
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -31,7 +31,7 @@
       <slant>normal</slant>
       <weight>normal</weight>
     </font>
-    <font place="OSD">
+    <font place="OnScreenDisplay">
       <name>sans</name>
       <size>10</size>
       <slant>normal</slant>

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -298,7 +298,8 @@ enum_font_place(const char *place)
 		return FONT_PLACE_ACTIVEWINDOW;
 	} else if (!strcasecmp(place, "MenuItem")) {
 		return FONT_PLACE_MENUITEM;
-	} else if (!strcasecmp(place, "OSD")) {
+	} else if (!strcasecmp(place, "OnScreenDisplay")
+			|| !strcasecmp(place, "OSD")) {
 		return FONT_PLACE_OSD;
 	}
 	return FONT_PLACE_UNKNOWN;


### PR DESCRIPTION
...to comply with [Openbox 3.6 spec](http://openbox.org/wiki/Help:Configuration#Theme)

"OSD" is still honoured to maintain backward compatibility