### PR TITLE
src/osd.c: Prevent showing invalid window

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -179,7 +179,10 @@ first_view(struct server *server)
 	struct wl_list *list_head =
 		&server->workspace_current->tree->children;
 	wl_list_for_each_reverse(node, list_head, link) {
-		return node_view_from_node(node);
+		struct view *view = node_view_from_node(node);
+		if (isfocusable(view)) {
+			return view;
+		}
 	}
 	return NULL;
 }

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -216,6 +216,10 @@ desktop_cycle_view(struct server *server, struct view *start_view,
 	 *   - Pre-select the top view if NOT already focused
 	 *   - Otherwise select the view second from the top
 	 */
+
+	/* Make sure to have all nodes in their actual ordering */
+	osd_preview_restore(server);
+
 	if (!start_view) {
 		start_view = first_view(server);
 		if (!start_view || start_view != desktop_focused_view(server)) {
@@ -232,9 +236,6 @@ desktop_cycle_view(struct server *server, struct view *start_view,
 
 	/* Scene nodes are ordered like last node == displayed topmost */
 	iter = dir == LAB_CYCLE_DIR_FORWARD ? get_prev_item : get_next_item;
-
-	/* Make sure to have all nodes in their actual ordering */
-	osd_preview_restore(server);
 
 	do {
 		list_item = iter(list_item);

--- a/src/osd.c
+++ b/src/osd.c
@@ -124,6 +124,8 @@ osd_on_view_destroy(struct view *view)
 		 * If we are the current OSD selected view, cycle
 		 * to the next because we are dying.
 		 */
+
+		/* Also resets preview node */
 		osd_state->cycle_view = desktop_cycle_view(view->server,
 			osd_state->cycle_view, LAB_CYCLE_DIR_BACKWARD);
 
@@ -137,6 +139,11 @@ osd_on_view_destroy(struct view *view)
 		}
 	}
 
+	if (osd_state->cycle_view) {
+		/* Update the OSD to reflect the view has now gone. */
+		osd_update(view->server);
+	}
+
 	if (view->scene_tree) {
 		struct wlr_scene_node *node = &view->scene_tree->node;
 		if (osd_state->preview_anchor == node) {
@@ -146,11 +153,6 @@ osd_on_view_destroy(struct view *view)
 			 */
 			osd_state->preview_anchor = lab_wlr_scene_get_prev_node(node);
 		}
-	}
-
-	if (osd_state->cycle_view) {
-		/* Update the OSD to reflect the view has now gone. */
-		osd_update(view->server);
 	}
 }
 

--- a/src/osd.c
+++ b/src/osd.c
@@ -226,7 +226,7 @@ osd_update(struct server *server)
 	struct wl_list *node_list =
 		&server->workspace_current->tree->children;
 
-	if (wl_list_empty(node_list)) {
+	if (wl_list_empty(node_list) || !server->osd_state.cycle_view) {
 		osd_finish(server);
 		return;
 	}


### PR DESCRIPTION
This might happen when closing the last
application "to tray" like VLC, Discord or Steam.

Reported-by: @Flrian

@jlindgren90 testing for regressions of the original use-case of detached search window appreciated.