### PR TITLE
rcxml: Make sure a default libinput category always exists

### DIFF
--- a/include/config/libinput.h
+++ b/include/config/libinput.h
@@ -28,5 +28,6 @@ struct libinput_category {
 
 enum device_type get_device_type(const char *s);
 struct libinput_category *libinput_category_create(void);
+struct libinput_category *libinput_category_get_default(void);
 
 #endif /* __LABWC_LIBINPUT_H */

--- a/src/config/libinput.c
+++ b/src/config/libinput.c
@@ -9,6 +9,7 @@
 static void
 libinput_category_init(struct libinput_category *l)
 {
+	l->type = DEFAULT_DEVICE;
 	l->name = NULL;
 	l->pointer_speed = -2;
 	l->natural_scroll = -1;
@@ -42,4 +43,20 @@ libinput_category_create(void)
 	libinput_category_init(l);
 	wl_list_insert(&rc.libinput_categories, &l->link);
 	return l;
+}
+
+/*
+ * The default category is the first one with type == DEFAULT_DEVICE and
+ * no name. After rcxml_read(), a default category always exists.
+ */
+struct libinput_category *
+libinput_category_get_default(void)
+{
+	struct libinput_category *l;
+	wl_list_for_each(l, &rc.libinput_categories, link) {
+		if (l->type == DEFAULT_DEVICE && !l->name) {
+			return l;
+		}
+	}
+	return NULL;
 }

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -680,10 +680,10 @@ post_processing(void)
 	if (!rc.font_osd.name) {
 		rc.font_osd.name = xstrdup("sans");
 	}
-	if (!wl_list_length(&rc.libinput_categories)) {
+	if (!libinput_category_get_default()) {
 		/* So we still allow tap to click by default */
 		struct libinput_category *l = libinput_category_create();
-		l->type = DEFAULT_DEVICE;
+		assert(l && libinput_category_get_default() == l);
 	}
 	if (!wl_list_length(&rc.workspace_config.workspaces)) {
 		struct workspace *workspace = znew(*workspace);

--- a/src/seat.c
+++ b/src/seat.c
@@ -75,14 +75,16 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		} else if (device_category->type == current_type) {
 			dc = device_category;
 		} else if (device_category->type == DEFAULT_DEVICE && !dc) {
+			/* Match default category as last-resort */
 			dc = device_category;
 		}
 	}
 
-	if (!dc) {
-		wlr_log(WLR_INFO, "Skipping libinput configuration for device");
-		return;
-	}
+	/*
+	 * The above logic should have always matched SOME category
+	 * (the default category if none other took precedence)
+	 */
+	assert(dc);
 
 	if (libinput_device_config_tap_get_finger_count(libinput_dev) <= 0) {
 		wlr_log(WLR_INFO, "tap unavailable");


### PR DESCRIPTION
Previously, if `rc.xml` defined only non-default libinput categories, no default category was created. This meant that `configure_libinput()` might totally skip configuring some devices even with default settings, like tap-to-click.

Fix this by making sure that a default category is always created.