### PR TITLE
view/ssd: Minor refactoring to make code more modular

### DIFF
--- a/include/ssd.h
+++ b/include/ssd.h
@@ -81,7 +81,6 @@ struct ssd_state_title_width {
 };
 
 struct ssd {
-	bool enabled;
 	struct wlr_scene_tree *tree;
 
 	/*

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -117,6 +117,13 @@ struct ssd {
 		struct ssd_sub_tree active;
 		struct ssd_sub_tree inactive;
 	} border;
+
+	/*
+	 * Space between the extremities of the view's wlr_surface
+	 * and the max extents of the server-side decorations.
+	 * For xdg-shell views with CSD, this margin is zero.
+	 */
+	struct border margin;
 };
 
 struct ssd_part {

--- a/include/view.h
+++ b/include/view.h
@@ -133,6 +133,7 @@ void view_set_fullscreen(struct view *view, bool fullscreen,
 void view_toggle_maximize(struct view *view);
 void view_toggle_decorations(struct view *view);
 void view_toggle_always_on_top(struct view *view);
+void view_move_to_workspace(struct view *view, struct workspace *workspace);
 void view_set_decorations(struct view *view, bool decorations);
 void view_toggle_fullscreen(struct view *view);
 void view_adjust_for_layout_change(struct view *view);

--- a/include/view.h
+++ b/include/view.h
@@ -59,13 +59,6 @@ struct view {
 	/* user defined geometry before maximize / tiling / fullscreen */
 	struct wlr_box natural_geometry;
 
-	/*
-	 * margin refers to the space between the extremities of the
-	 * wlr_surface and the max extents of the server-side decorations.
-	 * For xdg-shell views with CSD, this margin is zero.
-	 */
-	struct border margin;
-
 	struct view_pending_move_resize {
 		bool update_x, update_y;
 		int x, y;

--- a/include/view.h
+++ b/include/view.h
@@ -126,6 +126,7 @@ struct wlr_output *view_wlr_output(struct view *view);
 void view_store_natural_geometry(struct view *view);
 void view_center(struct view *view);
 void view_restore_to(struct view *view, struct wlr_box geometry);
+void view_set_untiled(struct view *view);
 void view_maximize(struct view *view, bool maximize,
 	bool store_natural_geometry);
 void view_set_fullscreen(struct view *view, bool fullscreen,

--- a/include/view.h
+++ b/include/view.h
@@ -48,6 +48,7 @@ struct view {
 
 	bool mapped;
 	bool been_mapped;
+	bool ssd_enabled;
 	bool minimized;
 	bool maximized;
 	uint32_t tiled;  /* private, enum view_edge in src/view.c */

--- a/include/workspaces.h
+++ b/include/workspaces.h
@@ -21,7 +21,6 @@ struct workspace {
 
 void workspaces_init(struct server *server);
 void workspaces_switch_to(struct workspace *target);
-void workspaces_send_to(struct view *view, struct workspace *target);
 void workspaces_destroy(struct server *server);
 void workspaces_osd_hide(struct seat *seat);
 struct workspace *workspaces_find(struct workspace *anchor, const char *name);

--- a/src/action.c
+++ b/src/action.c
@@ -247,18 +247,22 @@ actions_run(struct view *activator, struct server *server,
 			wl_display_terminate(server->wl_display);
 			break;
 		case ACTION_TYPE_MOVE_TO_EDGE:
-			if (arg) {
-				view_move_to_edge(view, action_str_from_arg(arg));
-			} else {
+			if (!arg) {
 				wlr_log(WLR_ERROR, "Missing argument for MoveToEdge");
+				break;
+			}
+			if (view) {
+				view_move_to_edge(view, action_str_from_arg(arg));
 			}
 			break;
 		case ACTION_TYPE_SNAP_TO_EDGE:
-			if (arg) {
+			if (!arg) {
+				wlr_log(WLR_ERROR, "Missing argument for SnapToEdge");
+				break;
+			}
+			if (view) {
 				view_snap_to_edge(view, action_str_from_arg(arg),
 					/*store_natural_geometry*/ true);
-			} else {
-				wlr_log(WLR_ERROR, "Missing argument for SnapToEdge");
 			}
 			break;
 		case ACTION_TYPE_NEXT_WINDOW:

--- a/src/action.c
+++ b/src/action.c
@@ -353,7 +353,7 @@ actions_run(struct view *activator, struct server *server,
 				char *target_name = action_str_from_arg(arg);
 				target = workspaces_find(view->workspace, target_name);
 				if (target) {
-					workspaces_send_to(view, target);
+					view_move_to_workspace(view, target);
 				}
 			}
 			break;

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -74,7 +74,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 		 * Reset tiled state but keep the same geometry as the
 		 * starting point for the resize.
 		 */
-		view->tiled = 0;
+		view_set_untiled(view);
 		cursor_set(seat, cursor_get_from_edge(edges));
 		break;
 	default:
@@ -146,7 +146,7 @@ interactive_finish(struct view *view)
 		if (mode == LAB_INPUT_STATE_MOVE) {
 			if (!snap_to_edge(view)) {
 				/* Reset tiled state if not snapped */
-				view->tiled = 0;
+				view_set_untiled(view);
 			}
 		}
 		/* Update focus/cursor image */

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -41,7 +41,7 @@ resistance_move_apply(struct view *view, double *x, double *y)
 	struct wlr_box tgeom = {.x = *x, .y = *y, .width = view->w,
 		.height = view->h};
 	struct output *output;
-	struct border border = view->margin;
+	struct border border = view->ssd.margin;
 	struct edges view_edges; /* The edges of the current view */
 	struct edges target_edges; /* The desired edges */
 	struct edges other_edges; /* The edges of the monitor/other view */
@@ -112,7 +112,7 @@ resistance_resize_apply(struct view *view, struct wlr_box *new_view_geo)
 		.height = view->h};
 	struct wlr_box tgeom = {.x = new_view_geo->x, .y = new_view_geo->y,
 		.width = new_view_geo->width, .height = new_view_geo->height};
-	struct border border = view->margin;
+	struct border border = view->ssd.margin;
 	struct edges view_edges; /* The edges of the current view */
 	struct edges target_edges; /* The desired edges */
 	struct edges other_edges; /* The edges of the monitor/other view */

--- a/src/server.c
+++ b/src/server.c
@@ -40,7 +40,7 @@ reload_config_and_theme(void)
 
 	struct view *view;
 	wl_list_for_each(view, &g_server->views, link) {
-		if (!view->mapped || !view->ssd.enabled) {
+		if (!view->mapped || !view->ssd_enabled) {
 			continue;
 		}
 		ssd_reload(view);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -161,7 +161,7 @@ ssd_create(struct view *view)
 	ssd_extents_create(view);
 	ssd_border_create(view);
 	ssd_titlebar_create(view);
-	view->margin = ssd_thickness(view);
+	view->ssd.margin = ssd_thickness(view);
 	ssd_set_active(view, is_active);
 }
 
@@ -175,14 +175,14 @@ ssd_update_geometry(struct view *view)
 	if (!view->ssd.enabled) {
 		if (view->ssd.tree && view->ssd.tree->node.enabled) {
 			wlr_scene_node_set_enabled(&view->ssd.tree->node, false);
-			view->margin = ssd_thickness(view);
+			view->ssd.margin = ssd_thickness(view);
 		}
 		return;
 	} else if (!view->ssd.tree) {
 		ssd_create(view);
 	} else if (!view->ssd.tree->node.enabled) {
 		wlr_scene_node_set_enabled(&view->ssd.tree->node, true);
-		view->margin = ssd_thickness(view);
+		view->ssd.margin = ssd_thickness(view);
 	}
 
 	int width = view->w;

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -16,7 +16,7 @@
 struct border
 ssd_thickness(struct view *view)
 {
-	if (!view->ssd.enabled) {
+	if (!view->ssd_enabled) {
 		struct border border = { 0 };
 		return border;
 	}
@@ -172,7 +172,7 @@ ssd_update_geometry(struct view *view)
 		return;
 	}
 
-	if (!view->ssd.enabled) {
+	if (!view->ssd_enabled) {
 		if (view->ssd.tree && view->ssd.tree->node.enabled) {
 			wlr_scene_node_set_enabled(&view->ssd.tree->node, false);
 			view->ssd.margin = ssd_thickness(view);

--- a/src/view.c
+++ b/src/view.c
@@ -522,10 +522,23 @@ view_toggle_always_on_top(struct view *view)
 	assert(view);
 	if (is_always_on_top(view)) {
 		view->workspace = view->server->workspace_current;
-		wlr_scene_node_reparent(&view->scene_tree->node, view->workspace->tree);
+		wlr_scene_node_reparent(&view->scene_tree->node,
+			view->workspace->tree);
 	} else {
 		wlr_scene_node_reparent(&view->scene_tree->node,
 			view->server->view_tree_always_on_top);
+	}
+}
+
+void
+view_move_to_workspace(struct view *view, struct workspace *workspace)
+{
+	assert(view);
+	assert(workspace);
+	if (view->workspace != workspace) {
+		view->workspace = workspace;
+		wlr_scene_node_reparent(&view->scene_tree->node,
+			workspace->tree);
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -404,7 +404,7 @@ view_apply_maximized_geometry(struct view *view)
 		box.width /= output->wlr_output->scale;
 	}
 
-	if (view->ssd.enabled) {
+	if (view->ssd_enabled) {
 		struct border border = ssd_thickness(view);
 		box.x += border.left;
 		box.y += border.top;
@@ -514,7 +514,7 @@ void
 view_toggle_decorations(struct view *view)
 {
 	assert(view);
-	view_set_decorations(view, !view->ssd.enabled);
+	view_set_decorations(view, !view->ssd_enabled);
 }
 
 static bool
@@ -554,8 +554,8 @@ void
 view_set_decorations(struct view *view, bool decorations)
 {
 	assert(view);
-	if (view->ssd.enabled != decorations && !view->fullscreen) {
-		view->ssd.enabled = decorations;
+	if (view->ssd_enabled != decorations && !view->fullscreen) {
+		view->ssd_enabled = decorations;
 		ssd_update_geometry(view);
 		if (view->maximized) {
 			view_apply_maximized_geometry(view);

--- a/src/view.c
+++ b/src/view.c
@@ -116,7 +116,6 @@ void
 view_set_activated(struct view *view)
 {
 	assert(view);
-
 	struct view *last = view->server->focused_view;
 	if (last == view) {
 		return;
@@ -131,6 +130,7 @@ view_set_activated(struct view *view)
 void
 view_close(struct view *view)
 {
+	assert(view);
 	if (view->impl->close) {
 		view->impl->close(view);
 	}
@@ -139,6 +139,7 @@ view_close(struct view *view)
 void
 view_move(struct view *view, int x, int y)
 {
+	assert(view);
 	if (view->impl->move) {
 		view->impl->move(view, x, y);
 	}
@@ -147,6 +148,7 @@ view_move(struct view *view, int x, int y)
 void
 view_moved(struct view *view)
 {
+	assert(view);
 	wlr_scene_node_set_position(&view->scene_tree->node, view->x, view->y);
 	view_discover_output(view);
 	ssd_update_geometry(view);
@@ -157,6 +159,7 @@ view_moved(struct view *view)
 void
 view_move_resize(struct view *view, struct wlr_box geo)
 {
+	assert(view);
 	if (view->impl->configure) {
 		view->impl->configure(view, geo);
 	}
@@ -178,6 +181,7 @@ round_to_increment(int val, int base, int inc)
 void
 view_adjust_size(struct view *view, int *w, int *h)
 {
+	assert(view);
 	int min_width = MIN_VIEW_WIDTH;
 	int min_height = MIN_VIEW_HEIGHT;
 #if HAVE_XWAYLAND
@@ -208,6 +212,7 @@ view_adjust_size(struct view *view, int *w, int *h)
 void
 view_minimize(struct view *view, bool minimized)
 {
+	assert(view);
 	if (view->minimized == minimized) {
 		return;
 	}
@@ -240,6 +245,7 @@ view_minimize(struct view *view, bool minimized)
 struct wlr_output *
 view_wlr_output(struct view *view)
 {
+	assert(view);
 	double closest_x, closest_y;
 	struct wlr_output *wlr_output = NULL;
 	wlr_output_layout_closest_point(view->server->output_layout, wlr_output,
@@ -312,6 +318,7 @@ set_fallback_geometry(struct view *view)
 void
 view_store_natural_geometry(struct view *view)
 {
+	assert(view);
 	/**
 	 * If an application was started maximized or fullscreened, its
 	 * natural_geometry width/height may still be zero in which case we set
@@ -330,6 +337,7 @@ view_store_natural_geometry(struct view *view)
 void
 view_center(struct view *view)
 {
+	assert(view);
 	int x, y;
 	if (view_compute_centered_position(view, view->w, view->h, &x, &y)) {
 		view_move(view, x, y);
@@ -444,6 +452,7 @@ set_maximized(struct view *view, bool maximized)
 void
 view_restore_to(struct view *view, struct wlr_box geometry)
 {
+	assert(view);
 	if (view->fullscreen) {
 		return;
 	}
@@ -456,6 +465,7 @@ view_restore_to(struct view *view, struct wlr_box geometry)
 void
 view_maximize(struct view *view, bool maximize, bool store_natural_geometry)
 {
+	assert(view);
 	if (view->maximized == maximize) {
 		return;
 	}
@@ -487,6 +497,7 @@ view_maximize(struct view *view, bool maximize, bool store_natural_geometry)
 void
 view_toggle_maximize(struct view *view)
 {
+	assert(view);
 	view_maximize(view, !view->maximized,
 		/*store_natural_geometry*/ true);
 }
@@ -494,6 +505,7 @@ view_toggle_maximize(struct view *view)
 void
 view_toggle_decorations(struct view *view)
 {
+	assert(view);
 	view_set_decorations(view, !view->ssd.enabled);
 }
 
@@ -507,6 +519,7 @@ is_always_on_top(struct view *view)
 void
 view_toggle_always_on_top(struct view *view)
 {
+	assert(view);
 	if (is_always_on_top(view)) {
 		view->workspace = view->server->workspace_current;
 		wlr_scene_node_reparent(&view->scene_tree->node, view->workspace->tree);
@@ -519,6 +532,7 @@ view_toggle_always_on_top(struct view *view)
 void
 view_set_decorations(struct view *view, bool decorations)
 {
+	assert(view);
 	if (view->ssd.enabled != decorations && !view->fullscreen) {
 		view->ssd.enabled = decorations;
 		ssd_update_geometry(view);
@@ -533,6 +547,7 @@ view_set_decorations(struct view *view, bool decorations)
 void
 view_toggle_fullscreen(struct view *view)
 {
+	assert(view);
 	view_set_fullscreen(view, !view->fullscreen, NULL);
 }
 
@@ -540,6 +555,7 @@ void
 view_set_fullscreen(struct view *view, bool fullscreen,
 		struct wlr_output *wlr_output)
 {
+	assert(view);
 	if (fullscreen != !view->fullscreen) {
 		return;
 	}
@@ -590,6 +606,7 @@ view_set_fullscreen(struct view *view, bool fullscreen,
 void
 view_adjust_for_layout_change(struct view *view)
 {
+	assert(view);
 	struct wlr_output_layout *layout = view->server->output_layout;
 	if (view->fullscreen) {
 		if (wlr_output_layout_get(layout, view->fullscreen)) {
@@ -640,6 +657,7 @@ view_output_leave(struct view *view, struct wlr_output *wlr_output)
 void
 view_discover_output(struct view *view)
 {
+	assert(view);
 	struct output *old_output = view->output;
 	struct output *new_output = view_output(view);
 	if (old_output != new_output) {
@@ -656,6 +674,7 @@ view_discover_output(struct view *view)
 void
 view_on_output_destroy(struct view *view)
 {
+	assert(view);
 	view_output_leave(view, view->output->wlr_output);
 	view->output = NULL;
 }
@@ -663,10 +682,7 @@ view_on_output_destroy(struct view *view)
 void
 view_move_to_edge(struct view *view, const char *direction)
 {
-	if (!view) {
-		wlr_log(WLR_ERROR, "no view");
-		return;
-	}
+	assert(view);
 	struct output *output = view_output(view);
 	if (!output) {
 		wlr_log(WLR_ERROR, "no output");
@@ -733,10 +749,7 @@ void
 view_snap_to_edge(struct view *view, const char *direction,
 		bool store_natural_geometry)
 {
-	if (!view) {
-		wlr_log(WLR_ERROR, "no view");
-		return;
-	}
+	assert(view);
 	if (view->fullscreen) {
 		return;
 	}
@@ -800,6 +813,8 @@ view_snap_to_edge(struct view *view, const char *direction,
 const char *
 view_get_string_prop(struct view *view, const char *prop)
 {
+	assert(view);
+	assert(prop);
 	if (view->impl->get_string_prop) {
 		return view->impl->get_string_prop(view, prop);
 	}
@@ -809,6 +824,7 @@ view_get_string_prop(struct view *view, const char *prop)
 void
 view_update_title(struct view *view)
 {
+	assert(view);
 	const char *title = view_get_string_prop(view, "title");
 	if (!view->toplevel_handle || !title) {
 		return;
@@ -820,6 +836,7 @@ view_update_title(struct view *view)
 void
 view_update_app_id(struct view *view)
 {
+	assert(view);
 	const char *app_id = view_get_string_prop(view, "app_id");
 	if (!view->toplevel_handle || !app_id) {
 		return;
@@ -831,6 +848,7 @@ view_update_app_id(struct view *view)
 void
 view_destroy(struct view *view)
 {
+	assert(view);
 	struct server *server = view->server;
 	bool need_cursor_update = false;
 

--- a/src/view.c
+++ b/src/view.c
@@ -447,7 +447,7 @@ set_maximized(struct view *view, bool maximized)
 
 /*
  * Un-maximize view and move it to specific geometry. Does not reset
- * tiled state (set view->tiled = 0 manually if you want that).
+ * tiled state (use view_set_untiled() if you want that).
  */
 void
 view_restore_to(struct view *view, struct wlr_box geometry)
@@ -460,6 +460,14 @@ view_restore_to(struct view *view, struct wlr_box geometry)
 		set_maximized(view, false);
 	}
 	view_move_resize(view, geometry);
+}
+
+/* Reset tiled state of view without changing geometry */
+void
+view_set_untiled(struct view *view)
+{
+	assert(view);
+	view->tiled = VIEW_EDGE_INVALID;
 }
 
 void

--- a/src/view.c
+++ b/src/view.c
@@ -88,10 +88,10 @@ view_get_edge_snap_box(struct view *view, struct output *output,
 		break;
 	}
 	struct wlr_box dst = {
-		.x = x_offset + usable.x + view->margin.left,
-		.y = y_offset + usable.y + view->margin.top,
-		.width = base_width - view->margin.left - view->margin.right,
-		.height = base_height - view->margin.top - view->margin.bottom,
+		.x = x_offset + usable.x + view->ssd.margin.left,
+		.y = y_offset + usable.y + view->ssd.margin.top,
+		.width = base_width - view->ssd.margin.left - view->ssd.margin.right,
+		.height = base_height - view->ssd.margin.top - view->ssd.margin.bottom,
 	};
 
 	return dst;
@@ -276,8 +276,8 @@ view_compute_centered_position(struct view *view, int w, int h, int *x, int *y)
 	}
 
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
-	int width = w + view->margin.left + view->margin.right;
-	int height = h + view->margin.top + view->margin.bottom;
+	int width = w + view->ssd.margin.left + view->ssd.margin.right;
+	int height = h + view->ssd.margin.top + view->ssd.margin.bottom;
 	*x = usable.x + (usable.width - width) / 2;
 	*y = usable.y + (usable.height - height) / 2;
 
@@ -292,8 +292,8 @@ view_compute_centered_position(struct view *view, int w, int h, int *x, int *y)
 #if HAVE_XWAYLAND
 	/* TODO: refactor xwayland.c functions to get rid of this */
 	if (view->type == LAB_XWAYLAND_VIEW) {
-		*x += view->margin.left;
-		*y += view->margin.top;
+		*x += view->ssd.margin.left;
+		*y += view->ssd.margin.top;
 	}
 #endif
 
@@ -725,18 +725,18 @@ view_move_to_edge(struct view *view, const char *direction)
 
 	int x = 0, y = 0;
 	if (!strcasecmp(direction, "left")) {
-		x = usable.x + view->margin.left + rc.gap;
+		x = usable.x + view->ssd.margin.left + rc.gap;
 		y = view->y;
 	} else if (!strcasecmp(direction, "up")) {
 		x = view->x;
-		y = usable.y + view->margin.top + rc.gap;
+		y = usable.y + view->ssd.margin.top + rc.gap;
 	} else if (!strcasecmp(direction, "right")) {
-		x = usable.x + usable.width - view->w - view->margin.right
+		x = usable.x + usable.width - view->w - view->ssd.margin.right
 			- rc.gap;
 		y = view->y;
 	} else if (!strcasecmp(direction, "down")) {
 		x = view->x;
-		y = usable.y + usable.height - view->h - view->margin.bottom
+		y = usable.y + usable.height - view->h - view->ssd.margin.bottom
 			- rc.gap;
 	} else {
 		wlr_log(WLR_ERROR, "invalid edge");

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -271,18 +271,6 @@ workspaces_switch_to(struct workspace *target)
 }
 
 void
-workspaces_send_to(struct view *view, struct workspace *target)
-{
-	assert(view);
-	assert(target);
-	if (view->workspace == target) {
-		return;
-	}
-	wlr_scene_node_reparent(&view->scene_tree->node, target->tree);
-	view->workspace = target;
-}
-
-void
 workspaces_osd_hide(struct seat *seat)
 {
 	assert(seat);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -276,8 +276,8 @@ position_xdg_toplevel_view(struct view *view)
 		view->x = center_x - view->xdg_surface->current.geometry.width / 2;
 		view->y = center_y - view->xdg_surface->current.geometry.height / 2;
 	}
-	view->x += view->margin.left;
-	view->y += view->margin.top;
+	view->x += view->ssd.margin.left;
+	view->y += view->ssd.margin.top;
 }
 
 static const char *

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -400,7 +400,7 @@ map(struct view *view)
 		view->been_mapped = true;
 	}
 
-	if (view->ssd.enabled && !view->fullscreen && !view->maximized) {
+	if (view->ssd_enabled && !view->fullscreen && !view->maximized) {
 		top_left_edge_boundary_check(view);
 	}
 


### PR DESCRIPTION
I'm trying to make the code a bit easier to understand through better organization. We already have some "modules" of a sort: a "view" module, an "ssd" module, etc. This change simply makes the code follow some rules such as:

- `struct ssd` is only modified by the "ssd" module (ssd.c and related files)
- `struct view` is only modified by the "view" module (view.c and related files)

The changes in detail are:

- Move `ssd::enabled` to `view::ssd_enabled` since it's written by view.c, not ssd.c
- Move `view::margin` to `ssd::margin` since it's written by ssd.c, not view.c
- Add `view_set_untiled()` rather than writing to `view::tiled` outside view.c
- Rename and move `workspaces_send_to()` to `view_move_to_workspace()` since it modifies `struct view`

Elsewhere, I have been experimenting with some preprocessor magic to actually enforce this type of organization (i.e. make it a compiler error if it's not followed). If that's of interest, I can submit it in a follow-up merge request, but I figured I'd start with the small changes.