### PR TITLE
layer: improve keyboard-interactivity

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -323,6 +323,7 @@ get_cursor_context(struct server *server)
 		ret.type = LAB_SSD_ROOT;
 		return ret;
 	}
+
 #if HAVE_XWAYLAND
 	if (node->type == WLR_SCENE_NODE_BUFFER) {
 		struct wlr_surface *surface = lab_wlr_surface_from_node(node);
@@ -382,6 +383,9 @@ get_cursor_context(struct server *server)
 		if (node->type == WLR_SCENE_NODE_BUFFER) {
 			struct wlr_surface *surface = lab_wlr_surface_from_node(node);
 			if (surface) {
+				if (wlr_surface_is_layer_surface(surface)) {
+					ret.type = LAB_SSD_LAYER_SURFACE;
+				}
 				if (is_layer_descendant(node)) {
 					/*
 					 * layer-shell subsurfaces need to be


### PR DESCRIPTION
- Process layer-shell keyboard interactivity in the map and commit handlers only, rather than in layers_arrange(). This allows handling of the layer-surface that emitted the event rather than iterating over all surfaces in the output layer-tree, and therefore avoids having to guess which surface should have keyboard preference (and it might not be the last one added to the list which was the assumption previously).

- Prevent seat_focus_surface() from setting keyboard focus if a layer-shell surface with exclusive keyboard-interactivity has the focus.

- Set cursor_context type for layer-surfaces without node-descriptors in order to set keyboard focus correctly in cursor_button_press().

Tested satisfactorily with xfce4-panel and gtk-layer-demo.

Fixes #725 and #704