### PR TITLE
build: drop pixman dependency after wlr_scene switch

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,6 @@ glib = dependency('glib-2.0')
 cairo = dependency('cairo')
 pangocairo = dependency('pangocairo')
 input = dependency('libinput', version: '>=1.14')
-pixman = dependency('pixman-1')
 math = cc.find_library('m')
 
 if get_option('xwayland').enabled() and not wlroots_has_xwayland
@@ -92,7 +91,6 @@ labwc_deps = [
   drm,
   pangocairo,
   input,
-  pixman,
   math,
 ]
 


### PR DESCRIPTION
Meson adds `-Wl,--as-needed` (unless `-Db_asneeded=false`) by default. For example, packaging log diff:
```diff
 =>> Checking shared library dependencies
  0x0000000000000001 NEEDED               Shared library: [libc.so.7]
  0x0000000000000001 NEEDED               Shared library: [libcairo.so.2]
  0x0000000000000001 NEEDED               Shared library: [libglib-2.0.so.0]
  0x0000000000000001 NEEDED               Shared library: [libgobject-2.0.so.0]
  0x0000000000000001 NEEDED               Shared library: [libinput.so.10]
+ 0x0000000000000001 NEEDED               Shared library: [libintl.so.8]
  0x0000000000000001 NEEDED               Shared library: [libm.so.5]
  0x0000000000000001 NEEDED               Shared library: [libpango-1.0.so.0]
  0x0000000000000001 NEEDED               Shared library: [libpangocairo-1.0.so.0]
- 0x0000000000000001 NEEDED               Shared library: [libpixman-1.so.0]
  0x0000000000000001 NEEDED               Shared library: [libwayland-server.so.0]
- 0x0000000000000001 NEEDED               Shared library: [libwlroots.so.10]
+ 0x0000000000000001 NEEDED               Shared library: [libwlroots.so.11]
  0x0000000000000001 NEEDED               Shared library: [libxkbcommon.so.0]
  0x0000000000000001 NEEDED               Shared library: [libxml2.so.2]
```
