### PR TITLE
view: make view_move_resize always work

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -162,7 +162,6 @@ view_moved(struct view *view)
 	}
 }
 
-/* N.B. Use view_move() if not resizing. */
 void
 view_move_resize(struct view *view, struct wlr_box geo)
 {
@@ -417,13 +416,7 @@ view_apply_region_geometry(struct view *view)
 	geo.width -= margin.left + margin.right;
 	geo.height -= margin.top + margin.bottom;
 
-	if (view->pending.width == geo.width
-			&& view->pending.height == geo.height) {
-		/* move horizontally/vertically without changing size */
-		view_move(view, geo.x, geo.y);
-	} else {
-		view_move_resize(view, geo);
-	}
+	view_move_resize(view, geo);
 }
 
 static void
@@ -439,13 +432,7 @@ view_apply_tiled_geometry(struct view *view, struct output *output)
 	}
 
 	struct wlr_box dst = view_get_edge_snap_box(view, output, view->tiled);
-	if (view->pending.width == dst.width
-			&& view->pending.height == dst.height) {
-		/* move horizontally/vertically without changing size */
-		view_move(view, dst.x, dst.y);
-	} else {
-		view_move_resize(view, dst);
-	}
+	view_move_resize(view, dst);
 }
 
 static void


### PR DESCRIPTION
It was not working before because in the case of wayland we are only dealing with sizes as wayland has no notion of a global position. A wayland client would thus not necessarily respond to a configure request which sets the same size again. This causes us to also not apply a new position set in view->pending because there may be no commit from the client in those cases.

We previously worked around this issue in some parts of the code to check our new sizes against the pending ones and if they were the same we would call view_move instead. That had two issues:

- Not all parts of the code did that which could end up delaying the positioning either to the next completely unrelated xdg commit event or to the next view_move call

- The code started to repeat itself, e.g. the same condition with calls to either view_move or view_move_resize based on the result

This patch fixes it by doing the check in the xdg configure handler instead. Xwayland is unaffected by this issue as we are always configuring a xwayland client with both, position and size.

---
Void build error is unrelated to this PR