### PR TITLE
xdg: Fix positioning of initially-maximized views

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -340,16 +340,21 @@ xdg_toplevel_view_map(struct view *view)
 		 * view_set_fullscreen/view_maximize() below). "Current"
 		 * dimensions remain zero until handle_commit().
 		 */
-		view->pending.width = xdg_surface->current.geometry.width;
-		view->pending.height = xdg_surface->current.geometry.height;
+		if (wlr_box_empty(&view->pending)) {
+			view->pending.width =
+				xdg_surface->current.geometry.width;
+			view->pending.height =
+				xdg_surface->current.geometry.height;
+		}
 
-		position_xdg_toplevel_view(view);
 		if (!view->fullscreen && requested->fullscreen) {
 			view_set_fullscreen(view, true,
 				requested->fullscreen_output);
 		} else if (!view->maximized && requested->maximized) {
 			view_maximize(view, true,
 				/*store_natural_geometry*/ true);
+		} else if (view_is_floating(view)) {
+			position_xdg_toplevel_view(view);
 		}
 
 		view_moved(view);

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -534,7 +534,7 @@ map(struct view *view)
 	if (!view->been_mapped) {
 		view_set_decorations(view, want_deco(xwayland_surface));
 
-		if (!view->maximized && !view->fullscreen) {
+		if (view_is_floating(view)) {
 			set_initial_position(view, xwayland_surface);
 		}
 
@@ -549,7 +549,7 @@ map(struct view *view)
 		view->been_mapped = true;
 	}
 
-	if (view->ssd_enabled && !view->fullscreen && !view->maximized) {
+	if (view->ssd_enabled && view_is_floating(view)) {
 		top_left_edge_boundary_check(view);
 	}
 


### PR DESCRIPTION
This is a minimal fix for the regression described in #760. It basically restores the status quo prior to 103a2a8f6c38a8eb664160e369477cad98003598.

- Don't overwrite pending size in `map()` if it was already set
- Don't reposition view in `map()` if maximized/fullscreen

Also, as future-proofing in case we one day allow initially-tiled views, replace explicit maximized/fullscreen checks with `view_is_floating()`.

I haven't attempted to address the separate (pre-existing) issue of `foot --maximized` always appearing on the top-left output (regardless of cursor position). There may also be issues with saving/restoring natural geometry for initially-maximized xdg-shell views -- I suspect that has never worked correctly (hence the `set_fallback_geometry()` workaround in `view.c`).