### PR TITLE
output,xwayland: Add support for _NET_WM_STRUT_PARTIAL

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -112,6 +112,8 @@ struct view_impl {
 	struct view_size_hints (*get_size_hints)(struct view *self);
 	/* if not implemented, VIEW_WANTS_FOCUS_ALWAYS is assumed */
 	enum view_wants_focus (*wants_focus)(struct view *self);
+	/* returns true if view reserves space at screen edge */
+	bool (*has_strut_partial)(struct view *self);
 };
 
 struct view {
@@ -427,6 +429,14 @@ void view_append_children(struct view *view, struct wl_array *children);
  * views/surfaces.
  */
 bool view_is_related(struct view *view, struct wlr_surface *surface);
+
+/**
+ * view_has_strut_partial() - returns true for views that reserve space
+ * at a screen edge (e.g. panels). These views are treated as if they
+ * have the fixedPosition window rule: i.e. they are not restricted to
+ * the usable area and cannot be moved/resized interactively.
+ */
+bool view_has_strut_partial(struct view *view);
 
 const char *view_get_string_prop(struct view *view, const char *prop);
 void view_update_title(struct view *view);

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -6,6 +6,8 @@
 #include "view.h"
 
 struct wlr_compositor;
+struct wlr_output;
+struct wlr_output_layout;
 
 struct xwayland_unmanaged {
 	struct server *server;
@@ -37,6 +39,7 @@ struct xwayland_view {
 	struct wl_listener set_class;
 	struct wl_listener set_decorations;
 	struct wl_listener set_override_redirect;
+	struct wl_listener set_strut_partial;
 
 	/* Not (yet) implemented */
 /*	struct wl_listener set_role; */
@@ -57,6 +60,10 @@ struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
 void xwayland_server_init(struct server *server,
 	struct wlr_compositor *compositor);
 void xwayland_server_finish(struct server *server);
+
+void xwayland_adjust_usable_area(struct view *view,
+	struct wlr_output_layout *layout, struct wlr_output *output,
+	struct wlr_box *usable);
 
 void xwayland_update_workarea(struct server *server);
 

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -35,7 +35,9 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 		return;
 	}
 
-	if (window_rules_get_property(view, "fixedPosition") == LAB_PROP_TRUE) {
+	/* Prevent moving/resizing fixed-position and panel-like views */
+	if (window_rules_get_property(view, "fixedPosition") == LAB_PROP_TRUE
+			|| view_has_strut_partial(view)) {
 		return;
 	}
 

--- a/src/output.c
+++ b/src/output.c
@@ -603,6 +603,16 @@ update_usable_area(struct output *output)
 	struct wlr_box old = output->usable_area;
 	layers_arrange(output);
 
+#if HAVE_XWAYLAND
+	struct view *view;
+	wl_list_for_each(view, &output->server->views, link) {
+		if (view->mapped && view->type == LAB_XWAYLAND_VIEW) {
+			xwayland_adjust_usable_area(view,
+				output->server->output_layout,
+				output->wlr_output, &output->usable_area);
+		}
+	}
+#endif
 	return !wlr_box_equal(&old, &output->usable_area);
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -593,7 +593,9 @@ view_adjust_floating_geometry(struct view *view, struct wlr_box *geometry)
 		return false;
 	}
 
-	if (window_rules_get_property(view, "fixedPosition") == LAB_PROP_TRUE) {
+	/* Avoid moving panels out of their own reserved area ("strut") */
+	if (window_rules_get_property(view, "fixedPosition") == LAB_PROP_TRUE
+			|| view_has_strut_partial(view)) {
 		return false;
 	}
 
@@ -1541,6 +1543,14 @@ view_is_related(struct view *view, struct wlr_surface *surface)
 		return view->impl->is_related(view, surface);
 	}
 	return false;
+}
+
+bool
+view_has_strut_partial(struct view *view)
+{
+	assert(view);
+	return view->impl->has_strut_partial &&
+		view->impl->has_strut_partial(view);
 }
 
 const char *

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -103,6 +103,14 @@ xwayland_view_wants_focus(struct view *view)
 	return VIEW_WANTS_FOCUS_NEVER;
 }
 
+static bool
+xwayland_view_has_strut_partial(struct view *view)
+{
+	struct wlr_xwayland_surface *xsurface =
+		xwayland_surface_from_view(view);
+	return (bool)xsurface->strut_partial;
+}
+
 static struct wlr_xwayland_surface *
 top_parent_of(struct view *view)
 {
@@ -786,6 +794,7 @@ static const struct view_impl xwayland_view_impl = {
 	.is_related = xwayland_view_is_related,
 	.get_size_hints = xwayland_view_get_size_hints,
 	.wants_focus = xwayland_view_wants_focus,
+	.has_strut_partial = xwayland_view_has_strut_partial,
 };
 
 void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -291,6 +291,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&xwayland_view->set_class.link);
 	wl_list_remove(&xwayland_view->set_decorations.link);
 	wl_list_remove(&xwayland_view->set_override_redirect.link);
+	wl_list_remove(&xwayland_view->set_strut_partial.link);
 
 	view_destroy(view);
 }
@@ -464,6 +465,18 @@ handle_set_override_redirect(struct wl_listener *listener, void *data)
 }
 
 static void
+handle_set_strut_partial(struct wl_listener *listener, void *data)
+{
+	struct xwayland_view *xwayland_view =
+		wl_container_of(listener, xwayland_view, set_strut_partial);
+	struct view *view = &xwayland_view->base;
+
+	if (view->mapped) {
+		output_update_all_usable_areas(view->server, false);
+	}
+}
+
+static void
 set_initial_position(struct view *view,
 		struct wlr_xwayland_surface *xwayland_surface)
 {
@@ -605,6 +618,11 @@ xwayland_view_map(struct view *view)
 
 	view_impl_map(view);
 	view->been_mapped = true;
+
+	/* Update usable area to account for XWayland "struts" (panels) */
+	if (xwayland_surface->strut_partial) {
+		output_update_all_usable_areas(view->server, false);
+	}
 }
 
 static void
@@ -617,6 +635,11 @@ xwayland_view_unmap(struct view *view, bool client_request)
 	wl_list_remove(&view->commit.link);
 	wlr_scene_node_set_enabled(&view->scene_tree->node, false);
 	view_impl_unmap(view);
+
+	/* Update usable area to account for XWayland "struts" (panels) */
+	if (xwayland_surface_from_view(view)->strut_partial) {
+		output_update_all_usable_areas(view->server, false);
+	}
 
 	/*
 	 * If the view was explicitly unmapped by the client (rather
@@ -806,6 +829,7 @@ xwayland_view_create(struct server *server,
 	CONNECT_SIGNAL(xsurface, xwayland_view, set_class);
 	CONNECT_SIGNAL(xsurface, xwayland_view, set_decorations);
 	CONNECT_SIGNAL(xsurface, xwayland_view, set_override_redirect);
+	CONNECT_SIGNAL(xsurface, xwayland_view, set_strut_partial);
 
 	wl_list_insert(&view->server->views, &view->link);
 
@@ -928,6 +952,94 @@ xwayland_server_finish(struct server *server)
 	 */
 	server->xwayland = NULL;
 	wlr_xwayland_destroy(xwayland);
+}
+
+static bool
+intervals_overlap(int start_a, int end_a, int start_b, int end_b)
+{
+	/* check for empty intervals */
+	if (end_a <= start_a || end_b <= start_b) {
+		return false;
+	}
+
+	return start_a < start_b ?
+		start_b < end_a :  /* B starts within A */
+		start_a < end_b;   /* A starts within B */
+}
+
+/*
+ * Subtract the area of an XWayland view (e.g. panel) from the usable
+ * area of the output based on _NET_WM_STRUT_PARTIAL property.
+ */
+void
+xwayland_adjust_usable_area(struct view *view, struct wlr_output_layout *layout,
+		struct wlr_output *output, struct wlr_box *usable)
+{
+	assert(view);
+	assert(layout);
+	assert(output);
+	assert(usable);
+
+	if (view->type != LAB_XWAYLAND_VIEW) {
+		return;
+	}
+
+	xcb_ewmh_wm_strut_partial_t *strut =
+		xwayland_surface_from_view(view)->strut_partial;
+	if (!strut) {
+		return;
+	}
+
+	/* these are layout coordinates */
+	struct wlr_box lb = { 0 };
+	wlr_output_layout_get_box(layout, NULL, &lb);
+	struct wlr_box ob = { 0 };
+	wlr_output_layout_get_box(layout, output, &ob);
+
+	/*
+	 * strut->right/bottom are offsets from the lower right corner
+	 * of the X11 screen, which should generally correspond with the
+	 * lower right corner of the output layout
+	 */
+	double strut_left = strut->left;
+	double strut_right = (lb.x + lb.width) - strut->right;
+	double strut_top = strut->top;
+	double strut_bottom = (lb.y + lb.height) - strut->bottom;
+
+	/* convert layout to output coordinates */
+	wlr_output_layout_output_coords(layout, output,
+		&strut_left, &strut_top);
+	wlr_output_layout_output_coords(layout, output,
+		&strut_right, &strut_bottom);
+
+	/* deal with right/bottom rather than width/height */
+	int usable_right = usable->x + usable->width;
+	int usable_bottom = usable->y + usable->height;
+
+	/* here we mix output and layout coordinates; be careful */
+	if (strut_left > usable->x && strut_left < usable_right
+			&& intervals_overlap(ob.y, ob.y + ob.height,
+			strut->left_start_y, strut->left_end_y + 1)) {
+		usable->x = strut_left;
+	}
+	if (strut_right > usable->x && strut_right < usable_right
+			&& intervals_overlap(ob.y, ob.y + ob.height,
+			strut->right_start_y, strut->right_end_y + 1)) {
+		usable_right = strut_right;
+	}
+	if (strut_top > usable->y && strut_top < usable_bottom
+			&& intervals_overlap(ob.x, ob.x + ob.width,
+			strut->top_start_x, strut->top_end_x + 1)) {
+		usable->y = strut_top;
+	}
+	if (strut_bottom > usable->y && strut_bottom < usable_bottom
+			&& intervals_overlap(ob.x, ob.x + ob.width,
+			strut->bottom_start_x, strut->bottom_end_x + 1)) {
+		usable_bottom = strut_bottom;
+	}
+
+	usable->width = usable_right - usable->x;
+	usable->height = usable_bottom - usable->y;
 }
 
 void


### PR DESCRIPTION
Account for space taken up by XWayland panels (as indicated by the
_NET_WM_STRUT_PARTIAL property) in the `usable_area` calculation.

This makes it possible to use labwc in a "transitional" setup, where it
replaces the X11 window manager and compositor, but most other parts of
a existing X11 desktop environment can still be used via XWayland.

(Some remaining drawbacks of such a setup would be the lack of desktop
icons, and native Wayland clients not showing up in X11-based taskbars.)

This is a draft because:
- it depends on a change to wlroots, something like https://github.com/jlindgren90/wlroots/commit/b8055330159b86d5e88d01596a16fc1a44361c97.
- I'm looking for feedback on whether this is useful to anyone else besides me.

The first commit, however, could be merged on its own (without any wlroots changes).