### PR TITLE
interactive: Clean up natural_geometry hacks

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -480,8 +480,11 @@ void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
 /* view_wlr_output - return the output that a view is mostly on */
 struct wlr_output *view_wlr_output(struct view *view);
+void view_store_natural_geometry(struct view *view);
 void view_center(struct view *view);
-void view_maximize(struct view *view, bool maximize);
+void view_restore_to(struct view *view, struct wlr_box geometry);
+void view_maximize(struct view *view, bool maximize,
+	bool store_natural_geometry);
 void view_set_fullscreen(struct view *view, bool fullscreen,
 	struct wlr_output *wlr_output);
 void view_toggle_maximize(struct view *view);
@@ -492,7 +495,8 @@ void view_toggle_fullscreen(struct view *view);
 void view_adjust_for_layout_change(struct view *view);
 void view_discover_output(struct view *view);
 void view_move_to_edge(struct view *view, const char *direction);
-void view_snap_to_edge(struct view *view, const char *direction);
+void view_snap_to_edge(struct view *view, const char *direction,
+	bool store_natural_geometry);
 const char *view_get_string_prop(struct view *view, const char *prop);
 void view_update_title(struct view *view);
 void view_update_app_id(struct view *view);
@@ -562,7 +566,8 @@ void seat_reset_pressed(struct seat *seat);
 
 void interactive_begin(struct view *view, enum input_mode mode,
 		      uint32_t edges);
-void interactive_end(struct view *view);
+void interactive_finish(struct view *view);
+void interactive_cancel(struct view *view);
 
 void output_init(struct server *server);
 void output_manager_init(struct server *server);

--- a/src/action.c
+++ b/src/action.c
@@ -254,7 +254,8 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_SNAP_TO_EDGE:
 			if (arg) {
-				view_snap_to_edge(view, action_str_from_arg(arg));
+				view_snap_to_edge(view, action_str_from_arg(arg),
+					/*store_natural_geometry*/ true);
 			} else {
 				wlr_log(WLR_ERROR, "Missing argument for SnapToEdge");
 			}

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -848,7 +848,7 @@ cursor_button_release(struct seat *seat, struct wlr_pointer_button_event *event)
 
 	if (server->input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
 		/* Exit interactive move/resize mode */
-		interactive_end(server->grabbed_view);
+		interactive_finish(server->grabbed_view);
 		return;
 	}
 

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -20,7 +20,8 @@ handle_toplevel_handle_request_maximize(struct wl_listener *listener, void *data
 		toplevel_handle_request_maximize);
 	struct wlr_foreign_toplevel_handle_v1_maximized_event *event = data;
 	if (view) {
-		view_maximize(view, event->maximized);
+		view_maximize(view, event->maximized,
+			/*store_natural_geometry*/ true);
 	}
 }
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -144,7 +144,8 @@ static void
 handle_request_maximize(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, request_maximize);
-	view_maximize(view, view->xdg_surface->toplevel->requested.maximized);
+	view_maximize(view, view->xdg_surface->toplevel->requested.maximized,
+		/*store_natural_geometry*/ true);
 }
 
 static void
@@ -314,7 +315,8 @@ xdg_toplevel_view_map(struct view *view)
 			view_set_fullscreen(view, true,
 				requested->fullscreen_output);
 		} else if (!view->maximized && requested->maximized) {
-			view_maximize(view, true);
+			view_maximize(view, true,
+				/*store_natural_geometry*/ true);
 		}
 
 		view_moved(view);


### PR DESCRIPTION
There are a couple of sketchy things going on here:

- interactive_begin() pokes its own values into view->natural_geometry to force view_maximize() to set a particular geometry.
- interactive_end() "fixes" view->natural_geometry after calling view_maximize() to save the original geometry from the start of the interactive move/resize.

Let's adjust/expand the API of view.c so that the interactive.c can avoid this "back door" of overwriting view->natural_geometry directly.

This also addresses an issue where the natural_geometry was not saved correctly when dragging and snapping a window to a screen edge.

Fixes: #633