### PR TITLE
src/view.c: on un-fullscreen restore SSD before applying previous geometry

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -638,6 +638,10 @@ view_set_fullscreen(struct view *view, bool fullscreen,
 		view_apply_fullscreen_geometry(view, view->fullscreen);
 	} else {
 		view->fullscreen = false;
+		/* Re-show decorations when no longer fullscreen */
+		if (view->ssd_enabled) {
+			decorate(view);
+		}
 		/* Restore non-fullscreen geometry */
 		if (view->maximized) {
 			view_apply_maximized_geometry(view);
@@ -645,10 +649,6 @@ view_set_fullscreen(struct view *view, bool fullscreen,
 			view_apply_tiled_geometry(view, NULL);
 		} else {
 			view_apply_unmaximized_geometry(view);
-		}
-		/* Re-show decorations when no longer fullscreen */
-		if (view->ssd_enabled) {
-			decorate(view);
 		}
 	}
 


### PR DESCRIPTION
Before this patch following would cause the SSD to be rendered offscreen:
- snap a window to left or right edge
- toggle fullscreen to fullscreen
- toggle fullscreen to un-fullscreen

To fix that restore the SSD before calculating the new geometry.