### PR TITLE
view: Refactor view->output usage

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -138,9 +138,7 @@ void view_restore_to(struct view *view, struct wlr_box geometry);
 void view_set_untiled(struct view *view);
 void view_maximize(struct view *view, bool maximize,
 	bool store_natural_geometry);
-/* output is optional, defaults to current nearest output */
-void view_set_fullscreen(struct view *view, bool fullscreen,
-	struct output *output);
+void view_set_fullscreen(struct view *view, bool fullscreen);
 void view_toggle_maximize(struct view *view);
 void view_toggle_decorations(struct view *view);
 void view_toggle_always_on_top(struct view *view);

--- a/include/view.h
+++ b/include/view.h
@@ -131,9 +131,7 @@ void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
 struct output *view_output(struct view *view);
 void view_store_natural_geometry(struct view *view);
-/* output is optional, defaults to current nearest output */
-void view_center(struct view *view, struct output *output,
-	const struct wlr_box *ref);
+void view_center(struct view *view, const struct wlr_box *ref);
 void view_restore_to(struct view *view, struct wlr_box geometry);
 void view_set_untiled(struct view *view);
 void view_maximize(struct view *view, bool maximize,

--- a/include/view.h
+++ b/include/view.h
@@ -151,7 +151,6 @@ void view_move_to_workspace(struct view *view, struct workspace *workspace);
 void view_set_decorations(struct view *view, bool decorations);
 void view_toggle_fullscreen(struct view *view);
 void view_adjust_for_layout_change(struct view *view);
-void view_discover_output(struct view *view);
 void view_move_to_edge(struct view *view, const char *direction);
 void view_snap_to_edge(struct view *view, const char *direction,
 	bool store_natural_geometry);

--- a/include/view.h
+++ b/include/view.h
@@ -129,7 +129,6 @@ void view_move_resize(struct view *view, struct wlr_box geo);
 void view_move(struct view *view, int x, int y);
 void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
-struct output *view_output(struct view *view);
 void view_store_natural_geometry(struct view *view);
 void view_center(struct view *view, const struct wlr_box *ref);
 void view_restore_to(struct view *view, struct wlr_box geometry);

--- a/include/view.h
+++ b/include/view.h
@@ -147,6 +147,13 @@ void view_move(struct view *view, int x, int y);
 void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
 void view_store_natural_geometry(struct view *view);
+
+/**
+ * view_center - center view within some region
+ * @view: view to be centered
+ * @ref: optional reference region (in layout coordinates) to center
+ * within; if NULL, view is centered within usable area of its output
+ */
 void view_center(struct view *view, const struct wlr_box *ref);
 void view_restore_to(struct view *view, struct wlr_box geometry);
 void view_set_untiled(struct view *view);

--- a/include/view.h
+++ b/include/view.h
@@ -38,6 +38,22 @@ struct view {
 	enum view_type type;
 	const struct view_impl *impl;
 	struct wl_list link;
+
+	/*
+	 * The output that the view is displayed on. Specifically:
+	 *
+	 *  - For floating views, this is the output nearest to the
+	 *    center of the view. It is computed automatically when the
+	 *    view is moved or the output layout changes.
+	 *
+	 *  - For fullscreen/maximized/tiled views, this is the output
+	 *    used to compute the view's geometry. The view remains on
+	 *    the same output unless it is disabled or disconnected.
+	 *
+	 * Many view functions (e.g. view_center(), view_fullscreen(),
+	 * view_maximize(), etc.) allow specifying a particular output
+	 * by setting view->output explicitly before calling them.
+	 */
 	struct output *output;
 	struct workspace *workspace;
 	struct wlr_surface *surface;

--- a/include/view.h
+++ b/include/view.h
@@ -52,7 +52,7 @@ struct view {
 	 *
 	 * Many view functions (e.g. view_center(), view_fullscreen(),
 	 * view_maximize(), etc.) allow specifying a particular output
-	 * by setting view->output explicitly before calling them.
+	 * by calling view_set_output() beforehand.
 	 */
 	struct output *output;
 	struct workspace *workspace;
@@ -131,6 +131,7 @@ struct xdg_toplevel_view {
 };
 
 void view_set_activated(struct view *view);
+void view_set_output(struct view *view, struct output *output);
 void view_close(struct view *view);
 
 /**

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -25,7 +25,7 @@ handle_request_fullscreen(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, toplevel.fullscreen);
 	struct wlr_foreign_toplevel_handle_v1_fullscreen_event *event = data;
-	view_set_fullscreen(view, event->fullscreen, NULL);
+	view_set_fullscreen(view, event->fullscreen);
 }
 
 static void

--- a/src/view.c
+++ b/src/view.c
@@ -254,18 +254,16 @@ view_minimize(struct view *view, bool minimized)
 }
 
 static bool
-view_compute_centered_position(struct view *view, struct output *output,
-		const struct wlr_box *ref, int w, int h, int *x, int *y)
+view_compute_centered_position(struct view *view, const struct wlr_box *ref,
+		int w, int h, int *x, int *y)
 {
 	if (w <= 0 || h <= 0) {
 		wlr_log(WLR_ERROR, "view has empty geometry, not centering");
 		return false;
 	}
+	struct output *output = view_output(view);
 	if (!output_is_usable(output)) {
-		output = view_output(view);
-		if (!output_is_usable(output)) {
-			return false;
-		}
+		return false;
 	}
 
 	struct border margin = ssd_get_margin(view->ssd);
@@ -299,7 +297,7 @@ set_fallback_geometry(struct view *view)
 {
 	view->natural_geometry.width = LAB_FALLBACK_WIDTH;
 	view->natural_geometry.height = LAB_FALLBACK_HEIGHT;
-	view_compute_centered_position(view, NULL, NULL,
+	view_compute_centered_position(view, NULL,
 		view->natural_geometry.width,
 		view->natural_geometry.height,
 		&view->natural_geometry.x,
@@ -331,12 +329,12 @@ view_store_natural_geometry(struct view *view)
 }
 
 void
-view_center(struct view *view, struct output *output, const struct wlr_box *ref)
+view_center(struct view *view, const struct wlr_box *ref)
 {
 	assert(view);
 	int x, y;
-	if (view_compute_centered_position(view, output, ref,
-			view->pending.width, view->pending.height, &x, &y)) {
+	if (view_compute_centered_position(view, ref, view->pending.width,
+			view->pending.height, &x, &y)) {
 		view_move(view, x, y);
 	}
 }
@@ -352,8 +350,8 @@ view_apply_natural_geometry(struct view *view)
 	} else {
 		/* reposition if original geometry is offscreen */
 		struct wlr_box box = view->natural_geometry;
-		if (view_compute_centered_position(view, NULL, NULL,
-				box.width, box.height, &box.x, &box.y)) {
+		if (view_compute_centered_position(view, NULL, box.width,
+				box.height, &box.x, &box.y)) {
 			view_move_resize(view, box);
 		}
 	}
@@ -777,7 +775,7 @@ view_adjust_for_layout_change(struct view *view)
 			if (!wlr_output_layout_intersects(
 					view->server->output_layout,
 					NULL, &view->pending)) {
-				view_center(view, NULL, NULL);
+				view_center(view, NULL);
 			}
 		}
 	}

--- a/src/view.c
+++ b/src/view.c
@@ -687,7 +687,7 @@ void
 view_toggle_fullscreen(struct view *view)
 {
 	assert(view);
-	view_set_fullscreen(view, !view->fullscreen, NULL);
+	view_set_fullscreen(view, !view->fullscreen);
 }
 
 /* For internal use only. Does not update geometry. */
@@ -722,19 +722,17 @@ set_fullscreen(struct view *view, bool fullscreen)
 }
 
 void
-view_set_fullscreen(struct view *view, bool fullscreen, struct output *output)
+view_set_fullscreen(struct view *view, bool fullscreen)
 {
 	assert(view);
 	if (fullscreen == view->fullscreen) {
 		return;
 	}
 	if (fullscreen) {
+		struct output *output = view_output(view);
 		if (!output_is_usable(output)) {
-			output = view_output(view);
-			if (!output_is_usable(output)) {
-				/* Prevent fullscreen with no available outputs */
-				return;
-			}
+			/* Prevent fullscreen with no available outputs */
+			return;
 		}
 		/*
 		 * Fullscreen via keybind or client request cancels

--- a/src/view.c
+++ b/src/view.c
@@ -102,11 +102,6 @@ view_get_edge_snap_box(struct view *view, struct output *output,
 	return dst;
 }
 
-/*
- * At present, a view can only 'enter' one output at a time, although the view
- * may span multiple outputs. Ideally we would handle multiple outputs, but
- * this method is the simplest form of what we want.
- */
 static void
 view_discover_output(struct view *view)
 {

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -179,7 +179,7 @@ handle_request_maximize(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, request_maximize);
 	if (!view->mapped && !view->output) {
-		view->output = output_nearest_to_cursor(view->server);
+		view_set_output(view, output_nearest_to_cursor(view->server));
 	}
 	view_maximize(view, xdg_toplevel_from_view(view)->requested.maximized,
 		/*store_natural_geometry*/ true);
@@ -191,14 +191,8 @@ set_fullscreen_from_request(struct view *view,
 {
 	if (!view->fullscreen && requested->fullscreen
 			&& requested->fullscreen_output) {
-		struct output *output = output_from_wlr_output(view->server,
-			requested->fullscreen_output);
-		if (output_is_usable(output)) {
-			view->output = output;
-		} else {
-			wlr_log(WLR_ERROR,
-				"invalid output in fullscreen request");
-		}
+		view_set_output(view, output_from_wlr_output(view->server,
+			requested->fullscreen_output));
 	}
 	view_set_fullscreen(view, requested->fullscreen);
 }
@@ -208,7 +202,7 @@ handle_request_fullscreen(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, request_fullscreen);
 	if (!view->mapped && !view->output) {
-		view->output = output_nearest_to_cursor(view->server);
+		view_set_output(view, output_nearest_to_cursor(view->server));
 	}
 	set_fullscreen_from_request(view,
 		&xdg_toplevel_from_view(view)->requested);
@@ -315,7 +309,7 @@ position_xdg_toplevel_view(struct view *view)
 		struct view *parent = lookup_view_by_xdg_toplevel(
 			view->server, parent_xdg_toplevel);
 		assert(parent);
-		view->output = parent->output;
+		view_set_output(view, parent->output);
 		view_center(view, &parent->pending);
 	}
 }
@@ -341,7 +335,7 @@ xdg_toplevel_view_map(struct view *view)
 	}
 	view->mapped = true;
 	if (!view->output) {
-		view->output = output_nearest_to_cursor(view->server);
+		view_set_output(view, output_nearest_to_cursor(view->server));
 	}
 	struct wlr_xdg_surface *xdg_surface = xdg_surface_from_view(view);
 	view->surface = xdg_surface->surface;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -306,7 +306,7 @@ position_xdg_toplevel_view(struct view *view)
 		xdg_toplevel_from_view(view)->parent;
 
 	if (!parent_xdg_toplevel) {
-		view_center(view, output_nearest_to_cursor(view->server), NULL);
+		view_center(view, NULL);
 	} else {
 		/*
 		 * If child-toplevel-views, we center-align relative to their
@@ -315,7 +315,8 @@ position_xdg_toplevel_view(struct view *view)
 		struct view *parent = lookup_view_by_xdg_toplevel(
 			view->server, parent_xdg_toplevel);
 		assert(parent);
-		view_center(view, view_output(parent), &parent->pending);
+		view->output = view_output(parent);
+		view_center(view, &parent->pending);
 	}
 }
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -315,7 +315,7 @@ position_xdg_toplevel_view(struct view *view)
 		struct view *parent = lookup_view_by_xdg_toplevel(
 			view->server, parent_xdg_toplevel);
 		assert(parent);
-		view->output = view_output(parent);
+		view->output = parent->output;
 		view_center(view, &parent->pending);
 	}
 }

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -178,6 +178,9 @@ static void
 handle_request_maximize(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, request_maximize);
+	if (!view->mapped && !view->output) {
+		view->output = output_nearest_to_cursor(view->server);
+	}
 	view_maximize(view, xdg_toplevel_from_view(view)->requested.maximized,
 		/*store_natural_geometry*/ true);
 }
@@ -186,6 +189,9 @@ static void
 handle_request_fullscreen(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, request_fullscreen);
+	if (!view->mapped && !view->output) {
+		view->output = output_nearest_to_cursor(view->server);
+	}
 	struct wlr_xdg_toplevel *xdg_toplevel = xdg_toplevel_from_view(view);
 	struct output *output = output_from_wlr_output(view->server,
 		xdg_toplevel->requested.fullscreen_output);
@@ -317,6 +323,9 @@ xdg_toplevel_view_map(struct view *view)
 		return;
 	}
 	view->mapped = true;
+	if (!view->output) {
+		view->output = output_nearest_to_cursor(view->server);
+	}
 	struct wlr_xdg_surface *xdg_surface = xdg_surface_from_view(view);
 	view->surface = xdg_surface->surface;
 	wlr_scene_node_set_enabled(&view->scene_tree->node, true);

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -313,7 +313,7 @@ handle_request_fullscreen(struct wl_listener *listener, void *data)
 	if (!view->mapped) {
 		ensure_initial_geometry_and_output(view);
 	}
-	view_set_fullscreen(view, fullscreen, NULL);
+	view_set_fullscreen(view, fullscreen);
 }
 
 static void
@@ -429,7 +429,7 @@ xwayland_view_map(struct view *view)
 	struct wlr_xwayland_surface *xwayland_surface =
 		xwayland_surface_from_view(view);
 	if (!view->fullscreen && xwayland_surface->fullscreen) {
-		view_set_fullscreen(view, true, NULL);
+		view_set_fullscreen(view, true);
 	}
 
 	if (view->surface != xwayland_surface->surface) {

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -400,7 +400,7 @@ set_initial_position(struct view *view,
 		/* Just make sure the view is on-screen */
 		view_adjust_for_layout_change(view);
 	} else {
-		view_center(view, output_nearest_to_cursor(view->server), NULL);
+		view_center(view, NULL);
 	}
 }
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -96,7 +96,7 @@ ensure_initial_geometry_and_output(struct view *view)
 		 * Just use the cursor output since we don't know yet
 		 * whether the surface position is meaningful.
 		 */
-		view->output = output_nearest_to_cursor(view->server);
+		view_set_output(view, output_nearest_to_cursor(view->server));
 	}
 }
 


### PR DESCRIPTION
Needs more thorough testing but I'm looking for initial feedback on the approach.

This comes with two (intentional) behavior changes:
- Maximized/tiled views now try harder to remain on the same output if the output layout changes
- Initially maximized xdg-shell views now appear on the cursor output (resolves #767)

`view->output` is now used as follows (copy & pasting from `view.h`):
```
/*
 * The output that the view is displayed on. Specifically:
 *
 *  - For floating views, this is the output nearest to the
 *    center of the view. It is computed automatically when the
 *    view is moved or the output layout changes.
 *
 *  - For fullscreen/maximized/tiled views, this is the output
 *    used to compute the view's geometry. The view remains on
 *    the same output unless it is disabled or disconnected.
 *
 * Many view functions (e.g. view_center(), view_fullscreen(),
 * view_maximize(), etc.) allow specifying a particular output
 * by setting view->output explicitly before calling them.
 */
```