### PR TITLE
Fix various crashes related to no outputs available

### DIFF
--- a/src/layers.c
+++ b/src/layers.c
@@ -316,6 +316,12 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 		struct wlr_output *output = wlr_output_layout_output_at(
 			server->output_layout, server->seat.cursor->x,
 			server->seat.cursor->y);
+		if (!output) {
+			wlr_log(WLR_INFO,
+				"No output available to assign layer surface");
+			wlr_layer_surface_v1_destroy(layer_surface);
+			return;
+		}
 		layer_surface->output = output;
 	}
 
@@ -360,11 +366,6 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 	surface->node_destroy.notify = handle_node_destroy;
 	wl_signal_add(&surface->scene_layer_surface->tree->node.events.destroy,
 		&surface->node_destroy);
-
-	if (!output) {
-		wlr_log(WLR_ERROR, "no output for layer");
-		return;
-	}
 
 	/*
 	 * Temporarily set the layer's current state to pending so that

--- a/src/layers.c
+++ b/src/layers.c
@@ -117,6 +117,7 @@ handle_output_destroy(struct wl_listener *listener, void *data)
 	struct lab_layer_surface *layer =
 		wl_container_of(listener, layer, output_destroy);
 	layer->scene_layer_surface->layer_surface->output = NULL;
+	wlr_layer_surface_v1_destroy(layer->scene_layer_surface->layer_surface);
 }
 
 static void
@@ -272,18 +273,12 @@ handle_new_popup(struct wl_listener *listener, void *data)
 		wl_container_of(listener, toplevel, new_popup);
 	struct wlr_xdg_popup *wlr_popup = data;
 
-	int lx, ly;
 	struct server *server = toplevel->server;
 	struct wlr_scene_layer_surface_v1 *surface = toplevel->scene_layer_surface;
-	wlr_scene_node_coords(&surface->tree->node, &lx, &ly);
-
-	if (!surface->layer_surface->output) {
-		/* Work-around for moving layer shell surfaces on output destruction */
-		struct wlr_output *wlr_output;
-		wlr_output = wlr_output_layout_output_at(server->output_layout, lx, ly);
-		surface->layer_surface->output = wlr_output;
-	}
 	struct output *output = surface->layer_surface->output->data;
+
+	int lx, ly;
+	wlr_scene_node_coords(&surface->tree->node, &lx, &ly);
 
 	struct wlr_box output_box = { 0 };
 	wlr_output_layout_get_box(server->output_layout,

--- a/src/layers.c
+++ b/src/layers.c
@@ -156,6 +156,7 @@ handle_node_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&layer->map.link);
 	wl_list_remove(&layer->unmap.link);
 	wl_list_remove(&layer->surface_commit.link);
+	wl_list_remove(&layer->new_popup.link);
 	wl_list_remove(&layer->output_destroy.link);
 	wl_list_remove(&layer->node_destroy.link);
 	free(layer);

--- a/src/layers.c
+++ b/src/layers.c
@@ -38,6 +38,7 @@ arrange_one_layer(struct output *output, const struct wlr_box *full_area,
 void
 layers_arrange(struct output *output)
 {
+	assert(output);
 	struct wlr_box full_area = { 0 };
 	wlr_output_effective_resolution(output->wlr_output,
 		&full_area.width, &full_area.height);
@@ -166,9 +167,13 @@ static void
 handle_unmap(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_surface *layer = wl_container_of(listener, layer, unmap);
-	layers_arrange(layer->scene_layer_surface->layer_surface->output->data);
+	struct wlr_layer_surface_v1 *layer_surface =
+		layer->scene_layer_surface->layer_surface;
+	if (layer_surface->output) {
+		layers_arrange(layer_surface->output->data);
+	}
 	struct seat *seat = &layer->server->seat;
-	if (seat->focused_layer == layer->scene_layer_surface->layer_surface) {
+	if (seat->focused_layer == layer_surface) {
 		seat_set_focus_layer(seat, NULL);
 	}
 }

--- a/src/output.c
+++ b/src/output.c
@@ -434,6 +434,9 @@ output_from_wlr_output(struct server *server, struct wlr_output *wlr_output)
 struct wlr_box
 output_usable_area_in_layout_coords(struct output *output)
 {
+	if (!output) {
+		return (struct wlr_box){0};
+	}
 	struct wlr_box box = output->usable_area;
 	double ox = 0, oy = 0;
 	wlr_output_layout_output_coords(output->server->output_layout,

--- a/src/output.c
+++ b/src/output.c
@@ -44,6 +44,13 @@ output_destroy_notify(struct wl_listener *listener, void *data)
 	wl_list_remove(&output->frame.link);
 	wl_list_remove(&output->destroy.link);
 
+	int nr_layers = sizeof(output->layer_tree) / sizeof(output->layer_tree[0]);
+	for (int i = 0; i < nr_layers; i++) {
+		wlr_scene_node_destroy(&output->layer_tree[i]->node);
+	}
+	wlr_scene_node_destroy(&output->layer_popup_tree->node);
+	wlr_scene_node_destroy(&output->osd_tree->node);
+
 	struct view *view;
 	struct server *server = output->server;
 	wl_list_for_each(view, &server->views, link) {
@@ -238,7 +245,7 @@ output_update_for_layout_change(struct server *server)
 
 	/*
 	 * "Move" each wlr_output_cursor (in per-output coordinates) to
-	 * align with the seat cursor.  Set a default cursor image so
+	 * align with the seat cursor. Set a default cursor image so
 	 * that the cursor isn't invisible on new outputs.
 	 *
 	 * TODO: remember the most recent cursor image (see cursor.c)

--- a/src/view.c
+++ b/src/view.c
@@ -358,8 +358,8 @@ static void
 view_apply_natural_geometry(struct view *view)
 {
 	struct wlr_output_layout *layout = view->server->output_layout;
-	if (wlr_output_layout_intersects(layout, NULL,
-			&view->natural_geometry)) {
+	if (wlr_output_layout_intersects(layout, NULL, &view->natural_geometry)
+			|| wl_list_empty(&layout->outputs)) {
 		/* restore to original geometry */
 		view_move_resize(view, view->natural_geometry);
 	} else {

--- a/src/view.c
+++ b/src/view.c
@@ -396,6 +396,7 @@ view_apply_tiled_geometry(struct view *view, struct output *output)
 static void
 view_apply_fullscreen_geometry(struct view *view, struct wlr_output *wlr_output)
 {
+	assert(wlr_output);
 	struct output *output =
 		output_from_wlr_output(view->server, wlr_output);
 	struct wlr_box box = { 0 };
@@ -619,15 +620,19 @@ view_set_fullscreen(struct view *view, bool fullscreen,
 	if (fullscreen != !view->fullscreen) {
 		return;
 	}
+	if (!wlr_output) {
+		wlr_output = view_wlr_output(view);
+		if (!wlr_output && fullscreen) {
+			/* Prevent fullscreen with no available outputs */
+			return;
+		}
+	}
 	if (view->impl->set_fullscreen) {
 		view->impl->set_fullscreen(view, fullscreen);
 	}
 	if (view->toplevel_handle) {
 		wlr_foreign_toplevel_handle_v1_set_fullscreen(
 			view->toplevel_handle, fullscreen);
-	}
-	if (!wlr_output) {
-		wlr_output = view_wlr_output(view);
 	}
 	if (fullscreen) {
 		/*


### PR DESCRIPTION
- [x] `output_usable_area_from_cursor_coords()`, called for example when spawning a new window
- [x] `view_set_fullscreen()`
- [x] `view_apply_fullscreen_geometry()`
- [x] `new_layer_surface_notify()`
- [x] potentially `src/layers.c` `new_popup_notify()`
- [x] destroy layer surfaces on assigned output destruction, thus finally get https://github.com/labwc/labwc/issues/369#issuecomment-1254189860 done.
- [x] verify layer popups are destroyed when loosing the output
- [x] ensure fullscreen'd windows get properly un-fullscreen'd (including being restored to their natural geometry) if their output goes away

There might be more issues, most of this has been tested by running nested:
- `sleep 5; foot`
- `sleep 5; foot -F`
- `sleep 5; wtype -M logo f` (which is bound to `ToggleFullscreen` in my nested instance)
- `sleep 5; wl_framework/run_example wl_framework/examples/wl_example_panel.py`

and then closing the nested labwc window.