### PR TITLE
output: Add output_update_usable_area/all_usable_areas()

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -423,6 +423,8 @@ void output_init(struct server *server);
 void output_manager_init(struct server *server);
 struct output *output_from_wlr_output(struct server *server,
 	struct wlr_output *wlr_output);
+void output_update_usable_area(struct output *output);
+void output_update_all_usable_areas(struct server *server, bool enforce_view_arrange);
 struct wlr_box output_usable_area_in_layout_coords(struct output *output);
 struct wlr_box output_usable_area_from_cursor_coords(struct server *server);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,

--- a/src/server.c
+++ b/src/server.c
@@ -97,10 +97,7 @@ seat_disinhibit_input(struct seat *seat)
 	 * Triggers a refocus of the topmost surface layer if necessary
 	 * TODO: Make layer surface focus per-output based on cursor position
 	 */
-	struct output *output;
-	wl_list_for_each(output, &seat->server->outputs, link) {
-		layers_arrange(output);
-	}
+	output_update_all_usable_areas(seat->server, /*enforce_view_arrange*/ false);
 }
 
 static void


### PR DESCRIPTION
Move the desktop_arrange_all_views() call outside layers_arrange() into a new function, output_update_usable_area().  The new function currently does exactly what layers_arrange() used to, but will be expanded in a later commit.

Add output_update_all_usable_areas(), which is the same as calling output_update_usable_area() for each output, but only calls desktop_arrange_all_views() once.

Rebased and slightly modified by @Consolatis

---

Split off from #625 and addressed the review commits.
Further change:
- call `cursor_update_focus()` on layer surface commits which change something other than just the buffer content itself to keep the `pointer.enter` event working for new layer surfaces spawning under the cursor (and when moving / resizing layer surfaces).