### PR TITLE
view: Unify view_move()/view_move_resize()

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -26,7 +26,6 @@ struct view_impl {
 	void (*close)(struct view *view);
 	const char *(*get_string_prop)(struct view *view, const char *prop);
 	void (*map)(struct view *view);
-	void (*move)(struct view *view, int x, int y);
 	void (*set_activated)(struct view *view, bool activated);
 	void (*set_fullscreen)(struct view *view, bool fullscreen);
 	void (*unmap)(struct view *view);

--- a/src/view.c
+++ b/src/view.c
@@ -143,9 +143,11 @@ void
 view_move(struct view *view, int x, int y)
 {
 	assert(view);
-	if (view->impl->move) {
-		view->impl->move(view, x, y);
-	}
+	view_move_resize(view, (struct wlr_box){
+		.x = x, .y = y,
+		.width = view->pending.width,
+		.height = view->pending.height
+	});
 }
 
 void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -387,22 +387,6 @@ handle_set_class(struct wl_listener *listener, void *data)
 }
 
 static void
-move(struct view *view, int x, int y)
-{
-	view->current.x = x;
-	view->current.y = y;
-
-	/* override any previous pending move */
-	view->pending.x = x;
-	view->pending.y = y;
-
-	struct wlr_xwayland_surface *s = xwayland_surface_from_view(view);
-	wlr_xwayland_surface_configure(s, (int16_t)x, (int16_t)y,
-		(uint16_t)s->width, (uint16_t)s->height);
-	view_moved(view);
-}
-
-static void
 _close(struct view *view)
 {
 	wlr_xwayland_surface_close(xwayland_surface_from_view(view));
@@ -615,7 +599,6 @@ static const struct view_impl xwl_view_impl = {
 	.close = _close,
 	.get_string_prop = get_string_prop,
 	.map = map,
-	.move = move,
 	.set_activated = set_activated,
 	.set_fullscreen = set_fullscreen,
 	.unmap = unmap,


### PR DESCRIPTION
`view->impl->move()` is a specific case of `view->impl->configure()`. To reduce code duplication, we can use `view->impl->configure()` for pure moves (without resize) as well.

xwayland's `move()` function also possibly contained a race condition when there was a pending resize, as it used the current surface width/height rather than the pending width/height. Now we use the pending width/height so there is no race condition.

This may resolve the visual glitch @Consolatis mentioned in https://github.com/labwc/labwc/pull/775#issuecomment-1426973649. But I wasn't able to reproduce the glitch myself, so I can't verify.