### PR TITLE
xwayland: Hide unmanaged nodes on unmap()

### DIFF
--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include <assert.h>
 #include "common/list.h"
 #include "common/mem.h"
 #include "labwc.h"
@@ -35,6 +36,7 @@ unmanaged_handle_map(struct wl_listener *listener, void *data)
 	struct xwayland_unmanaged *unmanaged =
 		wl_container_of(listener, unmanaged, map);
 	struct wlr_xwayland_surface *xsurface = unmanaged->xwayland_surface;
+	assert(!unmanaged->node);
 
 	/* Stack new surface on top */
 	wlr_xwayland_surface_restack(xsurface, NULL, XCB_STACK_MODE_ABOVE);
@@ -94,9 +96,11 @@ unmanaged_handle_unmap(struct wl_listener *listener, void *data)
 		wl_container_of(listener, unmanaged, unmap);
 	struct wlr_xwayland_surface *xsurface = unmanaged->xwayland_surface;
 	struct seat *seat = &unmanaged->server->seat;
+	assert(unmanaged->node);
 
 	wl_list_remove(&unmanaged->link);
 	wl_list_remove(&unmanaged->set_geometry.link);
+	wlr_scene_node_set_enabled(unmanaged->node, false);
 
 	/*
 	 * Mark the node as gone so a racing configure event


### PR DESCRIPTION
Since xwayland commit 9e4b7948df5a9a67632bb606150ec171b5519672 there is a one-second delay between XWayland surfaces being unmapped and destroyed.  This revealed that we were not actually handling the unmap() signal correctly for unmanaged surfaces.

Fixes: #597

Thanks @Consolatis for the suggestion.