### PR TITLE
view: Use pending geometry for positioning logic

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -169,9 +169,6 @@ void view_reload_ssd(struct view *view);
 void view_impl_map(struct view *view);
 void view_adjust_size(struct view *view, int *w, int *h);
 
-bool view_compute_centered_position(struct view *view, int w, int h,
-	int *x, int *y);
-
 void view_on_output_destroy(struct view *view);
 void view_destroy(struct view *view);
 

--- a/src/view.c
+++ b/src/view.c
@@ -243,7 +243,7 @@ view_output(struct view *view)
 	return output_from_wlr_output(view->server, wlr_output);
 }
 
-bool
+static bool
 view_compute_centered_position(struct view *view, int w, int h, int *x, int *y)
 {
 	struct output *output = view_output(view);

--- a/src/view.c
+++ b/src/view.c
@@ -310,10 +310,10 @@ view_store_natural_geometry(struct view *view)
 	 * natural_geometry width/height may still be zero in which case we set
 	 * some fallback values. This is the case with foot and Qt applications.
 	 */
-	if (wlr_box_empty(&view->current)) {
+	if (wlr_box_empty(&view->pending)) {
 		set_fallback_geometry(view);
 	} else {
-		view->natural_geometry = view->current;
+		view->natural_geometry = view->pending;
 	}
 }
 
@@ -322,8 +322,8 @@ view_center(struct view *view)
 {
 	assert(view);
 	int x, y;
-	if (view_compute_centered_position(view, view->current.width,
-			view->current.height, &x, &y)) {
+	if (view_compute_centered_position(view, view->pending.width,
+			view->pending.height, &x, &y)) {
 		view_move(view, x, y);
 	}
 }
@@ -417,8 +417,8 @@ view_apply_region_geometry(struct view *view)
 	geo.width -= margin.left + margin.right;
 	geo.height -= margin.top + margin.bottom;
 
-	if (view->current.width == geo.width
-			&& view->current.height == geo.height) {
+	if (view->pending.width == geo.width
+			&& view->pending.height == geo.height) {
 		/* move horizontally/vertically without changing size */
 		view_move(view, geo.x, geo.y);
 	} else {
@@ -439,8 +439,8 @@ view_apply_tiled_geometry(struct view *view, struct output *output)
 	}
 
 	struct wlr_box dst = view_get_edge_snap_box(view, output, view->tiled);
-	if (view->current.width == dst.width
-			&& view->current.height == dst.height) {
+	if (view->pending.width == dst.width
+			&& view->pending.height == dst.height) {
 		/* move horizontally/vertically without changing size */
 		view_move(view, dst.x, dst.y);
 	} else {
@@ -755,7 +755,7 @@ view_adjust_for_layout_change(struct view *view)
 	} else if (!view_apply_special_geometry(view)) {
 		/* reposition view if it's offscreen */
 		if (!wlr_output_layout_intersects(layout, NULL,
-				&view->current)) {
+				&view->pending)) {
 			view_center(view);
 		}
 	}
@@ -811,17 +811,17 @@ view_move_to_edge(struct view *view, const char *direction)
 	int x = 0, y = 0;
 	if (!strcasecmp(direction, "left")) {
 		x = usable.x + margin.left + rc.gap;
-		y = view->current.y;
+		y = view->pending.y;
 	} else if (!strcasecmp(direction, "up")) {
-		x = view->current.x;
+		x = view->pending.x;
 		y = usable.y + margin.top + rc.gap;
 	} else if (!strcasecmp(direction, "right")) {
-		x = usable.x + usable.width - view->current.width
+		x = usable.x + usable.width - view->pending.width
 			- margin.right - rc.gap;
-		y = view->current.y;
+		y = view->pending.y;
 	} else if (!strcasecmp(direction, "down")) {
-		x = view->current.x;
-		y = usable.y + usable.height - view->current.height
+		x = view->pending.x;
+		y = usable.y + usable.height - view->pending.height
 			- margin.bottom - rc.gap;
 	} else {
 		wlr_log(WLR_ERROR, "invalid edge");

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -348,6 +348,14 @@ xdg_toplevel_view_map(struct view *view)
 		foreign_toplevel_handle_create(view);
 		view_set_decorations(view, has_ssd(view));
 
+		/*
+		 * Set initial "pending" dimensions (may be modified by
+		 * view_set_fullscreen/view_maximize() below). "Current"
+		 * dimensions remain zero until handle_commit().
+		 */
+		view->pending.width = xdg_surface->current.geometry.width;
+		view->pending.height = xdg_surface->current.geometry.height;
+
 		position_xdg_toplevel_view(view);
 		if (!view->fullscreen && requested->fullscreen) {
 			view_set_fullscreen(view, true,

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -284,20 +284,7 @@ position_xdg_toplevel_view(struct view *view)
 			output_usable_area_from_cursor_coords(view->server);
 		view->current.x = box.x;
 		view->current.y = box.y;
-
-		/* Center the view without touching its w and h fields. This means we
-		 * can't simply set w/h and call view_center().  w and h fields should
-		 * only be modified at commit, or they will not be in sync with the
-		 * scene tree
-		 */
-		int w = xdg_surface->current.geometry.width;
-		int h = xdg_surface->current.geometry.height;
-		if (w && h) {
-			int x, y;
-			if (view_compute_centered_position(view, w, h, &x, &y)) {
-				view_move(view, x, y);
-			}
-		}
+		view_center(view);
 	} else {
 		/*
 		 * If child-toplevel-views, we center-align relative to their


### PR DESCRIPTION
- Make sure that `view->pending_move_resize` is always up-to-date for mapped views
- Use `view->pending_move_resize` rather than `view->x/y/w/h` for view positioning logic

By using the pending (most recently requested) dimensions instead of the current (displayed) dimensions of the view for positioning logic, we can avoid race conditions that might occur if we try to reposition a view while there is a pending move/resize that has not been processed yet.

This *should* fix #671 (I have not verified the fix since reproducing the issue looks quite involved).

It also greatly simplifies the logic that was committed in #680 since we can now use `view_center()` again, still without touching `view->w/h` before commit. I did test that there is no regression of that fix.