### PR TITLE
Use scene-node approach for layers and simplify usage of wlr_scene_node_at()

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -298,7 +298,6 @@ struct output {
 	struct server *server;
 	struct wlr_output *wlr_output;
 	struct wlr_scene_output *scene_output;
-	struct wl_list layers[LAB_NR_LAYERS];
 	struct wlr_scene_tree *layer_tree[LAB_NR_LAYERS];
 	struct wlr_scene_tree *layer_popup_tree;
 	struct wlr_scene_tree *osd_tree;

--- a/include/layers.h
+++ b/include/layers.h
@@ -11,7 +11,7 @@ struct lab_layer_surface {
 	struct wl_list link; /* output::layers */
 	struct wlr_scene_layer_surface_v1 *scene_layer_surface;
 
-	struct wl_listener destroy;
+	struct wl_listener node_destroy;
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener surface_commit;

--- a/include/layers.h
+++ b/include/layers.h
@@ -10,18 +10,16 @@ struct output;
 struct lab_layer_surface {
 	struct wl_list link; /* output::layers */
 	struct wlr_scene_layer_surface_v1 *scene_layer_surface;
+	struct server *server;
 
-	struct wl_listener node_destroy;
+	bool mapped;
+
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener surface_commit;
 	struct wl_listener output_destroy;
+	struct wl_listener node_destroy;
 	struct wl_listener new_popup;
-
-	struct wlr_box geo;
-	bool mapped;
-	/* TODO: add extent? */
-	struct server *server;
 };
 
 struct lab_layer_popup {

--- a/include/layers.h
+++ b/include/layers.h
@@ -8,7 +8,6 @@ struct server;
 struct output;
 
 struct lab_layer_surface {
-	struct wl_list link; /* output::layers */
 	struct wlr_scene_layer_surface_v1 *scene_layer_surface;
 	struct server *server;
 

--- a/src/layers.c
+++ b/src/layers.c
@@ -247,7 +247,7 @@ move_popup_to_top_layer(struct lab_layer_surface *toplevel,
 	struct server *server = toplevel->server;
 	struct wlr_output *wlr_output =
 		toplevel->scene_layer_surface->layer_surface->output;
-	struct output *output = output_from_wlr_output(server, wlr_output);
+	struct output *output = (struct output *)wlr_output->data;
 	struct wlr_box box = { 0 };
 	wlr_output_layout_get_box(server->output_layout, wlr_output, &box);
 	int lx = toplevel->scene_layer_surface->tree->node.x + box.x;

--- a/src/layers.c
+++ b/src/layers.c
@@ -112,7 +112,7 @@ layers_arrange(struct output *output)
 }
 
 static void
-output_destroy_notify(struct wl_listener *listener, void *data)
+handle_output_destroy(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_surface *layer =
 		wl_container_of(listener, layer, output_destroy);
@@ -120,7 +120,7 @@ output_destroy_notify(struct wl_listener *listener, void *data)
 }
 
 static void
-surface_commit_notify(struct wl_listener *listener, void *data)
+handle_surface_commit(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_surface *layer =
 		wl_container_of(listener, layer, surface_commit);
@@ -149,7 +149,7 @@ surface_commit_notify(struct wl_listener *listener, void *data)
 }
 
 static void
-destroy_notify(struct wl_listener *listener, void *data)
+handle_node_destroy(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_surface *layer =
 		wl_container_of(listener, layer, node_destroy);
@@ -163,7 +163,7 @@ destroy_notify(struct wl_listener *listener, void *data)
 }
 
 static void
-unmap_notify(struct wl_listener *listener, void *data)
+handle_unmap(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_surface *layer = wl_container_of(listener, layer, unmap);
 	layers_arrange(layer->scene_layer_surface->layer_surface->output->data);
@@ -174,7 +174,7 @@ unmap_notify(struct wl_listener *listener, void *data)
 }
 
 static void
-map_notify(struct wl_listener *listener, void *data)
+handle_map(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_surface *layer = wl_container_of(listener, layer, map);
 	layers_arrange(layer->scene_layer_surface->layer_surface->output->data);
@@ -261,7 +261,7 @@ move_popup_to_top_layer(struct lab_layer_surface *toplevel,
 
 /* This popup's parent is a shell-layer surface */
 static void
-new_popup_notify(struct wl_listener *listener, void *data)
+handle_new_popup(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_surface *toplevel =
 		wl_container_of(listener, toplevel, new_popup);
@@ -307,7 +307,7 @@ new_popup_notify(struct wl_listener *listener, void *data)
 }
 
 static void
-new_layer_surface_notify(struct wl_listener *listener, void *data)
+handle_new_layer_surface(struct wl_listener *listener, void *data)
 {
 	struct server *server = wl_container_of(
 		listener, server, new_layer_surface);
@@ -341,24 +341,24 @@ new_layer_surface_notify(struct wl_listener *listener, void *data)
 	surface->server = server;
 	surface->scene_layer_surface->layer_surface = layer_surface;
 
-	surface->surface_commit.notify = surface_commit_notify;
+	surface->surface_commit.notify = handle_surface_commit;
 	wl_signal_add(&layer_surface->surface->events.commit,
 		&surface->surface_commit);
 
-	surface->map.notify = map_notify;
+	surface->map.notify = handle_map;
 	wl_signal_add(&layer_surface->events.map, &surface->map);
 
-	surface->unmap.notify = unmap_notify;
+	surface->unmap.notify = handle_unmap;
 	wl_signal_add(&layer_surface->events.unmap, &surface->unmap);
 
-	surface->new_popup.notify = new_popup_notify;
+	surface->new_popup.notify = handle_new_popup;
 	wl_signal_add(&layer_surface->events.new_popup, &surface->new_popup);
 
-	surface->output_destroy.notify = output_destroy_notify;
+	surface->output_destroy.notify = handle_output_destroy;
 	wl_signal_add(&layer_surface->output->events.destroy,
 		&surface->output_destroy);
 
-	surface->node_destroy.notify = destroy_notify;
+	surface->node_destroy.notify = handle_node_destroy;
 	wl_signal_add(&surface->scene_layer_surface->tree->node.events.destroy,
 		&surface->node_destroy);
 
@@ -381,7 +381,7 @@ void
 layers_init(struct server *server)
 {
 	server->layer_shell = wlr_layer_shell_v1_create(server->wl_display);
-	server->new_layer_surface.notify = new_layer_surface_notify;
+	server->new_layer_surface.notify = handle_new_layer_surface;
 	wl_signal_add(&server->layer_shell->events.new_surface,
 		&server->new_layer_surface);
 }

--- a/src/layers.c
+++ b/src/layers.c
@@ -72,12 +72,11 @@ layers_arrange(struct output *output)
 	memcpy(&output->usable_area, &usable_area, sizeof(struct wlr_box));
 
 	/* Find topmost keyboard interactive layer, if such a layer exists */
-	uint32_t layers_above_shell[] = {
+	uint32_t layers_above_views[] = {
 		ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY,
 		ZWLR_LAYER_SHELL_V1_LAYER_TOP,
 	};
-	size_t nlayers = sizeof(layers_above_shell)
-		/ sizeof(layers_above_shell[0]);
+	size_t nlayers = sizeof(layers_above_views) / sizeof(layers_above_views[0]);
 	struct lab_layer_surface *topmost = NULL;
 	struct wlr_scene_node *node;
 	for (size_t i = 0; i < nlayers; ++i) {

--- a/src/layers.c
+++ b/src/layers.c
@@ -69,7 +69,7 @@ layers_arrange(struct output *output)
 			scene_output->y);
 	}
 
-	memcpy(&output->usable_area, &usable_area, sizeof(struct wlr_box));
+	memcpy(&output->usable_area, &usable_area, sizeof(output->usable_area));
 
 	/* Find topmost keyboard interactive layer, if such a layer exists */
 	uint32_t layers_above_views[] = {

--- a/src/output.c
+++ b/src/output.c
@@ -145,9 +145,8 @@ new_output_notify(struct wl_listener *listener, void *data)
 	 * Create layer-trees (background, bottom, top and overlay) and
 	 * a layer-popup-tree.
 	 */
-	int nr_layers = sizeof(output->layers) / sizeof(output->layers[0]);
+	int nr_layers = sizeof(output->layer_tree) / sizeof(output->layer_tree[0]);
 	for (int i = 0; i < nr_layers; i++) {
-		wl_list_init(&output->layers[i]);
 		output->layer_tree[i] =
 			wlr_scene_tree_create(&server->scene->tree);
 		node_descriptor_create(&output->layer_tree[i]->node,


### PR DESCRIPTION
Related to issue #667

This will supersede PR #685 

TODO

- [x] Use nodes for popups too
- [x] In commit-handler deal with changed layer
- [x] Ensure pointer-enter-event is sent when new layer-surface appears under pointer (without the pointer moving)
- [x] Rename all handlers to `handle_*` rather than `*_notify`
- [x] Remove redundant `struct wlr_box geo` in `layers.h` 

Later
- Use ARRAY_SIZE macro
