### PR TITLE
menu: Dynamically adjust menu width

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -41,6 +41,14 @@ A theme consists of a themerc file and optionally some xbm icons.
 	Vertical padding size, used for spacing out elements in the window decorations.
 	Default is 3.
 
+*menu.items.padding.x*
+	Horizontal padding of menu text entries in pixels.
+	Default is 7.
+
+*menu.items.padding.y*
+	Vertical padding of menu text entries in pixels.
+	Default is 4.
+
 *menu.overlap.x*
 	Horizontal overlap in pixels between submenus and their parents. A
 	positive value move submenus over the top of their parents, whereas a

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -59,6 +59,14 @@ A theme consists of a themerc file and optionally some xbm icons.
 	Vertical offset in pixels between submenus and their parents. Positive
 	values for downwards and negative for upwards. Default is 0.
 
+*menu.width.min*
+	Minimal width for menus. Default is 20.
+	A fixed width can be achieved by setting .min and .max to the same value.
+
+*menu.width.max*
+	Maximal width for menus. Default is 200.
+	A fixed width can be achieved by setting .min and .max to the same value.
+
 *window.active.border.color*
 	Border color of active window
 

--- a/include/common/scaled_font_buffer.h
+++ b/include/common/scaled_font_buffer.h
@@ -25,7 +25,7 @@ struct scaled_font_buffer {
 /**
  * Create an auto scaling font buffer, providing a wlr_scene_buffer node for
  * display. It gets destroyed automatically when the backing scaled_scene_buffer
- * is being destoyed which in turn happens automatically when the backing
+ * is being destroyed which in turn happens automatically when the backing
  * wlr_scene_buffer (or one of its parents) is being destroyed.
  *
  * To actually show some text, scaled_font_buffer_update() has to be called.
@@ -47,5 +47,13 @@ struct scaled_font_buffer *scaled_font_buffer_create(struct wlr_scene_tree *pare
  */
 void scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
 	int max_width, struct font *font, float *color, const char *arrow);
+
+/**
+ * Update the max width of an existing auto scaling font buffer
+ * and force a new render.
+ *
+ * No steps are taken to detect if its actually required to render a new buffer.
+ */
+void scaled_font_buffer_set_max_width(struct scaled_font_buffer *self, int max_width);
 
 #endif /* __LAB_COMMON_SCALED_FONT_BUFFER_H */

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -33,6 +33,7 @@ struct menuitem {
 	struct menu *submenu;
 	bool selectable;
 	int height;
+	int native_width;
 	struct wlr_scene_tree *tree;
 	struct menu_scene normal;
 	struct menu_scene selected;

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -61,8 +61,7 @@ struct menu {
 	struct view *triggered_by_view;  /* may be NULL */
 };
 
-void menu_init_rootmenu(struct server *server);
-void menu_init_windowmenu(struct server *server);
+void menu_init(struct server *server);
 void menu_finish(void);
 
 /**

--- a/include/theme.h
+++ b/include/theme.h
@@ -53,6 +53,9 @@ struct theme {
 	float menu_items_active_bg_color[4];
 	float menu_items_active_text_color[4];
 
+	int menu_min_width;
+	int menu_max_width;
+
 	int menu_separator_line_thickness;
 	int menu_separator_padding_width;
 	int menu_separator_padding_height;

--- a/include/theme.h
+++ b/include/theme.h
@@ -45,6 +45,9 @@ struct theme {
 	float window_inactive_button_close_unpressed_image_color[4];
 	/* TODO: add pressed and hover colors for buttons */
 
+	int menu_item_padding_x;
+	int menu_item_padding_y;
+
 	float menu_items_bg_color[4];
 	float menu_items_text_color[4];
 	float menu_items_active_bg_color[4];

--- a/include/theme.h
+++ b/include/theme.h
@@ -50,7 +50,7 @@ struct theme {
 	float menu_items_active_bg_color[4];
 	float menu_items_active_text_color[4];
 
-	int menu_separator_width;
+	int menu_separator_line_thickness;
 	int menu_separator_padding_width;
 	int menu_separator_padding_height;
 	float menu_separator_color[4];

--- a/src/common/scaled_font_buffer.c
+++ b/src/common/scaled_font_buffer.c
@@ -90,3 +90,10 @@ scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
 	/* Invalidate cache and force a new render */
 	scaled_scene_buffer_invalidate_cache(self->scaled_buffer);
 }
+
+void
+scaled_font_buffer_set_max_width(struct scaled_font_buffer *self, int max_width)
+{
+	self->max_width = max_width;
+	scaled_scene_buffer_invalidate_cache(self->scaled_buffer);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -169,8 +169,7 @@ main(int argc, char *argv[])
 	rc.theme = &theme;
 	server.theme = &theme;
 
-	menu_init_rootmenu(&server);
-	menu_init_windowmenu(&server);
+	menu_init(&server);
 
 	session_autostart_init(rc.config_dir);
 	if (startup_cmd) {

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -24,8 +24,6 @@
 #include "theme.h"
 
 #define MENUWIDTH (110)
-#define MENU_ITEM_PADDING_Y (4)
-#define MENU_ITEM_PADDING_X (7)
 
 /* state-machine variables for processing <item></item> */
 static bool in_item;
@@ -88,12 +86,12 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 
 	if (!menu->item_height) {
 		menu->item_height = font_height(&rc.font_menuitem)
-			+ 2 * MENU_ITEM_PADDING_Y;
+			+ 2 * theme->menu_item_padding_y;
 	}
 	menuitem->height = menu->item_height;
 
 	int x, y;
-	int item_max_width = MENUWIDTH - 2 * MENU_ITEM_PADDING_X;
+	int item_max_width = MENUWIDTH - 2 * theme->menu_item_padding_x;
 
 	/* Menu item root node */
 	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
@@ -138,7 +136,7 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 		&rc.font_menuitem, theme->menu_items_active_text_color, arrow);
 
 	/* Center font nodes */
-	x = MENU_ITEM_PADDING_X;
+	x = theme->menu_item_padding_x;
 	y = (menu->item_height - menuitem->normal.buffer->height) / 2;
 	wlr_scene_node_set_position(menuitem->normal.text, x, y);
 	y = (menu->item_height - menuitem->selected.buffer->height) / 2;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -575,8 +575,8 @@ menu_hide_submenu(const char *id)
 	}
 }
 
-void
-menu_init_rootmenu(struct server *server)
+static void
+init_rootmenu(struct server *server)
 {
 	parse_xml("menu.xml", server);
 	struct menu *menu = menu_get_by_id("root-menu");
@@ -594,8 +594,8 @@ menu_init_rootmenu(struct server *server)
 	}
 }
 
-void
-menu_init_windowmenu(struct server *server)
+static void
+init_windowmenu(struct server *server)
 {
 	struct menu *menu = menu_get_by_id("client-menu");
 
@@ -638,6 +638,13 @@ menu_init_windowmenu(struct server *server)
 	if (wl_list_length(&rc.workspace_config.workspaces) == 1) {
 		menu_hide_submenu("workspaces");
 	}
+}
+
+void
+menu_init(struct server *server)
+{
+	init_rootmenu(server);
+	init_windowmenu(server);
 }
 
 void
@@ -799,6 +806,5 @@ menu_reconfigure(struct server *server)
 {
 	menu_finish();
 	server->menu_current = NULL;
-	menu_init_rootmenu(server);
-	menu_init_windowmenu(server);
+	menu_init(server);
 }

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -166,7 +166,7 @@ separator_create(struct menu *menu, const char *label)
 	menuitem->selectable = false;
 	struct server *server = menu->server;
 	struct theme *theme = server->theme;
-	menuitem->height = theme->menu_separator_width +
+	menuitem->height = theme->menu_separator_line_thickness +
 			2 * theme->menu_separator_padding_height;
 
 	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
@@ -178,12 +178,11 @@ separator_create(struct menu *menu, const char *label)
 		MENUWIDTH, menuitem->height,
 		theme->menu_items_bg_color)->node;
 
-	/* theme->menu_separator_width is the line-thickness (so height here) */
 	int width = MENUWIDTH - 2 * theme->menu_separator_padding_width;
 	menuitem->normal.text = &wlr_scene_rect_create(
 		menuitem->normal.tree,
 		width > 0 ? width : 0,
-		theme->menu_separator_width,
+		theme->menu_separator_line_thickness,
 		theme->menu_separator_color)->node;
 
 	wlr_scene_node_set_position(&menuitem->tree->node, 0, menu->size.height);

--- a/src/theme.c
+++ b/src/theme.c
@@ -128,6 +128,9 @@ theme_builtin(struct theme *theme)
 	parse_hexstr("#dddad6", theme->menu_items_active_bg_color);
 	parse_hexstr("#000000", theme->menu_items_active_text_color);
 
+	theme->menu_item_padding_x = 7;
+	theme->menu_item_padding_y = 4;
+
 	theme->menu_separator_line_thickness = 1;
 	theme->menu_separator_padding_width = 6;
 	theme->menu_separator_padding_height = 3;
@@ -166,6 +169,12 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match(key, "padding.height")) {
 		theme->padding_height = atoi(value);
+	}
+	if (match(key, "menu.items.padding.x")) {
+		theme->menu_item_padding_x = atoi(value);
+	}
+	if (match(key, "menu.items.padding.y")) {
+		theme->menu_item_padding_y = atoi(value);
 	}
 	if (match(key, "menu.overlap.x")) {
 		theme->menu_overlap_x = atoi(value);

--- a/src/theme.c
+++ b/src/theme.c
@@ -131,6 +131,9 @@ theme_builtin(struct theme *theme)
 	theme->menu_item_padding_x = 7;
 	theme->menu_item_padding_y = 4;
 
+	theme->menu_min_width = 20;
+	theme->menu_max_width = 200;
+
 	theme->menu_separator_line_thickness = 1;
 	theme->menu_separator_padding_width = 6;
 	theme->menu_separator_padding_height = 3;
@@ -258,6 +261,13 @@ entry(struct theme *theme, const char *key, const char *value)
 	if (match(key, "window.inactive.button.close.unpressed.image.color")) {
 		parse_hexstr(value,
 			theme->window_inactive_button_close_unpressed_image_color);
+	}
+
+	if (match(key, "menu.width.min")) {
+		theme->menu_min_width = atoi(value);
+	}
+	if (match(key, "menu.width.max")) {
+		theme->menu_max_width = atoi(value);
 	}
 
 	if (match(key, "menu.items.bg.color")) {
@@ -486,6 +496,13 @@ post_processing(struct theme *theme)
 
 	if (rc.corner_radius >= theme->title_height) {
 		theme->title_height = rc.corner_radius + 1;
+	}
+
+	if (theme->menu_max_width < theme->menu_min_width) {
+		wlr_log(WLR_ERROR,
+			"Adjusting menu.width.max: .max (%d) lower than .min (%d)",
+			theme->menu_max_width, theme->menu_min_width);
+		theme->menu_max_width = theme->menu_min_width;
 	}
 
 	/* Inherit OSD settings if not set */

--- a/src/theme.c
+++ b/src/theme.c
@@ -128,7 +128,7 @@ theme_builtin(struct theme *theme)
 	parse_hexstr("#dddad6", theme->menu_items_active_bg_color);
 	parse_hexstr("#000000", theme->menu_items_active_text_color);
 
-	theme->menu_separator_width = 1;
+	theme->menu_separator_line_thickness = 1;
 	theme->menu_separator_padding_width = 6;
 	theme->menu_separator_padding_height = 3;
 	parse_hexstr("#888888", theme->menu_separator_color);
@@ -265,7 +265,7 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 
 	if (match(key, "menu.separator.width")) {
-		theme->menu_separator_width = atoi(value);
+		theme->menu_separator_line_thickness = atoi(value);
 	}
 	if (match(key, "menu.separator.padding.width")) {
 		theme->menu_separator_padding_width = atoi(value);


### PR DESCRIPTION
This PR introduces four new theme variables:
- `menu.items.padding.x`
- `menu.items.padding.y`
- `menu.width.min` (menus will never be smaller than this)
- `menu.width.max` (menus will never be wider than this + padding)

Missing:
- [x] parsing theme config, uses a default of 20 / 200
- [x] docs
- [x] rename `scaled_font_buffer_resize` to `scaled_font_buffer_set_max_width`
- [x] squash last commits

~~The way I wired this up is not optimal: When creating a new menu item the width will be compared to the stored width of the whole menu and if the new item width is wider, all existing items will be resized and the new width will be set for the menu.
This means that we may end up unnecessarily resizing items multiple times. However, this only happens while parsing `menu.xml` so it shouldn't be an issue in practice. Feels a bit hackish though.~~