### PR TITLE
ToggleKeybinds per window

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -105,6 +105,11 @@ Actions are used in menus and keyboard/mouse bindings.
 	to Virtual Machines, VNC clients or nested compositors.
 	A second call will restore all original keybinds.
 
+	This action will only affect the window that had keyboard focus when
+	the binding was executed. Thus when switching to another window, all
+	the usual keybinds will function again until switching back to the
+	original window. There can be multiple windows with this mode set.
+
 *<action name="FocusOutput" output="HDMI-A-1" />*
 	Give focus to topmost window on given output and warp the cursor
 	to the center of the window. If the given output does not contain

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -78,6 +78,10 @@ labwc-config(5).
 *window.inactive.border.color*
 	Border color of inactive window
 
+*window.active.indicator.toggled-keybind.color*
+	Status indicator for the ToggleKeybinds action. Can be set to the same
+	value as set for window.active.border.color to disable the status indicator.
+
 *window.active.title.bg.color*
 	Background color for the focused window's titlebar
 

--- a/docs/themerc
+++ b/docs/themerc
@@ -13,6 +13,9 @@ padding.height: 3
 window.active.border.color: #dddad6
 window.inactive.border.color: #f6f5f4
 
+# ToggleKeybinds status indicator
+window.active.indicator.toggled-keybind.color: #ff0000
+
 # window titlebar background
 window.active.title.bg.color: #dddad6
 window.inactive.title.bg.color: #f6f5f4

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -121,7 +121,7 @@ struct seat {
 	struct wlr_idle_inhibit_manager_v1 *wlr_idle_inhibit_manager;
 
 	/* In support for ToggleKeybinds */
-	bool inhibit_keybinds;
+	uint32_t nr_inhibited_keybind_views;
 
 	/* Used to hide the workspace OSD after switching workspaces */
 	struct wl_event_source *workspace_osd_timer;

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -64,6 +64,8 @@ void ssd_update_title(struct ssd *ssd);
 void ssd_update_geometry(struct ssd *ssd);
 void ssd_destroy(struct ssd *ssd);
 
+void ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable);
+
 struct ssd_hover_state *ssd_hover_state_new(void);
 void ssd_update_button_hover(struct wlr_scene_node *node,
 	struct ssd_hover_state *hover_state);

--- a/include/theme.h
+++ b/include/theme.h
@@ -27,6 +27,8 @@ struct theme {
 	float window_active_border_color[4];
 	float window_inactive_border_color[4];
 
+	float window_toggled_keybinds_color[4];
+
 	float window_active_title_bg_color[4];
 	float window_inactive_title_bg_color[4];
 

--- a/include/view.h
+++ b/include/view.h
@@ -82,6 +82,7 @@ struct view {
 	bool maximized;
 	bool fullscreen;
 	uint32_t tiled;  /* private, enum view_edge in src/view.c */
+	bool inhibits_keybinds;
 
 	/* Pointer to an output owned struct region, may be NULL */
 	struct region *tiled_region;
@@ -145,6 +146,9 @@ struct xdg_toplevel_view {
 	struct wl_listener set_app_id;
 	struct wl_listener new_popup;
 };
+
+bool view_inhibits_keybinds(struct view *view);
+void view_toggle_keybinds(struct view *view);
 
 void view_set_activated(struct view *view);
 void view_set_output(struct view *view, struct output *output);

--- a/src/action.c
+++ b/src/action.c
@@ -721,9 +721,9 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_TOGGLE_KEYBINDS:
-			server->seat.inhibit_keybinds = !server->seat.inhibit_keybinds;
-			wlr_log(WLR_DEBUG, "%s keybinds",
-				server->seat.inhibit_keybinds ? "Disabled" : "Enabled");
+			if (view) {
+				view_toggle_keybinds(view);
+			}
 			break;
 		case ACTION_TYPE_FOCUS_OUTPUT:
 			{

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -91,7 +91,8 @@ handle_keybinding(struct server *server, uint32_t modifiers, xkb_keysym_t sym)
 		if (modifiers ^ keybind->modifiers) {
 			continue;
 		}
-		if (server->seat.inhibit_keybinds
+		if (server->seat.nr_inhibited_keybind_views
+				&& view_inhibits_keybinds(desktop_focused_view(server))
 				&& !actions_contain_toggle_keybinds(&keybind->actions)) {
 			continue;
 		}

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -163,6 +163,7 @@ ssd_create(struct view *view, bool active)
 	ssd_titlebar_create(ssd);
 	ssd->margin = ssd_thickness(view);
 	ssd_set_active(ssd, active);
+	ssd_enable_keybind_inhibit_indicator(ssd, view->inhibits_keybinds);
 	ssd->state.geometry = view->current;
 
 	return ssd;
@@ -270,6 +271,22 @@ ssd_set_active(struct ssd *ssd, bool active)
 	wlr_scene_node_set_enabled(&ssd->titlebar.active.tree->node, active);
 	wlr_scene_node_set_enabled(&ssd->border.inactive.tree->node, !active);
 	wlr_scene_node_set_enabled(&ssd->titlebar.inactive.tree->node, !active);
+}
+
+void
+ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable)
+{
+	if (!ssd) {
+		return;
+	}
+
+	float *color = enable
+		? rc.theme->window_toggled_keybinds_color
+		: rc.theme->window_active_border_color;
+
+	struct ssd_part *part = ssd_get_part(&ssd->border.active.parts, LAB_SSD_PART_TOP);
+	struct wlr_scene_rect *rect = lab_wlr_scene_get_rect(part->node);
+	wlr_scene_rect_set_color(rect, color);
 }
 
 struct ssd_hover_state *

--- a/src/theme.c
+++ b/src/theme.c
@@ -100,6 +100,8 @@ theme_builtin(struct theme *theme)
 	parse_hexstr("#dddad6", theme->window_active_border_color);
 	parse_hexstr("#f6f5f4", theme->window_inactive_border_color);
 
+	parse_hexstr("#ff0000", theme->window_toggled_keybinds_color);
+
 	parse_hexstr("#dddad6", theme->window_active_title_bg_color);
 	parse_hexstr("#f6f5f4", theme->window_inactive_title_bg_color);
 
@@ -193,6 +195,10 @@ entry(struct theme *theme, const char *key, const char *value)
 	if (match_glob(key, "border.color")) {
 		parse_hexstr(value, theme->window_active_border_color);
 		parse_hexstr(value, theme->window_inactive_border_color);
+	}
+
+	if (match_glob(key, "window.active.indicator.toggled-keybind.color")) {
+		parse_hexstr(value, theme->window_toggled_keybinds_color);
 	}
 
 	if (match_glob(key, "window.active.title.bg.color")) {


### PR DESCRIPTION
Did some more work on the new `ToggleKeybinds` action so that it works per window (view).
I started with storing a list of surfaces in `struct seat` and only inhibiting keybinds when one of those surfaces had focus.
Then switched to storing a list of views instead of surfaces and finally ended up on just a simple `bool` for `struct view` + a counter for `struct seat`. The counter is just a performance optimization so we don't have to check further unless that counter is `> 0`.

I've also added a (pretty strange) SSD status indicator as a proof of concept:
![20230305_10h38m04s_grim](https://user-images.githubusercontent.com/35009135/222953033-0c577248-2557-4054-ab83-3e1634a18af5.png)

I am not sure what the best approach for the status indicator would be, turning the whole border to another color isn't that easy because we'd actually have to redraw the rounded corners as well (as they are also part of the border).
Alternatives I can think of (but different options very welcome):
- we could render some text (like just a `!` or `Keybinds inhibited`) and put it after the title.
- we could load an additional xbm icon and throw it somewhere on the titlebar
- we could render some icon (xbm or cairo, for example some small red dot) on the top right of the actual surface