### PR TITLE
include/labwc.h: Provide MIN/MAX macros

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -61,6 +61,14 @@
 #define XCURSOR_DEFAULT "left_ptr"
 #define XCURSOR_SIZE 24
 
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
 enum input_mode {
 	LAB_INPUT_STATE_PASSTHROUGH = 0,
 	LAB_INPUT_STATE_MOVE,

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -123,10 +123,8 @@ get_scale_box(struct wlr_buffer *buffer, double container_width,
 
 	/* Scale down buffer if required */
 	if (icon_geo.width && icon_geo.height) {
-		#define MIN(a, b) ((a) < (b) ? (a) : (b))
 		double scale = MIN(container_width / icon_geo.width,
 			container_height / icon_geo.height);
-		#undef MIN
 		if (scale < 1.0f) {
 			icon_geo.width = (double)icon_geo.width * scale;
 			icon_geo.height = (double)icon_geo.height * scale;

--- a/src/view.c
+++ b/src/view.c
@@ -14,8 +14,6 @@
 #define LAB_FALLBACK_WIDTH  640
 #define LAB_FALLBACK_HEIGHT 480
 
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-
 /**
  * All view_apply_xxx_geometry() functions must *not* modify
  * any state besides repositioning or resizing the view.

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -7,8 +7,6 @@
 #include "view.h"
 #include "workspaces.h"
 
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-
 static int
 round_to_increment(int val, int base, int inc)
 {


### PR DESCRIPTION
As discussed in https://github.com/labwc/labwc/pull/712#discussion_r1061114212

We could also move the macros from `labwc.h` to some other header, I don't particularly mind either variant.