### PR TITLE
ssd: Cosmetic cleanups & add debug helpers

### DIFF
--- a/include/ssd.h
+++ b/include/ssd.h
@@ -2,8 +2,7 @@
 #ifndef __LABWC_SSD_H
 #define __LABWC_SSD_H
 
-#include "buffer.h"
-#include <wlr/util/box.h>
+#include <wayland-server-core.h>
 
 #define BUTTON_COUNT 4
 #define BUTTON_WIDTH 26
@@ -50,10 +49,10 @@ enum ssd_part_type {
 
 /* Forward declare arguments */
 struct view;
-struct wl_list;
-struct wlr_box;
+struct wlr_buffer;
+struct wlr_scene;
+struct wlr_scene_node;
 struct wlr_scene_tree;
-struct scaled_font_buffer;
 
 struct border {
 	int top;
@@ -155,9 +154,10 @@ void ssd_update_button_hover(struct wlr_scene_node *node,
 	struct ssd_hover_state *hover_state);
 
 /* Public SSD helpers */
-enum ssd_part_type ssd_at(struct view *view, double lx, double ly);
-enum ssd_part_type ssd_get_part_type(
-	struct view *view, struct wlr_scene_node *node);
+enum ssd_part_type ssd_at(const struct ssd *ssd,
+	struct wlr_scene *scene, double lx, double ly);
+enum ssd_part_type ssd_get_part_type(const struct ssd *ssd,
+	struct wlr_scene_node *node);
 uint32_t ssd_resize_edges(enum ssd_part_type type);
 bool ssd_is_button(enum ssd_part_type type);
 bool ssd_part_contains(enum ssd_part_type whole, enum ssd_part_type candidate);
@@ -189,17 +189,17 @@ struct ssd_part *ssd_get_part(
 void ssd_destroy_parts(struct wl_list *list);
 
 /* SSD internal */
-void ssd_titlebar_create(struct view *view);
-void ssd_titlebar_update(struct view *view);
-void ssd_titlebar_destroy(struct view *view);
+void ssd_titlebar_create(struct ssd *ssd);
+void ssd_titlebar_update(struct ssd *ssd);
+void ssd_titlebar_destroy(struct ssd *ssd);
 
-void ssd_border_create(struct view *view);
-void ssd_border_update(struct view *view);
-void ssd_border_destroy(struct view *view);
+void ssd_border_create(struct ssd *ssd);
+void ssd_border_update(struct ssd *ssd);
+void ssd_border_destroy(struct ssd *ssd);
 
-void ssd_extents_create(struct view *view);
-void ssd_extents_update(struct view *view);
-void ssd_extents_destroy(struct view *view);
+void ssd_extents_create(struct ssd *ssd);
+void ssd_extents_update(struct ssd *ssd);
+void ssd_extents_destroy(struct ssd *ssd);
 
 /* TODO: clean up / update */
 struct border ssd_thickness(struct view *view);

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -205,4 +205,9 @@ void ssd_extents_destroy(struct ssd *ssd);
 struct border ssd_thickness(struct view *view);
 struct wlr_box ssd_max_extents(struct view *view);
 
+/* SSD debug helpers */
+bool ssd_debug_is_root_node(const struct ssd *ssd, struct wlr_scene_node *node);
+const char *ssd_debug_get_node_name(const struct ssd *ssd,
+	struct wlr_scene_node *node);
+
 #endif /* __LABWC_SSD_H */

--- a/src/action.c
+++ b/src/action.c
@@ -161,8 +161,8 @@ show_menu(struct server *server, struct view *view, const char *menu_name)
 		if (!view) {
 			return;
 		}
-		enum ssd_part_type type = ssd_at(view, server->seat.cursor->x,
-			server->seat.cursor->y);
+		enum ssd_part_type type = ssd_at(&view->ssd, server->scene,
+			server->seat.cursor->x, server->seat.cursor->y);
 		if (type == LAB_SSD_BUTTON_WINDOW_MENU) {
 			force_menu_top_left = true;
 		} else if (ssd_part_contains(LAB_SSD_PART_TITLEBAR, type)) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -4,6 +4,7 @@
 #include "common/scene-helpers.h"
 #include "labwc.h"
 #include "node.h"
+#include "ssd.h"
 #include "view.h"
 
 #define HEADER_CHARS "------------------------------"
@@ -59,26 +60,8 @@ get_view_part(struct view *view, struct wlr_scene_node *node)
 	if (view && node == view->scene_node) {
 		return "view->scene_node";
 	}
-	if (!view || !view->ssd.tree) {
-		return NULL;
-	}
-	if (node == &view->ssd.tree->node) {
-		return "view->ssd";
-	}
-	if (node == &view->ssd.titlebar.active.tree->node) {
-		return "titlebar.active";
-	}
-	if (node == &view->ssd.titlebar.inactive.tree->node) {
-		return "titlebar.inactive";
-	}
-	if (node == &view->ssd.border.active.tree->node) {
-		return "border.active";
-	}
-	if (node == &view->ssd.border.inactive.tree->node) {
-		return "border.inactive";
-	}
-	if (node == &view->ssd.extents.tree->node) {
-		return "extents";
+	if (view) {
+		return ssd_debug_get_node_name(&view->ssd, node);
 	}
 	return NULL;
 }
@@ -175,8 +158,8 @@ dump_tree(struct server *server, struct wlr_scene_node *node,
 	printf("%s %*c %4d  %4d  [%p]\n", type, padding, ' ', x, y, node);
 
 	if ((IGNORE_MENU && node == &server->menu_tree->node)
-			|| (IGNORE_SSD && view && view->ssd.tree
-			&& node == &view->ssd.tree->node)) {
+			|| (IGNORE_SSD && view
+			&& ssd_debug_is_root_node(&view->ssd, node))) {
 		printf("%*c%s\n", pos + 4 + INDENT_SIZE, ' ', "<skipping children>");
 		return;
 	}

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -339,7 +339,7 @@ get_cursor_context(struct server *server)
 			case LAB_NODE_DESC_VIEW:
 			case LAB_NODE_DESC_XDG_POPUP:
 				ret.view = desc->data;
-				ret.type = ssd_get_part_type(ret.view, ret.node);
+				ret.type = ssd_get_part_type(&ret.view->ssd, ret.node);
 				if (ret.type == LAB_SSD_CLIENT) {
 					ret.surface = lab_wlr_surface_from_node(ret.node);
 				}

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -267,3 +267,39 @@ ssd_set_active(struct view *view, bool active)
 	wlr_scene_node_set_enabled(&ssd->border.inactive.tree->node, !active);
 	wlr_scene_node_set_enabled(&ssd->titlebar.inactive.tree->node, !active);
 }
+
+bool
+ssd_debug_is_root_node(const struct ssd *ssd, struct wlr_scene_node *node)
+{
+	if (!ssd->tree || !node) {
+		return false;
+	}
+	return node == &ssd->tree->node;
+}
+
+const char *
+ssd_debug_get_node_name(const struct ssd *ssd, struct wlr_scene_node *node)
+{
+	if (!ssd->tree || !node) {
+		return NULL;
+	}
+	if (node == &ssd->tree->node) {
+		return "view->ssd";
+	}
+	if (node == &ssd->titlebar.active.tree->node) {
+		return "titlebar.active";
+	}
+	if (node == &ssd->titlebar.inactive.tree->node) {
+		return "titlebar.inactive";
+	}
+	if (node == &ssd->border.active.tree->node) {
+		return "border.active";
+	}
+	if (node == &ssd->border.inactive.tree->node) {
+		return "border.inactive";
+	}
+	if (node == &ssd->extents.tree->node) {
+		return "extents";
+	}
+	return NULL;
+}

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -6,13 +6,14 @@
 #include "theme.h"
 #include "view.h"
 
-#define FOR_EACH_STATE(view, tmp) FOR_EACH(tmp, \
-	&(view)->ssd.border.active, \
-	&(view)->ssd.border.inactive)
+#define FOR_EACH_STATE(ssd, tmp) FOR_EACH(tmp, \
+	&(ssd)->border.active, \
+	&(ssd)->border.inactive)
 
 void
-ssd_border_create(struct view *view)
+ssd_border_create(struct ssd *ssd)
 {
+	struct view *view = wl_container_of(ssd, view, ssd);
 	struct theme *theme = view->server->theme;
 	int width = view->w;
 	int height = view->h;
@@ -22,11 +23,11 @@ ssd_border_create(struct view *view)
 	struct wlr_scene_tree *parent;
 	struct ssd_sub_tree *subtree;
 
-	FOR_EACH_STATE(view, subtree) {
-		subtree->tree = wlr_scene_tree_create(view->ssd.tree);
+	FOR_EACH_STATE(ssd, subtree) {
+		subtree->tree = wlr_scene_tree_create(ssd->tree);
 		parent = subtree->tree;
 		wlr_scene_node_set_position(&parent->node, -theme->border_width, 0);
-		if (subtree == &view->ssd.border.active) {
+		if (subtree == &ssd->border.active) {
 			color = theme->window_active_border_color;
 		} else {
 			color = theme->window_inactive_border_color;
@@ -48,8 +49,9 @@ ssd_border_create(struct view *view)
 }
 
 void
-ssd_border_update(struct view *view)
+ssd_border_update(struct ssd *ssd)
 {
+	struct view *view = wl_container_of(ssd, view, ssd);
 	struct theme *theme = view->server->theme;
 
 	int width = view->w;
@@ -59,7 +61,7 @@ ssd_border_update(struct view *view)
 	struct ssd_part *part;
 	struct wlr_scene_rect *rect;
 	struct ssd_sub_tree *subtree;
-	FOR_EACH_STATE(view, subtree) {
+	FOR_EACH_STATE(ssd, subtree) {
 		wl_list_for_each(part, &subtree->parts, link) {
 			rect = lab_wlr_scene_get_rect(part->node);
 			switch (part->type) {
@@ -92,14 +94,14 @@ ssd_border_update(struct view *view)
 }
 
 void
-ssd_border_destroy(struct view *view)
+ssd_border_destroy(struct ssd *ssd)
 {
-	if (!view->ssd.border.active.tree) {
+	if (!ssd->border.active.tree) {
 		return;
 	}
 
 	struct ssd_sub_tree *subtree;
-	FOR_EACH_STATE(view, subtree) {
+	FOR_EACH_STATE(ssd, subtree) {
 		ssd_destroy_parts(&subtree->parts);
 		wlr_scene_node_destroy(&subtree->tree->node);
 		subtree->tree = NULL;

--- a/src/view.c
+++ b/src/view.c
@@ -87,11 +87,13 @@ view_get_edge_snap_box(struct view *view, struct output *output,
 		base_height = usable.height - 2 * rc.gap;
 		break;
 	}
+
+	struct border margin = view->ssd.margin;
 	struct wlr_box dst = {
-		.x = x_offset + usable.x + view->ssd.margin.left,
-		.y = y_offset + usable.y + view->ssd.margin.top,
-		.width = base_width - view->ssd.margin.left - view->ssd.margin.right,
-		.height = base_height - view->ssd.margin.top - view->ssd.margin.bottom,
+		.x = x_offset + usable.x + margin.left,
+		.y = y_offset + usable.y + margin.top,
+		.width = base_width - margin.left - margin.right,
+		.height = base_height - margin.top - margin.bottom,
 	};
 
 	return dst;
@@ -276,9 +278,10 @@ view_compute_centered_position(struct view *view, int w, int h, int *x, int *y)
 		return false;
 	}
 
+	struct border margin = view->ssd.margin;
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
-	int width = w + view->ssd.margin.left + view->ssd.margin.right;
-	int height = h + view->ssd.margin.top + view->ssd.margin.bottom;
+	int width = w + margin.left + margin.right;
+	int height = h + margin.top + margin.bottom;
 	*x = usable.x + (usable.width - width) / 2;
 	*y = usable.y + (usable.height - height) / 2;
 
@@ -293,8 +296,8 @@ view_compute_centered_position(struct view *view, int w, int h, int *x, int *y)
 #if HAVE_XWAYLAND
 	/* TODO: refactor xwayland.c functions to get rid of this */
 	if (view->type == LAB_XWAYLAND_VIEW) {
-		*x += view->ssd.margin.left;
-		*y += view->ssd.margin.top;
+		*x += margin.left;
+		*y += margin.top;
 	}
 #endif
 
@@ -726,6 +729,8 @@ view_move_to_edge(struct view *view, const char *direction)
 		wlr_log(WLR_ERROR, "invalid edge");
 		return;
 	}
+
+	struct border margin = view->ssd.margin;
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
 	if (usable.height == output->wlr_output->height
 			&& output->wlr_output->scale != 1) {
@@ -738,18 +743,18 @@ view_move_to_edge(struct view *view, const char *direction)
 
 	int x = 0, y = 0;
 	if (!strcasecmp(direction, "left")) {
-		x = usable.x + view->ssd.margin.left + rc.gap;
+		x = usable.x + margin.left + rc.gap;
 		y = view->y;
 	} else if (!strcasecmp(direction, "up")) {
 		x = view->x;
-		y = usable.y + view->ssd.margin.top + rc.gap;
+		y = usable.y + margin.top + rc.gap;
 	} else if (!strcasecmp(direction, "right")) {
-		x = usable.x + usable.width - view->w - view->ssd.margin.right
+		x = usable.x + usable.width - view->w - margin.right
 			- rc.gap;
 		y = view->y;
 	} else if (!strcasecmp(direction, "down")) {
 		x = view->x;
-		y = usable.y + usable.height - view->h - view->ssd.margin.bottom
+		y = usable.y + usable.height - view->h - margin.bottom
 			- rc.gap;
 	} else {
 		wlr_log(WLR_ERROR, "invalid edge");

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -7,12 +7,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include "buffer.h"
 #include "common/font.h"
 #include "common/graphic-helpers.h"
 #include "common/list.h"
 #include "common/mem.h"
 #include "labwc.h"
-#include "view.h"
 #include "workspaces.h"
 
 /* Internal helpers */


### PR DESCRIPTION
Split off from #640.

- Minimize includes in `ssd.h`
- Avoid repetitive `view->ssd.margin` pattern
- Use `struct ssd *` or `const struct ssd *` rather than `struct view *`
  where convenient
- Add `ssd_debug` helpers

Part of the motivation is to make it easier to separate `struct ssd`
from `struct view` in a future commit (i.e. the rest of #640).