### PR TITLE
Update for wlroots 0.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           apt-get install -y git clang \
             hwdata \
             libxml2-dev libcairo2-dev libpango1.0-dev \
-            librsvg2-dev
+            librsvg2-dev libxcb-ewmh-dev
           apt-get build-dep -y wlroots
 
       - name: Install FreeBSD dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
           pacman-key --init
           pacman -Syu --noconfirm
           pacman -S --noconfirm git meson clang wlroots libdrm libinput \
-            wayland-protocols cairo pango libxml2 xorg-xwayland librsvg
+            wayland-protocols cairo pango libxml2 xorg-xwayland librsvg libdisplay-info
 
       - name: Install Debian Testing dependencies
         if: matrix.name == 'Debian'
@@ -77,7 +77,7 @@ jobs:
           apt-get update
           apt-get upgrade -y
           apt-get install -y git clang \
-            hwdata \
+            hwdata libdisplay-info-dev \
             libxml2-dev libcairo2-dev libpango1.0-dev \
             librsvg2-dev libxcb-ewmh-dev
           apt-get build-dep -y wlroots
@@ -91,7 +91,7 @@ jobs:
             sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
             pkg set -yn pkg:mesa-dri # hack to skip llvm dependency
             pkg install -y git meson gcc pkgconf cairo pango evdev-proto \
-              hwdata wayland-protocols wlroots
+              hwdata wayland-protocols wlroots libdisplay-info
           run: echo "setup done"
 
       - name: Install Void Linux dependencies
@@ -110,7 +110,7 @@ jobs:
             xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
             xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel \
             xcb-util-keysyms-devel xcb-util-xrm-devel xorg-server-xwayland \
-            hwids \
+            hwids libdisplay-info-devel \
             librsvg-devel \
             libglib-devel cairo-devel pango-devel
 

--- a/include/common/scene-helpers.h
+++ b/include/common/scene-helpers.h
@@ -2,10 +2,13 @@
 #ifndef LABWC_SCENE_HELPERS_H
 #define LABWC_SCENE_HELPERS_H
 
+#include <stdbool.h>
+
 struct wlr_scene_node;
 struct wlr_scene_rect;
 struct wlr_scene_tree;
 struct wlr_surface;
+struct wlr_scene_output;
 
 struct wlr_scene_rect *lab_wlr_scene_get_rect(struct wlr_scene_node *node);
 struct wlr_scene_tree *lab_scene_tree_from_node(struct wlr_scene_node *node);
@@ -17,5 +20,8 @@ struct wlr_surface *lab_wlr_surface_from_node(struct wlr_scene_node *node);
  * Return NULL if previous link is list-head which means node is bottom-most
  */
 struct wlr_scene_node *lab_wlr_scene_get_prev_node(struct wlr_scene_node *node);
+
+/* A variant of wlr_scene_output_commit() that respects wlr_output->pending */
+bool lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output);
 
 #endif /* LABWC_SCENE_HELPERS_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -201,6 +201,7 @@ struct server {
 	struct wlr_renderer *renderer;
 	struct wlr_allocator *allocator;
 	struct wlr_backend *backend;
+	struct wlr_session *session;
 
 	struct wlr_xdg_shell *xdg_shell;
 	struct wlr_layer_shell_v1 *layer_shell;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -339,6 +339,7 @@ struct output {
 
 	struct wl_listener destroy;
 	struct wl_listener frame;
+	struct wl_listener request_state;
 
 	bool leased;
 };

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -229,6 +229,7 @@ struct server {
 
 	struct seat seat;
 	struct wlr_scene *scene;
+	struct wlr_scene_output_layout *scene_layout;
 
 	/* cursor interactive */
 	enum input_mode input_mode;

--- a/include/view.h
+++ b/include/view.h
@@ -70,6 +70,13 @@ enum view_wants_focus {
 struct view;
 struct wlr_surface;
 
+/* Common to struct view and struct xwayland_unmanaged */
+struct mappable {
+	bool connected;
+	struct wl_listener map;
+	struct wl_listener unmap;
+};
+
 /* Basic size hints (subset of XSizeHints from X11) */
 struct view_size_hints {
 	int min_width;
@@ -194,8 +201,8 @@ struct view {
 		struct wl_listener destroy;
 	} toplevel;
 
-	struct wl_listener map;
-	struct wl_listener unmap;
+	struct mappable mappable;
+
 	struct wl_listener destroy;
 	struct wl_listener surface_destroy;
 	struct wl_listener commit;
@@ -345,6 +352,10 @@ view_is_focusable(struct view *view) {
 	return view_is_focusable_from(view, NULL);
 }
 
+void mappable_connect(struct mappable *mappable, struct wlr_surface *surface,
+	wl_notify_func_t notify_map, wl_notify_func_t notify_unmap);
+void mappable_disconnect(struct mappable *mappable);
+
 void view_toggle_keybinds(struct view *view);
 
 void view_set_activated(struct view *view, bool activated);
@@ -427,6 +438,7 @@ void view_adjust_size(struct view *view, int *w, int *h);
 
 void view_evacuate_region(struct view *view);
 void view_on_output_destroy(struct view *view);
+void view_connect_map(struct view *view, struct wlr_surface *surface);
 void view_destroy(struct view *view);
 
 enum view_axis view_axis_parse(const char *direction);

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -13,12 +13,14 @@ struct xwayland_unmanaged {
 	struct wlr_scene_node *node;
 	struct wl_list link;
 
+	struct mappable mappable;
+
+	struct wl_listener associate;
+	struct wl_listener dissociate;
 	struct wl_listener request_activate;
 	struct wl_listener request_configure;
 /*	struct wl_listener request_fullscreen; */
 	struct wl_listener set_geometry;
-	struct wl_listener map;
-	struct wl_listener unmap;
 	struct wl_listener destroy;
 	struct wl_listener set_override_redirect;
 };
@@ -28,6 +30,8 @@ struct xwayland_view {
 	struct wlr_xwayland_surface *xwayland_surface;
 
 	/* Events unique to XWayland views */
+	struct wl_listener associate;
+	struct wl_listener dissociate;
 	struct wl_listener request_activate;
 	struct wl_listener request_configure;
 	struct wl_listener set_class;

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,7 @@ glib = dependency('glib-2.0')
 cairo = dependency('cairo')
 pangocairo = dependency('pangocairo')
 input = dependency('libinput', version: '>=1.14')
+pixman = dependency('pixman-1')
 math = cc.find_library('m')
 png = dependency('libpng')
 svg = dependency('librsvg-2.0', version: '>=2.46', required: false)
@@ -111,6 +112,7 @@ labwc_deps = [
   drm,
   pangocairo,
   input,
+  pixman,
   math,
   png,
 ]

--- a/meson.build
+++ b/meson.build
@@ -51,7 +51,7 @@ add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 wlroots = dependency(
   'wlroots',
   default_options: ['default_library=static', 'examples=false'],
-  version: ['>=0.16.0', '<0.17.0'],
+  version: ['>=0.17.0', '<0.18.0'],
 )
 
 wlroots_has_xwayland = wlroots.get_variable('have_xwayland') == 'true'

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -26,7 +26,7 @@ lab_wlr_surface_from_node(struct wlr_scene_node *node)
 
 	if (node && node->type == WLR_SCENE_NODE_BUFFER) {
 		buffer = wlr_scene_buffer_from_node(node);
-		scene_surface = wlr_scene_surface_from_buffer(buffer);
+		scene_surface = wlr_scene_surface_try_from_buffer(buffer);
 		if (scene_surface) {
 			return scene_surface->surface;
 		}

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <assert.h>
+#include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_scene.h>
+#include <wlr/util/log.h>
 #include "common/scene-helpers.h"
 
 struct wlr_scene_rect *
@@ -44,4 +46,39 @@ lab_wlr_scene_get_prev_node(struct wlr_scene_node *node)
 		return NULL;
 	}
 	return prev;
+}
+
+/*
+ * This is a copy of wlr_scene_output_commit()
+ * as it doesn't use the pending state at all.
+ */
+bool
+lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output)
+{
+	assert(scene_output);
+	struct wlr_output *wlr_output = scene_output->output;
+	struct wlr_output_state *state = &wlr_output->pending;
+
+	if (!wlr_output->needs_frame && !pixman_region32_not_empty(
+			&scene_output->damage_ring.current)) {
+		return false;
+	}
+	if (!wlr_scene_output_build_state(scene_output, state, NULL)) {
+		wlr_log(WLR_ERROR, "Failed to build output state for %s",
+			wlr_output->name);
+		return false;
+	}
+	if (!wlr_output_commit(wlr_output)) {
+		wlr_log(WLR_ERROR, "Failed to commit output %s",
+			wlr_output->name);
+		return false;
+	}
+	/*
+	 * FIXME: Remove the following line as soon as
+	 * https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4253
+	 * is merged. At that point wlr_scene handles damage tracking internally
+	 * again.
+	 */
+	wlr_damage_ring_rotate(&scene_output->damage_ring);
+	return true;
 }

--- a/src/decorations/kde-deco.c
+++ b/src/decorations/kde-deco.c
@@ -63,7 +63,7 @@ handle_new_server_decoration(struct wl_listener *listener, void *data)
 	struct kde_deco *kde_deco = znew(*kde_deco);
 	kde_deco->wlr_kde_decoration = wlr_deco;
 
-	if (wlr_surface_is_xdg_surface(wlr_deco->surface)) {
+	if (wlr_deco->surface) {
 		/*
 		 * Depending on the application event flow, the supplied
 		 * wlr_surface may already have been set up as a xdg_surface
@@ -72,7 +72,7 @@ handle_new_server_decoration(struct wl_listener *listener, void *data)
 		 * kde_server_decoration_set_view().
 		 */
 		struct wlr_xdg_surface *xdg_surface =
-			wlr_xdg_surface_from_wlr_surface(wlr_deco->surface);
+			wlr_xdg_surface_try_from_wlr_surface(wlr_deco->surface);
 		if (xdg_surface && xdg_surface->data) {
 			kde_deco->view = (struct view *)xdg_surface->data;
 			handle_mode(&kde_deco->mode, wlr_deco);

--- a/src/decorations/xdg-deco.c
+++ b/src/decorations/xdg-deco.c
@@ -56,7 +56,7 @@ static void
 xdg_toplevel_decoration(struct wl_listener *listener, void *data)
 {
 	struct wlr_xdg_toplevel_decoration_v1 *wlr_xdg_decoration = data;
-	struct wlr_xdg_surface *xdg_surface = wlr_xdg_decoration->surface;
+	struct wlr_xdg_surface *xdg_surface = wlr_xdg_decoration->toplevel->base;
 	if (!xdg_surface || !xdg_surface->data) {
 		wlr_log(WLR_ERROR,
 			"Invalid surface supplied for xdg decorations");

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -97,9 +97,9 @@ desktop_focus_view_or_surface(struct seat *seat, struct view *view,
 	if (view) {
 		desktop_focus_view(view, raise);
 #if HAVE_XWAYLAND
-	} else if (wlr_surface_is_xwayland_surface(surface)) {
+	} else {
 		struct wlr_xwayland_surface *xsurface =
-			wlr_xwayland_surface_from_wlr_surface(surface);
+			wlr_xwayland_surface_try_from_wlr_surface(surface);
 		if (xsurface && wlr_xwayland_or_surface_wants_focus(xsurface)) {
 			seat_focus_surface(seat, surface);
 		}
@@ -432,7 +432,7 @@ get_cursor_context(struct server *server)
 		if (node->type == WLR_SCENE_NODE_BUFFER) {
 			struct wlr_surface *surface = lab_wlr_surface_from_node(node);
 			if (surface) {
-				if (wlr_surface_is_layer_surface(surface)) {
+				if (wlr_layer_surface_v1_try_from_wlr_surface(surface)) {
 					ret.type = LAB_SSD_LAYER_SURFACE;
 				}
 				if (is_layer_descendant(node)) {

--- a/src/dnd.c
+++ b/src/dnd.c
@@ -32,7 +32,8 @@ handle_surface_commit(struct wl_listener *listener, void *data)
 	struct wlr_scene_tree *surface_tree = self->icon->data;
 	if (surface_tree) {
 		wlr_scene_node_set_position(&surface_tree->node,
-			surface->sx, surface->sy);
+			surface_tree->node.x + surface->current.dx,
+			surface_tree->node.y + surface->current.dy);
 	}
 }
 

--- a/src/dnd.c
+++ b/src/dnd.c
@@ -89,9 +89,9 @@ drag_icon_create(struct seat *seat, struct wlr_drag_icon *wlr_icon)
 	self->events.unmap.notify = handle_icon_unmap;
 	self->events.destroy.notify = handle_icon_destroy;
 
-	wl_signal_add(&wlr_icon->events.map, &self->events.map);
+	wl_signal_add(&wlr_icon->surface->events.map, &self->events.map);
 	wl_signal_add(&wlr_icon->surface->events.commit, &self->events.commit);
-	wl_signal_add(&wlr_icon->events.unmap, &self->events.unmap);
+	wl_signal_add(&wlr_icon->surface->events.unmap, &self->events.unmap);
 	wl_signal_add(&wlr_icon->events.destroy, &self->events.destroy);
 }
 

--- a/src/idle.c
+++ b/src/idle.c
@@ -2,7 +2,6 @@
 
 #include <assert.h>
 #include <stdlib.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include "common/mem.h"
@@ -14,7 +13,6 @@ struct lab_idle_inhibitor {
 };
 
 struct lab_idle_manager {
-	struct wlr_idle *kde;
 	struct wlr_idle_notifier_v1 *ext;
 	struct {
 		struct wlr_idle_inhibit_manager_v1 *manager;
@@ -40,7 +38,6 @@ handle_idle_inhibitor_destroy(struct wl_listener *listener, void *data)
 		bool still_inhibited =
 			wl_list_length(&manager->inhibitor.manager->inhibitors) > 1;
 		wlr_idle_notifier_v1_set_inhibited(manager->ext, still_inhibited);
-		wlr_idle_set_enabled(manager->kde, manager->wlr_seat, !still_inhibited);
 	}
 
 	wl_list_remove(&idle_inhibitor->on_destroy.link);
@@ -59,7 +56,6 @@ handle_idle_inhibitor_new(struct wl_listener *listener, void *data)
 	wl_signal_add(&wlr_inhibitor->events.destroy, &inhibitor->on_destroy);
 
 	wlr_idle_notifier_v1_set_inhibited(manager->ext, true);
-	wlr_idle_set_enabled(manager->kde, manager->wlr_seat, false);
 }
 
 static void
@@ -80,7 +76,6 @@ idle_manager_create(struct wl_display *display, struct wlr_seat *wlr_seat)
 	manager = znew(*manager);
 	manager->wlr_seat = wlr_seat;
 
-	manager->kde = wlr_idle_create(display);
 	manager->ext = wlr_idle_notifier_v1_create(display);
 
 	manager->inhibitor.manager = wlr_idle_inhibit_v1_create(display);
@@ -105,6 +100,5 @@ idle_manager_notify_activity(struct wlr_seat *seat)
 		return;
 	}
 
-	wlr_idle_notify_activity(manager->kde, seat);
 	wlr_idle_notifier_v1_notify_activity(manager->ext, seat);
 }

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -252,8 +252,8 @@ cursor_set(struct seat *seat, enum lab_cursors cursor)
 		return;
 	}
 
-	wlr_xcursor_manager_set_cursor_image(
-		seat->xcursor_manager, cursor_names[cursor], seat->cursor);
+	wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
+		cursor_names[cursor]);
 	seat->server_cursor = cursor;
 }
 
@@ -274,8 +274,15 @@ cursor_update_image(struct seat *seat)
 		}
 		return;
 	}
-	wlr_xcursor_manager_set_cursor_image(
-		seat->xcursor_manager, cursor_names[cursor], seat->cursor);
+	/*
+	 * Call wlr_cursor_unset_image() first to force wlroots to
+	 * update the cursor (e.g. for a new output). Otherwise,
+	 * wlr_cursor_set_xcursor() may detect that we are setting the
+	 * same cursor as before, and do nothing.
+	 */
+	wlr_cursor_unset_image(seat->cursor);
+	wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager,
+		cursor_names[cursor]);
 }
 
 bool

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -100,11 +100,11 @@ cursor_get_from_ssd(enum ssd_part_type view_area)
 static struct wlr_surface *
 get_toplevel(struct wlr_surface *surface)
 {
-	while (surface && wlr_surface_is_xdg_surface(surface)) {
+	while (surface) {
 		struct wlr_xdg_surface *xdg_surface =
-			wlr_xdg_surface_from_wlr_surface(surface);
+			wlr_xdg_surface_try_from_wlr_surface(surface);
 		if (!xdg_surface) {
-			return NULL;
+			break;
 		}
 
 		switch (xdg_surface->role) {
@@ -117,7 +117,7 @@ get_toplevel(struct wlr_surface *surface)
 			continue;
 		}
 	}
-	if (surface && wlr_surface_is_layer_surface(surface)) {
+	if (surface && wlr_layer_surface_v1_try_from_wlr_surface(surface)) {
 		return surface;
 	}
 	return NULL;
@@ -329,7 +329,7 @@ process_cursor_motion_out_of_surface(struct server *server, uint32_t time)
 	if (view) {
 		lx = view->current.x;
 		ly = view->current.y;
-	} else if (node && wlr_surface_is_layer_surface(surface)) {
+	} else if (node && wlr_layer_surface_v1_try_from_wlr_surface(surface)) {
 		wlr_scene_node_coords(node, &lx, &ly);
 #if HAVE_XWAYLAND
 	} else if (node && node->parent == server->unmanaged_tree) {
@@ -917,7 +917,7 @@ cursor_button_press(struct seat *seat, struct wlr_pointer_button_event *event)
 	 */
 	if (ctx.type == LAB_SSD_LAYER_SURFACE) {
 		struct wlr_layer_surface_v1 *layer =
-			wlr_layer_surface_v1_from_wlr_surface(ctx.surface);
+			wlr_layer_surface_v1_try_from_wlr_surface(ctx.surface);
 		if (layer && layer->current.keyboard_interactive) {
 			seat_set_focus_layer(seat, layer);
 		}

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -18,13 +18,7 @@ static bool should_cancel_cycling_on_next_key_release;
 static void
 change_vt(struct server *server, unsigned int vt)
 {
-	if (!wlr_backend_is_multi(server->backend)) {
-		return;
-	}
-	struct wlr_session *session = wlr_backend_get_session(server->backend);
-	if (session) {
-		wlr_session_change_vt(session, vt);
-	}
+	wlr_session_change_vt(server->session, vt);
 }
 
 bool

--- a/src/layers.c
+++ b/src/layers.c
@@ -22,6 +22,8 @@
 #include "labwc.h"
 #include "node.h"
 
+#define LAB_LAYERSHELL_VERSION 4
+
 static void
 apply_override(struct output *output, struct wlr_box *usable_area)
 {
@@ -428,7 +430,8 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 void
 layers_init(struct server *server)
 {
-	server->layer_shell = wlr_layer_shell_v1_create(server->wl_display);
+	server->layer_shell = wlr_layer_shell_v1_create(server->wl_display,
+		LAB_LAYERSHELL_VERSION);
 	server->new_layer_surface.notify = handle_new_layer_surface;
 	wl_signal_add(&server->layer_shell->events.new_surface,
 		&server->new_layer_surface);

--- a/src/layers.c
+++ b/src/layers.c
@@ -175,8 +175,8 @@ handle_surface_commit(struct wl_listener *listener, void *data)
 		process_keyboard_interactivity(layer);
 	}
 
-	if (committed || layer->mapped != layer_surface->mapped) {
-		layer->mapped = layer_surface->mapped;
+	if (committed || layer->mapped != layer_surface->surface->mapped) {
+		layer->mapped = layer_surface->surface->mapped;
 		output_update_usable_area(output);
 		/*
 		 * Update cursor focus here to ensure we
@@ -401,10 +401,10 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 		&surface->surface_commit);
 
 	surface->map.notify = handle_map;
-	wl_signal_add(&layer_surface->events.map, &surface->map);
+	wl_signal_add(&layer_surface->surface->events.map, &surface->map);
 
 	surface->unmap.notify = handle_unmap;
-	wl_signal_add(&layer_surface->events.unmap, &surface->unmap);
+	wl_signal_add(&layer_surface->surface->events.unmap, &surface->unmap);
 
 	surface->new_popup.notify = handle_new_popup;
 	wl_signal_add(&layer_surface->events.new_popup, &surface->new_popup);

--- a/src/output.c
+++ b/src/output.c
@@ -330,8 +330,12 @@ output_config_apply(struct server *server,
 			struct wlr_box pos = {0};
 			wlr_output_layout_get_box(server->output_layout, o, &pos);
 			if (pos.x != head->state.x || pos.y != head->state.y) {
-				/* This overrides the automatic layout */
-				wlr_output_layout_move(server->output_layout, o,
+				/*
+				 * This overrides the automatic layout
+				 *
+				 * wlr_output_layout_add() in fact means _move()
+				 */
+				wlr_output_layout_add(server->output_layout, o,
 					head->state.x, head->state.y);
 			}
 		}

--- a/src/output.c
+++ b/src/output.c
@@ -32,7 +32,7 @@ output_frame_notify(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	wlr_scene_output_commit(output->scene_output);
+	wlr_scene_output_commit(output->scene_output, NULL);
 
 	struct timespec now = { 0 };
 	clock_gettime(CLOCK_MONOTONIC, &now);

--- a/src/server.c
+++ b/src/server.c
@@ -5,10 +5,6 @@
 #include <sys/wait.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
-
-/* Temporary fix for a wlroots bug: missing forward declares in the gamma header */
-#include <wlr/types/wlr_output.h>
-
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_input_inhibitor.h>
 #include <wlr/types/wlr_presentation_time.h>

--- a/src/server.c
+++ b/src/server.c
@@ -5,6 +5,10 @@
 #include <sys/wait.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
+
+/* Temporary fix for a wlroots bug: missing forward declares in the gamma header */
+#include <wlr/types/wlr_output.h>
+
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_input_inhibitor.h>
 #include <wlr/types/wlr_presentation_time.h>

--- a/src/server.c
+++ b/src/server.c
@@ -244,7 +244,8 @@ server_init(struct server *server)
 	 * backend based on the current environment, such as opening an x11
 	 * window if an x11 server is running.
 	 */
-	server->backend = wlr_backend_autocreate(server->wl_display);
+	server->backend = wlr_backend_autocreate(
+		server->wl_display, &server->session);
 	if (!server->backend) {
 		wlr_log(WLR_ERROR, "unable to create backend");
 		fprintf(stderr, helpful_seat_error_message);

--- a/src/server.c
+++ b/src/server.c
@@ -30,6 +30,8 @@
 #include "workspaces.h"
 #include "xwayland.h"
 
+#define LAB_WLR_COMPOSITOR_VERSION (5)
+
 static struct wlr_compositor *compositor;
 static struct wl_event_source *sighup_source;
 static struct wl_event_source *sigint_source;
@@ -330,8 +332,8 @@ server_init(struct server *server)
 	 * room for you to dig your fingers in and play with their behavior if
 	 * you want.
 	 */
-	compositor =
-		wlr_compositor_create(server->wl_display, server->renderer);
+	compositor = wlr_compositor_create(server->wl_display,
+		LAB_WLR_COMPOSITOR_VERSION, server->renderer);
 	if (!compositor) {
 		wlr_log(WLR_ERROR, "unable to create the wlroots compositor");
 		exit(EXIT_FAILURE);

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -42,10 +42,10 @@ refocus_output(struct session_lock_output *output)
 
 	struct session_lock_output *iter;
 	wl_list_for_each(iter, &output->lock->session_lock_outputs, link) {
-		if (iter == output || !iter->surface) {
+		if (iter == output || !iter->surface || !iter->surface->surface) {
 			continue;
 		}
-		if (iter->surface->mapped) {
+		if (iter->surface->surface->mapped) {
 			focus_surface(output->lock, iter->surface->surface);
 			return;
 		}
@@ -110,7 +110,7 @@ found_lock_output:
 	wl_signal_add(&lock_surface->events.destroy, &lock_output->surface_destroy);
 
 	lock_output->surface_map.notify = handle_surface_map;
-	wl_signal_add(&lock_surface->events.map, &lock_output->surface_map);
+	wl_signal_add(&lock_surface->surface->events.map, &lock_output->surface_map);
 
 	lock_output_reconfigure(lock_output);
 }

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -143,7 +143,7 @@ handle_commit(struct wl_listener *listener, void *data)
 	struct session_lock_output *output = wl_container_of(listener, output, commit);
 	uint32_t require_reconfigure = WLR_OUTPUT_STATE_MODE
 		| WLR_OUTPUT_STATE_SCALE | WLR_OUTPUT_STATE_TRANSFORM;
-	if (event->committed & require_reconfigure) {
+	if (event->state->committed & require_reconfigure) {
 		lock_output_reconfigure(output);
 	}
 }

--- a/src/view.c
+++ b/src/view.c
@@ -34,20 +34,16 @@ view_from_wlr_surface(struct wlr_surface *surface)
 	 * - find a way to get rid of xdg/xwayland-specific stuff
 	 * - look up root/toplevel surface if passed a subsurface?
 	 */
-	if (wlr_surface_is_xdg_surface(surface)) {
-		struct wlr_xdg_surface *xdg_surface =
-			wlr_xdg_surface_from_wlr_surface(surface);
-		if (xdg_surface) {
-			return xdg_surface->data;
-		}
+	struct wlr_xdg_surface *xdg_surface =
+		wlr_xdg_surface_try_from_wlr_surface(surface);
+	if (xdg_surface) {
+		return xdg_surface->data;
 	}
 #if HAVE_XWAYLAND
-	if (wlr_surface_is_xwayland_surface(surface)) {
-		struct wlr_xwayland_surface *xsurface =
-			wlr_xwayland_surface_from_wlr_surface(surface);
-		if (xsurface) {
-			return xsurface->data;
-		}
+	struct wlr_xwayland_surface *xsurface =
+		wlr_xwayland_surface_try_from_wlr_surface(surface);
+	if (xsurface) {
+		return xsurface->data;
 	}
 #endif
 	return NULL;

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -63,8 +63,7 @@ void
 xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup)
 {
 	struct wlr_xdg_surface *parent =
-		wlr_surface_is_xdg_surface(wlr_popup->parent) ?
-		wlr_xdg_surface_from_wlr_surface(wlr_popup->parent) : NULL;
+		wlr_xdg_surface_try_from_wlr_surface(wlr_popup->parent);
 	if (!parent) {
 		wlr_log(WLR_ERROR, "parent is not a valid XDG surface");
 		return;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -164,20 +164,6 @@ set_pending_configure_serial(struct view *view, uint32_t serial)
 }
 
 static void
-handle_map(struct wl_listener *listener, void *data)
-{
-	struct view *view = wl_container_of(listener, view, map);
-	view->impl->map(view);
-}
-
-static void
-handle_unmap(struct wl_listener *listener, void *data)
-{
-	struct view *view = wl_container_of(listener, view, unmap);
-	view->impl->unmap(view, /* client_request */ true);
-}
-
-static void
 handle_destroy(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, destroy);
@@ -688,8 +674,7 @@ xdg_surface_new(struct wl_listener *listener, void *data)
 	/* In support of xdg popups */
 	xdg_surface->surface->data = tree;
 
-	CONNECT_SIGNAL(xdg_surface, view, map);
-	CONNECT_SIGNAL(xdg_surface, view, unmap);
+	view_connect_map(view, xdg_surface->surface);
 	CONNECT_SIGNAL(xdg_surface, view, destroy);
 
 	struct wlr_xdg_toplevel *toplevel = xdg_surface->toplevel;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -579,12 +579,12 @@ xdg_activation_handle_request(struct wl_listener *listener, void *data)
 {
 	const struct wlr_xdg_activation_v1_request_activate_event *event = data;
 
-	if (!wlr_surface_is_xdg_surface(event->surface)) {
+	struct wlr_xdg_surface *xdg_surface =
+		wlr_xdg_surface_try_from_wlr_surface(event->surface);
+	if (!xdg_surface) {
 		return;
 	}
-	struct wlr_xdg_surface *xdg_surface =
-		wlr_xdg_surface_from_wlr_surface(event->surface);
-	struct view *view = xdg_surface ? xdg_surface->data : NULL;
+	struct view *view = xdg_surface->data;
 
 	if (!view) {
 		wlr_log(WLR_INFO, "Not activating surface - no view attached to surface");

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -168,7 +168,7 @@ handle_request_activate(struct wl_listener *listener, void *data)
 	struct view *view = desktop_topmost_focusable_view(server);
 	if (view && view->type == LAB_XWAYLAND_VIEW) {
 		struct wlr_xwayland_surface *surf =
-			wlr_xwayland_surface_from_wlr_surface(view->surface);
+			wlr_xwayland_surface_try_from_wlr_surface(view->surface);
 		if (surf && surf->pid != xsurface->pid) {
 			return;
 		}

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -701,8 +701,7 @@ xwayland_view_is_related(struct view *view, struct wlr_surface *surface)
 	struct wlr_xwayland_surface *xsurface =
 		xwayland_surface_from_view(view);
 	struct wlr_xwayland_surface *xsurface2 =
-		wlr_surface_is_xwayland_surface(surface) ?
-		wlr_xwayland_surface_from_wlr_surface(surface) : NULL;
+		wlr_xwayland_surface_try_from_wlr_surface(surface);
 
 	return (xsurface2 && xsurface2->pid == xsurface->pid);
 }

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 7b32c25a4fbdcde4197a06c8e0ff638c54753bd7
+revision = 0bb574239d3b164596677bf4cec371ff0671dc4f
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 9f793d350379872aeee56ea5c476adfeedc8bc88
+revision = 258bf9be1e44d8a2fb953d727ff4ffcf9ebd6503
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 70c1a5724814d2f786f7d3a0e55a05f11af14029
+revision = 18bafbfc57039e16d1dabd78b882b3d6477f76b5
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = f5917f0247600b65edec1735234d00de57d577a8
+revision = a289f812d62059d5aac92cbd374dcb7b03bb08a6
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 26676c8c072f813dc2d7e2b2dfe9e2701ce361a7
+revision = 70c1a5724814d2f786f7d3a0e55a05f11af14029
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = f9bd416d4156942ce3951a6c5cf9f81a3cf4a3dd
+revision = 7b32c25a4fbdcde4197a06c8e0ff638c54753bd7
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 0.16
+revision = 5b23987349dde587100c792bb6d180c930e6f2bd
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 657ca2205ff4d5f70cf294d9b5720acf2eaf76b4
+revision = bdc34401ba8e4a59b3464c17fa5acf43ca417e57
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 18bafbfc57039e16d1dabd78b882b3d6477f76b5
+revision = 214df8eda07d18b032abfcf525c8344e077c0c7e
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = bdc34401ba8e4a59b3464c17fa5acf43ca417e57
+revision = f5917f0247600b65edec1735234d00de57d577a8
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = a289f812d62059d5aac92cbd374dcb7b03bb08a6
+revision = 5fb0007e0249388792f3772c30bfabf8d551dec0
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = e7c556fcf61eb3121d741cd4da526b2619862678
+revision = 097ea84cda70a71ad8ea5940b3b3d277167424e5
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 097ea84cda70a71ad8ea5940b3b3d277167424e5
+revision = f9bd416d4156942ce3951a6c5cf9f81a3cf4a3dd
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 258bf9be1e44d8a2fb953d727ff4ffcf9ebd6503
+revision = e7c556fcf61eb3121d741cd4da526b2619862678
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 5b23987349dde587100c792bb6d180c930e6f2bd
+revision = 9f793d350379872aeee56ea5c476adfeedc8bc88
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 214df8eda07d18b032abfcf525c8344e077c0c7e
+revision = 657ca2205ff4d5f70cf294d9b5720acf2eaf76b4
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 5fb0007e0249388792f3772c30bfabf8d551dec0
+revision = 0.17
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 0bb574239d3b164596677bf4cec371ff0671dc4f
+revision = 26676c8c072f813dc2d7e2b2dfe9e2701ce361a7
 
 [provide]
 dependency_names = wlroots


### PR DESCRIPTION
This is a set of changes required to build with wlroots `master` / 0.17.0-dev (labwc `master` currently uses wlroots 0.16.x).

Perhaps it will be useful to other wanting to use wlroots-git. I plan to update/rebase it as further breaking changes are made on the wlroots side.