### PR TITLE
ToggleShowDesktop

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -83,6 +83,9 @@ Actions are used in menus and keyboard/mouse bindings.
 	Send active window to workspace.
 	Supported values are the same as for GoToDesktop.
 
+*<action name="ToggleShowDesktop">*
+	Hide / unhide all windows
+
 *<action name="None">*
 	If used as the only action for a binding: clear an earlier defined binding.
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -129,6 +129,9 @@
     <keybind key="W-a">
       <action name="ToggleMaximize" />
     </keybind>
+    <keybind key="W-d">
+      <action name="ToggleShowDesktop" />
+    </keybind>
     <keybind key="A-Left">
       <action name="MoveToEdge" direction="left" />
     </keybind>

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -363,6 +363,7 @@ void desktop_move_to_front(struct view *view);
 void desktop_move_to_back(struct view *view);
 void desktop_focus_and_activate_view(struct seat *seat, struct view *view);
 void desktop_arrange_all_views(struct server *server);
+void desktop_toggle(struct server *server);
 
 enum lab_cycle_dir {
 	LAB_CYCLE_DIR_NONE,

--- a/src/action.c
+++ b/src/action.c
@@ -59,7 +59,8 @@ enum action_type {
 	ACTION_TYPE_RESIZE,
 	ACTION_TYPE_GO_TO_DESKTOP,
 	ACTION_TYPE_SEND_TO_DESKTOP,
-	ACTION_TYPE_SNAP_TO_REGION
+	ACTION_TYPE_SNAP_TO_REGION,
+	ACTION_TYPE_TOGGLE_SHOW_DESKTOP,
 };
 
 const char *action_names[] = {
@@ -88,6 +89,7 @@ const char *action_names[] = {
 	"GoToDesktop",
 	"SendToDesktop",
 	"SnapToRegion",
+	"ToggleShowDesktop",
 	NULL
 };
 
@@ -445,6 +447,8 @@ actions_run(struct view *activator, struct server *server,
 				wlr_log(WLR_ERROR, "Invalid SnapToRegion id: '%s'", region_name);
 			}
 			break;
+		case ACTION_TYPE_TOGGLE_SHOW_DESKTOP:
+			desktop_toggle(server);
 		case ACTION_TYPE_NONE:
 			break;
 		case ACTION_TYPE_INVALID:

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -567,6 +567,7 @@ static struct {
 	{ "A-F3", "Execute", "bemenu-run" },
 	{ "A-F4", "Close", NULL },
 	{ "W-a", "ToggleMaximize", NULL },
+	{ "W-d", "ToggleShowDesktop", NULL },
 	{ "A-Left", "MoveToEdge", "left" },
 	{ "A-Right", "MoveToEdge", "right" },
 	{ "A-Up", "MoveToEdge", "up" },


### PR DESCRIPTION
Fixes #455 

The main thing to watch out for while testing this is if after pressing `W-d`, random actions correctly restore all windows, namely
- [x] pressing `W-d` again
- [x] opening a new application
- [ ] switching workspaces (only works if there are window on that target workspace)
- [ ] `A-Tab` OSD (works once switched but fails while still in the OSD)
- [x] activating a window via panel
- other?

TODO:
- We should restore all windows when we start the `A-Tab` selection
- We should restore all windows when switching workspaces
- A panel will still show a window being active even though its not even visible anymore. The reason is that we don't have any public way to "disable" a view other than via minimizing or activating a different view. This is an issue:
  - when switching to an empty workspace
  - when toggling show desktop
- There are multiple options to fix that (which should be done in a separate PR):
  - `view_set_activated()` gets a `bool` argument 
  - we have to expose the view internal `_view_set_activated(struct view *view, bool activated)` function
  - we add a new public `view_unset_activated()` function, this would be my favorite as there is only a very limited amount of callers that need this so we don't have to complicate the API for other callers.