### PR TITLE
xwayland: Fix size issue when starting VLC fullscreen

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -106,6 +106,13 @@ struct xdg_toplevel_view {
 	struct wl_listener new_popup;
 };
 
+static inline bool
+view_is_floating(struct view *view)
+{
+	return !view->fullscreen && !view->maximized && !view->tiled
+		&& !view->tiled_region;
+}
+
 void view_set_activated(struct view *view);
 void view_close(struct view *view);
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -280,6 +280,20 @@ handle_request_configure(struct wl_listener *listener, void *data)
 	int height = event->height;
 	view_adjust_size(view, &width, &height);
 
+	/*
+	 * If a configure request is received while maximized/
+	 * fullscreen/tiled, update the natural geometry only. This
+	 * appears to be the desired behavior e.g. when starting VLC in
+	 * fullscreen mode.
+	 */
+	if (!view_is_floating(view)) {
+		view->natural_geometry.x = event->x;
+		view->natural_geometry.y = event->y;
+		view->natural_geometry.width = width;
+		view->natural_geometry.height = height;
+		return;
+	}
+
 	configure(view, (struct wlr_box){event->x, event->y, width, height});
 }
 


### PR DESCRIPTION
This fixes an issue when starting VLC in fullscreen mode (using XWayland). The VLC window would end up much smaller than the full screen, but undecorated.

The immediate cause appears to be that labwc receives, for the VLC view, a `request_fullscreen` event followed by a `request_configure` event (with the non-fullscreen geometry). I am not certain if this is the order VLC is actually sending the events, or if they get received out-of-order for some reason.

Anyway, the intent (judging from the behavior under Openbox) appears to be that the geometry sent via the `request_configure` event should be the natural geometry of the VLC window if/when VLC eventually leaves fullscreen mode.

Misc. notes:
- `view_is_floating()` is separate because I imagine that it may be useful in other places as well - in fact, it has been already been useful in some other changes I have been working on locally (not yet ready for review).
- Further changes are needed to correctly save the natural geometry in the general case, for applications that start fullscreen or maximized -- I have this working (for XWayland) and will submit it in a separate pull request,