### PR TITLE
menu: Reuse action argument parsing from rcxml.c

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -20,6 +20,8 @@ struct action {
 
 struct action *action_create(const char *action_name);
 void action_arg_add_str(struct action *action, char *key, const char *value);
+void action_arg_from_xml_node(struct action *action, char *nodename, char *content);
+
 void actions_run(struct view *activator, struct server *server,
 	struct wl_list *actions, uint32_t resize_edges);
 void action_list_free(struct wl_list *action_list);

--- a/src/action.c
+++ b/src/action.c
@@ -88,6 +88,32 @@ const char *action_names[] = {
 	NULL
 };
 
+void
+action_arg_from_xml_node(struct action *action, char *nodename, char *content)
+{
+	assert(action);
+	if (!strcmp(nodename, "command.action")) {
+		/* Execute */
+		action_arg_add_str(action, NULL, content);
+	} else if (!strcmp(nodename, "execute.action")) {
+		/*
+		 * <action name="Execute"><execute>foo</execute></action>
+		 * is deprecated, but we support it anyway for backward
+		 * compatibility with old openbox-menu generators
+		 */
+		action_arg_add_str(action, NULL, content);
+	} else if (!strcmp(nodename, "direction.action")) {
+		/* MoveToEdge, SnapToEdge */
+		action_arg_add_str(action, NULL, content);
+	} else if (!strcmp(nodename, "menu.action")) {
+		/* ShowMenu */
+		action_arg_add_str(action, NULL, content);
+	} else if (!strcmp(nodename, "to.action")) {
+		/* GoToDesktop, SendToDesktop */
+		action_arg_add_str(action, NULL, content);
+	}
+}
+
 static char *
 action_str_from_arg(struct action_arg *arg)
 {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -47,24 +47,6 @@ static void load_default_key_bindings(void);
 static void load_default_mouse_bindings(void);
 
 static void
-fill_common(char *nodename, char *content, struct action *action)
-{
-	if (!strcmp(nodename, "command.action")) {
-		/* Execute */
-		action_arg_add_str(action, NULL, content);
-	} else if (!strcmp(nodename, "direction.action")) {
-		/* MoveToEdge, SnapToEdge */
-		action_arg_add_str(action, NULL, content);
-	} else if (!strcmp(nodename, "menu.action")) {
-		/* ShowMenu */
-		action_arg_add_str(action, NULL, content);
-	} else if (!strcmp(nodename, "to.action")) {
-		/* GoToDesktop, SendToDesktop */
-		action_arg_add_str(action, NULL, content);
-	}
-}
-
-static void
 fill_keybind(char *nodename, char *content)
 {
 	if (!content) {
@@ -93,7 +75,7 @@ fill_keybind(char *nodename, char *content)
 		wlr_log(WLR_ERROR, "expect <action name=\"\"> element first. "
 			"nodename: '%s' content: '%s'", nodename, content);
 	} else {
-		fill_common(nodename, content, current_keybind_action);
+		action_arg_from_xml_node(current_keybind_action, nodename, content);
 	}
 }
 
@@ -146,7 +128,7 @@ fill_mousebind(char *nodename, char *content)
 		wlr_log(WLR_ERROR, "expect <action name=\"\"> element first. "
 			"nodename: '%s' content: '%s'", nodename, content);
 	} else {
-		fill_common(nodename, content, current_mousebind_action);
+		action_arg_from_xml_node(current_mousebind_action, nodename, content);
 	}
 }
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -283,19 +283,8 @@ fill_item(char *nodename, char *content)
 	} else if (!current_item_action) {
 		wlr_log(WLR_ERROR, "expect <action name=\"\"> element first. "
 			"nodename: '%s' content: '%s'", nodename, content);
-	} else if (!strcmp(nodename, "command.action")) {
-		/* Execute */
-		action_arg_add_str(current_item_action, NULL, content);
-	} else if (!strcmp(nodename, "execute.action")) {
-		/*
-		 * <action name="Execute"><execute>foo</execute></action>
-		 * is deprecated, but we support it anyway for backward
-		 * compatibility with old openbox-menu generators
-		 */
-		action_arg_add_str(current_item_action, NULL, content);
-	} else if (!strcmp(nodename, "to.action")) {
-		/* GoToDesktop, SendToDesktop */
-		action_arg_add_str(current_item_action, NULL, content);
+	} else {
+		action_arg_from_xml_node(current_item_action, nodename, content);
 	}
 }
 


### PR DESCRIPTION
This fixes being unable to use the `direction` argument in menu entries.

Reported-by: mahk via IRC