### PR TITLE
cursor: Restore drag icon after the move to scene-graph

### DIFF
--- a/include/dnd.h
+++ b/include/dnd.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LAB_DND_H
+#define __LAB_DND_H
+
+#include <wayland-server-core.h>
+
+struct seat;
+struct wlr_drag_icon;
+struct wlr_scene_tree;
+
+struct drag_icon {
+	struct wlr_scene_tree *icon_tree;
+	struct wlr_drag_icon *icon;
+	struct {
+		struct wl_listener map;
+		struct wl_listener commit;
+		struct wl_listener unmap;
+		struct wl_listener destroy;
+	} events;
+};
+
+void dnd_init(struct seat *seat);
+void dnd_icons_show(struct seat *seat, bool show);
+void dnd_icons_move(struct seat *seat, double x, double y);
+void dnd_finish(struct seat *seat);
+
+#endif /* __LAB_DND_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -104,7 +104,6 @@ struct seat {
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;
 
-	struct wlr_drag_icon *drag_icon;
 	struct wlr_pointer_constraint_v1 *current_constraint;
 	struct wlr_idle *wlr_idle;
 	struct wlr_idle_inhibit_manager_v1 *wlr_idle_inhibit_manager;
@@ -136,6 +135,16 @@ struct seat {
 		uint32_t resize_edges;
 	} pressed;
 
+	struct {
+		bool active;
+		struct {
+			struct wl_listener request;
+			struct wl_listener start;
+			struct wl_listener destroy;
+		} events;
+		struct wlr_scene_tree *icons;
+	} drag;
+
 	struct wl_client *active_client_while_inhibited;
 	struct wl_list inputs;
 	struct wl_listener new_input;
@@ -163,9 +172,6 @@ struct seat {
 	struct wl_listener touch_motion;
 	struct wl_listener touch_frame;
 
-	struct wl_listener request_start_drag;
-	struct wl_listener start_drag;
-	struct wl_listener destroy_drag;
 	struct wl_listener constraint_commit;
 	struct wl_listener idle_inhibitor_create;
 	struct wl_listener pressed_surface_destroy;

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include "common/list.h"
 #include "common/scene-helpers.h"
+#include "dnd.h"
 #include "labwc.h"
 #include "layers.h"
 #include "node.h"
@@ -295,9 +296,19 @@ get_cursor_context(struct server *server)
 {
 	struct cursor_context ret = {.type = LAB_SSD_NONE};
 	struct wlr_cursor *cursor = server->seat.cursor;
+
+	/* Prevent drag icons to be on top of the hitbox detection */
+	if (server->seat.drag.active) {
+		dnd_icons_show(&server->seat, false);
+	}
+
 	struct wlr_scene_node *node =
 		wlr_scene_node_at(&server->scene->tree.node,
 			cursor->x, cursor->y, &ret.sx, &ret.sy);
+
+	if (server->seat.drag.active) {
+		dnd_icons_show(&server->seat, true);
+	}
 
 	ret.node = node;
 	if (!node) {

--- a/src/dnd.c
+++ b/src/dnd.c
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <assert.h>
+#include <wlr/types/wlr_data_device.h>
+#include <wlr/types/wlr_scene.h>
+#include <wlr/util/log.h>
+#include "common/mem.h"
+#include "dnd.h"
+#include "labwc.h"  /* for struct seat */
+
+/* Internal DnD icon handlers */
+static void
+handle_icon_map(struct wl_listener *listener, void *data)
+{
+	struct drag_icon *self = wl_container_of(listener, self, events.map);
+	struct wlr_drag_icon *icon = data;
+	if (icon->data) {
+		struct wlr_scene_tree *surface_tree = icon->data;
+		wlr_scene_node_set_enabled(&surface_tree->node, true);
+	} else {
+		icon->data = wlr_scene_subsurface_tree_create(
+			self->icon_tree, icon->surface);
+	}
+}
+
+static void
+handle_surface_commit(struct wl_listener *listener, void *data)
+{
+	struct drag_icon *self = wl_container_of(listener, self, events.commit);
+	struct wlr_surface *surface = data;
+	struct wlr_scene_tree *surface_tree = self->icon->data;
+	if (surface_tree) {
+		wlr_scene_node_set_position(&surface_tree->node,
+			surface->sx, surface->sy);
+	}
+}
+
+static void
+handle_icon_unmap(struct wl_listener *listener, void *data)
+{
+	struct drag_icon *self = wl_container_of(listener, self, events.unmap);
+	struct wlr_drag_icon *icon = data;
+	struct wlr_scene_tree *surface_tree = icon->data;
+	if (surface_tree) {
+		wlr_scene_node_set_enabled(&surface_tree->node, false);
+	}
+}
+
+static void
+handle_icon_destroy(struct wl_listener *listener, void *data)
+{
+	struct drag_icon *self = wl_container_of(listener, self, events.destroy);
+
+	wl_list_remove(&self->events.map.link);
+	wl_list_remove(&self->events.commit.link);
+	wl_list_remove(&self->events.unmap.link);
+	wl_list_remove(&self->events.destroy.link);
+
+	if (self->icon->data) {
+		struct wlr_scene_tree *tree = self->icon->data;
+		wlr_scene_node_destroy(&tree->node);
+	}
+
+	self->icon = NULL;
+	self->icon_tree = NULL;
+	free(self);
+}
+
+static void
+drag_icon_create(struct seat *seat, struct wlr_drag_icon *wlr_icon)
+{
+	assert(seat);
+	assert(wlr_icon);
+	struct drag_icon *self = znew(*self);
+
+	self->icon = wlr_icon;
+	self->icon_tree = seat->drag.icons;
+
+	/* Position will be updated by cursor movement */
+	wlr_scene_node_set_position(&self->icon_tree->node,
+		seat->cursor->x, seat->cursor->y);
+	wlr_scene_node_raise_to_top(&self->icon_tree->node);
+
+	/* Set up events */
+	self->events.map.notify = handle_icon_map;
+	self->events.commit.notify = handle_surface_commit;
+	self->events.unmap.notify = handle_icon_unmap;
+	self->events.destroy.notify = handle_icon_destroy;
+
+	wl_signal_add(&wlr_icon->events.map, &self->events.map);
+	wl_signal_add(&wlr_icon->surface->events.commit, &self->events.commit);
+	wl_signal_add(&wlr_icon->events.unmap, &self->events.unmap);
+	wl_signal_add(&wlr_icon->events.destroy, &self->events.destroy);
+}
+
+/* Internal DnD handlers */
+static void
+handle_drag_request(struct wl_listener *listener, void *data)
+{
+	struct seat *seat = wl_container_of(listener, seat, drag.events.request);
+	struct wlr_seat_request_start_drag_event *event = data;
+
+	if (wlr_seat_validate_pointer_grab_serial(
+			seat->seat, event->origin, event->serial)) {
+		wlr_seat_start_pointer_drag(seat->seat, event->drag,
+			event->serial);
+	} else {
+		wlr_data_source_destroy(event->drag->source);
+		wlr_log(WLR_ERROR, "wrong source for drag request");
+	}
+}
+
+static void
+handle_drag_start(struct wl_listener *listener, void *data)
+{
+	struct seat *seat = wl_container_of(listener, seat, drag.events.start);
+	assert(!seat->drag.active);
+	struct wlr_drag *drag = data;
+
+	seat->drag.active = true;
+	seat_reset_pressed(seat);
+	if (drag->icon) {
+		/* Cleans up automatically on drag->icon->events.detroy */
+		drag_icon_create(seat, drag->icon);
+		wlr_scene_node_set_enabled(&seat->drag.icons->node, true);
+	}
+	wl_signal_add(&drag->events.destroy, &seat->drag.events.destroy);
+}
+
+static void
+handle_drag_destroy(struct wl_listener *listener, void *data)
+{
+	struct seat *seat = wl_container_of(listener, seat, drag.events.destroy);
+	assert(seat->drag.active);
+
+	seat->drag.active = false;
+	wl_list_remove(&seat->drag.events.destroy.link);
+	wlr_scene_node_set_enabled(&seat->drag.icons->node, false);
+	/* TODO: Not sure we actually need the following */
+	desktop_focus_topmost_mapped_view(seat->server);
+}
+
+/* Public API */
+void
+dnd_init(struct seat *seat)
+{
+	seat->drag.icons = wlr_scene_tree_create(&seat->server->scene->tree);
+	wlr_scene_node_set_enabled(&seat->drag.icons->node, false);
+
+	seat->drag.events.request.notify = handle_drag_request;
+	seat->drag.events.start.notify = handle_drag_start;
+	seat->drag.events.destroy.notify = handle_drag_destroy;
+
+	wl_signal_add(&seat->seat->events.request_start_drag,
+		&seat->drag.events.request);
+	wl_signal_add(&seat->seat->events.start_drag, &seat->drag.events.start);
+	/*
+	 * destroy.notify is listened to in handle_drag_start() and reset in
+	 * handle_drag_destroy()
+	 */
+}
+
+void
+dnd_icons_show(struct seat *seat, bool show)
+{
+	wlr_scene_node_set_enabled(&seat->drag.icons->node, show);
+}
+
+void
+dnd_icons_move(struct seat *seat, double x, double y)
+{
+	wlr_scene_node_set_position(&seat->drag.icons->node, x, y);
+}
+
+void dnd_finish(struct seat *seat)
+{
+	wlr_scene_node_destroy(&seat->drag.icons->node);
+	wl_list_remove(&seat->drag.events.request.link);
+	wl_list_remove(&seat->drag.events.start.link);
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ labwc_sources = files(
   'cursor.c',
   'debug.c',
   'desktop.c',
+  'dnd.c',
   'foreign.c',
   'interactive.c',
   'keyboard.c',


### PR DESCRIPTION
This is still very much work-in-progress but at least shows drag icons again.

![drag_icon](https://user-images.githubusercontent.com/35009135/190884863-54896c0d-ed97-4944-9e47-843af3b8ab55.png)

Missing:
- [x] ~~remove debug logs~~
- [x] ~~figure out why `thunar` doesn't accept its own drag events (e.g. move file into directory). works in sway~~
- [x] ~~figure out why `thunar` doesn't appear to set the cursor icon but only a drag icon. works in sway AFAIR~~
- [x] ~~potentially refactor some stuff~~