### PR TITLE
desktop: Avoid centering views without initial geometry

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -46,10 +46,21 @@ desktop_move_to_back(struct view *view)
 void
 desktop_arrange_all_views(struct server *server)
 {
-	/* Adjust window positions/sizes */
+	/*
+	 * Adjust window positions/sizes. Skip views with no size since
+	 * we can't do anything useful with them; they will presumably
+	 * be initialized with valid positions/sizes later.
+	 *
+	 * We do not simply check view->mapped/been_mapped here because
+	 * views can have maximized/fullscreen geometry applied while
+	 * still unmapped. We do want to adjust the geometry of those
+	 * views.
+	 */
 	struct view *view;
 	wl_list_for_each(view, &server->views, link) {
-		view_adjust_for_layout_change(view);
+		if (!wlr_box_empty(&view->pending)) {
+			view_adjust_for_layout_change(view);
+		}
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -245,6 +245,10 @@ view_output(struct view *view)
 static bool
 view_compute_centered_position(struct view *view, int w, int h, int *x, int *y)
 {
+	if (w <= 0 || h <= 0) {
+		wlr_log(WLR_ERROR, "view has empty geometry, not centering");
+		return false;
+	}
 	struct output *output = view_output(view);
 	if (!output) {
 		return false;


### PR DESCRIPTION
While working on a different change, I noticed that in some cases (generally at labwc startup, when several windows are created at once) we were calling `view_compute_centered_position()` with an empty width/height. This occurs because `desktop_arrange_all_views()` has no regard for whether views are mapped or have an initial width/height set yet.

I don't think there were any user-observable side effects, but even so it seems best to avoid calling `view_compute_centered_position()` for views that have no initial width/height, since it's useless and (to me at least) unexpected, which could lead to surprises in future development.