### PR TITLE
Chase wlroots: output test assert

### DIFF
--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 694e9bbb9d7114f39311d93e885e010606a88dae
+revision = 05454618cd2d49fb3a5f0c560b0d2c455cf32467
 
 [provide]
 dependency_names = wlroots


### PR DESCRIPTION
This fixes an assert on output test when
running with the headless backend.

To update the wlroots subproject use
meson subprojects update wlroots

Chases wlroots 05454618cd2d49fb3a5f0c560b0d2c455cf32467
xwayland: split headers

Fixes #605