### PR TITLE
xdg: Save natural_geometry.x/y with initially maximized view

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -420,7 +420,7 @@ bool output_is_usable(struct output *output);
 void output_update_usable_area(struct output *output);
 void output_update_all_usable_areas(struct server *server, bool layout_changed);
 struct wlr_box output_usable_area_in_layout_coords(struct output *output);
-struct wlr_box output_usable_area_from_cursor_coords(struct server *server);
+struct output *output_from_cursor_coords(struct server *server);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
 

--- a/include/view.h
+++ b/include/view.h
@@ -130,11 +130,13 @@ void view_move(struct view *view, int x, int y);
 void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
 void view_store_natural_geometry(struct view *view);
-void view_center(struct view *view);
+/* output is optional, defaults to current nearest output */
+void view_center(struct view *view, struct output *output);
 void view_restore_to(struct view *view, struct wlr_box geometry);
 void view_set_untiled(struct view *view);
 void view_maximize(struct view *view, bool maximize,
 	bool store_natural_geometry);
+/* output is optional, defaults to current nearest output */
 void view_set_fullscreen(struct view *view, bool fullscreen,
 	struct output *output);
 void view_toggle_maximize(struct view *view);

--- a/include/view.h
+++ b/include/view.h
@@ -129,9 +129,11 @@ void view_move_resize(struct view *view, struct wlr_box geo);
 void view_move(struct view *view, int x, int y);
 void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
+struct output *view_output(struct view *view);
 void view_store_natural_geometry(struct view *view);
 /* output is optional, defaults to current nearest output */
-void view_center(struct view *view, struct output *output);
+void view_center(struct view *view, struct output *output,
+	const struct wlr_box *ref);
 void view_restore_to(struct view *view, struct wlr_box geometry);
 void view_set_untiled(struct view *view);
 void view_maximize(struct view *view, bool maximize,

--- a/src/output.c
+++ b/src/output.c
@@ -518,14 +518,13 @@ output_usable_area_in_layout_coords(struct output *output)
 	return box;
 }
 
-struct wlr_box
-output_usable_area_from_cursor_coords(struct server *server)
+struct output *
+output_from_cursor_coords(struct server *server)
 {
 	struct wlr_output *wlr_output;
 	wlr_output = wlr_output_layout_output_at(server->output_layout,
 		server->seat.cursor->x, server->seat.cursor->y);
-	struct output *output = output_from_wlr_output(server, wlr_output);
-	return output_usable_area_in_layout_coords(output);
+	return output_from_wlr_output(server, wlr_output);
 }
 
 void

--- a/src/view.c
+++ b/src/view.c
@@ -260,11 +260,11 @@ view_compute_centered_position(struct view *view, struct output *output,
 	*y = usable.y + (usable.height - height) / 2;
 
 	/* If view is bigger than usable area, just top/left align it */
-	if (*x < 0) {
-		*x = 0;
+	if (*x < usable.x) {
+		*x = usable.x;
 	}
-	if (*y < 0) {
-		*y = 0;
+	if (*y < usable.y) {
+		*y = usable.y;
 	}
 
 #if HAVE_XWAYLAND

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -273,12 +273,12 @@ lookup_view_by_xdg_toplevel(struct server *server,
 static void
 position_xdg_toplevel_view(struct view *view)
 {
-	struct wlr_xdg_surface *xdg_surface = xdg_surface_from_view(view);
 	struct wlr_xdg_toplevel *parent_xdg_toplevel =
 		xdg_toplevel_from_view(view)->parent;
 
 	if (!parent_xdg_toplevel) {
-		view_center(view, output_from_cursor_coords(view->server));
+		view_center(view, output_from_cursor_coords(view->server),
+			NULL);
 	} else {
 		/*
 		 * If child-toplevel-views, we center-align relative to their
@@ -287,17 +287,8 @@ position_xdg_toplevel_view(struct view *view)
 		struct view *parent = lookup_view_by_xdg_toplevel(
 			view->server, parent_xdg_toplevel);
 		assert(parent);
-		int center_x = parent->current.x + parent->current.width / 2;
-		int center_y = parent->current.y + parent->current.height / 2;
-		view->current.x = center_x
-			- xdg_surface->current.geometry.width / 2;
-		view->current.y = center_y
-			- xdg_surface->current.geometry.height / 2;
+		view_center(view, view_output(parent), &parent->pending);
 	}
-
-	struct border margin = ssd_get_margin(view->ssd);
-	view->current.x += margin.left;
-	view->current.y += margin.top;
 }
 
 static const char *

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -278,11 +278,7 @@ position_xdg_toplevel_view(struct view *view)
 		xdg_toplevel_from_view(view)->parent;
 
 	if (!parent_xdg_toplevel) {
-		struct wlr_box box =
-			output_usable_area_from_cursor_coords(view->server);
-		view->current.x = box.x;
-		view->current.y = box.y;
-		view_center(view);
+		view_center(view, output_from_cursor_coords(view->server));
 	} else {
 		/*
 		 * If child-toplevel-views, we center-align relative to their

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -440,11 +440,7 @@ set_initial_position(struct view *view,
 		/* Just make sure the view is on-screen */
 		view_adjust_for_layout_change(view);
 	} else {
-		struct wlr_box box =
-			output_usable_area_from_cursor_coords(view->server);
-		view->current.x = box.x;
-		view->current.y = box.y;
-		view_center(view);
+		view_center(view, output_from_cursor_coords(view->server));
 	}
 }
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -440,7 +440,8 @@ set_initial_position(struct view *view,
 		/* Just make sure the view is on-screen */
 		view_adjust_for_layout_change(view);
 	} else {
-		view_center(view, output_from_cursor_coords(view->server));
+		view_center(view, output_from_cursor_coords(view->server),
+			NULL);
 	}
 }
 


### PR DESCRIPTION
Fixes an issue where, if Thunar was started maximized, it would un-maximize to the top-left corner rather than the center. This occurs because we are storing a valid `natural_geometry.width/height` but leaving `natural_geometry.x/y` as 0,0.

In order to make `position_xdg_toplevel_view()` work without writing to `view->current` or calling `view_move()`, I made `view_compute_centered_position()` public again and added an `output` parameter.

Background/off-topic/related to #767:
Unlike `foot --maximized`, Thunar maximizes *at* map rather than sending a separate request *before* map. As a result, we are able to save the natural geometry, but also get a flicker at startup while the view adjusts to the maximized size. So currently it seems that either approach (Thunar vs. `foot` behavior) has its own disadvantage.