### PR TITLE
Enable more compiler warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,13 +19,24 @@ add_project_arguments(
 
 cc = meson.get_compiler('c')
 
-add_project_arguments(cc.get_supported_arguments(
-  [
-    '-Wno-unused-parameter',
-    '-Wundef',
-  ]),
-  language: 'c',
-)
+add_project_arguments(cc.get_supported_arguments([
+  '-Wundef',
+  '-Wlogical-op',
+  '-Wmissing-include-dirs',
+  '-Wold-style-definition',
+  '-Wpointer-arith',
+  '-Winit-self',
+  '-Wstrict-prototypes',
+  '-Wimplicit-fallthrough=2',
+  '-Wendif-labels',
+  '-Wstrict-aliasing=2',
+  '-Woverflow',
+  '-Wmissing-prototypes',
+  '-Walloca',
+  '-Wunused-macros',
+
+  '-Wno-unused-parameter',
+]), language: 'c')
 
 version='"@0@"'.format(meson.project_version())
 git = find_program('git', native: true, required: false)

--- a/src/common/dir.c
+++ b/src/common/dir.c
@@ -73,7 +73,7 @@ build_theme_path(struct ctx *ctx, char *prefix, const char *path)
 	}
 }
 
-char *
+static char *
 find_dir(struct ctx *ctx)
 {
 	char *debug = getenv("LABWC_DEBUG_DIR_CONFIG_AND_THEME");

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <wlr/types/wlr_scene.h>
+#include "common/scene-helpers.h"
 
 struct wlr_scene_rect *
 lab_wlr_scene_get_rect(struct wlr_scene_node *node)

--- a/src/common/string-helpers.c
+++ b/src/common/string-helpers.c
@@ -2,6 +2,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
+#include "common/string-helpers.h"
 
 static void
 rtrim(char **s)

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -530,7 +530,7 @@ rcxml_parse_xml(struct buf *b)
 }
 
 static void
-rcxml_init()
+rcxml_init(void)
 {
 	static bool has_run;
 

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -11,6 +11,7 @@
 #include "common/mem.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"
+#include "config/session.h"
 
 static bool
 isfile(const char *path)
@@ -51,7 +52,7 @@ error:
 	free(value.buf);
 }
 
-void
+static void
 read_environment_file(const char *filename)
 {
 	char *line = NULL;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -515,7 +515,7 @@ cursor_update_focus(struct server *server)
 		/*cursor_has_moved*/ false);
 }
 
-void
+static void
 handle_constraint_commit(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, constraint_commit);
@@ -523,7 +523,7 @@ handle_constraint_commit(struct wl_listener *listener, void *data)
 	assert(constraint->surface = data);
 }
 
-void
+static void
 destroy_constraint(struct wl_listener *listener, void *data)
 {
 	struct constraint *constraint = wl_container_of(listener, constraint,
@@ -621,7 +621,7 @@ cursor_motion(struct wl_listener *listener, void *data)
 	process_cursor_motion(seat->server, event->time_msec);
 }
 
-void
+static void
 cursor_motion_absolute(struct wl_listener *listener, void *data)
 {
 	/*
@@ -890,7 +890,7 @@ cursor_button_release(struct seat *seat, struct wlr_pointer_button_event *event)
 	}
 }
 
-void
+static void
 cursor_button(struct wl_listener *listener, void *data)
 {
 	/*
@@ -943,7 +943,7 @@ compare_delta(const struct wlr_pointer_axis_event *event, double *accum)
 	return 0;
 }
 
-bool
+static bool
 handle_cursor_axis(struct server *server, struct cursor_context *ctx,
 		struct wlr_pointer_axis_event *event)
 {
@@ -989,7 +989,7 @@ handle_cursor_axis(struct server *server, struct cursor_context *ctx,
 	return handled;
 }
 
-void
+static void
 cursor_axis(struct wl_listener *listener, void *data)
 {
 	/*
@@ -1016,7 +1016,7 @@ cursor_axis(struct wl_listener *listener, void *data)
 	}
 }
 
-void
+static void
 cursor_frame(struct wl_listener *listener, void *data)
 {
 	/*

--- a/src/debug.c
+++ b/src/debug.c
@@ -2,6 +2,7 @@
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/scene-helpers.h"
+#include "debug.h"
 #include "labwc.h"
 #include "node.h"
 #include "ssd.h"

--- a/src/key-state.c
+++ b/src/key-state.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include "key-state.h"
 
 #define MAX_PRESSED_KEYS (16)
 

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "config/rcxml.h"
 #include "labwc.h"
+#include "resistance.h"
 #include "view.h"
 
 struct edges {

--- a/src/server.c
+++ b/src/server.c
@@ -160,6 +160,7 @@ server_global_filter(const struct wl_client *client, const struct wl_global *glo
 {
 	const struct wl_interface *iface = wl_global_get_interface(global);
 	struct server *server = (struct server *)data;
+	/* Silence unused var compiler warnings */
 	(void)iface; (void)server;
 
 #if HAVE_XWAYLAND

--- a/src/xbm/tokenize.c
+++ b/src/xbm/tokenize.c
@@ -30,7 +30,7 @@ add_token(enum token_type token_type)
 }
 
 static void
-get_identifier_token()
+get_identifier_token(void)
 {
 	struct token *token = tokens + nr_tokens - 1;
 	token->name[token->pos] = current_buffer_position[0];
@@ -79,7 +79,7 @@ get_number_token(void)
 }
 
 static void
-get_special_char_token()
+get_special_char_token(void)
 {
 	struct token *token = tokens + nr_tokens - 1;
 	token->name[0] = current_buffer_position[0];


### PR DESCRIPTION
Basically just copied over the compiler warning settings from wlroots and fixed those that came up for me.

We might want to keep `-Wmissing-field-initializers` and `-Wmissing-braces` though, wlroots disables these (which is what this PR is doing as well). See https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html for a description of both.

Another candidate to enable: `-Wunused-macros`, it only detects unused defines in `.c` files though.