### PR TITLE
src/view.c: move xwayland specific function to xwayland.c

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -351,6 +351,7 @@ void xdg_toplevel_decoration(struct wl_listener *listener, void *data);
 void xdg_surface_new(struct wl_listener *listener, void *data);
 
 #if HAVE_XWAYLAND
+bool xwayland_apply_size_hints(struct view *view, int *w, int *h);
 void xwayland_surface_new(struct wl_listener *listener, void *data);
 struct xwayland_unmanaged *xwayland_unmanaged_create(struct server *server,
 	struct wlr_xwayland_surface *xsurface);


### PR DESCRIPTION
Also remove the `<xcb/xcb_icccm.h>` include as its already included by
`"labwc.h"` -> `<wlr/xwayland.h>` -> `<wlr/xwayland/xwayland.h>`.

Addresses https://github.com/labwc/labwc/pull/682#issuecomment-1357614626