### PR TITLE
src/config/rcxml.c: Check for modifiers when merging mousebinds

### DIFF
--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -658,7 +658,8 @@ merge_mouse_bindings(void)
 			if (existing->context == current->context
 					&& existing->button == current->button
 					&& existing->direction == current->direction
-					&& existing->mouse_event == current->mouse_event) {
+					&& existing->mouse_event == current->mouse_event
+					&& existing->modifiers == current->modifiers) {
 				wl_list_remove(&existing->link);
 				action_list_free(&existing->actions);
 				free(existing);


### PR DESCRIPTION
Previously mosuebinds for the same context using the same button but different modifiers would be merged, e.g. only the last one would survive the merge. This commit adds the missing check for keyboard modifiers.

Fixes #630

Reported-by: @lidgnulinux