### PR TITLE
ssd: Hide implementation details from the outside world

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LABWC_SSD_INTERNAL_H
+#define __LABWC_SSD_INTERNAL_H
+
+#include "ssd.h"
+
+#define FOR_EACH(tmp, ...) \
+{ \
+	__typeof__(tmp) _x[] = { __VA_ARGS__, NULL }; \
+	size_t _i = 0; \
+	for ((tmp) = _x[_i]; _i < sizeof(_x) / sizeof(_x[0]) - 1; (tmp) = _x[++_i])
+
+#define FOR_EACH_END }
+
+struct ssd_button {
+	struct view *view;
+	enum ssd_part_type type;
+	struct wlr_scene_node *hover;
+
+	struct wl_listener destroy;
+};
+
+struct ssd_sub_tree {
+	struct wlr_scene_tree *tree;
+	struct wl_list parts; /* ssd_part::link */
+};
+
+struct ssd_state_title_width {
+	int width;
+	bool truncated;
+};
+
+struct ssd {
+	struct view *view;
+	struct wlr_scene_tree *tree;
+
+	/*
+	 * Cache for current values.
+	 * Used to detect actual changes so we
+	 * don't update things we don't have to.
+	 */
+	struct {
+		int x;
+		int y;
+		int width;
+		int height;
+		struct ssd_state_title {
+			char *text;
+			struct ssd_state_title_width active;
+			struct ssd_state_title_width inactive;
+		} title;
+	} state;
+
+	/* An invisble area around the view which allows resizing */
+	struct ssd_sub_tree extents;
+
+	/* The top of the view, containing buttons, title, .. */
+	struct {
+		/* struct wlr_scene_tree *tree;      unused for now */
+		struct ssd_sub_tree active;
+		struct ssd_sub_tree inactive;
+	} titlebar;
+
+	/* Borders allow resizing as well */
+	struct {
+		/* struct wlr_scene_tree *tree;      unused for now */
+		struct ssd_sub_tree active;
+		struct ssd_sub_tree inactive;
+	} border;
+
+	/*
+	 * Space between the extremities of the view's wlr_surface
+	 * and the max extents of the server-side decorations.
+	 * For xdg-shell views with CSD, this margin is zero.
+	 */
+	struct border margin;
+};
+
+struct ssd_part {
+	enum ssd_part_type type;
+
+	/* Buffer pointer. May be NULL */
+	struct scaled_font_buffer *buffer;
+
+	/* This part represented in scene graph */
+	struct wlr_scene_node *node;
+
+	/* Targeted geometry. May be NULL */
+	struct wlr_box *geometry;
+
+	struct wl_list link;
+};
+
+struct ssd_hover_state {
+	struct view *view;
+	struct wlr_scene_node *node;
+};
+
+struct wlr_buffer;
+struct wlr_scene_tree;
+
+/* SSD internal helpers to create various SSD elements */
+/* TODO: Replace some common args with a struct */
+struct ssd_part *add_scene_part(
+	struct wl_list *part_list, enum ssd_part_type type);
+struct ssd_part *add_scene_rect(
+	struct wl_list *list, enum ssd_part_type type,
+	struct wlr_scene_tree *parent, int width, int height, int x, int y,
+	float color[4]);
+struct ssd_part *add_scene_buffer(
+	struct wl_list *list, enum ssd_part_type type,
+	struct wlr_scene_tree *parent, struct wlr_buffer *buffer, int x, int y);
+struct ssd_part *add_scene_button(
+	struct wl_list *part_list, enum ssd_part_type type,
+	struct wlr_scene_tree *parent, float *bg_color,
+	struct wlr_buffer *icon_buffer, int x, struct view *view);
+struct ssd_part *add_scene_button_corner(
+	struct wl_list *part_list, enum ssd_part_type type,
+	enum ssd_part_type corner_type, struct wlr_scene_tree *parent,
+	struct wlr_buffer *corner_buffer, struct wlr_buffer *icon_buffer,
+	int x, struct view *view);
+
+/* SSD internal helpers */
+struct ssd_part *ssd_get_part(
+	struct wl_list *part_list, enum ssd_part_type type);
+void ssd_destroy_parts(struct wl_list *list);
+
+/* SSD internal */
+void ssd_titlebar_create(struct ssd *ssd);
+void ssd_titlebar_update(struct ssd *ssd);
+void ssd_titlebar_destroy(struct ssd *ssd);
+
+void ssd_border_create(struct ssd *ssd);
+void ssd_border_update(struct ssd *ssd);
+void ssd_border_destroy(struct ssd *ssd);
+
+void ssd_extents_create(struct ssd *ssd);
+void ssd_extents_update(struct ssd *ssd);
+void ssd_extents_destroy(struct ssd *ssd);
+
+#endif /* __LABWC_SSD_INTERNAL_H */

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -8,14 +8,6 @@
 #define BUTTON_WIDTH 26
 #define EXTENDED_AREA 8
 
-#define FOR_EACH(tmp, ...) \
-{ \
-	__typeof__(tmp) _x[] = { __VA_ARGS__, NULL }; \
-	size_t _i = 0; \
-	for ((tmp) = _x[_i]; _i < sizeof(_x) / sizeof(_x[0]) - 1; (tmp) = _x[++_i])
-
-#define FOR_EACH_END }
-
 /*
  * Sequence these according to the order they should be processed for
  * press and hover events. Bear in mind that some of their respective
@@ -48,101 +40,18 @@ enum ssd_part_type {
 };
 
 /* Forward declare arguments */
+struct ssd;
+struct ssd_button;
+struct ssd_hover_state;
 struct view;
-struct wlr_buffer;
 struct wlr_scene;
 struct wlr_scene_node;
-struct wlr_scene_tree;
 
 struct border {
 	int top;
 	int right;
 	int bottom;
 	int left;
-};
-
-struct ssd_button {
-	struct view *view;
-	enum ssd_part_type type;
-	struct wlr_scene_node *hover;
-
-	struct wl_listener destroy;
-};
-
-struct ssd_sub_tree {
-	struct wlr_scene_tree *tree;
-	struct wl_list parts; /* ssd_part::link */
-};
-
-struct ssd_state_title_width {
-	int width;
-	bool truncated;
-};
-
-struct ssd {
-	struct view *view;
-	struct wlr_scene_tree *tree;
-
-	/*
-	 * Cache for current values.
-	 * Used to detect actual changes so we
-	 * don't update things we don't have to.
-	 */
-	struct {
-		int x;
-		int y;
-		int width;
-		int height;
-		struct ssd_state_title {
-			char *text;
-			struct ssd_state_title_width active;
-			struct ssd_state_title_width inactive;
-		} title;
-	} state;
-
-	/* An invisble area around the view which allows resizing */
-	struct ssd_sub_tree extents;
-
-	/* The top of the view, containing buttons, title, .. */
-	struct {
-		/* struct wlr_scene_tree *tree;      unused for now */
-		struct ssd_sub_tree active;
-		struct ssd_sub_tree inactive;
-	} titlebar;
-
-	/* Borders allow resizing as well */
-	struct {
-		/* struct wlr_scene_tree *tree;      unused for now */
-		struct ssd_sub_tree active;
-		struct ssd_sub_tree inactive;
-	} border;
-
-	/*
-	 * Space between the extremities of the view's wlr_surface
-	 * and the max extents of the server-side decorations.
-	 * For xdg-shell views with CSD, this margin is zero.
-	 */
-	struct border margin;
-};
-
-struct ssd_part {
-	enum ssd_part_type type;
-
-	/* Buffer pointer. May be NULL */
-	struct scaled_font_buffer *buffer;
-
-	/* This part represented in scene graph */
-	struct wlr_scene_node *node;
-
-	/* Targeted geometry. May be NULL */
-	struct wlr_box *geometry;
-
-	struct wl_list link;
-};
-
-struct ssd_hover_state {
-	struct view *view;
-	struct wlr_scene_node *node;
 };
 
 /*
@@ -165,6 +74,9 @@ struct ssd_hover_state *ssd_hover_state_new(void);
 void ssd_update_button_hover(struct wlr_scene_node *node,
 	struct ssd_hover_state *hover_state);
 
+enum ssd_part_type ssd_button_get_type(const struct ssd_button *button);
+struct view *ssd_button_get_view(const struct ssd_button *button);
+
 /* Public SSD helpers */
 enum ssd_part_type ssd_at(const struct ssd *ssd,
 	struct wlr_scene *scene, double lx, double ly);
@@ -173,45 +85,6 @@ enum ssd_part_type ssd_get_part_type(const struct ssd *ssd,
 uint32_t ssd_resize_edges(enum ssd_part_type type);
 bool ssd_is_button(enum ssd_part_type type);
 bool ssd_part_contains(enum ssd_part_type whole, enum ssd_part_type candidate);
-
-/* SSD internal helpers to create various SSD elements */
-/* TODO: Replace some common args with a struct */
-struct ssd_part *add_scene_part(
-	struct wl_list *part_list, enum ssd_part_type type);
-struct ssd_part *add_scene_rect(
-	struct wl_list *list, enum ssd_part_type type,
-	struct wlr_scene_tree *parent, int width, int height, int x, int y,
-	float color[4]);
-struct ssd_part *add_scene_buffer(
-	struct wl_list *list, enum ssd_part_type type,
-	struct wlr_scene_tree *parent, struct wlr_buffer *buffer, int x, int y);
-struct ssd_part *add_scene_button(
-	struct wl_list *part_list, enum ssd_part_type type,
-	struct wlr_scene_tree *parent, float *bg_color,
-	struct wlr_buffer *icon_buffer, int x, struct view *view);
-struct ssd_part *add_scene_button_corner(
-	struct wl_list *part_list, enum ssd_part_type type,
-	enum ssd_part_type corner_type, struct wlr_scene_tree *parent,
-	struct wlr_buffer *corner_buffer, struct wlr_buffer *icon_buffer,
-	int x, struct view *view);
-
-/* SSD internal helpers */
-struct ssd_part *ssd_get_part(
-	struct wl_list *part_list, enum ssd_part_type type);
-void ssd_destroy_parts(struct wl_list *list);
-
-/* SSD internal */
-void ssd_titlebar_create(struct ssd *ssd);
-void ssd_titlebar_update(struct ssd *ssd);
-void ssd_titlebar_destroy(struct ssd *ssd);
-
-void ssd_border_create(struct ssd *ssd);
-void ssd_border_update(struct ssd *ssd);
-void ssd_border_destroy(struct ssd *ssd);
-
-void ssd_extents_create(struct ssd *ssd);
-void ssd_extents_update(struct ssd *ssd);
-void ssd_extents_destroy(struct ssd *ssd);
 
 /* TODO: clean up / update */
 struct border ssd_thickness(struct view *view);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -352,8 +352,8 @@ get_cursor_context(struct server *server)
 				struct ssd_button *button =
 					node_ssd_button_from_node(node);
 				ret.node = node;
-				ret.type = button->type;
-				ret.view = button->view;
+				ret.type = ssd_button_get_type(button);
+				ret.view = ssd_button_get_view(button);
 				return ret;
 			}
 			case LAB_NODE_DESC_LAYER_SURFACE:

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -10,7 +10,7 @@
 #include "common/mem.h"
 #include "common/scene-helpers.h"
 #include "labwc.h"
-#include "ssd.h"
+#include "ssd-internal.h"
 #include "theme.h"
 #include "view.h"
 
@@ -284,6 +284,18 @@ struct ssd_hover_state *
 ssd_hover_state_new(void)
 {
 	return znew(struct ssd_hover_state);
+}
+
+enum ssd_part_type
+ssd_button_get_type(const struct ssd_button *button)
+{
+	return button ? button->type : LAB_SSD_NONE;
+}
+
+struct view *
+ssd_button_get_view(const struct ssd_button *button)
+{
+	return button ? button->view : NULL;
 }
 
 bool

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -2,7 +2,7 @@
 
 #include "common/scene-helpers.h"
 #include "labwc.h"
-#include "ssd.h"
+#include "ssd-internal.h"
 #include "theme.h"
 #include "view.h"
 

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -3,7 +3,7 @@
 #include "common/mem.h"
 #include "common/scene-helpers.h"
 #include "labwc.h"
-#include "ssd.h"
+#include "ssd-internal.h"
 #include "theme.h"
 #include "view.h"
 

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -5,7 +5,7 @@
 #include "common/mem.h"
 #include "labwc.h"
 #include "node.h"
-#include "ssd.h"
+#include "ssd-internal.h"
 
 /* Internal helpers */
 static void

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -9,7 +9,7 @@
 #include "common/scene-helpers.h"
 #include "labwc.h"
 #include "node.h"
-#include "ssd.h"
+#include "ssd-internal.h"
 #include "theme.h"
 #include "view.h"
 


### PR DESCRIPTION
The basic idea is as the title says, to hide as much of the SSD logic so that it's only visible to the source files starting in `ssd_`.

Changes in detail:

- Add new ssd-internal.h header
- Move all ssd structs and internal functions to ssd-internal.h
- Allocate `struct ssd` and `struct ssd_hover_state` separately
- Add a few accessors to replace direct access into ssd structs
- Store a pointer to the `struct view` in `struct ssd`
- Pass `struct ssd *` instead of `struct view *` to ssd functions
- Add `view_reload_ssd()`, replacing `ssd_reload()` and surrounding logic
- Move some parts of debug functions to ssd.c

The fact that we now have both `ssd_new()` and `ssd_create()` isn't ideal (though the functions do have different purposes). Perhaps at some point we can revisit those and clarify the naming at least.

There shouldn't be any functional change here, but more testing would definitely be appreciated to be sure my fingers didn't slip somewhere ;)