### PR TITLE
src/output.c: only overwrite the automatic layout if necessary

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -314,8 +314,13 @@ output_config_apply(struct server *server,
 		}
 
 		if (output_enabled) {
-			wlr_output_layout_move(server->output_layout, o,
-				head->state.x, head->state.y);
+			struct wlr_box pos = {0};
+			wlr_output_layout_get_box(server->output_layout, o, &pos);
+			if (pos.x != head->state.x || pos.y != head->state.y) {
+				/* This overrides the automatic layout */
+				wlr_output_layout_move(server->output_layout, o,
+					head->state.x, head->state.y);
+			}
 		}
 
 		if (need_to_remove) {


### PR DESCRIPTION
The wlroots `wlr_output_layout` provides two different modes of operation:
- automatically
- manually

In automatic mode wlroots reacts to new / removed outputs and resolution
changes and then adjusts the output positions within the layout itself.

The manual mode disables this behavior and thus it is the whole
responsibility of the caller (e.g. us relaying whatever wdisplays /
kanshi provides) to ensure that the layout is somewhat sane. E.g. that
it doesn't have any holes between outputs and there are no overlapping
outputs.

The mode is set for each output individually. To use (and keep using)
the automatic mode, outputs have to be added via the `_add_auto()` variant
(which we do) and they are not allowed to be moved via `_move()` (which
we currently do and thus break the automatic layout).

To fix that, this patch compares the user(tool) supplied position to the
automatically calculated position and only if they differ we call `_move()`. 