### PR TITLE
CI: automatically rebuild labwc.github.io

### DIFF
--- a/.github/workflows/labwc.github.io.yml
+++ b/.github/workflows/labwc.github.io.yml
@@ -1,0 +1,24 @@
+# Triggers a rebuild and deploy of labwc.github.io when man pages change
+#
+# https://stackoverflow.com/a/65514259
+
+name: "labwc.github.io"
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'v0.5_disabled'
+    paths:
+      - 'docs/*.scd'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: labwc.github.io
+        env:
+          GITHUB_TOKEN: ${{ secrets.WEB_DEPLOY_TOKEN }}
+        run: |
+          gh api repos/labwc/labwc.github.io/dispatches \
+            --raw-field event_type=rebuild


### PR DESCRIPTION
This is the final piece of the puzzle to automatically regenerate and deploy https://labwc.github.io whenever there are new commits in this repository that change the man pages.

Before this actually works we need to create a new token that provides access to the labwc.github.io repository.

I've tested this on my forked repos using a Personal access token, to be exact a fine-grained token for just the labwc.github.io repository which required these rights (and only those):
- Read and Write access to `Contents`
- Read and Write access to `Pages`
- Read access to `Metadata` (automatically selected once the other two are selected)

Finally, that resulting token (`github_pat_...` for me) must be stored as a repo (or potentially organization) secret. The secret must be named `WEB_DEPLOY_TOKEN`. The maximal duration a token can be valid seems to be a year so the token (and therefore the secret value) must be updated every year.

So to sum up:
- we need a token that is restricted to the labwc.github.io repo
- that token must have the least possible permissions, which sadly seems to include `Write` for `Contents` to be allowed to trigger a workflow dispatch
- that token must be stored as secret using the name `WEB_DEPLOY_TOKEN` (either in the labwc repository or the orga itself)
- this PR can be merged
- future PRs that change man pages should automatically trigger a labwc.github.io rebuild once merged