### PR TITLE
src/foreign.c: refactor

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -73,12 +73,15 @@ struct view {
 
 	struct ssd *ssd;
 
-	struct wlr_foreign_toplevel_handle_v1 *toplevel_handle;
-	struct wl_listener toplevel_handle_request_maximize;
-	struct wl_listener toplevel_handle_request_minimize;
-	struct wl_listener toplevel_handle_request_fullscreen;
-	struct wl_listener toplevel_handle_request_activate;
-	struct wl_listener toplevel_handle_request_close;
+	struct foreign_toplevel {
+		struct wlr_foreign_toplevel_handle_v1 *handle;
+		struct wl_listener maximize;
+		struct wl_listener minimize;
+		struct wl_listener fullscreen;
+		struct wl_listener activate;
+		struct wl_listener close;
+		struct wl_listener destroy;
+	} toplevel;
 
 	struct wl_listener map;
 	struct wl_listener unmap;

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -4,71 +4,71 @@
 #include "workspaces.h"
 
 static void
-handle_toplevel_handle_request_minimize(struct wl_listener *listener, void *data)
+handle_request_minimize(struct wl_listener *listener, void *data)
 {
-	struct view *view = wl_container_of(listener, view,
-		toplevel_handle_request_minimize);
+	struct view *view = wl_container_of(listener, view, toplevel.minimize);
 	struct wlr_foreign_toplevel_handle_v1_minimized_event *event = data;
-	if (view) {
-		view_minimize(view, event->minimized);
-	}
+	view_minimize(view, event->minimized);
 }
 
 static void
-handle_toplevel_handle_request_maximize(struct wl_listener *listener, void *data)
+handle_request_maximize(struct wl_listener *listener, void *data)
 {
-	struct view *view = wl_container_of(listener, view,
-		toplevel_handle_request_maximize);
+	struct view *view = wl_container_of(listener, view, toplevel.maximize);
 	struct wlr_foreign_toplevel_handle_v1_maximized_event *event = data;
-	if (view) {
-		view_maximize(view, event->maximized,
-			/*store_natural_geometry*/ true);
-	}
+	view_maximize(view, event->maximized, /*store_natural_geometry*/ true);
 }
 
 static void
-handle_toplevel_handle_request_fullscreen(struct wl_listener *listener, void *data)
+handle_request_fullscreen(struct wl_listener *listener, void *data)
 {
-	struct view *view = wl_container_of(listener, view,
-		toplevel_handle_request_fullscreen);
+	struct view *view = wl_container_of(listener, view, toplevel.fullscreen);
 	struct wlr_foreign_toplevel_handle_v1_fullscreen_event *event = data;
-	if (view) {
-		view_set_fullscreen(view, event->fullscreen, NULL);
-	}
+	view_set_fullscreen(view, event->fullscreen, NULL);
 }
 
 static void
-handle_toplevel_handle_request_activate(struct wl_listener *listener, void *data)
+handle_request_activate(struct wl_listener *listener, void *data)
 {
-	struct view *view = wl_container_of(listener, view,
-		toplevel_handle_request_activate);
+	struct view *view = wl_container_of(listener, view, toplevel.activate);
 	// struct wlr_foreign_toplevel_handle_v1_activated_event *event = data;
 	/* In a multi-seat world we would select seat based on event->seat here. */
-	if (view) {
-		if (view->workspace != view->server->workspace_current) {
-			workspaces_switch_to(view->workspace);
-		}
-		desktop_focus_and_activate_view(&view->server->seat, view);
-		desktop_move_to_front(view);
+	if (view->workspace != view->server->workspace_current) {
+		workspaces_switch_to(view->workspace);
 	}
+	desktop_focus_and_activate_view(&view->server->seat, view);
+	desktop_move_to_front(view);
 }
 
 static void
-handle_toplevel_handle_request_close(struct wl_listener *listener, void *data)
+handle_request_close(struct wl_listener *listener, void *data)
 {
-	struct view *view = wl_container_of(listener, view,
-		toplevel_handle_request_close);
-	if (view) {
-		view_close(view);
-	}
+	struct view *view = wl_container_of(listener, view, toplevel.close);
+	view_close(view);
+}
+
+static void
+handle_destroy(struct wl_listener *listener, void *data)
+{
+	struct view *view = wl_container_of(listener, view, toplevel.destroy);
+	struct foreign_toplevel *toplevel = &view->toplevel;
+	wl_list_remove(&toplevel->maximize.link);
+	wl_list_remove(&toplevel->minimize.link);
+	wl_list_remove(&toplevel->fullscreen.link);
+	wl_list_remove(&toplevel->activate.link);
+	wl_list_remove(&toplevel->close.link);
+	wl_list_remove(&toplevel->destroy.link);
+	toplevel->handle = NULL;
 }
 
 void
 foreign_toplevel_handle_create(struct view *view)
 {
-	view->toplevel_handle = wlr_foreign_toplevel_handle_v1_create(
+	struct foreign_toplevel *toplevel = &view->toplevel;
+
+	toplevel->handle = wlr_foreign_toplevel_handle_v1_create(
 		view->server->foreign_toplevel_manager);
-	if (!view->toplevel_handle) {
+	if (!toplevel->handle) {
 		wlr_log(WLR_ERROR, "cannot create foreign toplevel handle for (%s)",
 			view_get_string_prop(view, "title"));
 		return;
@@ -80,33 +80,28 @@ foreign_toplevel_handle_create(struct view *view)
 			view_get_string_prop(view, "title"));
 		return;
 	}
-	wlr_foreign_toplevel_handle_v1_output_enter(view->toplevel_handle,
-		wlr_output);
+	wlr_foreign_toplevel_handle_v1_output_enter(toplevel->handle, wlr_output);
 
-	view->toplevel_handle_request_maximize.notify =
-		handle_toplevel_handle_request_maximize;
-	wl_signal_add(&view->toplevel_handle->events.request_maximize,
-		&view->toplevel_handle_request_maximize);
+	toplevel->maximize.notify = handle_request_maximize;
+	wl_signal_add(&toplevel->handle->events.request_maximize,
+		&toplevel->maximize);
 
-	view->toplevel_handle_request_minimize.notify =
-		handle_toplevel_handle_request_minimize;
-	wl_signal_add(&view->toplevel_handle->events.request_minimize,
-		&view->toplevel_handle_request_minimize);
+	toplevel->minimize.notify = handle_request_minimize;
+	wl_signal_add(&toplevel->handle->events.request_minimize,
+		&toplevel->minimize);
 
-	view->toplevel_handle_request_fullscreen.notify =
-		handle_toplevel_handle_request_fullscreen;
-	wl_signal_add(&view->toplevel_handle->events.request_fullscreen,
-		&view->toplevel_handle_request_fullscreen);
+	toplevel->fullscreen.notify = handle_request_fullscreen;
+	wl_signal_add(&toplevel->handle->events.request_fullscreen,
+		&toplevel->fullscreen);
 
-	view->toplevel_handle_request_activate.notify =
-		handle_toplevel_handle_request_activate;
-	wl_signal_add(&view->toplevel_handle->events.request_activate,
-		&view->toplevel_handle_request_activate);
+	toplevel->activate.notify = handle_request_activate;
+	wl_signal_add(&toplevel->handle->events.request_activate,
+		&toplevel->activate);
 
-	view->toplevel_handle_request_close.notify =
-		handle_toplevel_handle_request_close;
-	wl_signal_add(&view->toplevel_handle->events.request_close,
-		&view->toplevel_handle_request_close);
+	toplevel->close.notify = handle_request_close;
+	wl_signal_add(&toplevel->handle->events.request_close,
+		&toplevel->close);
 
-	/* TODO: hook up remaining signals (destroy) */
+	toplevel->destroy.notify = handle_destroy;
+	wl_signal_add(&toplevel->handle->events.destroy, &toplevel->destroy);
 }

--- a/src/view.c
+++ b/src/view.c
@@ -109,9 +109,9 @@ _view_set_activated(struct view *view, bool activated)
 	if (view->impl->set_activated) {
 		view->impl->set_activated(view, activated);
 	}
-	if (view->toplevel_handle) {
+	if (view->toplevel.handle) {
 		wlr_foreign_toplevel_handle_v1_set_activated(
-			view->toplevel_handle, activated);
+			view->toplevel.handle, activated);
 	}
 }
 
@@ -191,9 +191,9 @@ view_minimize(struct view *view, bool minimized)
 	if (view->minimized == minimized) {
 		return;
 	}
-	if (view->toplevel_handle) {
+	if (view->toplevel.handle) {
 		wlr_foreign_toplevel_handle_v1_set_minimized(
-			view->toplevel_handle, minimized);
+			view->toplevel.handle, minimized);
 	}
 	view->minimized = minimized;
 	if (minimized) {
@@ -514,9 +514,9 @@ set_maximized(struct view *view, bool maximized)
 	if (view->impl->maximize) {
 		view->impl->maximize(view, maximized);
 	}
-	if (view->toplevel_handle) {
+	if (view->toplevel.handle) {
 		wlr_foreign_toplevel_handle_v1_set_maximized(
-			view->toplevel_handle, maximized);
+			view->toplevel.handle, maximized);
 	}
 	view->maximized = maximized;
 }
@@ -693,9 +693,9 @@ view_set_fullscreen(struct view *view, bool fullscreen,
 	if (view->impl->set_fullscreen) {
 		view->impl->set_fullscreen(view, fullscreen);
 	}
-	if (view->toplevel_handle) {
+	if (view->toplevel.handle) {
 		wlr_foreign_toplevel_handle_v1_set_fullscreen(
-			view->toplevel_handle, fullscreen);
+			view->toplevel.handle, fullscreen);
 	}
 	if (fullscreen) {
 		/*
@@ -759,18 +759,18 @@ view_adjust_for_layout_change(struct view *view)
 static void
 view_output_enter(struct view *view, struct wlr_output *wlr_output)
 {
-	if (view->toplevel_handle) {
+	if (view->toplevel.handle) {
 		wlr_foreign_toplevel_handle_v1_output_enter(
-			view->toplevel_handle, wlr_output);
+			view->toplevel.handle, wlr_output);
 	}
 }
 
 static void
 view_output_leave(struct view *view, struct wlr_output *wlr_output)
 {
-	if (view->toplevel_handle) {
+	if (view->toplevel.handle) {
 		wlr_foreign_toplevel_handle_v1_output_leave(
-			view->toplevel_handle, wlr_output);
+			view->toplevel.handle, wlr_output);
 	}
 }
 
@@ -990,11 +990,11 @@ view_update_title(struct view *view)
 {
 	assert(view);
 	const char *title = view_get_string_prop(view, "title");
-	if (!view->toplevel_handle || !title) {
+	if (!view->toplevel.handle || !title) {
 		return;
 	}
 	ssd_update_title(view->ssd);
-	wlr_foreign_toplevel_handle_v1_set_title(view->toplevel_handle, title);
+	wlr_foreign_toplevel_handle_v1_set_title(view->toplevel.handle, title);
 }
 
 void
@@ -1002,11 +1002,11 @@ view_update_app_id(struct view *view)
 {
 	assert(view);
 	const char *app_id = view_get_string_prop(view, "app_id");
-	if (!view->toplevel_handle || !app_id) {
+	if (!view->toplevel.handle || !app_id) {
 		return;
 	}
 	wlr_foreign_toplevel_handle_v1_set_app_id(
-		view->toplevel_handle, app_id);
+		view->toplevel.handle, app_id);
 }
 
 void
@@ -1026,8 +1026,8 @@ view_destroy(struct view *view)
 	struct server *server = view->server;
 	bool need_cursor_update = false;
 
-	if (view->toplevel_handle) {
-		wlr_foreign_toplevel_handle_v1_destroy(view->toplevel_handle);
+	if (view->toplevel.handle) {
+		wlr_foreign_toplevel_handle_v1_destroy(view->toplevel.handle);
 	}
 
 	if (server->grabbed_view == view) {

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -185,9 +185,9 @@ handle_unmap(struct wl_listener *listener, void *data)
 	 * foreign-toplevel protocol to avoid panels and the like still showing
 	 * them.
 	 */
-	if (view->toplevel_handle) {
-		wlr_foreign_toplevel_handle_v1_destroy(view->toplevel_handle);
-		view->toplevel_handle = NULL;
+	if (view->toplevel.handle) {
+		wlr_foreign_toplevel_handle_v1_destroy(view->toplevel.handle);
+		view->toplevel.handle = NULL;
 	}
 }
 
@@ -491,7 +491,7 @@ map(struct view *view)
 		view->scene_node = &tree->node;
 	}
 
-	if (!view->toplevel_handle) {
+	if (!view->toplevel.handle) {
 		foreign_toplevel_handle_create(view);
 	}
 


### PR DESCRIPTION
I have a another branch waiting that depends on this PR which moves the foreign-toplevel output notifications over to the scene graph emitted events.

Only actual change besides some refactoring:
- implement the `destroy` handler (which just removes the event listeners, required for the follow up PR).