### PR TITLE
Prevent cursor based region-snapping when starting a move with A-Left 

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -164,6 +164,8 @@ struct seat {
 	/* Private use by regions.c */
 	struct region *region_active;
 	struct region_overlay region_overlay;
+	/* Used to prevent region snapping when starting a move with A-Left */
+	bool region_prevent_snap;
 
 	struct wl_client *active_client_while_inhibited;
 	struct wl_list inputs;

--- a/include/regions.h
+++ b/include/regions.h
@@ -33,8 +33,8 @@ struct region_overlay {
 	};
 };
 
-/* Can be used as a cheap check to detect if there are any regions configured */
-bool regions_available(void);
+/* Returns true if we should show the region overlay or snap to region */
+bool regions_should_snap(struct server *server);
 
 /**
  * regions_reconfigure*() - re-initializes all regions from struct rc.

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -190,17 +190,14 @@ process_cursor_move(struct server *server, uint32_t time)
 	view_move(view, dx, dy);
 
 	/* Region overlay */
-	if (!regions_available()) {
+	if (!regions_should_snap(server)) {
 		return;
 	}
-	struct wlr_keyboard *keyboard = &server->seat.keyboard_group->keyboard;
-	if (keyboard_any_modifiers_pressed(keyboard)) {
-		struct region *region = regions_from_cursor(server);
-		if (region) {
-			regions_show_overlay(view, &server->seat, region);
-		} else {
-			regions_hide_overlay(&server->seat);
-		}
+	struct region *region = regions_from_cursor(server);
+	if (region) {
+		regions_show_overlay(view, &server->seat, region);
+	} else {
+		regions_hide_overlay(&server->seat);
 	}
 }
 

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -56,6 +56,11 @@ keyboard_modifiers_notify(struct wl_listener *listener, void *data)
 	struct wlr_keyboard_key_event *event = data;
 	struct wlr_keyboard *wlr_keyboard = keyboard->wlr_keyboard;
 
+	if (server->input_mode == LAB_INPUT_STATE_MOVE) {
+		/* Any change to the modifier state re-enable region snap */
+		seat->region_prevent_snap = false;
+	}
+
 	if (server->osd_state.cycle_view || server->grabbed_view
 			|| seat->workspace_osd_shown_by_modifier) {
 		if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -53,7 +53,6 @@ keyboard_modifiers_notify(struct wl_listener *listener, void *data)
 	struct keyboard *keyboard = wl_container_of(listener, keyboard, modifier);
 	struct seat *seat = keyboard->base.seat;
 	struct server *server = seat->server;
-	struct wlr_keyboard_key_event *event = data;
 	struct wlr_keyboard *wlr_keyboard = keyboard->wlr_keyboard;
 
 	if (server->input_mode == LAB_INPUT_STATE_MOVE) {
@@ -63,8 +62,7 @@ keyboard_modifiers_notify(struct wl_listener *listener, void *data)
 
 	if (server->osd_state.cycle_view || server->grabbed_view
 			|| seat->workspace_osd_shown_by_modifier) {
-		if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED
-				&& !keyboard_any_modifiers_pressed(wlr_keyboard))  {
+		if (!keyboard_any_modifiers_pressed(wlr_keyboard))  {
 			if (server->osd_state.cycle_view) {
 				if (key_state_nr_keys()) {
 					should_cancel_cycling_on_next_key_release = true;

--- a/src/regions.c
+++ b/src/regions.c
@@ -17,9 +17,16 @@
 #include "view.h"
 
 bool
-regions_available(void)
+regions_should_snap(struct server *server)
 {
-	return !wl_list_empty(&rc.regions);
+	if (server->input_mode != LAB_INPUT_STATE_MOVE
+			|| wl_list_empty(&rc.regions)
+			|| server->seat.region_prevent_snap) {
+		return false;
+	}
+
+	struct wlr_keyboard *keyboard = &server->seat.keyboard_group->keyboard;
+	return keyboard_any_modifiers_pressed(keyboard);
 }
 
 static void


### PR DESCRIPTION
When wanting to snap to a region when starting the move
operation with A-Left (or a similar mousebind which includes a
modifier), the modifier - or another one - must be pressed again.

Fixes #761

---
Also includes a fix for the wlr_keyboard `modifier` event coming from wlroots.
We were just lucky that it didn't cause any issues, we were casting a `wlr_keyboard` pointer to a `wlr_keyboard_key_event` pointer before.