### PR TITLE
src/workspaces.c: prevent re-focus for always-on-top views

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -143,6 +143,7 @@ void view_set_fullscreen(struct view *view, bool fullscreen,
 void view_toggle_maximize(struct view *view);
 void view_toggle_decorations(struct view *view);
 void view_toggle_always_on_top(struct view *view);
+bool view_is_always_on_top(struct view *view);
 void view_move_to_workspace(struct view *view, struct workspace *workspace);
 void view_set_decorations(struct view *view, bool decorations);
 void view_toggle_fullscreen(struct view *view);

--- a/src/view.c
+++ b/src/view.c
@@ -522,9 +522,10 @@ view_toggle_decorations(struct view *view)
 	view_set_decorations(view, !view->ssd_enabled);
 }
 
-static bool
-is_always_on_top(struct view *view)
+bool
+view_is_always_on_top(struct view *view)
 {
+	assert(view);
 	return view->scene_tree->node.parent ==
 		view->server->view_tree_always_on_top;
 }
@@ -533,7 +534,7 @@ void
 view_toggle_always_on_top(struct view *view)
 {
 	assert(view);
-	if (is_always_on_top(view)) {
+	if (view_is_always_on_top(view)) {
 		view->workspace = view->server->workspace_current;
 		wlr_scene_node_reparent(&view->scene_tree->node,
 			view->workspace->tree);

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -241,22 +241,23 @@ void
 workspaces_switch_to(struct workspace *target)
 {
 	assert(target);
-	if (target == target->server->workspace_current) {
+	struct server *server = target->server;
+	if (target == server->workspace_current) {
 		return;
 	}
 
 	/* Disable the old workspace */
 	wlr_scene_node_set_enabled(
-		&target->server->workspace_current->tree->node, false);
+		&server->workspace_current->tree->node, false);
 
 	/* Enable the new workspace */
 	wlr_scene_node_set_enabled(&target->tree->node, true);
 
 	/* Save the last visited workspace */
-	target->server->workspace_last = target->server->workspace_current;
+	server->workspace_last = server->workspace_current;
 
 	/* Make sure new views will spawn on the new workspace */
-	target->server->workspace_current = target;
+	server->workspace_current = target;
 
 	/**
 	 * Make sure we are focusing what the user sees.
@@ -267,7 +268,7 @@ workspaces_switch_to(struct workspace *target)
 	desktop_focus_topmost_mapped_view(target->server);
 
 	/* And finally show the OSD */
-	_osd_show(target->server);
+	_osd_show(server);
 }
 
 void

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -13,6 +13,7 @@
 #include "common/list.h"
 #include "common/mem.h"
 #include "labwc.h"
+#include "view.h"
 #include "workspaces.h"
 
 /* Internal helpers */
@@ -259,13 +260,14 @@ workspaces_switch_to(struct workspace *target)
 	/* Make sure new views will spawn on the new workspace */
 	server->workspace_current = target;
 
-	/**
+	/*
 	 * Make sure we are focusing what the user sees.
-	 *
-	 * TODO: This is an issue for always-on-top views as they will
-	 * loose keyboard focus once switching to another workspace.
+	 * Only refocus if the focus is not already on an always-on-top view.
 	 */
-	desktop_focus_topmost_mapped_view(target->server);
+	struct view *view = desktop_focused_view(server);
+	if (!view || !view_is_always_on_top(view)) {
+		desktop_focus_topmost_mapped_view(server);
+	}
 
 	/* And finally show the OSD */
 	_osd_show(server);


### PR DESCRIPTION
Situation: Switching workspaces while having the keyboard focus on an always-on-top window

Options:

1. re-focus to the topmost window on the new workspace
2. re-focus to the topmost always-on-top window
3. if the focus is on an always-on-top window do not change focus at all, otherwise re-focus to the topmost window

`1.` is the current state which is kind of annoying because you'll loose the keyboard focus.
`2.` doesn't sound right either, imagine having some kind of chat or log-output set to always-on-top and giving it focus whenever switching workspaces
`3.` is the best UX option in my opinion thus what I implemented in this PR.
