### PR TITLE
Fix uses-after-free on exit

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -241,8 +241,15 @@ void
 keyboard_finish(struct seat *seat)
 {
 	if (seat->keyboard_group) {
+		/*
+		 * Caution - these event listeners are connected to
+		 * seat->keyboard_group->keyboard and must be
+		 * unregistered before wlr_keyboard_group_destroy(),
+		 * otherwise a use-after-free occurs.
+		 */
+		wl_list_remove(&seat->keyboard_key.link);
+		wl_list_remove(&seat->keyboard_modifiers.link);
 		wlr_keyboard_group_destroy(seat->keyboard_group);
+		seat->keyboard_group = NULL;
 	}
-	wl_list_remove(&seat->keyboard_key.link);
-	wl_list_remove(&seat->keyboard_modifiers.link);
 }

--- a/src/seat.c
+++ b/src/seat.c
@@ -317,8 +317,13 @@ seat_finish(struct server *server)
 	struct seat *seat = &server->seat;
 	wl_list_remove(&seat->new_input.link);
 	keyboard_finish(seat);
-	cursor_finish(seat);
+	/*
+	 * Caution - touch_finish() unregisters event listeners from
+	 * seat->cursor and must come before cursor_finish(), otherwise
+	 * a use-after-free occurs.
+	 */
 	touch_finish(seat);
+	cursor_finish(seat);
 }
 
 void


### PR DESCRIPTION
Fix a couple different use-after-free bugs due to unregistering a `wl_listener` after the event sender is already destroyed.

Off-topic: `QObject::connect()` solved this whole class of bugs a long time ago, by breaking the event connection as soon as either the event sender or recipient is destroyed.  Unfortunately a universal fix of that kind would probably require converting both `wlroots` and `labwc` to C++.