### PR TITLE
[very wip] window-rules in support of lxqt-panel

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -348,6 +348,7 @@ void xdg_toplevel_decoration(struct wl_listener *listener, void *data);
 
 void xdg_activation_handle_request(struct wl_listener *listener, void *data);
 
+void xdg_toplevel_view_convert_to_unmanaged(struct view *view);
 void xdg_surface_new(struct wl_listener *listener, void *data);
 
 void foreign_toplevel_handle_create(struct view *view);

--- a/include/node.h
+++ b/include/node.h
@@ -13,6 +13,7 @@ enum node_descriptor_type {
 	LAB_NODE_DESC_NODE = 0,
 	LAB_NODE_DESC_VIEW,
 	LAB_NODE_DESC_XDG_POPUP,
+	LAB_NODE_DESC_XDG_UNMANAGED,
 	LAB_NODE_DESC_LAYER_SURFACE,
 	LAB_NODE_DESC_LAYER_POPUP,
 	LAB_NODE_DESC_MENUITEM,
@@ -37,6 +38,7 @@ struct node_descriptor {
  * @data: struct to point to as follows:
  *   - LAB_NODE_DESC_VIEW           struct view
  *   - LAB_NODE_DESC_XDG_POPUP      struct view
+ *   - LAB_NODE_DESC_XDG_UNMANAGED  struct xdg_unmanaged
  *   - LAB_NODE_DESC_LAYER_SURFACE  struct lab_layer_surface
  *   - LAB_NODE_DESC_LAYER_POPUP    struct lab_layer_popup
  *   - LAB_NODE_DESC_MENUITEM       struct menuitem

--- a/include/view.h
+++ b/include/view.h
@@ -167,6 +167,7 @@ void view_adjust_size(struct view *view, int *w, int *h);
 void view_evacuate_region(struct view *view);
 void view_on_output_destroy(struct view *view);
 void view_destroy(struct view *view);
+void view_apply_rules(struct view *view);
 
 /* xdg.c */
 struct wlr_xdg_surface *xdg_surface_from_view(struct view *view);

--- a/include/xdg-unmanaged.h
+++ b/include/xdg-unmanaged.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __LABWC_XDG_UNMANAGED
+#define __LABWC_XDG_UNMANAGED
+
+struct server;
+struct wlr_xdg_surface;
+
+void xdg_unmanaged_create(struct server *server, struct wlr_xdg_surface *wlr_xdg_surface);
+
+#endif /* __LABWC_XDG_UNMANAGED */

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -348,6 +348,10 @@ get_cursor_context(struct server *server)
 					ret.surface = lab_wlr_surface_from_node(ret.node);
 				}
 				return ret;
+			case LAB_NODE_DESC_XDG_UNMANAGED:
+				ret.type = LAB_SSD_CLIENT;
+				ret.surface = lab_wlr_surface_from_node(ret.node);
+				return ret;
 			case LAB_NODE_DESC_SSD_BUTTON: {
 				/*
 				 * Always return the top scene node for SSD

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,7 @@ labwc_sources = files(
   'xdg.c',
   'xdg-deco.c',
   'xdg-popup.c',
+  'xdg-unmanaged.c',
 )
 
 if have_xwayland

--- a/src/view.c
+++ b/src/view.c
@@ -979,6 +979,26 @@ view_get_string_prop(struct view *view, const char *prop)
 }
 
 void
+view_apply_rules(struct view *view)
+{
+	if (!view->mapped) {
+		return;
+	}
+
+	/* TODO: read rc.xml <applications> element */
+	const char *title = view_get_string_prop(view, "title");
+	if (title && !strcmp(title, "lxqt-panel")) {
+		xdg_toplevel_view_convert_to_unmanaged(view);
+		return;
+	}
+	const char *app_id = view_get_string_prop(view, "app_id");
+	if (app_id && !strcmp(app_id, "lxqt-panel")) {
+		xdg_toplevel_view_convert_to_unmanaged(view);
+		return;
+	}
+}
+
+void
 view_update_title(struct view *view)
 {
 	assert(view);

--- a/src/xdg-unmanaged.c
+++ b/src/xdg-unmanaged.c
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <assert.h>
+#include "common/mem.h"
+#include "labwc.h"
+#include "node.h"
+#include "view.h"
+#include "view-impl-common.h"
+#include "workspaces.h"
+#include "xdg-unmanaged.h"
+
+struct xdg_unmanaged {
+	struct server *server;
+	struct wlr_xdg_surface *wlr_xdg_surface;
+	struct wlr_scene_tree *tree;
+	struct wlr_scene_node *node;
+
+	struct wl_listener destroy;
+};
+
+static void
+unmanaged_handle_destroy(struct wl_listener *listener, void *data)
+{
+	struct xdg_unmanaged *unmanaged = wl_container_of(listener, unmanaged, destroy);
+	wl_list_remove(&unmanaged->destroy.link);
+	free(unmanaged);
+}
+
+void
+xdg_unmanaged_create(struct server *server, struct wlr_xdg_surface *wlr_xdg_surface)
+{
+	struct xdg_unmanaged *unmanaged = znew(*unmanaged);
+	unmanaged->server = server;
+	unmanaged->wlr_xdg_surface = wlr_xdg_surface;
+
+	unmanaged->destroy.notify = unmanaged_handle_destroy;
+	wl_signal_add(&wlr_xdg_surface->events.destroy, &unmanaged->destroy);
+
+	unmanaged->tree = server->view_tree_always_on_top;
+	unmanaged->node = &wlr_scene_surface_create(unmanaged->tree,
+		wlr_xdg_surface->surface)->buffer->node;
+	node_descriptor_create(unmanaged->node, LAB_NODE_DESC_XDG_UNMANAGED, unmanaged);
+	wlr_scene_node_set_position(unmanaged->node, 0, 0);
+	cursor_update_focus(unmanaged->server);
+}

--- a/src/xdg-unmanaged.c
+++ b/src/xdg-unmanaged.c
@@ -15,12 +15,89 @@ struct xdg_unmanaged {
 	struct wlr_scene_node *node;
 
 	struct wl_listener destroy;
+	struct wl_listener new_popup;
 };
+
+struct popup {
+	struct wlr_xdg_popup *wlr_popup;
+	struct wlr_scene_tree *scene_tree;
+	struct wlr_box output_toplevel_sx_box;
+
+	struct wl_listener destroy;
+	struct wl_listener new_popup;
+};
+
+static void
+popup_handle_destroy(struct wl_listener *listener, void *data)
+{
+	struct popup *popup = wl_container_of(listener, popup, destroy);
+	wl_list_remove(&popup->destroy.link);
+	wl_list_remove(&popup->new_popup.link);
+	free(popup);
+}
+
+static void popup_handle_new_popup(struct wl_listener *listener, void *data);
+
+static struct popup *
+create_popup(struct wlr_xdg_popup *wlr_popup, struct wlr_scene_tree *parent,
+		struct wlr_box *output_toplevel_sx_box)
+{
+	struct popup *popup = znew(*popup);
+	popup->wlr_popup = wlr_popup;
+	popup->scene_tree = wlr_scene_xdg_surface_create(parent, wlr_popup->base);
+	if (!popup->scene_tree) {
+		free(popup);
+		return NULL;
+	}
+	node_descriptor_create(&popup->scene_tree->node,
+		LAB_NODE_DESC_LAYER_POPUP, popup);
+
+	popup->destroy.notify = popup_handle_destroy;
+	wl_signal_add(&wlr_popup->base->events.destroy, &popup->destroy);
+	popup->new_popup.notify = popup_handle_new_popup;
+	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);
+
+	wlr_xdg_popup_unconstrain_from_box(wlr_popup, output_toplevel_sx_box);
+	return popup;
+}
+
+static void
+popup_handle_new_popup(struct wl_listener *listener, void *data)
+{
+	struct popup *popup = wl_container_of(listener, popup, new_popup);
+	struct wlr_xdg_popup *wlr_popup = data;
+	struct popup *new_popup = create_popup(wlr_popup, popup->scene_tree,
+		&popup->output_toplevel_sx_box);
+	new_popup->output_toplevel_sx_box = popup->output_toplevel_sx_box;
+}
+
+static void
+handle_new_popup(struct wl_listener *listener, void *data)
+{
+	struct xdg_unmanaged *unmanaged = wl_container_of(listener, unmanaged, new_popup);
+	struct wlr_xdg_popup *wlr_popup = data;
+
+	int lx, ly;
+	wlr_scene_node_coords(unmanaged->node, &lx, &ly);
+
+	struct wlr_box output_box = { 0 };
+
+	struct wlr_box output_toplevel_sx_box = {
+		.x = output_box.x - lx,
+		.y = output_box.y - ly,
+		.width = output_box.width,
+		.height = output_box.height,
+	};
+	struct popup *popup = create_popup(wlr_popup,
+		unmanaged->tree, &output_toplevel_sx_box);
+	popup->output_toplevel_sx_box = output_toplevel_sx_box;
+}
 
 static void
 unmanaged_handle_destroy(struct wl_listener *listener, void *data)
 {
 	struct xdg_unmanaged *unmanaged = wl_container_of(listener, unmanaged, destroy);
+	wl_list_remove(&unmanaged->new_popup.link);
 	wl_list_remove(&unmanaged->destroy.link);
 	free(unmanaged);
 }
@@ -34,6 +111,9 @@ xdg_unmanaged_create(struct server *server, struct wlr_xdg_surface *wlr_xdg_surf
 
 	unmanaged->destroy.notify = unmanaged_handle_destroy;
 	wl_signal_add(&wlr_xdg_surface->events.destroy, &unmanaged->destroy);
+
+	unmanaged->new_popup.notify = handle_new_popup;
+	wl_signal_add(&wlr_xdg_surface->events.new_popup, &unmanaged->new_popup);
 
 	unmanaged->tree = server->view_tree_always_on_top;
 	unmanaged->node = &wlr_scene_surface_create(unmanaged->tree,

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -6,6 +6,7 @@
 #include "view.h"
 #include "view-impl-common.h"
 #include "workspaces.h"
+#include "xdg-unmanaged.h"
 
 static struct xdg_toplevel_view *
 xdg_toplevel_view_from_view(struct view *view)
@@ -132,6 +133,17 @@ handle_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&xdg_toplevel_view->new_popup.link);
 
 	view_destroy(view);
+}
+
+void
+xdg_toplevel_view_convert_to_unmanaged(struct view *view)
+{
+	struct wlr_xdg_surface *xdg_surface = xdg_surface_from_view(view);
+	struct server *server = view->server;
+
+	handle_unmap(&view->unmap, xdg_surface);
+	handle_destroy(&view->destroy, xdg_surface);
+	xdg_unmanaged_create(server, xdg_surface);
 }
 
 static void
@@ -375,6 +387,7 @@ xdg_toplevel_view_map(struct view *view)
 	wl_signal_add(&xdg_surface->surface->events.commit, &view->commit);
 
 	view_impl_map(view);
+	view_apply_rules(view);
 }
 
 static void


### PR DESCRIPTION
Related-to: #768

I'm not sure if this is a good idea, but would appreciate high-level thoughts on it.
Please ignore ugly code, etc - it's the general idea I'm wanting to test.

I can't get `lxqt-panel` to work on my machine (just get a completely transparent panel - both on labwc and openbox).
Have tested with this little script:

```python3
#!/usr/bin/env python3

from PyQt5.QtWidgets import *
from PyQt5.QtCore import *
import sys

class Panel(QWidget):
    def __init__(self):
        super().__init__()
        self.setGeometry(0, 0, 1362, 24)
        self.setWindowTitle('lxqt-panel')

        self.cb = QCheckBox('toggle title', self)
        self.cb.move(20, 0)
        self.cb.toggle()
        self.cb.stateChanged.connect(self.changeTitle)

        self.button = QPushButton("Close", self)
        self.cb.move(100, 0)
        self.button.clicked.connect(lambda:self.close())

        self.show()

    def changeTitle(self, state):
        if state == Qt.Checked:
            self.setWindowTitle('foo')
        else:
            self.setWindowTitle('lxqt-panel')

def main():
    app = QApplication(sys.argv)
    ex = Panel()
    sys.exit(app.exec_())

if __name__ == '__main__':
    main()
```