### PR TITLE
xdg: Use wlr_xdg_surface_get_geometry() to get size

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -325,10 +325,10 @@ xdg_toplevel_view_map(struct view *view)
 		 * dimensions remain zero until handle_commit().
 		 */
 		if (wlr_box_empty(&view->pending)) {
-			view->pending.width =
-				xdg_surface->current.geometry.width;
-			view->pending.height =
-				xdg_surface->current.geometry.height;
+			struct wlr_box size;
+			wlr_xdg_surface_get_geometry(xdg_surface, &size);
+			view->pending.width = size.width;
+			view->pending.height = size.height;
 		}
 
 		/*

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -3,7 +3,6 @@
 #include "common/mem.h"
 #include "labwc.h"
 #include "node.h"
-#include "ssd.h"
 #include "view.h"
 #include "workspaces.h"
 


### PR DESCRIPTION
Fixes the positioning issue with havoc mentioned in https://github.com/labwc/labwc/pull/794#issuecomment-1437427670.

Calling `position_xdg_toplevel_view()` from inside `handle_commit()` makes me a little nervous honestly, because it seems unexpected to be setting `view->pending` there. But it seems to work, and right now I can't think of any specific reasons not to do it. I'd appreciate someone else giving me a sanity check here, to make sure this doesn't break anything.