### PR TITLE
[RFC] Implement Kill action

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -11,6 +11,10 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="Close">*
 	Close top-most window.
 
+*<action name="Kill">*
+	Kill the process associated with the current window by sending it the
+	SIGTERM signal.
+
 *<action name="Execute"><command>*
 	Execute command.  Note that in the interest of backward compatibility,
 	labwc supports <execute> as an alternative to <command> even though

--- a/src/action.c
+++ b/src/action.c
@@ -37,6 +37,7 @@ enum action_type {
 	ACTION_TYPE_INVALID = 0,
 	ACTION_TYPE_NONE,
 	ACTION_TYPE_CLOSE,
+	ACTION_TYPE_KILL,
 	ACTION_TYPE_DEBUG,
 	ACTION_TYPE_EXECUTE,
 	ACTION_TYPE_EXIT,
@@ -63,6 +64,7 @@ const char *action_names[] = {
 	"INVALID",
 	"None",
 	"Close",
+	"Kill",
 	"Debug",
 	"Execute",
 	"Exit",
@@ -242,6 +244,17 @@ actions_run(struct view *activator, struct server *server,
 		case ACTION_TYPE_CLOSE:
 			if (view) {
 				view_close(view);
+			}
+			break;
+		case ACTION_TYPE_KILL:
+			if (view && view->surface) {
+				/* Send SIGTERM to the process associated with the surface */
+				pid_t pid = -1;
+				struct wl_client *client = view->surface->resource->client;
+				wl_client_get_credentials(client, &pid, NULL, NULL);
+				if (pid != -1) {
+					kill(pid, SIGTERM);
+				}
 			}
 			break;
 		case ACTION_TYPE_DEBUG:


### PR DESCRIPTION
This action forcibly disconnects clients, rather than requesting them to close. It's useful for when a client is misbehaving or frozen, but I'm not sure that it's necessarily the Right Thing. Specifically, it doesn't kill the process itself, which may be hung or unresponsive to a Wayland disconnection. Or, if the client supports "wayland robustness" (cf. David Edmundson), it might simply reconnect, which might not be the user's intention.

So, perhaps this action should instead be called "Disconnect". Perhaps I should instead (or additionally) implement a proper `Kill` action using `wl_client_get_credentials` to obtain the client pid. The [docs](https://wayland.freedesktop.org/docs/html/apc.html#Server-structwl__client_1a82a97cb3a66c1c56826a09a7b42453d9) for that function warn of potential race conditions, so I'm not sure the best (or any non-racy) way to do so, but that may not matter in practice.

Feedback would be appreciated.