### PR TITLE
xdg: Pending move/resize logic fixes

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -65,7 +65,6 @@ struct view {
 	struct wlr_box natural_geometry;
 
 	struct view_pending_move_resize {
-		bool update_x, update_y;
 		int x, y;
 		uint32_t width, height;
 		uint32_t configure_serial;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -227,6 +227,11 @@ xdg_toplevel_view_move(struct view *view, int x, int y)
 {
 	view->x = x;
 	view->y = y;
+
+	/* override any previous pending move */
+	view->pending_move_resize.x = x;
+	view->pending_move_resize.y = y;
+
 	view_moved(view);
 }
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -76,12 +76,12 @@ handle_commit(struct wl_listener *listener, void *data)
 
 	uint32_t serial = view->pending_move_resize.configure_serial;
 	if (serial > 0 && serial >= xdg_surface->current.configure_serial) {
-		if (view->pending_move_resize.update_x) {
+		if (view->x != view->pending_move_resize.x) {
 			update_required = true;
 			view->x = view->pending_move_resize.x +
 				view->pending_move_resize.width - size.width;
 		}
-		if (view->pending_move_resize.update_y) {
+		if (view->y != view->pending_move_resize.y) {
 			update_required = true;
 			view->y = view->pending_move_resize.y +
 				view->pending_move_resize.height - size.height;
@@ -205,8 +205,6 @@ xdg_toplevel_view_configure(struct view *view, struct wlr_box geo)
 {
 	view_adjust_size(view, &geo.width, &geo.height);
 
-	view->pending_move_resize.update_x = geo.x != view->x;
-	view->pending_move_resize.update_y = geo.y != view->y;
 	view->pending_move_resize.x = geo.x;
 	view->pending_move_resize.y = geo.y;
 	view->pending_move_resize.width = geo.width;


### PR DESCRIPTION
The pending move/resize logic in `xwayland.c` saw some fixes a while back in 80792d446f64a7ed01b04e39e11018b904413533 and 065c37d3f5eed86dc218c9722e245fa5fda9bd75. Portions of those fixes should have been applied to `xdg.c` as well. So I'm (very) belatedly circling back to make the logic in `xdg.c` consistent.

This removes the last use of the `pending_move_resize.update_x/y` flags, which can now be removed.

Please see commit messages for details.