### PR TITLE
Allow clearing key/mouse bindings

### DIFF
--- a/docs/rc.xml
+++ b/docs/rc.xml
@@ -23,6 +23,13 @@
     <keybind key="W-Return">
       <action name="Execute" command="foot" />
     </keybind>
+    <!--
+      Remove a previously defined keybind
+      A shorter alternative is <keybind key="W-F4" />
+    -->
+    <keybind key="W-F4">
+      <action name="None" />
+    </keybind>
   </keyboard>
 
   <mouse>

--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -28,4 +28,6 @@ struct keybind *keybind_create(const char *keybind);
  */
 uint32_t parse_modifier(const char *symname);
 
+bool keybind_the_same(struct keybind *a, struct keybind *b);
+
 #endif /* __LABWC_KEYBIND_H */

--- a/include/config/mousebind.h
+++ b/include/config/mousebind.h
@@ -48,5 +48,6 @@ enum mouse_event mousebind_event_from_str(const char *str);
 uint32_t mousebind_button_from_str(const char *str, uint32_t *modifiers);
 enum direction mousebind_direction_from_str(const char *str, uint32_t *modifiers);
 struct mousebind *mousebind_create(const char *context);
+bool mousebind_the_same(struct mousebind *a, struct mousebind *b);
 
 #endif /* __LABWC_MOUSEBIND_H */

--- a/src/action.c
+++ b/src/action.c
@@ -157,8 +157,14 @@ action_create(const char *action_name)
 		wlr_log(WLR_ERROR, "action name not specified");
 		return NULL;
 	}
+
+	enum action_type action_type = action_type_from_str(action_name);
+	if (action_type == ACTION_TYPE_NONE) {
+		return NULL;
+	}
+
 	struct action *action = znew(*action);
-	action->type = action_type_from_str(action_name);
+	action->type = action_type;
 	wl_list_init(&action->args);
 	return action;
 }
@@ -444,8 +450,6 @@ actions_run(struct view *activator, struct server *server,
 			} else {
 				wlr_log(WLR_ERROR, "Invalid SnapToRegion id: '%s'", region_name);
 			}
-			break;
-		case ACTION_TYPE_NONE:
 			break;
 		case ACTION_TYPE_INVALID:
 			wlr_log(WLR_ERROR, "Not executing unknown action");

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include <assert.h>
 #include <glib.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -26,13 +27,28 @@ parse_modifier(const char *symname)
 	}
 }
 
+bool
+keybind_the_same(struct keybind *a, struct keybind *b)
+{
+	assert(a && b);
+	if (a->modifiers != b->modifiers || a->keysyms_len != b->keysyms_len) {
+		return false;
+	}
+	for (size_t i = 0; i < a->keysyms_len; i++) {
+		if (a->keysyms[i] != b->keysyms[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+
 struct keybind *
 keybind_create(const char *keybind)
 {
 	struct keybind *k = znew(*k);
 	xkb_keysym_t keysyms[MAX_KEYSYMS];
 	gchar **symnames = g_strsplit(keybind, "-", -1);
-	for (int i = 0; symnames[i]; i++) {
+	for (size_t i = 0; symnames[i]; i++) {
 		char *symname = symnames[i];
 		uint32_t modifier = parse_modifier(symname);
 		if (modifier != 0) {

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -137,6 +137,17 @@ context_from_str(const char *str)
 	return LAB_SSD_NONE;
 }
 
+bool
+mousebind_the_same(struct mousebind *a, struct mousebind *b)
+{
+	assert(a && b);
+	return a->context == b->context
+		&& a->button == b->button
+		&& a->direction == b->direction
+		&& a->mouse_event == b->mouse_event
+		&& a->modifiers == b->modifiers;
+}
+
 struct mousebind *
 mousebind_create(const char *context)
 {

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -81,7 +81,7 @@ static bool
 handle_keybinding(struct server *server, uint32_t modifiers, xkb_keysym_t sym)
 {
 	struct keybind *keybind;
-	wl_list_for_each_reverse(keybind, &rc.keybinds, link) {
+	wl_list_for_each(keybind, &rc.keybinds, link) {
 		if (modifiers ^ keybind->modifiers) {
 			continue;
 		}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -279,7 +279,10 @@ fill_item(char *nodename, char *content)
 		 */
 	} else if (!strcmp(nodename, "name.action")) {
 		current_item_action = action_create(content);
-		wl_list_append(&current_item->actions, &current_item_action->link);
+		if (current_item_action) {
+			wl_list_append(&current_item->actions,
+				&current_item_action->link);
+		}
 	} else if (!current_item_action) {
 		wlr_log(WLR_ERROR, "expect <action name=\"\"> element first. "
 			"nodename: '%s' content: '%s'", nodename, content);


### PR DESCRIPTION
Fixes #567

I did not really test this in depth so draft for now until it received some proper testing.

Changes this PR is doing:
- when creating a `None` action we don't actually create an action at all and just return `NULL` for the action
- we deduplicate keybinds the same as mousebinds (so we also get rid of the `_reverse()` when checking for keybinds + loop over slightly less entries in the keybind list for every key event)
- after the deduplication, all bindings with an empty action list are removed

This means that both of these variants now cause the creation of a keybind without any action which then first replaces all previous binding for the same key and finally gets removed because it has an empty action list, effectively removing an earlier binding set for `W-F4`:
```xml
<keybind key="W-F4" />
<keybind key="W-F4">
	<action name="None" />
</keybind>
```

TODO:
- [x] rename `merge_xxx_bindings()` to `deduplicate_xxx_bindings()`
- [ ] Minor: `merge_mouse_bindings()` and `merge_key_bindings()` are straight up copies of each other but I can't think of an easy way to reuse just one function for both as they operate on different structs, even though we only access the same members. Any hints on how to deduplicate the deduplication functions appreciated. We could use a base `bind` struct as first member of both structs which only carries the `actions` list and `struct wl_list link` + supplying a function pointer for `xxx_the_same()` which would then do the upcast again but I am not sure if its worth it. It would also mean that we have to update all other loops over `rc.xxx_bindings` in labwc as the `link` member changed to `base.link`, same for all users of the bind actions. Another option could be to have `link` and `actions` being the first members in both structs, define a new struct with just these 2 members and then just cast the mouse/keybind structs to that new struct. So something like an overlay struct. That feels really hacky and pretty dirty though.