### PR TITLE
keyboard: Implement key repeat for keybindings

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -88,6 +88,10 @@ struct keyboard {
 	bool is_virtual;
 	struct wl_listener modifier;
 	struct wl_listener key;
+	/* key repeat for compositor keybinds */
+	uint32_t keybind_repeat_keycode;
+	int32_t keybind_repeat_rate;
+	struct wl_event_source *keybind_repeat;
 };
 
 struct seat {
@@ -533,6 +537,7 @@ struct view *desktop_focused_view(struct server *server);
 void desktop_focus_topmost_mapped_view(struct server *server);
 bool isfocusable(struct view *view);
 
+void keyboard_cancel_keybind_repeat(struct keyboard *keyboard);
 void keyboard_key_notify(struct wl_listener *listener, void *data);
 void keyboard_modifiers_notify(struct wl_listener *listener, void *data);
 void keyboard_init(struct seat *seat);

--- a/src/key-state.c
+++ b/src/key-state.c
@@ -12,6 +12,17 @@ struct key_array {
 
 static struct key_array pressed, bound, pressed_sent;
 
+static bool
+key_present(struct key_array *array, uint32_t keycode)
+{
+	for (int i = 0; i < array->nr_keys; ++i) {
+		if (array->keys[i] == keycode) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static void
 remove_key(struct key_array *array, uint32_t keycode)
 {
@@ -32,7 +43,9 @@ remove_key(struct key_array *array, uint32_t keycode)
 static void
 add_key(struct key_array *array, uint32_t keycode)
 {
-	array->keys[array->nr_keys++] = keycode;
+	if (!key_present(array, keycode) && array->nr_keys < MAX_PRESSED_KEYS) {
+		array->keys[array->nr_keys++] = keycode;
+	}
 }
 
 uint32_t *
@@ -74,12 +87,7 @@ key_state_store_pressed_keys_as_bound(void)
 bool
 key_state_corresponding_press_event_was_bound(uint32_t keycode)
 {
-	for (int i = 0; i < bound.nr_keys; ++i) {
-		if (bound.keys[i] == keycode) {
-			return true;
-		}
-	}
-	return false;
+	return key_present(&bound, keycode);
 }
 
 void

--- a/src/seat.c
+++ b/src/seat.c
@@ -24,6 +24,7 @@ input_device_destroy(struct wl_listener *listener, void *data)
 		struct keyboard *keyboard = (struct keyboard *)input;
 		wl_list_remove(&keyboard->key.link);
 		wl_list_remove(&keyboard->modifier.link);
+		keyboard_cancel_keybind_repeat(keyboard);
 	}
 	free(input);
 }


### PR DESCRIPTION
It seems that every Wayland client is expected to implement its own
key-repeat logic, rather than doing it server-side as in X11.  This
means that labwc also has to implement its own key-repeat logic for
compositor keybindings.
    
This is a very simplistic timer-based implementation.  It doesn't
attempt to synthesize accurate timestamps, and may lag depending
on system load, but it appears to get the job done.

I also fixed a potential array overflow in key-state.c (separate commit).

Fixes: #462