### PR TITLE
foreign: fix initial leave/enter event bug

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -344,7 +344,6 @@ xdg_toplevel_view_map(struct view *view)
 	if (!view->been_mapped) {
 		struct wlr_xdg_toplevel_requested *requested =
 			&xdg_toplevel_from_view(view)->requested;
-		foreign_toplevel_handle_create(view);
 		view_set_decorations(view, has_ssd(view));
 
 		position_xdg_toplevel_view(view);
@@ -357,6 +356,12 @@ xdg_toplevel_view_map(struct view *view)
 		}
 
 		view_moved(view);
+
+		/*
+		 * Create toplevel handle after initial positioning to ensure
+		 * enter event is sent to the right output
+		 */
+		foreign_toplevel_handle_create(view);
 		view->been_mapped = true;
 	}
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -491,10 +491,6 @@ map(struct view *view)
 		view->scene_node = &tree->node;
 	}
 
-	if (!view->toplevel_handle) {
-		foreign_toplevel_handle_create(view);
-	}
-
 	if (!view->been_mapped) {
 		view_set_decorations(view, want_deco(xwayland_surface));
 
@@ -504,6 +500,10 @@ map(struct view *view)
 
 		view_moved(view);
 		view->been_mapped = true;
+	}
+
+	if (!view->toplevel_handle) {
+		foreign_toplevel_handle_create(view);
 	}
 
 	if (view->ssd_enabled && !view->fullscreen && !view->maximized) {


### PR DESCRIPTION
Create foreign-toplevel-handle after initial view positioning to ensure leave/enter events are sent to the correct output.

Fixes: #744