### PR TITLE
output: Add output_nearest_to()

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -416,11 +416,12 @@ void output_init(struct server *server);
 void output_manager_init(struct server *server);
 struct output *output_from_wlr_output(struct server *server,
 	struct wlr_output *wlr_output);
+struct output *output_nearest_to(struct server *server, int lx, int ly);
+struct output *output_nearest_to_cursor(struct server *server);
 bool output_is_usable(struct output *output);
 void output_update_usable_area(struct output *output);
 void output_update_all_usable_areas(struct server *server, bool layout_changed);
 struct wlr_box output_usable_area_in_layout_coords(struct output *output);
-struct output *output_from_cursor_coords(struct server *server);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
 

--- a/src/output.c
+++ b/src/output.c
@@ -458,6 +458,25 @@ output_from_wlr_output(struct server *server, struct wlr_output *wlr_output)
 	return NULL;
 }
 
+struct output *
+output_nearest_to(struct server *server, int lx, int ly)
+{
+	double closest_x, closest_y;
+	wlr_output_layout_closest_point(server->output_layout, NULL, lx, ly,
+		&closest_x, &closest_y);
+
+	return output_from_wlr_output(server,
+		wlr_output_layout_output_at(server->output_layout,
+			closest_x, closest_y));
+}
+
+struct output *
+output_nearest_to_cursor(struct server *server)
+{
+	return output_nearest_to(server, server->seat.cursor->x,
+		server->seat.cursor->y);
+}
+
 bool
 output_is_usable(struct output *output)
 {
@@ -516,15 +535,6 @@ output_usable_area_in_layout_coords(struct output *output)
 	box.x -= ox;
 	box.y -= oy;
 	return box;
-}
-
-struct output *
-output_from_cursor_coords(struct server *server)
-{
-	struct wlr_output *wlr_output;
-	wlr_output = wlr_output_layout_output_at(server->output_layout,
-		server->seat.cursor->x, server->seat.cursor->y);
-	return output_from_wlr_output(server, wlr_output);
 }
 
 void

--- a/src/view.c
+++ b/src/view.c
@@ -226,15 +226,9 @@ struct output *
 view_output(struct view *view)
 {
 	assert(view);
-	double closest_x, closest_y;
-	struct wlr_output *wlr_output = NULL;
-	wlr_output_layout_closest_point(view->server->output_layout, wlr_output,
+	return output_nearest_to(view->server,
 		view->current.x + view->current.width / 2,
-		view->current.y + view->current.height / 2,
-		&closest_x, &closest_y);
-	wlr_output = wlr_output_layout_output_at(view->server->output_layout,
-		closest_x, closest_y);
-	return output_from_wlr_output(view->server, wlr_output);
+		view->current.y + view->current.height / 2);
 }
 
 static bool

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -277,8 +277,7 @@ position_xdg_toplevel_view(struct view *view)
 		xdg_toplevel_from_view(view)->parent;
 
 	if (!parent_xdg_toplevel) {
-		view_center(view, output_from_cursor_coords(view->server),
-			NULL);
+		view_center(view, output_nearest_to_cursor(view->server), NULL);
 	} else {
 		/*
 		 * If child-toplevel-views, we center-align relative to their

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -440,8 +440,7 @@ set_initial_position(struct view *view,
 		/* Just make sure the view is on-screen */
 		view_adjust_for_layout_change(view);
 	} else {
-		view_center(view, output_from_cursor_coords(view->server),
-			NULL);
+		view_center(view, output_nearest_to_cursor(view->server), NULL);
 	}
 }
 


### PR DESCRIPTION
Just a small cleanup:
- Factor out a generic bit of code from `view_output()` as `output_nearest_to()`.
- Reimplement `output_from_cursor_coords()` as `output_nearest_to_cursor()`.