### PR TITLE
ssd: Allocate `struct ssd` and `struct ssd_hover_state` separately

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -50,7 +50,6 @@
 #include "cursor.h"
 #include "config/keybind.h"
 #include "config/rcxml.h"
-#include "ssd.h"
 #if HAVE_NLS
 #include <libintl.h>
 #include <locale.h>
@@ -232,7 +231,7 @@ struct server {
 
 	/* SSD state */
 	struct view *focused_view;
-	struct ssd_hover_state ssd_hover_state;
+	struct ssd_hover_state *ssd_hover_state;
 
 	/* Tree for all non-layer xdg/xwayland-shell surfaces */
 	struct wlr_scene_tree *view_tree;

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -80,6 +80,7 @@ struct ssd_state_title_width {
 };
 
 struct ssd {
+	struct view *view;
 	struct wlr_scene_tree *tree;
 
 	/*
@@ -144,12 +145,23 @@ struct ssd_hover_state {
 	struct wlr_scene_node *node;
 };
 
-/* Public SSD API */
-void ssd_create(struct view *view, bool active);
-void ssd_set_active(struct view *view, bool active);
-void ssd_update_title(struct view *view);
-void ssd_update_geometry(struct view *view);
-void ssd_destroy(struct view *view);
+/*
+ * Public SSD API
+ *
+ * For convenience in dealing with non-SSD views, this API allows NULL
+ * ssd/button/node arguments and attempts to do something sensible in
+ * that case (e.g. no-op/return default values).
+ *
+ * NULL scene/view arguments are not allowed.
+ */
+struct ssd *ssd_create(struct view *view, bool active);
+struct border ssd_get_margin(const struct ssd *ssd);
+void ssd_set_active(struct ssd *ssd, bool active);
+void ssd_update_title(struct ssd *ssd);
+void ssd_update_geometry(struct ssd *ssd);
+void ssd_destroy(struct ssd *ssd);
+
+struct ssd_hover_state *ssd_hover_state_new(void);
 void ssd_update_button_hover(struct wlr_scene_node *node,
 	struct ssd_hover_state *hover_state);
 

--- a/include/view.h
+++ b/include/view.h
@@ -7,7 +7,6 @@
 #include <stdint.h>
 #include <wayland-util.h>
 #include <wlr/util/box.h>
-#include "ssd.h"
 
 /*
  * In labwc, a view is a container for surfaces which can be moved around by
@@ -21,6 +20,7 @@ enum view_type {
 #endif
 };
 
+struct view;
 struct view_impl {
 	void (*configure)(struct view *view, struct wlr_box geo);
 	void (*close)(struct view *view);
@@ -65,7 +65,7 @@ struct view {
 		uint32_t configure_serial;
 	} pending_move_resize;
 
-	struct ssd ssd;
+	struct ssd *ssd;
 
 	struct wlr_foreign_toplevel_handle_v1 *toplevel_handle;
 	struct wl_listener toplevel_handle_request_maximize;

--- a/src/action.c
+++ b/src/action.c
@@ -161,7 +161,7 @@ show_menu(struct server *server, struct view *view, const char *menu_name)
 		if (!view) {
 			return;
 		}
-		enum ssd_part_type type = ssd_at(&view->ssd, server->scene,
+		enum ssd_part_type type = ssd_at(view->ssd, server->scene,
 			server->seat.cursor->x, server->seat.cursor->y);
 		if (type == LAB_SSD_BUTTON_WINDOW_MENU) {
 			force_menu_top_left = true;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -330,7 +330,7 @@ cursor_update_common(struct server *server, struct cursor_context *ctx,
 	struct seat *seat = &server->seat;
 	struct wlr_seat *wlr_seat = seat->seat;
 
-	ssd_update_button_hover(ctx->node, &server->ssd_hover_state);
+	ssd_update_button_hover(ctx->node, server->ssd_hover_state);
 
 	if (server->input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
 		/*

--- a/src/debug.c
+++ b/src/debug.c
@@ -61,7 +61,7 @@ get_view_part(struct view *view, struct wlr_scene_node *node)
 		return "view->scene_node";
 	}
 	if (view) {
-		return ssd_debug_get_node_name(&view->ssd, node);
+		return ssd_debug_get_node_name(view->ssd, node);
 	}
 	return NULL;
 }
@@ -159,7 +159,7 @@ dump_tree(struct server *server, struct wlr_scene_node *node,
 
 	if ((IGNORE_MENU && node == &server->menu_tree->node)
 			|| (IGNORE_SSD && view
-			&& ssd_debug_is_root_node(&view->ssd, node))) {
+			&& ssd_debug_is_root_node(view->ssd, node))) {
 		printf("%*c%s\n", pos + 4 + INDENT_SIZE, ' ', "<skipping children>");
 		return;
 	}

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -339,7 +339,7 @@ get_cursor_context(struct server *server)
 			case LAB_NODE_DESC_VIEW:
 			case LAB_NODE_DESC_XDG_POPUP:
 				ret.view = desc->data;
-				ret.type = ssd_get_part_type(&ret.view->ssd, ret.node);
+				ret.type = ssd_get_part_type(ret.view->ssd, ret.node);
 				if (ret.type == LAB_SSD_CLIENT) {
 					ret.surface = lab_wlr_surface_from_node(ret.node);
 				}

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -41,7 +41,7 @@ resistance_move_apply(struct view *view, double *x, double *y)
 	struct wlr_box tgeom = {.x = *x, .y = *y, .width = view->w,
 		.height = view->h};
 	struct output *output;
-	struct border border = view->ssd.margin;
+	struct border border = ssd_get_margin(view->ssd);
 	struct edges view_edges; /* The edges of the current view */
 	struct edges target_edges; /* The desired edges */
 	struct edges other_edges; /* The edges of the monitor/other view */
@@ -112,7 +112,7 @@ resistance_resize_apply(struct view *view, struct wlr_box *new_view_geo)
 		.height = view->h};
 	struct wlr_box tgeom = {.x = new_view_geo->x, .y = new_view_geo->y,
 		.width = new_view_geo->width, .height = new_view_geo->height};
-	struct border border = view->ssd.margin;
+	struct border border = ssd_get_margin(view->ssd);
 	struct edges view_edges; /* The edges of the current view */
 	struct edges target_edges; /* The desired edges */
 	struct edges other_edges; /* The edges of the monitor/other view */

--- a/src/server.c
+++ b/src/server.c
@@ -221,6 +221,8 @@ server_init(struct server *server)
 	wl_list_init(&server->views);
 	wl_list_init(&server->unmanaged_surfaces);
 
+	server->ssd_hover_state = ssd_hover_state_new();
+
 	server->scene = wlr_scene_create();
 	if (!server->scene) {
 		wlr_log(WLR_ERROR, "unable to create scene");

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -13,7 +13,7 @@
 void
 ssd_border_create(struct ssd *ssd)
 {
-	struct view *view = wl_container_of(ssd, view, ssd);
+	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
 	int width = view->w;
 	int height = view->h;
@@ -51,7 +51,7 @@ ssd_border_create(struct ssd *ssd)
 void
 ssd_border_update(struct ssd *ssd)
 {
-	struct view *view = wl_container_of(ssd, view, ssd);
+	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
 
 	int width = view->w;

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -37,7 +37,7 @@ lab_wlr_output_layout_layout_coords(struct wlr_output_layout *layout,
 void
 ssd_extents_create(struct ssd *ssd)
 {
-	struct view *view = wl_container_of(ssd, view, ssd);
+	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
 	struct wl_list *part_list = &ssd->extents.parts;
 	int extended_area = EXTENDED_AREA;
@@ -98,7 +98,7 @@ ssd_extents_create(struct ssd *ssd)
 void
 ssd_extents_update(struct ssd *ssd)
 {
-	struct view *view = wl_container_of(ssd, view, ssd);
+	struct view *view = ssd->view;
 	if (view->maximized || view->fullscreen) {
 		wlr_scene_node_set_enabled(&ssd->extents.tree->node, false);
 		return;

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -20,7 +20,7 @@
 void
 ssd_titlebar_create(struct ssd *ssd)
 {
-	struct view *view = wl_container_of(ssd, view, ssd);
+	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
 	int width = view->w;
 
@@ -78,7 +78,7 @@ ssd_titlebar_create(struct ssd *ssd)
 			corner_top_right, close_button_unpressed,
 			width - BUTTON_WIDTH * 1, view);
 	} FOR_EACH_END
-	ssd_update_title(view);
+	ssd_update_title(ssd);
 }
 
 static bool
@@ -90,7 +90,7 @@ is_direct_child(struct wlr_scene_node *node, struct ssd_sub_tree *subtree)
 void
 ssd_titlebar_update(struct ssd *ssd)
 {
-	struct view *view = wl_container_of(ssd, view, ssd);
+	struct view *view = ssd->view;
 	int width = view->w;
 	if (width == ssd->state.width) {
 		return;
@@ -131,7 +131,7 @@ ssd_titlebar_update(struct ssd *ssd)
 			}
 		}
 	} FOR_EACH_END
-	ssd_update_title(view);
+	ssd_update_title(ssd);
 }
 
 void
@@ -169,7 +169,7 @@ ssd_titlebar_destroy(struct ssd *ssd)
 static void
 ssd_update_title_positions(struct ssd *ssd)
 {
-	struct view *view = wl_container_of(ssd, view, ssd);
+	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
 	int width = view->w;
 	int title_bg_width = width - BUTTON_WIDTH * BUTTON_COUNT;
@@ -219,13 +219,13 @@ ssd_update_title_positions(struct ssd *ssd)
 }
 
 void
-ssd_update_title(struct view *view)
+ssd_update_title(struct ssd *ssd)
 {
-	struct ssd *ssd = &view->ssd;
-	if (!ssd->tree) {
+	if (!ssd) {
 		return;
 	}
 
+	struct view *view = ssd->view;
 	char *title = (char *)view_get_string_prop(view, "title");
 	if (!title || !*title) {
 		return;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -303,8 +303,10 @@ position_xdg_toplevel_view(struct view *view)
 		view->x = center_x - xdg_surface->current.geometry.width / 2;
 		view->y = center_y - xdg_surface->current.geometry.height / 2;
 	}
-	view->x += view->ssd.margin.left;
-	view->y += view->ssd.margin.top;
+
+	struct border margin = ssd_get_margin(view->ssd);
+	view->x += margin.left;
+	view->y += margin.top;
 }
 
 static const char *


### PR DESCRIPTION
Allocating these structs separately allows them to be made opaque in a later commit.

- Store a pointer to the `struct view` in `struct ssd`
- Pass `struct ssd *` instead of `struct view *` to ssd functions
- Add `ssd_get_margin()` convenience function

Split off from #640.