### PR TITLE
view: Use wlr_box for current/pending geometry

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -2,6 +2,7 @@
 #ifndef __LABWC_SSD_INTERNAL_H
 #define __LABWC_SSD_INTERNAL_H
 
+#include <wlr/util/box.h>
 #include "ssd.h"
 
 #define FOR_EACH(tmp, ...) \
@@ -40,10 +41,7 @@ struct ssd {
 	 * don't update things we don't have to.
 	 */
 	struct {
-		int x;
-		int y;
-		int width;
-		int height;
+		struct wlr_box geometry;
 		struct ssd_state_title {
 			char *text;
 			struct ssd_state_title_width active;
@@ -51,7 +49,7 @@ struct ssd {
 		} title;
 	} state;
 
-	/* An invisble area around the view which allows resizing */
+	/* An invisible area around the view which allows resizing */
 	struct ssd_sub_tree extents;
 
 	/* The top of the view, containing buttons, title, .. */

--- a/include/view.h
+++ b/include/view.h
@@ -58,17 +58,28 @@ struct view {
 
 	struct wlr_output *fullscreen;
 
-	/* geometry of the wlr_surface contained within the view */
-	int x, y, w, h;
-
-	/* user defined geometry before maximize / tiling / fullscreen */
+	/*
+	 * Geometry of the wlr_surface contained within the view, as
+	 * currently displayed. Should be kept in sync with the
+	 * scene-graph at all times.
+	 */
+	struct wlr_box current;
+	/*
+	 * Expected geometry after any pending move/resize requests
+	 * have been processed. Should match current geometry when no
+	 * move/resize requests are pending.
+	 */
+	struct wlr_box pending;
+	/*
+	 * Saved geometry which will be restored when the view returns
+	 * to normal/floating state after being maximized/fullscreen/
+	 * tiled. Values are undefined/out-of-date when the view is not
+	 * maximized/fullscreen/tiled.
+	 */
 	struct wlr_box natural_geometry;
 
-	struct view_pending_move_resize {
-		int x, y;
-		uint32_t width, height;
-		uint32_t configure_serial;
-	} pending_move_resize;
+	/* used by xdg-shell views */
+	uint32_t pending_configure_serial;
 
 	struct ssd *ssd;
 

--- a/src/action.c
+++ b/src/action.c
@@ -214,8 +214,8 @@ show_menu(struct server *server, struct view *view, const char *menu_name)
 
 	int x, y;
 	if (force_menu_top_left) {
-		x = view->x;
-		y = view->y;
+		x = view->current.x;
+		y = view->current.y;
 	} else {
 		x = server->seat.cursor->x;
 		y = server->seat.cursor->y;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -210,9 +210,7 @@ process_cursor_resize(struct server *server, uint32_t time)
 	double dy = server->seat.cursor->y - server->grab_y;
 
 	struct view *view = server->grabbed_view;
-	struct wlr_box new_view_geo = {
-		.x = view->x, .y = view->y, .width = view->w, .height = view->h
-	};
+	struct wlr_box new_view_geo = view->current;
 
 	if (server->resize_edges & WLR_EDGE_TOP) {
 		new_view_geo.height = server->grab_box.height - dy;
@@ -320,8 +318,8 @@ process_cursor_motion_out_of_surface(struct server *server, uint32_t time)
 	int lx, ly;
 
 	if (view) {
-		lx = view->x;
-		ly = view->y;
+		lx = view->current.x;
+		ly = view->current.y;
 	} else if (node && wlr_surface_is_layer_surface(surface)) {
 		wlr_scene_node_coords(node, &lx, &ly);
 #if HAVE_XWAYLAND
@@ -435,11 +433,12 @@ cursor_get_resize_edges(struct wlr_cursor *cursor, struct cursor_context *ctx)
 {
 	uint32_t resize_edges = ssd_resize_edges(ctx->type);
 	if (ctx->view && !resize_edges) {
+		struct wlr_box box = ctx->view->current;
 		resize_edges |=
-			(int)cursor->x < ctx->view->x + ctx->view->w / 2 ?
+			(int)cursor->x < box.x + box.width / 2 ?
 				WLR_EDGE_LEFT : WLR_EDGE_RIGHT;
 		resize_edges |=
-			(int)cursor->y < ctx->view->y + ctx->view->h / 2 ?
+			(int)cursor->y < box.y + box.height / 2 ?
 				WLR_EDGE_TOP : WLR_EDGE_BOTTOM;
 	}
 	return resize_edges;

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -111,7 +111,7 @@ foreign_toplevel_update_outputs(struct view *view)
 {
 	assert(view->toplevel.handle);
 
-	struct wlr_box view_geo = { view->x, view->y, view->w, view->h };
+	struct wlr_box view_geo = view->current;
 	struct wlr_output_layout *layout = view->server->output_layout;
 
 	struct output *output;

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -26,12 +26,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 	 */
 	struct server *server = view->server;
 	struct seat *seat = &server->seat;
-	struct wlr_box geometry = {
-		.x = view->x,
-		.y = view->y,
-		.width = view->w,
-		.height = view->h
-	};
+	struct wlr_box geometry = view->current;
 
 	switch (mode) {
 	case LAB_INPUT_STATE_MOVE:
@@ -52,10 +47,12 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 			 * to keep it (in the snap-to-maximize case).
 			 */
 			geometry = view->natural_geometry;
-			geometry.x = max_move_scale(seat->cursor->x, view->x,
-				view->w, geometry.width);
-			geometry.y = max_move_scale(seat->cursor->y, view->y,
-				view->h, geometry.height);
+			geometry.x = max_move_scale(seat->cursor->x,
+				view->current.x, view->current.width,
+				geometry.width);
+			geometry.y = max_move_scale(seat->cursor->y,
+				view->current.y, view->current.height,
+				geometry.height);
 			view_restore_to(view, geometry);
 		} else {
 			/* Store natural geometry at start of move */

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -37,10 +37,9 @@ resistance_move_apply(struct view *view, double *x, double *y)
 {
 	struct server *server = view->server;
 	struct wlr_box mgeom, intersection;
-	struct wlr_box vgeom = {.x = view->x, .y = view->y, .width = view->w,
-		.height = view->h};
-	struct wlr_box tgeom = {.x = *x, .y = *y, .width = view->w,
-		.height = view->h};
+	struct wlr_box vgeom = view->current;
+	struct wlr_box tgeom = {.x = *x, .y = *y, .width = vgeom.width,
+		.height = vgeom.height};
 	struct output *output;
 	struct border border = ssd_get_margin(view->ssd);
 	struct edges view_edges; /* The edges of the current view */
@@ -48,15 +47,15 @@ resistance_move_apply(struct view *view, double *x, double *y)
 	struct edges other_edges; /* The edges of the monitor/other view */
 	struct edges flags = { 0 };
 
-	view_edges.left = view->x - border.left + 1;
-	view_edges.top = view->y - border.top + 1;
-	view_edges.right = view->x + view->w + border.right;
-	view_edges.bottom = view->y + view->h + border.bottom;
+	view_edges.left = vgeom.x - border.left + 1;
+	view_edges.top = vgeom.y - border.top + 1;
+	view_edges.right = vgeom.x + vgeom.width + border.right;
+	view_edges.bottom = vgeom.y + vgeom.height + border.bottom;
 
 	target_edges.left = *x - border.left;
 	target_edges.top = *y - border.top;
-	target_edges.right = *x + view->w + border.right;
-	target_edges.bottom = *y + view->h + border.bottom;
+	target_edges.right = *x + vgeom.width + border.right;
+	target_edges.bottom = *y + vgeom.height + border.bottom;
 
 	if (!rc.screen_edge_strength) {
 		return;
@@ -86,13 +85,13 @@ resistance_move_apply(struct view *view, double *x, double *y)
 		if (flags.left == 1) {
 			*x = other_edges.left + border.left;
 		} else if (flags.right == 1) {
-			*x = other_edges.right - view->w - border.right;
+			*x = other_edges.right - vgeom.width - border.right;
 		}
 
 		if (flags.top == 1) {
 			*y = other_edges.top + border.top;
 		} else if (flags.bottom == 1) {
-			*y = other_edges.bottom - view->h - border.bottom;
+			*y = other_edges.bottom - vgeom.height - border.bottom;
 		}
 
 		/* reset the flags */
@@ -109,20 +108,18 @@ resistance_resize_apply(struct view *view, struct wlr_box *new_view_geo)
 	struct server *server = view->server;
 	struct output *output;
 	struct wlr_box mgeom, intersection;
-	struct wlr_box vgeom = {.x = view->x, .y = view->y, .width = view->w,
-		.height = view->h};
-	struct wlr_box tgeom = {.x = new_view_geo->x, .y = new_view_geo->y,
-		.width = new_view_geo->width, .height = new_view_geo->height};
+	struct wlr_box vgeom = view->current;
+	struct wlr_box tgeom = *new_view_geo;
 	struct border border = ssd_get_margin(view->ssd);
 	struct edges view_edges; /* The edges of the current view */
 	struct edges target_edges; /* The desired edges */
 	struct edges other_edges; /* The edges of the monitor/other view */
 	struct edges flags = { 0 };
 
-	view_edges.left = view->x - border.left;
-	view_edges.top = view->y - border.top;
-	view_edges.right = view->x + view->w + border.right;
-	view_edges.bottom = view->y + view->h + border.bottom;
+	view_edges.left = vgeom.x - border.left;
+	view_edges.top = vgeom.y - border.top;
+	view_edges.right = vgeom.x + vgeom.width + border.right;
+	view_edges.bottom = vgeom.y + vgeom.height + border.bottom;
 
 	target_edges.left = new_view_geo->x - border.left;
 	target_edges.top = new_view_geo->y - border.top;
@@ -159,7 +156,7 @@ resistance_resize_apply(struct view *view, struct wlr_box *new_view_geo)
 			if (flags.left == 1) {
 				new_view_geo->x = other_edges.left
 					+ border.left;
-				new_view_geo->width = view->w;
+				new_view_geo->width = vgeom.width;
 			}
 		} else if (server->resize_edges & WLR_EDGE_RIGHT) {
 			if (flags.right == 1) {
@@ -172,7 +169,7 @@ resistance_resize_apply(struct view *view, struct wlr_box *new_view_geo)
 		if (server->resize_edges & WLR_EDGE_TOP) {
 			if (flags.top == 1) {
 				new_view_geo->y = other_edges.top + border.top;
-				new_view_geo->height = view->h;
+				new_view_geo->height = vgeom.height;
 			}
 		} else if (server->resize_edges & WLR_EDGE_BOTTOM) {
 			if (flags.bottom == 1) {

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -40,10 +40,10 @@ ssd_max_extents(struct view *view)
 	assert(view);
 	struct border border = ssd_thickness(view);
 	return (struct wlr_box){
-		.x = view->x - border.left,
-		.y = view->y - border.top,
-		.width = view->w + border.left + border.right,
-		.height = view->h + border.top + border.bottom,
+		.x = view->current.x - border.left,
+		.y = view->current.y - border.top,
+		.width = view->current.width + border.left + border.right,
+		.height = view->current.height + border.top + border.bottom,
 	};
 }
 
@@ -163,11 +163,7 @@ ssd_create(struct view *view, bool active)
 	ssd_titlebar_create(ssd);
 	ssd->margin = ssd_thickness(view);
 	ssd_set_active(ssd, active);
-
-	ssd->state.width = view->w;
-	ssd->state.height = view->h;
-	ssd->state.x = view->x;
-	ssd->state.y = view->y;
+	ssd->state.geometry = view->current;
 
 	return ssd;
 }
@@ -185,24 +181,20 @@ ssd_update_geometry(struct ssd *ssd)
 		return;
 	}
 
-	struct view *view = ssd->view;
-	if (view->w == ssd->state.width && view->h == ssd->state.height) {
-		if (view->x != ssd->state.x || view->y != ssd->state.y) {
+	struct wlr_box cached = ssd->state.geometry;
+	struct wlr_box current = ssd->view->current;
+	if (current.width == cached.width && current.height == cached.height) {
+		if (current.x != cached.x || current.y != cached.y) {
 			/* Dynamically resize extents based on position and usable_area */
 			ssd_extents_update(ssd);
-			ssd->state.x = view->x;
-			ssd->state.y = view->y;
+			ssd->state.geometry = current;
 		}
 		return;
 	}
 	ssd_extents_update(ssd);
 	ssd_border_update(ssd);
 	ssd_titlebar_update(ssd);
-
-	ssd->state.width = view->w;
-	ssd->state.height = view->h;
-	ssd->state.x = view->x;
-	ssd->state.y = view->y;
+	ssd->state.geometry = current;
 }
 
 void

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -15,8 +15,8 @@ ssd_border_create(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
-	int width = view->w;
-	int height = view->h;
+	int width = view->current.width;
+	int height = view->current.height;
 	int full_width = width + 2 * theme->border_width;
 
 	float *color;
@@ -54,8 +54,8 @@ ssd_border_update(struct ssd *ssd)
 	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
 
-	int width = view->w;
-	int height = view->h;
+	int width = view->current.width;
+	int height = view->current.height;
 	int full_width = width + 2 * theme->border_width;
 
 	struct ssd_part *part;

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -113,8 +113,8 @@ ssd_extents_update(struct ssd *ssd)
 
 	struct theme *theme = view->server->theme;
 
-	int width = view->w;
-	int height = view->h;
+	int width = view->current.width;
+	int height = view->current.height;
 	int full_height = height + theme->border_width * 2 + theme->title_height;
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = SSD_EXTENDED_AREA;

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -22,7 +22,7 @@ ssd_titlebar_create(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
-	int width = view->w;
+	int width = view->current.width;
 
 	float *color;
 	struct wlr_scene_tree *parent;
@@ -91,8 +91,8 @@ void
 ssd_titlebar_update(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
-	int width = view->w;
-	if (width == ssd->state.width) {
+	int width = view->current.width;
+	if (width == ssd->state.geometry.width) {
 		return;
 	}
 	struct theme *theme = view->server->theme;
@@ -171,7 +171,7 @@ ssd_update_title_positions(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
-	int width = view->w;
+	int width = view->current.width;
 	int title_bg_width = width - SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT;
 
 	int x, y;
@@ -239,7 +239,8 @@ ssd_update_title(struct ssd *ssd)
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
 	struct ssd_state_title_width *dstate;
-	int title_bg_width = view->w - SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT;
+	int title_bg_width = view->current.width
+		- SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT;
 
 	FOR_EACH_STATE(ssd, subtree) {
 		if (subtree == &ssd->titlebar.active) {

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -27,14 +27,15 @@ popup_unconstrain(struct view *view, struct wlr_xdg_popup *popup)
 	struct wlr_box *popup_box = &popup->current.geometry;
 	struct wlr_output_layout *output_layout = server->output_layout;
 	struct wlr_output *wlr_output = wlr_output_layout_output_at(
-		output_layout, view->x + popup_box->x, view->y + popup_box->y);
+		output_layout, view->current.x + popup_box->x,
+		view->current.y + popup_box->y);
 
 	struct wlr_box output_box;
 	wlr_output_layout_get_box(output_layout, wlr_output, &output_box);
 
 	struct wlr_box output_toplevel_box = {
-		.x = output_box.x - view->x,
-		.y = output_box.y - view->y,
+		.x = output_box.x - view->current.x,
+		.y = output_box.y - view->current.y,
 		.width = output_box.width,
 		.height = output_box.height,
 	};


### PR DESCRIPTION
Wrap up separate `x/y/width/height` fields into `struct wlr_box` for convenience.
No functional change.