### PR TITLE
Update cursor on next commit after xdg surface map

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -46,6 +46,7 @@ struct view {
 
 	bool mapped;
 	bool been_mapped;
+	bool committed_since_mapped;
 	bool ssd_enabled;
 	bool minimized;
 	bool maximized;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -66,7 +66,8 @@ handle_commit(struct wl_listener *listener, void *data)
 	struct wlr_box size;
 	wlr_xdg_surface_get_geometry(xdg_surface, &size);
 
-	bool update_required = false;
+	bool update_required = !view->committed_since_mapped;
+	view->committed_since_mapped = true;
 
 	if (view->w != size.width || view->h != size.height) {
 		update_required = true;
@@ -350,6 +351,7 @@ xdg_toplevel_view_map(struct view *view)
 		view_moved(view);
 		view->been_mapped = true;
 	}
+	view->committed_since_mapped = false;
 
 	view->commit.notify = handle_commit;
 	wl_signal_add(&xdg_surface->surface->events.commit, &view->commit);


### PR DESCRIPTION
Fixes the "new window opening" portion of #647.

I can put this in the same PR as #675 if desired--I just didn't know how long it would be until I found a decent fix, and the two really are, despite looking similar, pretty much independent bugs+fixes.