### PR TITLE
src/xdg.c: sync move with pending resize 

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -203,13 +203,17 @@ handle_set_app_id(struct wl_listener *listener, void *data)
 static void
 xdg_toplevel_view_move(struct view *view, int x, int y)
 {
-	view->current.x = x;
-	view->current.y = y;
-
 	/* override any previous pending move */
 	view->pending.x = x;
 	view->pending.y = y;
 
+	/* Syncs moves with resizes  */
+	if (view->pending_configure_serial > 0) {
+		return;
+	}
+
+	view->current.x = x;
+	view->current.y = y;
 	view_moved(view);
 }
 


### PR DESCRIPTION
Before this patch, configuring a surface with a new size,
immediately followed up by one or more view_move() calls
would move the surface to the new coordinates immediately
without waiting for the resize. This caused visual glitches
when for example dragging a maximized window: the position
would change but the size was still that of a maximized
window.

This patch fixes that by just ignoring view_move() requests
(but still updating view->pending) if there is a configure
request pending. Once the client commit comes in the new
size will be applied as usual.


---
This PR is depends on
- #774

Will rebase and "undraft" once merged.

---
Void build error is unrelated to this PR