### PR TITLE
src/view.c: view_is_floating() add missing tiled_region_evacuate check

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -116,13 +116,6 @@ struct xdg_toplevel_view {
 	struct wl_listener new_popup;
 };
 
-static inline bool
-view_is_floating(struct view *view)
-{
-	return !view->fullscreen && !view->maximized && !view->tiled
-		&& !view->tiled_region;
-}
-
 void view_set_activated(struct view *view);
 void view_close(struct view *view);
 
@@ -151,6 +144,7 @@ void view_toggle_decorations(struct view *view);
 void view_toggle_always_on_top(struct view *view);
 bool view_is_always_on_top(struct view *view);
 bool view_is_tiled(struct view *view);
+bool view_is_floating(struct view *view);
 void view_move_to_workspace(struct view *view, struct workspace *workspace);
 void view_set_decorations(struct view *view, bool decorations);
 void view_toggle_fullscreen(struct view *view);

--- a/src/view.c
+++ b/src/view.c
@@ -546,10 +546,15 @@ view_restore_to(struct view *view, struct wlr_box geometry)
 bool
 view_is_tiled(struct view *view)
 {
-	if (!view) {
-		return false;
-	}
-	return view->tiled || view->tiled_region || view->tiled_region_evacuate;
+	return view && (view->tiled || view->tiled_region
+		|| view->tiled_region_evacuate);
+}
+
+bool
+view_is_floating(struct view *view)
+{
+	return view && !(view->fullscreen || view->maximized || view->tiled
+		|| view->tiled_region || view->tiled_region_evacuate);
 }
 
 /* Reset tiled state of view without changing geometry */


### PR DESCRIPTION
Also
- remove static inline (e.g. trust the compiler to optimize)
- move from `include/view.h` to `src/view.c`

As mentioned in https://github.com/labwc/labwc/pull/753#discussion_r1102841140 there is one other case where we do `static inline` + function implementation in a header file: https://github.com/labwc/labwc/blob/master/include/common/list.h

But in that case I would argue that we don't have a proper place to put it, creating a new `.c` file just to define that single function seems a bit excessive.