### PR TITLE
view: Hide decorations for fullscreen views

### DIFF
--- a/include/ssd.h
+++ b/include/ssd.h
@@ -146,7 +146,7 @@ struct ssd_hover_state {
 };
 
 /* Public SSD API */
-void ssd_create(struct view *view);
+void ssd_create(struct view *view, bool active);
 void ssd_set_active(struct view *view, bool active);
 void ssd_update_title(struct view *view);
 void ssd_update_geometry(struct view *view);

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -150,7 +150,6 @@ void ssd_create(struct view *view);
 void ssd_set_active(struct view *view, bool active);
 void ssd_update_title(struct view *view);
 void ssd_update_geometry(struct view *view);
-void ssd_reload(struct view *view);
 void ssd_destroy(struct view *view);
 void ssd_update_button_hover(struct wlr_scene_node *node,
 	struct ssd_hover_state *hover_state);

--- a/include/view.h
+++ b/include/view.h
@@ -154,6 +154,7 @@ void view_snap_to_edge(struct view *view, const char *direction,
 const char *view_get_string_prop(struct view *view, const char *prop);
 void view_update_title(struct view *view);
 void view_update_app_id(struct view *view);
+void view_reload_ssd(struct view *view);
 
 void view_impl_map(struct view *view);
 void view_adjust_size(struct view *view, int *w, int *h);

--- a/src/server.c
+++ b/src/server.c
@@ -16,7 +16,6 @@
 #include "labwc.h"
 #include "layers.h"
 #include "menu/menu.h"
-#include "ssd.h"
 #include "theme.h"
 #include "view.h"
 #include "workspaces.h"
@@ -40,10 +39,7 @@ reload_config_and_theme(void)
 
 	struct view *view;
 	wl_list_for_each(view, &g_server->views, link) {
-		if (!view->mapped || !view->ssd_enabled) {
-			continue;
-		}
-		ssd_reload(view);
+		view_reload_ssd(view);
 	}
 
 	menu_reconfigure(g_server);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -191,16 +191,6 @@ ssd_update_geometry(struct view *view)
 	view->ssd.state.y = view->y;
 }
 
-void ssd_reload(struct view *view)
-{
-	if (!view->ssd.tree) {
-		return;
-	}
-
-	ssd_destroy(view);
-	ssd_create(view);
-}
-
 void
 ssd_destroy(struct view *view)
 {

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -145,14 +145,9 @@ ssd_resize_edges(enum ssd_part_type type)
 }
 
 void
-ssd_create(struct view *view)
+ssd_create(struct view *view, bool active)
 {
-	bool is_active = view->server->focused_view == view;
-
-	if (view->ssd.tree) {
-		ssd_set_active(view, is_active);
-		return;
-	}
+	assert(!view->ssd.tree);
 
 	view->ssd.tree = wlr_scene_tree_create(view->scene_tree);
 	wlr_scene_node_lower_to_bottom(&view->ssd.tree->node);
@@ -160,7 +155,7 @@ ssd_create(struct view *view)
 	ssd_border_create(view);
 	ssd_titlebar_create(view);
 	view->ssd.margin = ssd_thickness(view);
-	ssd_set_active(view, is_active);
+	ssd_set_active(view, active);
 }
 
 void

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -153,6 +153,11 @@ ssd_create(struct view *view, bool active)
 	ssd_titlebar_create(view);
 	view->ssd.margin = ssd_thickness(view);
 	ssd_set_active(view, active);
+
+	view->ssd.state.width = view->w;
+	view->ssd.state.height = view->h;
+	view->ssd.state.x = view->x;
+	view->ssd.state.y = view->y;
 }
 
 void
@@ -202,6 +207,7 @@ ssd_destroy(struct view *view)
 	ssd_extents_destroy(view);
 	wlr_scene_node_destroy(&view->ssd.tree->node);
 	view->ssd.tree = NULL;
+	view->ssd.margin = (struct border){ 0 };
 }
 
 bool

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -150,8 +150,6 @@ ssd_create(struct view *view)
 	bool is_active = view->server->focused_view == view;
 
 	if (view->ssd.tree) {
-		/* SSD was hidden. Just enable it */
-		wlr_scene_node_set_enabled(&view->ssd.tree->node, true);
 		ssd_set_active(view, is_active);
 		return;
 	}
@@ -168,21 +166,8 @@ ssd_create(struct view *view)
 void
 ssd_update_geometry(struct view *view)
 {
-	if (!view->scene_node) {
+	if (!view->ssd.tree) {
 		return;
-	}
-
-	if (!view->ssd_enabled) {
-		if (view->ssd.tree && view->ssd.tree->node.enabled) {
-			wlr_scene_node_set_enabled(&view->ssd.tree->node, false);
-			view->ssd.margin = ssd_thickness(view);
-		}
-		return;
-	} else if (!view->ssd.tree) {
-		ssd_create(view);
-	} else if (!view->ssd.tree->node.enabled) {
-		wlr_scene_node_set_enabled(&view->ssd.tree->node, true);
-		view->ssd.margin = ssd_thickness(view);
 	}
 
 	int width = view->w;

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -16,7 +16,11 @@
 struct border
 ssd_thickness(struct view *view)
 {
-	if (!view->ssd_enabled) {
+	/*
+	 * Check preconditions for displaying SSD. Note that this
+	 * needs to work even before ssd_create() has been called.
+	 */
+	if (!view->ssd_enabled || view->fullscreen) {
 		return (struct border){ 0 };
 	}
 	struct theme *theme = view->server->theme;

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -17,30 +17,27 @@ struct border
 ssd_thickness(struct view *view)
 {
 	if (!view->ssd_enabled) {
-		struct border border = { 0 };
-		return border;
+		return (struct border){ 0 };
 	}
 	struct theme *theme = view->server->theme;
-	struct border border = {
+	return (struct border){
 		.top = theme->title_height + theme->border_width,
 		.bottom = theme->border_width,
 		.left = theme->border_width,
 		.right = theme->border_width,
 	};
-	return border;
 }
 
 struct wlr_box
 ssd_max_extents(struct view *view)
 {
 	struct border border = ssd_thickness(view);
-	struct wlr_box box = {
+	return (struct wlr_box){
 		.x = view->x - border.left,
 		.y = view->y - border.top,
 		.width = view->w + border.left + border.right,
 		.height = view->h + border.top + border.bottom,
 	};
-	return box;
 }
 
 bool
@@ -165,9 +162,7 @@ ssd_update_geometry(struct view *view)
 		return;
 	}
 
-	int width = view->w;
-	int height = view->h;
-	if (width == view->ssd.state.width && height == view->ssd.state.height) {
+	if (view->w == view->ssd.state.width && view->h == view->ssd.state.height) {
 		if (view->x != view->ssd.state.x || view->y != view->ssd.state.y) {
 			/* Dynamically resize extents based on position and usable_area */
 			ssd_extents_update(view);
@@ -180,8 +175,8 @@ ssd_update_geometry(struct view *view)
 	ssd_border_update(view);
 	ssd_titlebar_update(view);
 
-	view->ssd.state.width = width;
-	view->ssd.state.height = height;
+	view->ssd.state.width = view->w;
+	view->ssd.state.height = view->h;
 	view->ssd.state.x = view->x;
 	view->ssd.state.y = view->y;
 }

--- a/src/view.c
+++ b/src/view.c
@@ -872,6 +872,16 @@ view_update_app_id(struct view *view)
 }
 
 void
+view_reload_ssd(struct view *view)
+{
+	assert(view);
+	if (view->ssd_enabled) {
+		ssd_destroy(view);
+		ssd_create(view);
+	}
+}
+
+void
 view_destroy(struct view *view)
 {
 	assert(view);

--- a/src/view.c
+++ b/src/view.c
@@ -557,7 +557,7 @@ view_set_decorations(struct view *view, bool decorations)
 	assert(view);
 	if (view->ssd_enabled != decorations && !view->fullscreen) {
 		if (decorations) {
-			ssd_create(view);
+			ssd_create(view, view == view->server->focused_view);
 		} else {
 			ssd_destroy(view);
 		}
@@ -877,7 +877,7 @@ view_reload_ssd(struct view *view)
 	assert(view);
 	if (view->ssd_enabled) {
 		ssd_destroy(view);
-		ssd_create(view);
+		ssd_create(view, view == view->server->focused_view);
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -556,8 +556,12 @@ view_set_decorations(struct view *view, bool decorations)
 {
 	assert(view);
 	if (view->ssd_enabled != decorations && !view->fullscreen) {
+		if (decorations) {
+			ssd_create(view);
+		} else {
+			ssd_destroy(view);
+		}
 		view->ssd_enabled = decorations;
-		ssd_update_geometry(view);
 		if (view->maximized) {
 			view_apply_maximized_geometry(view);
 		} else if (view->tiled) {


### PR DESCRIPTION
Fixes the pre-existing issue that @johanmalm noticed in #640, where decorations are shown around fullscreen views and can be visible on other outputs.

- Update `view_set_decorations()` and `view_set_fullscreen()` to disable decorations for fullscreen views
- Remove enable/disable logic from `ssd_update_geometry()` since it is now handled by `view_set_decorations()` and `view_set_fullscreen()`

Some minor fixes/cleanups as well:

- Use C99-style struct literals in `return` statements to eliminate unnecessary temporary variables
- Add an `active` argument to `ssd_create()` for consistency with `ssd_set_active()`
- Update `view->ssd.state` at the end of `ssd_create()` so that the next call to `ssd_update_geometry()` doesn't do unnecessary work
- Move `ssd_reload()` to `view_reload_ssd()` since it fits better in `view.c`
- Reset `view->ssd.margin` to zero at the end of `ssd_destroy()` to prevent accidentally using stale values

Seems to work in my testing, but additional testing would be appreciated. When leaving fullscreen, you can still see the decorations flicker for a frame or so around the fullscreen geometry -- I think this is because move/resize is an async operation, whereas redisplaying the decorations is immediate.