### PR TITLE
src/view.c: dont switch output on SnapToEdge if view is maximized

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -821,7 +821,7 @@ view_snap_to_edge(struct view *view, const char *direction,
 		return;
 	}
 
-	if (view->tiled == edge) {
+	if (view->tiled == edge && !view->maximized) {
 		/* We are already tiled for this edge and thus should switch outputs */
 		struct wlr_output *new_output = NULL;
 		struct wlr_output *current_output = output->wlr_output;


### PR DESCRIPTION
Before this on my setup with a single monitor the following would happen:
1. Snap to Edge
2. Maximize
3. Snapping to the original edge would not work