### PR TITLE
Fix minor coding-style violations

### DIFF
--- a/include/common/scaled_scene_buffer.h
+++ b/include/common/scaled_scene_buffer.h
@@ -59,7 +59,6 @@ struct scaled_scene_buffer *scaled_scene_buffer_create(
 /* Clear the cache of existing buffers, useful in case the content changes */
 void scaled_scene_buffer_invalidate_cache(struct scaled_scene_buffer *self);
 
-
 /* Private */
 struct scaled_scene_buffer_cache_entry {
 	struct wl_list link;   /* struct scaled_scene_buffer.cache */

--- a/include/workspaces.h
+++ b/include/workspaces.h
@@ -17,12 +17,11 @@ struct workspace {
 	struct wlr_scene_tree *tree;
 };
 
-
 void workspaces_init(struct server *server);
 void workspaces_switch_to(struct workspace *target);
 void workspaces_send_to(struct view *view, struct workspace *target);
 void workspaces_destroy(struct server *server);
 void workspaces_osd_hide(struct seat *seat);
-struct workspace * workspaces_find(struct workspace *anchor, const char *name);
+struct workspace *workspaces_find(struct workspace *anchor, const char *name);
 
 #endif /* __LABWC_WORKSPACES_H */

--- a/src/common/fd_util.c
+++ b/src/common/fd_util.c
@@ -12,17 +12,19 @@ void
 increase_nofile_limit(void)
 {
 	if (getrlimit(RLIMIT_NOFILE, &original_nofile_rlimit) != 0) {
-		wlr_log_errno(WLR_ERROR, "Failed to bump max open files limit: getrlimit(NOFILE) failed");
+		wlr_log_errno(WLR_ERROR,
+			"Failed to bump max open files limit: getrlimit(NOFILE) failed");
 		return;
 	}
 
 	struct rlimit new_rlimit = original_nofile_rlimit;
 	new_rlimit.rlim_cur = new_rlimit.rlim_max;
 	if (setrlimit(RLIMIT_NOFILE, &new_rlimit) != 0) {
-		wlr_log_errno(WLR_ERROR, "Failed to bump max open files limit: setrlimit(NOFILE) failed");
+		wlr_log_errno(WLR_ERROR,
+			"Failed to bump max open files limit: setrlimit(NOFILE) failed");
 
 		wlr_log(WLR_INFO, "Running with %d max open files",
-            (int)original_nofile_rlimit.rlim_cur);
+			(int)original_nofile_rlimit.rlim_cur);
 	}
 }
 

--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -42,7 +42,6 @@ multi_rect_set_size(struct multi_rect *rect, int width, int height)
 	int line_width = rect->line_width;
 
 	for (size_t i = 0; i < 3; i++) {
-
 		/* Reposition, top and left don't ever change */
 		wlr_scene_node_set_position(&rect->right[i]->node,
 			width - (i + 1) * line_width, i * line_width);

--- a/src/common/scaled_scene_buffer.c
+++ b/src/common/scaled_scene_buffer.c
@@ -112,8 +112,8 @@ _handle_node_destroy(struct wl_listener *listener, void *data)
 static void
 _handle_output_enter(struct wl_listener *listener, void *data)
 {
-	struct scaled_scene_buffer *self
-		= wl_container_of(listener, self, output_enter);
+	struct scaled_scene_buffer *self =
+		wl_container_of(listener, self, output_enter);
 	/* primary_output is the output most of the node area is in */
 	struct wlr_scene_output *primary = self->scene_buffer->primary_output;
 	/* scene_output is the output we just entered */
@@ -132,8 +132,8 @@ _handle_output_enter(struct wl_listener *listener, void *data)
 static void
 _handle_output_leave(struct wl_listener *listener, void *data)
 {
-	struct scaled_scene_buffer *self
-		= wl_container_of(listener, self, output_leave);
+	struct scaled_scene_buffer *self =
+		wl_container_of(listener, self, output_leave);
 	/* primary_output is the output most of the node area is in */
 	struct wlr_scene_output *primary = self->scene_buffer->primary_output;
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -608,7 +608,6 @@ load_default_mouse_bindings(void)
 				|| strcmp(current->context, mouse_combos[i - 1].context)
 				|| strcmp(current->button, mouse_combos[i - 1].button)
 				|| strcmp(current->event, mouse_combos[i - 1].event)) {
-
 			/* Create new mousebind */
 			m = mousebind_create(current->context);
 			m->button = mousebind_button_from_str(current->button,
@@ -640,7 +639,6 @@ merge_mouse_bindings(void)
 			if (existing->context == current->context
 					&& existing->button == current->button
 					&& existing->mouse_event == current->mouse_event) {
-
 				wl_list_remove(&existing->link);
 				action_list_free(&existing->actions);
 				free(existing);

--- a/src/debug.c
+++ b/src/debug.c
@@ -124,10 +124,10 @@ get_special(struct server *server, struct wlr_scene_node *node,
 	struct wlr_scene_tree *grand_parent =
 		node->parent ? node->parent->node.parent : NULL;
 	if (grand_parent == server->view_tree) {
-			*last_view = node_view_from_node(node);
+		*last_view = node_view_from_node(node);
 	}
 	if (node->parent == server->view_tree_always_on_top) {
-			*last_view = node_view_from_node(node);
+		*last_view = node_view_from_node(node);
 	}
 	const char *view_part = get_view_part(*last_view, node);
 	if (view_part) {

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -225,7 +225,7 @@ desktop_cycle_view(struct server *server, struct view *start_view,
 	assert(node->parent);
 	struct wl_list *list_head = &node->parent->children;
 	struct wl_list *list_item = &node->link;
-	struct wl_list *(*iter)(struct wl_list *);
+	struct wl_list *(*iter)(struct wl_list *list);
 
 	/* Scene nodes are ordered like last node == displayed topmost */
 	iter = dir == LAB_CYCLE_DIR_FORWARD ? get_prev_item : get_next_item;
@@ -336,8 +336,12 @@ get_cursor_context(struct server *server)
 				}
 				return ret;
 			case LAB_NODE_DESC_SSD_BUTTON: {
-				/* Always return the top scene node for SSD buttons */
-				struct ssd_button *button = node_ssd_button_from_node(node);
+				/*
+				 * Always return the top scene node for SSD
+				 * buttons
+				 */
+				struct ssd_button *button =
+					node_ssd_button_from_node(node);
 				ret.node = node;
 				ret.type = button->type;
 				ret.view = button->view;

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -24,7 +24,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 		 * If you think there is a good reason to allow it
 		 * feel free to open an issue explaining your use-case.
 		 */
-		 return;
+		return;
 	}
 	if (mode == LAB_INPUT_STATE_RESIZE
 			&& (view->fullscreen || view->maximized)) {

--- a/src/osd.c
+++ b/src/osd.c
@@ -328,7 +328,8 @@ osd_update(struct server *server)
 			PangoWeight weight = pango_font_description_get_weight(desc);
 			pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
 			pango_layout_set_font_description(layout, desc);
-			pango_layout_set_text(layout, server->workspace_current->name, -1);
+			pango_layout_set_text(layout,
+				server->workspace_current->name, -1);
 			pango_cairo_show_layout(cairo, layout);
 			pango_font_description_set_weight(desc, weight);
 			pango_layout_set_font_description(layout, desc);

--- a/src/output.c
+++ b/src/output.c
@@ -278,7 +278,8 @@ output_config_apply(struct server *server,
 		/* Only do Layout specific actions if the commit went trough */
 		if (need_to_add) {
 			wlr_output_layout_add_auto(server->output_layout, o);
-			output->scene_output = wlr_scene_get_scene_output(server->scene, o);
+			output->scene_output =
+				wlr_scene_get_scene_output(server->scene, o);
 			assert(output->scene_output);
 		}
 
@@ -291,7 +292,6 @@ output_config_apply(struct server *server,
 			wlr_output_layout_remove(server->output_layout, o);
 			output->scene_output = NULL;
 		}
-
 	}
 
 	server->pending_output_layout_change--;

--- a/src/server.c
+++ b/src/server.c
@@ -158,7 +158,7 @@ handle_drm_lease_request(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	for(size_t i = 0; i < req->n_connectors; ++i) {
+	for (size_t i = 0; i < req->n_connectors; ++i) {
 		struct output *output = req->connectors[i]->output->data;
 		if (!output) {
 			continue;
@@ -167,7 +167,8 @@ handle_drm_lease_request(struct wl_listener *listener, void *data)
 		wlr_output_enable(output->wlr_output, false);
 		wlr_output_commit(output->wlr_output);
 
-		wlr_output_layout_remove(output->server->output_layout, output->wlr_output);
+		wlr_output_layout_remove(output->server->output_layout,
+			output->wlr_output);
 		output->scene_output = NULL;
 
 		output->leased = true;
@@ -470,7 +471,6 @@ server_start(struct server *server)
 void
 server_finish(struct server *server)
 {
-
 #if HAVE_XWAYLAND
 	wlr_xwayland_destroy(server->xwayland);
 #endif

--- a/src/view.c
+++ b/src/view.c
@@ -304,6 +304,7 @@ set_fallback_geometry(struct view *view)
 		&view->natural_geometry.x,
 		&view->natural_geometry.y);
 }
+
 #undef LAB_FALLBACK_WIDTH
 #undef LAB_FALLBACK_HEIGHT
 

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -49,7 +49,6 @@ parse_workspace_index(const char *name)
 static void
 _osd_update(struct server *server)
 {
-
 	struct theme *theme = server->theme;
 
 	/* Settings */
@@ -138,7 +137,7 @@ _osd_update(struct server *server)
 			+ (output->usable_area.width - width) / 2
 			+ output_box.x;
 		int ly = output->usable_area.y
-			+ (output->usable_area.height - height ) / 2
+			+ (output->usable_area.height - height) / 2
 			+ output_box.y;
 		wlr_scene_node_set_position(&output->workspace_osd->node, lx, ly);
 		wlr_scene_buffer_set_buffer(output->workspace_osd, &buffer->base);
@@ -280,7 +279,6 @@ workspaces_send_to(struct view *view, struct workspace *target)
 	wlr_scene_node_reparent(&view->scene_tree->node, target->tree);
 	view->workspace = target;
 }
-
 
 void
 workspaces_osd_hide(struct seat *seat)


### PR DESCRIPTION
...based on https://github.com/johanmalm/checkpatch.pl

```
src/server.c:161: ERROR: space required before the open parenthesis '('
src/server.c:473: CHECK: Blank lines aren't necessary after an open brace '{'
src/desktop.c:228: WARNING: function definition argument 'struct wl_list *' should also have an identifier name
src/output.c:289: CHECK: Blank lines aren't necessary before a close brace '}'
src/interactive.c:20: WARNING: suspect code indent for conditional statements (8, 17)
src/interactive.c:27: WARNING: Statements should start on a tabstop
src/config/rcxml.c:607: CHECK: Blank lines aren't necessary after an open brace '{'
src/config/rcxml.c:638: CHECK: line length of 91 exceeds 90 columns
src/config/rcxml.c:639: CHECK: Blank lines aren't necessary after an open brace '{'
src/debug.c:126: WARNING: suspect code indent for conditional statements (8, 24)
src/debug.c:129: WARNING: suspect code indent for conditional statements (8, 24)
src/view.c:307: CHECK: Please use a blank line after function/struct/union/enum declarations
src/workspaces.c:52: CHECK: Blank lines aren't necessary after an open brace '{'
src/workspaces.c:147: ERROR: space prohibited before that close parenthesis ')'
src/workspaces.c:226: CHECK: line length of 91 exceeds 90 columns
src/workspaces.c:290: CHECK: Please don't use multiple blank lines
src/workspaces.c:328: WARNING: else is not generally useful after a break or return
src/cursor.c:18: ERROR: do not initialise statics to NULL
src/cursor.c:20: CHECK: Please don't use multiple blank lines
src/common/scaled_font_buffer.c:55: CHECK: Assignment operator '=' should be on the previous line
src/common/graphic-helpers.c:44: CHECK: Blank lines aren't necessary after an open brace '{'
src/common/graphic-helpers.c:71: CHECK: multiple assignments should be avoided
src/common/scaled_scene_buffer.c:115: CHECK: Assignment operator '=' should be on the previous line
src/common/scaled_scene_buffer.c:135: CHECK: Assignment operator '=' should be on the previous line
src/common/fd_util.c:15: CHECK: line length of 106 exceeds 90 columns
src/common/fd_util.c:22: CHECK: line length of 106 exceeds 90 columns
src/common/fd_util.c:25: ERROR: code indent should use tabs where possible
src/common/fd_util.c:25: WARNING: please, no spaces at the start of a line
include/workspaces.h:13: ERROR: code indent should use tabs where possible
include/workspaces.h:13: WARNING: Block comments use * on subsequent lines
include/workspaces.h:13: WARNING: Block comments use a trailing */ on a separate line
include/workspaces.h:20: CHECK: Please don't use multiple blank lines
include/workspaces.h:26: ERROR: "foo * bar" should be "foo *bar"
include/action.h:11: ERROR: code indent should use tabs where possible
include/action.h:12: ERROR: code indent should use tabs where possible
include/action.h:12: WARNING: Block comments use a trailing */ on a separate line
include/common/scaled_scene_buffer.h:62: CHECK: Please don't use multiple blank lines
```