### PR TITLE
view: Move xdg_surface + xwayland_surface to derived structs

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -40,13 +40,6 @@ struct view {
 	struct wl_list link;
 	struct output *output;
 	struct workspace *workspace;
-
-	union {
-		struct wlr_xdg_surface *xdg_surface;
-#if HAVE_XWAYLAND
-		struct wlr_xwayland_surface *xwayland_surface;
-#endif
-	};
 	struct wlr_surface *surface;
 	struct wlr_scene_tree *scene_tree;
 	struct wlr_scene_node *scene_node;
@@ -97,6 +90,7 @@ struct view {
 
 struct xdg_toplevel_view {
 	struct view base;
+	struct wlr_xdg_surface *xdg_surface;
 
 	/* Events unique to xdg-toplevel views */
 	struct wl_listener set_app_id;
@@ -106,6 +100,7 @@ struct xdg_toplevel_view {
 #if HAVE_XWAYLAND
 struct xwayland_view {
 	struct view base;
+	struct wlr_xwayland_surface *xwayland_surface;
 
 	/* Events unique to XWayland views */
 	struct wl_listener request_configure;
@@ -165,5 +160,13 @@ void view_adjust_size(struct view *view, int *w, int *h);
 
 void view_on_output_destroy(struct view *view);
 void view_destroy(struct view *view);
+
+/* xdg.c */
+struct wlr_xdg_surface *xdg_surface_from_view(struct view *view);
+
+/* xwayland.c */
+#if HAVE_XWAYLAND
+struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
+#endif
 
 #endif /* __LABWC_VIEW_H */

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -310,9 +310,9 @@ process_cursor_motion_out_of_surface(struct server *server, uint32_t time)
 	double sx = server->seat.cursor->x - lx;
 	double sy = server->seat.cursor->y - ly;
 	/* Take into account invisible xdg-shell CSD borders */
-	if (view && view->type == LAB_XDG_SHELL_VIEW && view->xdg_surface) {
+	if (view && view->type == LAB_XDG_SHELL_VIEW) {
 		struct wlr_box geo;
-		wlr_xdg_surface_get_geometry(view->xdg_surface, &geo);
+		wlr_xdg_surface_get_geometry(xdg_surface_from_view(view), &geo);
 		sx += geo.x;
 		sy += geo.y;
 	}

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -22,7 +22,7 @@ move_to_front(struct view *view)
 static struct wlr_xwayland_surface *
 top_parent_of(struct view *view)
 {
-	struct wlr_xwayland_surface *s = view->xwayland_surface;
+	struct wlr_xwayland_surface *s = xwayland_surface_from_view(view);
 	while (s->parent) {
 		s = s->parent;
 	}
@@ -35,6 +35,8 @@ move_xwayland_sub_views_to_front(struct view *parent)
 	if (!parent || parent->type != LAB_XWAYLAND_VIEW) {
 		return;
 	}
+	struct wlr_xwayland_surface *parent_xwayland_surface =
+		xwayland_surface_from_view(parent);
 	struct view *view, *next;
 	wl_list_for_each_reverse_safe(view, next, &parent->server->views, link)
 	{
@@ -48,7 +50,7 @@ move_xwayland_sub_views_to_front(struct view *parent)
 		if (!view->mapped && !view->minimized) {
 			continue;
 		}
-		if (top_parent_of(view) != parent->xwayland_surface) {
+		if (top_parent_of(view) != parent_xwayland_surface) {
 			continue;
 		}
 		move_to_front(view);

--- a/src/osd.c
+++ b/src/osd.c
@@ -35,7 +35,7 @@ is_title_different(struct view *view)
 #if HAVE_XWAYLAND
 	case LAB_XWAYLAND_VIEW:
 		return g_strcmp0(view_get_string_prop(view, "title"),
-			view->xwayland_surface->class);
+			view_get_string_prop(view, "class"));
 #endif
 	}
 	return 1;

--- a/src/view.c
+++ b/src/view.c
@@ -186,7 +186,8 @@ view_adjust_size(struct view *view, int *w, int *h)
 	int min_height = MIN_VIEW_HEIGHT;
 #if HAVE_XWAYLAND
 	if (view->type == LAB_XWAYLAND_VIEW) {
-		xcb_size_hints_t *hints = view->xwayland_surface->size_hints;
+		xcb_size_hints_t *hints =
+			xwayland_surface_from_view(view)->size_hints;
 
 		/*
 		 * Honor size increments from WM_SIZE_HINTS. Typically, X11


### PR DESCRIPTION
Following up on a suggestion in #641.

- Add `view_get_xdg_surface()` + `view_get_xwayland_surface()` accessors that `assert()` the view is of the expected type before returning.
- Fix a real bug in `xdg.c` `parent_of()` that dereferenced `view->xdg_surface->toplevel` without first checking `view->type`.

The goal of the new accessors is to catch similar bugs in future.