### PR TITLE
README.md: update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ The obligatory screenshot:
 
 To build, simply run:
 
-    meson build/
-    ninja -C build/
+    meson setup build/
+    meson compile -C build/
 
 Run-time dependencies include:
 


### PR DESCRIPTION
...because running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.