### PR TITLE
src/foreign.c: track outputs

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -345,6 +345,7 @@ void xdg_toplevel_decoration(struct wl_listener *listener, void *data);
 void xdg_surface_new(struct wl_listener *listener, void *data);
 
 void foreign_toplevel_handle_create(struct view *view);
+void foreign_toplevel_update_outputs(struct view *view);
 
 /*
  * desktop.c routines deal with a collection of views

--- a/include/view.h
+++ b/include/view.h
@@ -121,8 +121,6 @@ void view_move_resize(struct view *view, struct wlr_box geo);
 void view_move(struct view *view, int x, int y);
 void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
-/* view_wlr_output - return the output that a view is mostly on */
-struct wlr_output *view_wlr_output(struct view *view);
 void view_store_natural_geometry(struct view *view);
 void view_center(struct view *view);
 void view_restore_to(struct view *view, struct wlr_box geometry);

--- a/src/view.c
+++ b/src/view.c
@@ -220,7 +220,7 @@ view_minimize(struct view *view, bool minimized)
 }
 
 /* view_wlr_output - return the output that a view is mostly on */
-struct wlr_output *
+static struct wlr_output *
 view_wlr_output(struct view *view)
 {
 	assert(view);

--- a/src/view.c
+++ b/src/view.c
@@ -156,6 +156,9 @@ view_moved(struct view *view)
 	view_discover_output(view);
 	ssd_update_geometry(view->ssd);
 	cursor_update_focus(view->server);
+	if (view->toplevel.handle) {
+		foreign_toplevel_update_outputs(view);
+	}
 }
 
 /* N.B. Use view_move() if not resizing. */
@@ -754,23 +757,8 @@ view_adjust_for_layout_change(struct view *view)
 			view_center(view);
 		}
 	}
-}
-
-static void
-view_output_enter(struct view *view, struct wlr_output *wlr_output)
-{
 	if (view->toplevel.handle) {
-		wlr_foreign_toplevel_handle_v1_output_enter(
-			view->toplevel.handle, wlr_output);
-	}
-}
-
-static void
-view_output_leave(struct view *view, struct wlr_output *wlr_output)
-{
-	if (view->toplevel.handle) {
-		wlr_foreign_toplevel_handle_v1_output_leave(
-			view->toplevel.handle, wlr_output);
+		foreign_toplevel_update_outputs(view);
 	}
 }
 
@@ -783,24 +771,13 @@ void
 view_discover_output(struct view *view)
 {
 	assert(view);
-	struct output *old_output = view->output;
-	struct output *new_output = view_output(view);
-	if (old_output != new_output) {
-		view->output = new_output;
-		if (new_output) {
-			view_output_enter(view, new_output->wlr_output);
-		}
-		if (old_output) {
-			view_output_leave(view, old_output->wlr_output);
-		}
-	}
+	view->output = view_output(view);
 }
 
 void
 view_on_output_destroy(struct view *view)
 {
 	assert(view);
-	view_output_leave(view, view->output->wlr_output);
 	view->output = NULL;
 }
 


### PR DESCRIPTION
This is the 2nd iteration, the 1st one (using the `wlr_scene_buffer` `output_enter` / `output_leave` events) doesn't work because it will send an `output_leave` event whenever the window is completely occluded. It also required setting up a "click-through" `wlr_scene_buffer` on top of the view which required that its size kept getting synchronized with the actual view size.

This version now simply loops over all outputs and notifies the wlroots foreign_toplevel implementation about the current state.

The wlroots implementation takes care of
- de-duplicating the events (e.g. not send `output_enter` for the same output twice)
- listening to output destroy events, sending `output_leave` if the output was entered before

Benefits over our current implementation:
- will detect all outputs the view is on, not just the primary one
- will be called when
  - the view changed its position or size (including for maximize, fullscreen, tiling)
  - the output layout changes (e.g. the view position is still the same but now rendered on a different output)
  - completely separate from our window positioning / evacuation logic, that one tries to find the closest output (often the same as the one the window is mainly on) while we want to find all outputs intersecting the current window position / size here