### PR TITLE
Avoid setting `view->w` and `view->h` before xdg view commit

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -159,6 +159,9 @@ void view_reload_ssd(struct view *view);
 void view_impl_map(struct view *view);
 void view_adjust_size(struct view *view, int *w, int *h);
 
+bool view_compute_centered_position(struct view *view, int w, int h,
+	int *x, int *y);
+
 void view_on_output_destroy(struct view *view);
 void view_destroy(struct view *view);
 

--- a/src/view.c
+++ b/src/view.c
@@ -264,7 +264,7 @@ view_output(struct view *view)
 	return output_from_wlr_output(view->server, wlr_output);
 }
 
-static bool
+bool
 view_compute_centered_position(struct view *view, int w, int h, int *x, int *y)
 {
 	struct output *output = view_output(view);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -285,10 +285,19 @@ position_xdg_toplevel_view(struct view *view)
 			output_usable_area_from_cursor_coords(view->server);
 		view->x = box.x;
 		view->y = box.y;
-		view->w = xdg_surface->current.geometry.width;
-		view->h = xdg_surface->current.geometry.height;
-		if (view->w && view->h) {
-			view_center(view);
+
+		/* Center the view without touching its w and h fields. This means we
+		 * can't simply set w/h and call view_center().  w and h fields should
+		 * only be modified at commit, or they will not be in sync with the
+		 * scene tree
+		 */
+		int w = xdg_surface->current.geometry.width;
+		int h = xdg_surface->current.geometry.height;
+		if (w && h) {
+			int x, y;
+			if (view_compute_centered_position(view, w, h, &x, &y)) {
+				view_move(view, x, y);
+			}
 		}
 	} else {
 		/*


### PR DESCRIPTION
A cleaner fix for the second half of #647. Supersedes #676.