### PR TITLE
Revert "xwayland: Fix size issue when starting VLC fullscreen"

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -305,20 +305,6 @@ handle_request_configure(struct wl_listener *listener, void *data)
 	int height = event->height;
 	view_adjust_size(view, &width, &height);
 
-	/*
-	 * If a configure request is received while maximized/
-	 * fullscreen/tiled, update the natural geometry only. This
-	 * appears to be the desired behavior e.g. when starting VLC in
-	 * fullscreen mode.
-	 */
-	if (!view_is_floating(view)) {
-		view->natural_geometry.x = event->x;
-		view->natural_geometry.y = event->y;
-		view->natural_geometry.width = width;
-		view->natural_geometry.height = height;
-		return;
-	}
-
 	configure(view, (struct wlr_box){event->x, event->y, width, height});
 }
 


### PR DESCRIPTION
The fix caused a couple of issues:

1. Ignoring client configure requests caused some clients to hang and not repaint correctly. We are supposed to synthesize a ConfigureNotify event when ignore/override a client configure request, but this isn't possible with current wlroots.
2. Setting `view->natural_geometry` from client configure requests resulted in overwriting good values with bad in some cases (e.g. with tiled xfce4-terminal in xwayland mode).

For now, revert the fix. This does allow clients to mess with view positioning for maximized/fullscreen/tiled views, but right now the alternatives seem worse.

The original specific issue (VLC undoing its fullscreen geometry) is arguably a bug in VLC anyway.

This reverts commit 09599861ac726b142a79ed60035809f04c151457.

Fixes: #785 