### PR TITLE
keyboard: Fix SIGSEGV that showed up in out-of-memory fuzzing

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -226,8 +226,12 @@ keyboard_init(struct seat *seat)
 	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
 		XKB_KEYMAP_COMPILE_NO_FLAGS);
-	wlr_keyboard_set_keymap(kb, keymap);
-	xkb_keymap_unref(keymap);
+	if (keymap) {
+		wlr_keyboard_set_keymap(kb, keymap);
+		xkb_keymap_unref(keymap);
+	} else {
+		wlr_log(WLR_ERROR, "Failed to create xkb keymap");
+	}
 	xkb_context_unref(context);
 	wlr_keyboard_set_repeat_info(kb, rc.repeat_rate, rc.repeat_delay);
 


### PR DESCRIPTION
Stack trace:

    #0  xkb_keymap_ref (keymap=keymap@entry=0x0) at ../libxkbcommon/src/keymap.c:61
    #1  0x00007f53a344ab99 in wlr_keyboard_set_keymap (kb=kb@entry=0x5571af8cb9a0, keymap=keymap@entry=0x0)
        at ../types/wlr_keyboard.c:174
    #2  0x00005571ade057e0 in keyboard_init (seat=0x7ffca0389680) at ../src/keyboard.c:229
    #3  seat_init (server=0x7ffca0389570) at ../src/seat.c:307
    #4  server_init (server=0x7ffca0389570) at ../src/server.c:308

This is one of the more common `SIGSEGV` that still shows up after #552.  There are many others out of our control (especially in `libfontconfig` and `radeonsi_dri`) but let's fix what we can.