### PR TITLE
src/cursor.c: cursor names: use absence of "grab" to trigger fallback

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1090,7 +1090,7 @@ cursor_init(struct seat *seat)
 	wlr_xcursor_manager_load(seat->xcursor_manager, 1);
 
 	if (wlr_xcursor_manager_get_xcursor(seat->xcursor_manager,
-			cursors_xdg[LAB_CURSOR_DEFAULT], 1)) {
+			cursors_xdg[LAB_CURSOR_GRAB], 1)) {
 		cursor_names = cursors_xdg;
 	} else {
 		wlr_log(WLR_INFO,


### PR DESCRIPTION
This is necessary because wlroots backported a patch containing
cursor name aliases to the 0.16 branch. That internal mapping
does not alias "grab" to "grabbing" because it is not technically
part of the cursor-names spec.

To keep the "grab" cursor working on systems with no cursor theme
available (or in an unusual location) change the trigger for our
internal cursor name aliasing to "grab".

See wlroots commit [1e345c74c3ca5d2575aa975d4d9af87cd0c7ba13](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/1e345c74c3ca5d2575aa975d4d9af87cd0c7ba13)
Alias existing cursor defaults to cursor-spec cursor names

for further details.