### PR TITLE
Refactor view implementations following PR #720

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -365,7 +365,6 @@ void foreign_toplevel_update_outputs(struct view *view);
  *              cannot assume this means that the window actually has keyboard
  *              or pointer focus, in this compositor are they called together.
  */
-
 void desktop_move_to_front(struct view *view);
 void desktop_move_to_back(struct view *view);
 void desktop_focus_and_activate_view(struct seat *seat, struct view *view);

--- a/include/view-impl-common.h
+++ b/include/view-impl-common.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LABWC_VIEW_IMPL_COMMON_H
+#define __LABWC_VIEW_IMPL_COMMON_H
+/*
+ * Common code for view->impl functions
+ *
+ * Please note: only xdg-shell-toplevel-view and xwayland-view view_impl
+ * functions should call these functions.
+ */
+
+void view_impl_move_to_front(struct view *view);
+void view_impl_map(struct view *view);
+
+#endif /* __LABWC_VIEW_IMPL_COMMON_H */

--- a/include/view.h
+++ b/include/view.h
@@ -30,6 +30,7 @@ struct view_impl {
 	void (*set_fullscreen)(struct view *view, bool fullscreen);
 	void (*unmap)(struct view *view);
 	void (*maximize)(struct view *view, bool maximize);
+	void (*move_to_front)(struct view *view);
 };
 
 struct view {
@@ -162,7 +163,6 @@ void view_update_title(struct view *view);
 void view_update_app_id(struct view *view);
 void view_reload_ssd(struct view *view);
 
-void view_impl_map(struct view *view);
 void view_adjust_size(struct view *view, int *w, int *h);
 
 void view_evacuate_region(struct view *view);

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -45,8 +45,6 @@ void xwayland_unmanaged_create(struct server *server,
 struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
 
 bool xwayland_apply_size_hints(struct view *view, int *w, int *h);
-void xwayland_move_sub_views_to_front(struct view *parent,
-	void (*move_to_front)(struct view *view));
 
 void xwayland_server_init(struct server *server,
 	struct wlr_compositor *compositor);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -12,25 +12,16 @@
 #include "workspaces.h"
 #include "xwayland.h"
 
-static void
-move_to_front(struct view *view)
-{
-	wl_list_remove(&view->link);
-	wl_list_insert(&view->server->views, &view->link);
-	wlr_scene_node_raise_to_top(&view->scene_tree->node);
-}
-
 void
 desktop_move_to_front(struct view *view)
 {
 	if (!view) {
 		return;
 	}
-	move_to_front(view);
-#if HAVE_XWAYLAND
-	xwayland_move_sub_views_to_front(view, move_to_front);
-#endif
-	cursor_update_focus(view->server);
+	if (view->impl->move_to_front) {
+		view->impl->move_to_front(view);
+		cursor_update_focus(view->server);
+	}
 }
 
 void

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -6,6 +6,7 @@
 #include "key-state.h"
 #include "labwc.h"
 #include "regions.h"
+#include "view.h"
 #include "workspaces.h"
 
 static bool should_cancel_cycling_on_next_key_release;

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,7 +21,7 @@ labwc_sources = files(
   'touch.c',
   'theme.c',
   'view.c',
-  'view-impl.c',
+  'view-impl-common.c',
   'workspaces.c',
   'xdg.c',
   'xdg-deco.c',

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -1,16 +1,24 @@
 // SPDX-License-Identifier: GPL-2.0-only
-/* view-impl.c: common code for shell view->impl functions */
+/* view-impl-common.c: common code for shell view->impl functions */
 #include <stdio.h>
 #include <strings.h>
 #include "labwc.h"
 #include "view.h"
+#include "view-impl-common.h"
+
+void
+view_impl_move_to_front(struct view *view)
+{
+	wl_list_remove(&view->link);
+	wl_list_insert(&view->server->views, &view->link);
+	wlr_scene_node_raise_to_top(&view->scene_tree->node);
+}
 
 void
 view_impl_map(struct view *view)
 {
 	desktop_focus_and_activate_view(&view->server->seat, view);
 	desktop_move_to_front(view);
-
 	view_update_title(view);
 	view_update_app_id(view);
 }

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -4,6 +4,7 @@
 #include "labwc.h"
 #include "node.h"
 #include "view.h"
+#include "view-impl-common.h"
 #include "workspaces.h"
 
 struct wlr_xdg_surface *
@@ -389,6 +390,7 @@ static const struct view_impl xdg_toplevel_view_impl = {
 	.set_fullscreen = xdg_toplevel_view_set_fullscreen,
 	.unmap = xdg_toplevel_view_unmap,
 	.maximize = xdg_toplevel_view_maximize,
+	.move_to_front = view_impl_move_to_front,
 };
 
 void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -245,7 +245,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 }
 
 static void
-configure(struct view *view, struct wlr_box geo)
+xwayland_view_configure(struct view *view, struct wlr_box geo)
 {
 	view->pending = geo;
 	wlr_xwayland_surface_configure(xwayland_surface_from_view(view),
@@ -272,7 +272,8 @@ handle_request_configure(struct wl_listener *listener, void *data)
 	int height = event->height;
 	view_adjust_size(view, &width, &height);
 
-	configure(view, (struct wlr_box){event->x, event->y, width, height});
+	xwayland_view_configure(view,
+		(struct wlr_box){event->x, event->y, width, height});
 }
 
 static void
@@ -340,13 +341,13 @@ handle_set_class(struct wl_listener *listener, void *data)
 }
 
 static void
-_close(struct view *view)
+xwayland_view_close(struct view *view)
 {
 	wlr_xwayland_surface_close(xwayland_surface_from_view(view));
 }
 
 static const char *
-get_string_prop(struct view *view, const char *prop)
+xwayland_view_get_string_prop(struct view *view, const char *prop)
 {
 	struct wlr_xwayland_surface *xwayland_surface =
 		xwayland_surface_from_view(view);
@@ -425,7 +426,7 @@ top_left_edge_boundary_check(struct view *view)
 }
 
 static void
-map(struct view *view)
+xwayland_view_map(struct view *view)
 {
 	if (view->mapped) {
 		return;
@@ -494,7 +495,7 @@ map(struct view *view)
 }
 
 static void
-unmap(struct view *view)
+xwayland_view_unmap(struct view *view)
 {
 	if (!view->mapped) {
 		return;
@@ -506,7 +507,7 @@ unmap(struct view *view)
 }
 
 static void
-maximize(struct view *view, bool maximized)
+xwayland_view_maximize(struct view *view, bool maximized)
 {
 	wlr_xwayland_surface_set_maximized(xwayland_surface_from_view(view),
 		maximized);
@@ -544,14 +545,14 @@ move_sub_views_to_front(struct view *parent)
 }
 
 static void
-move_to_front(struct view *view)
+xwayland_view_move_to_front(struct view *view)
 {
 	view_impl_move_to_front(view);
 	move_sub_views_to_front(view);
 }
 
 static void
-set_activated(struct view *view, bool activated)
+xwayland_view_set_activated(struct view *view, bool activated)
 {
 	struct wlr_xwayland_surface *xwayland_surface =
 		xwayland_surface_from_view(view);
@@ -575,22 +576,22 @@ set_activated(struct view *view, bool activated)
 }
 
 static void
-set_fullscreen(struct view *view, bool fullscreen)
+xwayland_view_set_fullscreen(struct view *view, bool fullscreen)
 {
 	wlr_xwayland_surface_set_fullscreen(xwayland_surface_from_view(view),
 		fullscreen);
 }
 
-static const struct view_impl xwl_view_impl = {
-	.configure = configure,
-	.close = _close,
-	.get_string_prop = get_string_prop,
-	.map = map,
-	.set_activated = set_activated,
-	.set_fullscreen = set_fullscreen,
-	.unmap = unmap,
-	.maximize = maximize,
-	.move_to_front = move_to_front,
+static const struct view_impl xwayland_view_impl = {
+	.configure = xwayland_view_configure,
+	.close = xwayland_view_close,
+	.get_string_prop = xwayland_view_get_string_prop,
+	.map = xwayland_view_map,
+	.set_activated = xwayland_view_set_activated,
+	.set_fullscreen = xwayland_view_set_fullscreen,
+	.unmap = xwayland_view_unmap,
+	.maximize = xwayland_view_maximize,
+	.move_to_front = xwayland_view_move_to_front,
 };
 
 static void
@@ -615,7 +616,7 @@ handle_new_surface(struct wl_listener *listener, void *data)
 
 	view->server = server;
 	view->type = LAB_XWAYLAND_VIEW;
-	view->impl = &xwl_view_impl;
+	view->impl = &xwayland_view_impl;
 
 	/*
 	 * Set two-way view <-> xsurface association.  Usually the


### PR DESCRIPTION
Ref: https://github.com/labwc/labwc/pull/720#issuecomment-1374831834

- [x] Add view `move_to_front` method to avoid passing a function pointer as a function argument and to keep xwayland specific code in one place.
- [x] Prefix xwayland view_impl functions with `xwayland_view_`

Do later:

- Add view_impl apply_size_constraints to replace `xwayland.c`'s `xwayland_apply_size_hints()`
- `s/xwayland_server_init/xwayland_init/`
- `{xwayland,xdg_toplevel}_view_unmap()` code is the same. Move to `view-impl-common.c`
- ~~Move desktop_move_to_back() to view.c for consistency~~
