### PR TITLE
xwayland: Add xwayland.h and move more things to xwayland.c

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -43,9 +43,6 @@
 #include <wlr/types/wlr_virtual_pointer_v1.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/util/log.h>
-#if HAVE_XWAYLAND
-#include <wlr/xwayland.h>
-#endif
 #include <xkbcommon/xkbcommon.h>
 #include "cursor.h"
 #include "config/keybind.h"
@@ -217,7 +214,7 @@ struct server {
 #if HAVE_XWAYLAND
 	struct wlr_xwayland *xwayland;
 	struct wl_listener xwayland_ready;
-	struct wl_listener new_xwayland_surface;
+	struct wl_listener xwayland_new_surface;
 #endif
 
 	struct wlr_input_inhibit_manager *input_inhibit;
@@ -322,24 +319,6 @@ struct output {
 
 #undef LAB_NR_LAYERS
 
-#if HAVE_XWAYLAND
-struct xwayland_unmanaged {
-	struct server *server;
-	struct wlr_xwayland_surface *xwayland_surface;
-	struct wlr_scene_node *node;
-	struct wl_list link;
-
-	struct wl_listener request_activate;
-	struct wl_listener request_configure;
-/*	struct wl_listener request_fullscreen; */
-	struct wl_listener set_geometry;
-	struct wl_listener map;
-	struct wl_listener unmap;
-	struct wl_listener destroy;
-	struct wl_listener override_redirect;
-};
-#endif
-
 struct constraint {
 	struct seat *seat;
 	struct wlr_pointer_constraint_v1 *constraint;
@@ -357,14 +336,6 @@ void xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup);
 void xdg_toplevel_decoration(struct wl_listener *listener, void *data);
 
 void xdg_surface_new(struct wl_listener *listener, void *data);
-
-#if HAVE_XWAYLAND
-bool xwayland_apply_size_hints(struct view *view, int *w, int *h);
-void xwayland_surface_new(struct wl_listener *listener, void *data);
-struct xwayland_unmanaged *xwayland_unmanaged_create(struct server *server,
-	struct wlr_xwayland_surface *xsurface);
-void unmanaged_handle_map(struct wl_listener *listener, void *data);
-#endif
 
 void foreign_toplevel_handle_create(struct view *view);
 

--- a/include/view.h
+++ b/include/view.h
@@ -97,24 +97,6 @@ struct xdg_toplevel_view {
 	struct wl_listener new_popup;
 };
 
-#if HAVE_XWAYLAND
-struct xwayland_view {
-	struct view base;
-	struct wlr_xwayland_surface *xwayland_surface;
-
-	/* Events unique to XWayland views */
-	struct wl_listener request_configure;
-	struct wl_listener set_app_id;		/* TODO: s/set_app_id/class/ */
-	struct wl_listener set_decorations;
-	struct wl_listener override_redirect;
-
-	/* Not (yet) implemented */
-/*	struct wl_listener set_role; */
-/*	struct wl_listener set_window_type; */
-/*	struct wl_listener set_hints; */
-};
-#endif
-
 void view_set_activated(struct view *view);
 void view_close(struct view *view);
 
@@ -168,10 +150,5 @@ void view_destroy(struct view *view);
 
 /* xdg.c */
 struct wlr_xdg_surface *xdg_surface_from_view(struct view *view);
-
-/* xwayland.c */
-#if HAVE_XWAYLAND
-struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
-#endif
 
 #endif /* __LABWC_VIEW_H */

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LABWC_XWAYLAND_H
+#define __LABWC_XWAYLAND_H
+#include "config.h"
+#if HAVE_XWAYLAND
+#include "view.h"
+
+struct wlr_compositor;
+
+struct xwayland_unmanaged {
+	struct server *server;
+	struct wlr_xwayland_surface *xwayland_surface;
+	struct wlr_scene_node *node;
+	struct wl_list link;
+
+	struct wl_listener request_activate;
+	struct wl_listener request_configure;
+/*	struct wl_listener request_fullscreen; */
+	struct wl_listener set_geometry;
+	struct wl_listener map;
+	struct wl_listener unmap;
+	struct wl_listener destroy;
+	struct wl_listener override_redirect;
+};
+
+struct xwayland_view {
+	struct view base;
+	struct wlr_xwayland_surface *xwayland_surface;
+
+	/* Events unique to XWayland views */
+	struct wl_listener request_configure;
+	struct wl_listener set_app_id;		/* TODO: s/set_app_id/class/ */
+	struct wl_listener set_decorations;
+	struct wl_listener override_redirect;
+
+	/* Not (yet) implemented */
+/*	struct wl_listener set_role; */
+/*	struct wl_listener set_window_type; */
+/*	struct wl_listener set_hints; */
+};
+
+void xwayland_unmanaged_create(struct server *server,
+	struct wlr_xwayland_surface *xsurface, bool mapped);
+
+struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
+
+bool xwayland_apply_size_hints(struct view *view, int *w, int *h);
+void xwayland_move_sub_views_to_front(struct view *parent,
+	void (*move_to_front)(struct view *view));
+
+void xwayland_server_init(struct server *server,
+	struct wlr_compositor *compositor);
+void xwayland_server_finish(struct server *server);
+
+#endif /* HAVE_XWAYLAND */
+#endif /* __LABWC_XWAYLAND_H */

--- a/src/view.c
+++ b/src/view.c
@@ -8,6 +8,7 @@
 #include "ssd.h"
 #include "view.h"
 #include "workspaces.h"
+#include "xwayland.h"
 
 #define LAB_MIN_VIEW_WIDTH  100
 #define LAB_MIN_VIEW_HEIGHT  60

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <assert.h>
+#include <wlr/xwayland.h>
 #include "common/list.h"
 #include "common/mem.h"
 #include "labwc.h"
+#include "xwayland.h"
 
 static void
 unmanaged_handle_request_configure(struct wl_listener *listener, void *data)
@@ -30,7 +32,7 @@ unmanaged_handle_set_geometry(struct wl_listener *listener, void *data)
 	}
 }
 
-void
+static void
 unmanaged_handle_map(struct wl_listener *listener, void *data)
 {
 	struct xwayland_unmanaged *unmanaged =
@@ -140,9 +142,9 @@ unmanaged_handle_request_activate(struct wl_listener *listener, void *data)
 	wlr_log(WLR_DEBUG, "request_activate not handled\n");
 }
 
-struct xwayland_unmanaged *
+void
 xwayland_unmanaged_create(struct server *server,
-			  struct wlr_xwayland_surface *xsurface)
+		struct wlr_xwayland_surface *xsurface, bool mapped)
 {
 	struct xwayland_unmanaged *unmanaged = znew(*unmanaged);
 	unmanaged->server = server;
@@ -170,5 +172,7 @@ xwayland_unmanaged_create(struct server *server,
 		&unmanaged->request_activate);
 	unmanaged->request_activate.notify = unmanaged_handle_request_activate;
 
-	return unmanaged;
+	if (mapped) {
+		unmanaged_handle_map(&unmanaged->map, xsurface);
+	}
 }


### PR DESCRIPTION
- Move xwayland-specific struct definitions to new `xwayland.h` header
- Move `xwayland_move_sub_views_to_front()` from `desktop.c` to `xwayland.c`
- Split out `xwayland_server_init/finish()` from `server_init/finish()`
- Rename `new_xwayland_surface` -> `xwayland_new_surface` and `xwayland_surface_new()` -> `handle_new_surface()` for consistency
- Add `mapped` argument to `xwayland_unmanaged_create()` so that we can make `unmanaged_handle_map()` private to `xwayland-unmanaged.c`