### PR TITLE
Fix positioning of initially-maximized XWayland views

### DIFF
--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -169,16 +169,18 @@ ssd_create(struct view *view)
 void
 ssd_update_geometry(struct view *view)
 {
-	if (!view->ssd.tree || !view->scene_node) {
+	if (!view->scene_node) {
 		return;
 	}
 
 	if (!view->ssd.enabled) {
-		if (view->ssd.tree->node.enabled) {
+		if (view->ssd.tree && view->ssd.tree->node.enabled) {
 			wlr_scene_node_set_enabled(&view->ssd.tree->node, false);
 			view->margin = ssd_thickness(view);
 		}
 		return;
+	} else if (!view->ssd.tree) {
+		ssd_create(view);
 	} else if (!view->ssd.tree->node.enabled) {
 		wlr_scene_node_set_enabled(&view->ssd.tree->node, true);
 		view->margin = ssd_thickness(view);

--- a/src/view.c
+++ b/src/view.c
@@ -466,15 +466,7 @@ view_toggle_maximize(struct view *view)
 void
 view_toggle_decorations(struct view *view)
 {
-	if (!view->fullscreen) {
-		view->ssd.enabled = !view->ssd.enabled;
-		ssd_update_geometry(view);
-		if (view->maximized) {
-			view_apply_maximized_geometry(view);
-		} else if (view->tiled) {
-			view_apply_tiled_geometry(view, NULL);
-		}
-	}
+	view_set_decorations(view, !view->ssd.enabled);
 }
 
 static bool

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -303,11 +303,7 @@ xdg_toplevel_view_map(struct view *view)
 		struct wlr_xdg_toplevel_requested *requested =
 			&view->xdg_surface->toplevel->requested;
 		foreign_toplevel_handle_create(view);
-
-		view->ssd.enabled = has_ssd(view);
-		if (view->ssd.enabled) {
-			ssd_create(view);
-		}
+		view_set_decorations(view, has_ssd(view));
 
 		position_xdg_toplevel_view(view);
 		if (!view->fullscreen && requested->fullscreen) {

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -384,10 +384,7 @@ map(struct view *view)
 	}
 
 	if (!view->been_mapped) {
-		view->ssd.enabled = want_deco(view);
-		if (view->ssd.enabled) {
-			ssd_create(view);
-		}
+		view_set_decorations(view, want_deco(view));
 
 		if (!view->maximized && !view->fullscreen) {
 			set_initial_position(view);


### PR DESCRIPTION
`map()` in `xwayland.c` called `ssd_create()` but did not call `view_apply_maximized_geometry()` afterward, resulting in the decorations being displayed off-screen.

Rather than calling `view_apply_maximized_geometry()` in more places, let's reuse the existing call in `view_set_decorations()`, and extend `ssd_update_geometry()` to call `ssd_create()` when needed.

I also included a second commit which simply deduplicates some code, by having `view_toggle_decorations()` call `view_set_decorations()`.