### PR TITLE
docs: add hint for using wev

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -168,7 +168,8 @@ The rest of this man page describes configuration options.
 	Define a key binding in the format *modifier-key*, where supported
 	modifiers include S (shift); C (control); A (alt); W (super). Unlike
 	Openbox, multiple space-separated key combinations and key-chains are
-	not supported.
+	not supported. The application "wev" (wayland event viewer) is packaged
+	in a lot of distributions and can be used to view all available keynames.
 
 *<keyboard><keybind key=""><action name="">*
 	Keybind action. See labwc-action(5)


### PR DESCRIPTION
This probably solves this issue: #456 

I don't know what the policy about linking in man-pages is, but perhaps it would also be okay to link to the wev source page? Perhaps it would even be useful to mention the `xkbcommon-keysyms.h` header file.