### PR TITLE
Unbreak build without Xwayland (in wlroots)

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2,12 +2,15 @@
 #include <assert.h>
 #include <stdio.h>
 #include <strings.h>
-#include <xcb/xcb_icccm.h>
 #include "common/scene-helpers.h"
 #include "labwc.h"
 #include "ssd.h"
 #include "menu/menu.h"
 #include "workspaces.h"
+
+#if HAVE_XWAYLAND
+#include <xcb/xcb_icccm.h>
+#endif
 
 #define LAB_FALLBACK_WIDTH 640
 #define LAB_FALLBACK_HEIGHT 480


### PR DESCRIPTION
Found downstream when building everything with X11 disabled (not just labwc). See also [error log](https://github.com/labwc/labwc/files/10258590/labwc-0.6.0.log).
