### PR TITLE
Ensure cursor is correctly scaled at startup

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -335,6 +335,9 @@ handle_output_manager_apply(struct wl_listener *listener, void *data)
 		wlr_xcursor_manager_load(server->seat.xcursor_manager,
 			output->wlr_output->scale);
 	}
+
+	/* Re-set cursor image in case scale changed */
+	cursor_update_focus(server);
 }
 
 /*


### PR DESCRIPTION
Fixes (the size portion of) #681. The other half has an upstream fix as noted in the issue thread.