### PR TITLE
view: Rediscover output in view_adjust_for_layout_change()

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -487,7 +487,9 @@ view_apply_maximized_geometry(struct view *view)
 static bool
 view_apply_special_geometry(struct view *view)
 {
-	if (view->maximized) {
+	if (view->fullscreen) {
+		view_apply_fullscreen_geometry(view);
+	} else if (view->maximized) {
 		view_apply_maximized_geometry(view);
 	} else if (view->tiled) {
 		view_apply_tiled_geometry(view, NULL);
@@ -729,13 +731,8 @@ view_set_fullscreen(struct view *view, bool fullscreen, struct output *output)
 	}
 
 	set_fullscreen(view, fullscreen);
-	if (fullscreen) {
-		view_apply_fullscreen_geometry(view);
-	} else {
-		/* Restore non-fullscreen geometry */
-		if (!view_apply_special_geometry(view)) {
-			view_apply_natural_geometry(view);
-		}
+	if (!view_apply_special_geometry(view)) {
+		view_apply_natural_geometry(view);
 	}
 }
 


### PR DESCRIPTION
Currently, `view_discover_output()` is only called by `view_moved()`. To be
consistent, we should also call `view_discover_output()` when the output
layout changes, since this can effectively "move" views to a different
output without actually calling `view_moved()`.

Letting `view->output` get out-of-date probably had minimal/obscure
effects in the current code, since in many cases we ignore `view->output`
altogether and find the nearest output "on the fly" with `view_output()`.
Nevertheless, I think it's still a bug and should be fixed.

Includes some slight refactoring in `view.c`:

 - Add fullscreen case to `view_apply_special_geometry()`
 - Split out private `set_fullscreen()` helper from `view_set_fullscreen()`
   (similar to existing `set_maximized/view_set_maximized()` split)