### PR TITLE
view: Fix SSD margin computation

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -559,12 +559,16 @@ view_set_decorations(struct view *view, bool decorations)
 {
 	assert(view);
 	if (view->ssd_enabled != decorations && !view->fullscreen) {
+		/*
+		 * Set view->ssd_enabled first since it is referenced
+		 * within the call tree of ssd_create()
+		 */
+		view->ssd_enabled = decorations;
 		if (decorations) {
 			ssd_create(view, view == view->server->focused_view);
 		} else {
 			ssd_destroy(view);
 		}
-		view->ssd_enabled = decorations;
 		if (view->maximized) {
 			view_apply_maximized_geometry(view);
 		} else if (view->tiled) {


### PR DESCRIPTION
If `view->ssd_enabled` is false when calling `ssd_create()` then `ssd_thickness()` returns zeroes which are stored in `ssd->margins`.

The quick fix is just to ensure we set `view->ssd_enabled` before calling `ssd_create()`. At some point, it might be nice to refactor so that `ssd_create()` does not reference `view->ssd_enabled`.

Fixes #653 which was a regression caused by #650 (oops).