### PR TITLE
cursor: Call wlr_seat_pointer_notify_clear_focus() only if needed

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -369,8 +369,10 @@ cursor_update_common(struct server *server, struct cursor_context *ctx,
 		 * cursor image will be set by request_cursor_notify()
 		 * in response to the enter event.
 		 */
-		if (ctx->surface != wlr_seat->pointer_state.focused_surface
-				|| seat->server_cursor != LAB_CURSOR_CLIENT) {
+		bool has_focus = (ctx->surface ==
+			wlr_seat->pointer_state.focused_surface);
+
+		if (!has_focus || seat->server_cursor != LAB_CURSOR_CLIENT) {
 			/*
 			 * Enter the surface if necessary.  Usually we
 			 * prevent re-entering an already focused
@@ -382,7 +384,9 @@ cursor_update_common(struct server *server, struct cursor_context *ctx,
 			 * if a server-side cursor was set and we need
 			 * to trigger a cursor image update.
 			 */
-			wlr_seat_pointer_notify_clear_focus(wlr_seat);
+			if (has_focus) {
+				wlr_seat_pointer_notify_clear_focus(wlr_seat);
+			}
 			wlr_seat_pointer_notify_enter(wlr_seat, ctx->surface,
 				ctx->sx, ctx->sy);
 			seat->server_cursor = LAB_CURSOR_CLIENT;


### PR DESCRIPTION
In #565 @Consolatis determined that we are unnecessarily sending extra "clear focus" events during drag-and-drop, which confuses the drag source.  This is a fairly minimal fix for that same issue.

The other changes in #565 are no doubt perfectly valid in their own right, but as I suggested in the comments there, it may be worthwhile to start with the minimal fix and add the other changes in later commits, if only for the sake of bisect-ability.

I think @Consolatis was on-board with this approach (see https://github.com/labwc/labwc/pull/565#issuecomment-1255497600) and was maybe going to submit the minimal fix anyway, but since he hasn't gotten around to it yet, I figured I'd go ahead and create the pull request.  Hopefully this isn't stepping on any toes :)

I verified that this fixes drag-and-drop of files into folders within the same Thunar window.