### PR TITLE
output: Use better arg naming for output_update_all_usable_areas()

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -433,7 +433,7 @@ void output_manager_init(struct server *server);
 struct output *output_from_wlr_output(struct server *server,
 	struct wlr_output *wlr_output);
 void output_update_usable_area(struct output *output);
-void output_update_all_usable_areas(struct server *server, bool enforce_view_arrange);
+void output_update_all_usable_areas(struct server *server, bool layout_changed);
 struct wlr_box output_usable_area_in_layout_coords(struct output *output);
 struct wlr_box output_usable_area_from_cursor_coords(struct server *server);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,

--- a/src/output.c
+++ b/src/output.c
@@ -240,7 +240,7 @@ output_init(struct server *server)
 static void
 output_update_for_layout_change(struct server *server)
 {
-	output_update_all_usable_areas(server, /*enforce_view_arrange*/ true);
+	output_update_all_usable_areas(server, /*layout_changed*/ true);
 
 	/*
 	 * "Move" each wlr_output_cursor (in per-output coordinates) to
@@ -451,7 +451,7 @@ output_update_usable_area(struct output *output)
 }
 
 void
-output_update_all_usable_areas(struct server *server, bool enforce_view_arrange)
+output_update_all_usable_areas(struct server *server, bool layout_changed)
 {
 	bool usable_area_changed = false;
 	struct output *output;
@@ -459,7 +459,7 @@ output_update_all_usable_areas(struct server *server, bool enforce_view_arrange)
 	wl_list_for_each(output, &server->outputs, link) {
 		usable_area_changed |= update_usable_area(output);
 	}
-	if (usable_area_changed || enforce_view_arrange) {
+	if (usable_area_changed || layout_changed) {
 		desktop_arrange_all_views(server);
 	}
 }

--- a/src/server.c
+++ b/src/server.c
@@ -97,7 +97,7 @@ seat_disinhibit_input(struct seat *seat)
 	 * Triggers a refocus of the topmost surface layer if necessary
 	 * TODO: Make layer surface focus per-output based on cursor position
 	 */
-	output_update_all_usable_areas(seat->server, /*enforce_view_arrange*/ false);
+	output_update_all_usable_areas(seat->server, /*layout_changed*/ false);
 }
 
 static void


### PR DESCRIPTION
This restores the original approach of naming the argument `layout_changed` which fits much better than `enforce_view_arrange`. Especially when extending the function to also handle region updates once merged.