### PR TITLE
ssd: Fix segfault when disabling output with fullscreen view

### DIFF
--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -24,16 +24,6 @@ add_extent(struct wl_list *part_list, enum ssd_part_type type,
 	return part;
 }
 
-static void
-lab_wlr_output_layout_layout_coords(struct wlr_output_layout *layout,
-		struct wlr_output *output, int *x, int *y)
-{
-	struct wlr_output_layout_output *l_output;
-	l_output = wlr_output_layout_get(layout, output);
-	*x += l_output->x;
-	*y += l_output->y;
-}
-
 void
 ssd_extents_create(struct ssd *ssd)
 {
@@ -110,6 +100,11 @@ ssd_extents_update(struct ssd *ssd)
 	if (!view->output) {
 		return;
 	}
+	struct wlr_output_layout_output *l_output = wlr_output_layout_get(
+		view->server->output_layout, view->output->wlr_output);
+	if (!l_output) {
+		return;
+	}
 
 	struct theme *theme = view->server->theme;
 
@@ -128,10 +123,9 @@ ssd_extents_update(struct ssd *ssd)
 	struct wlr_scene_rect *rect;
 
 	/* Convert usable area into layout coordinates */
-	struct wlr_box usable_area;
-	memcpy(&usable_area, &view->output->usable_area, sizeof(struct wlr_box));
-	lab_wlr_output_layout_layout_coords(view->server->output_layout,
-		view->output->wlr_output, &usable_area.x, &usable_area.y);
+	struct wlr_box usable_area = view->output->usable_area;
+	usable_area.x += l_output->x;
+	usable_area.y += l_output->y;
 
 	/* Remember base layout coordinates */
 	int base_x, base_y;


### PR DESCRIPTION
`wlr_output_layout_get()` returns `NULL` for disabled outputs.

Backtrace (abbreviated):

     #0  lab_wlr_output_layout_layout_coords at ../src/ssd/ssd_extents.c:33
     #1  ssd_extents_update at ../src/ssd/ssd_extents.c:133
     #2  ssd_extents_create at ../src/ssd/ssd_extents.c:95
     #3  ssd_create at ../src/ssd/ssd.c:161
     #4  decorate.part.0.lto_priv.0 at ../src/view.c:637
     #5  decorate at ../src/view.c:636
     #6  view_set_fullscreen at ../src/view.c:716
     #7  view_adjust_for_layout_change ../src/view.c:745
     #8  desktop_arrange_all_views ../src/desktop.c:52
     #9  output_update_all_usable_areas at ../src/output.c:495
     #10 output_update_for_layout_change at ../src/output.c:263
     #11 do_output_layout_change at ../src/output.c:423
     #12 do_output_layout_change at ../src/cursor.c:267
     #13 output_config_apply at ../src/output.c:334
     #14 handle_output_manager_apply at ../src/output.c:354