### PR TITLE
view: Add view_evacuate_regions()

### DIFF
--- a/include/regions.h
+++ b/include/regions.h
@@ -15,6 +15,7 @@ struct multi_rect;
 /* Double use: rcxml.c for config and output.c for usage */
 struct region {
 	struct wl_list link; /* struct rcxml.regions, struct output.regions */
+	struct output *output;
 	char *name;
 	struct wlr_box geo;
 	struct wlr_box percentage;

--- a/include/regions.h
+++ b/include/regions.h
@@ -2,6 +2,8 @@
 #ifndef __LABWC_REGIONS_H
 #define __LABWC_REGIONS_H
 
+#include <wlr/util/box.h>
+
 struct seat;
 struct view;
 struct server;

--- a/include/view.h
+++ b/include/view.h
@@ -162,6 +162,7 @@ void view_reload_ssd(struct view *view);
 void view_impl_map(struct view *view);
 void view_adjust_size(struct view *view, int *w, int *h);
 
+void view_evacuate_region(struct view *view);
 void view_on_output_destroy(struct view *view);
 void view_destroy(struct view *view);
 

--- a/src/regions.c
+++ b/src/regions.c
@@ -164,6 +164,7 @@ regions_reconfigure_output(struct output *output)
 	wl_list_for_each(region, &rc.regions, link) {
 		struct region *region_new = znew(*region_new);
 		/* Create a copy */
+		region_new->output = output;
 		region_new->name = xstrdup(region->name);
 		region_new->percentage = region->percentage;
 		wl_list_append(&output->regions, &region_new->link);
@@ -214,14 +215,9 @@ regions_evacuate_output(struct output *output)
 {
 	assert(output);
 	struct view *view;
-	struct region *region;
-
 	wl_list_for_each(view, &output->server->views, link) {
-		wl_list_for_each(region, &output->regions, link) {
-			if (view->tiled_region == region) {
-				view_evacuate_region(view);
-				break;
-			}
+		if (view->tiled_region && view->tiled_region->output == output) {
+			view_evacuate_region(view);
 		}
 	}
 }

--- a/src/regions.c
+++ b/src/regions.c
@@ -219,12 +219,7 @@ regions_evacuate_output(struct output *output)
 	wl_list_for_each(view, &output->server->views, link) {
 		wl_list_for_each(region, &output->regions, link) {
 			if (view->tiled_region == region) {
-				if (!view->tiled_region_evacuate) {
-					view->tiled_region_evacuate =
-						xstrdup(region->name);
-				}
-				/* Prevent carrying around a dangling pointer */
-				view->tiled_region = NULL;
+				view_evacuate_region(view);
 				break;
 			}
 		}

--- a/src/view.c
+++ b/src/view.c
@@ -775,6 +775,17 @@ view_discover_output(struct view *view)
 }
 
 void
+view_evacuate_region(struct view *view)
+{
+	assert(view);
+	assert(view->tiled_region);
+	if (!view->tiled_region_evacuate) {
+		view->tiled_region_evacuate = xstrdup(view->tiled_region->name);
+	}
+	view->tiled_region = NULL;
+}
+
+void
 view_on_output_destroy(struct view *view)
 {
 	assert(view);


### PR DESCRIPTION
Just a slight refactoring to follow the existing precedent that `struct view` fields are typically only modified within `view.c`.