### PR TITLE
view: close popups on focus-change, SSD mouse-event and window switching

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -24,6 +24,7 @@ struct view;
 struct view_impl {
 	void (*configure)(struct view *view, struct wlr_box geo);
 	void (*close)(struct view *view);
+	void (*close_popups)(struct view *view);
 	const char *(*get_string_prop)(struct view *view, const char *prop);
 	void (*map)(struct view *view);
 	void (*set_activated)(struct view *view, bool activated);
@@ -134,6 +135,7 @@ struct xdg_toplevel_view {
 void view_set_activated(struct view *view);
 void view_set_output(struct view *view, struct output *output);
 void view_close(struct view *view);
+void view_close_popups(struct view *view);
 
 /**
  * view_move_resize - resize and move view

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -818,6 +818,9 @@ handle_press_mousebinding(struct server *server, struct cursor_context *ctx,
 				continue;
 			}
 			consumed_by_frame_context |= mousebind->context == LAB_SSD_FRAME;
+			if (ctx->view) {
+				view_close_popups(ctx->view);
+			}
 			actions_run(ctx->view, server, &mousebind->actions, resize_edges);
 		}
 	}

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -55,10 +55,20 @@ desktop_arrange_all_views(struct server *server)
 	}
 }
 
+static void
+close_all_popups(struct server *server)
+{
+	struct view *view;
+	wl_list_for_each(view, &server->views, link) {
+		view_close_popups(view);
+	}
+}
+
 void
 desktop_focus_and_activate_view(struct seat *seat, struct view *view)
 {
 	if (!view) {
+		close_all_popups(seat->server);
 		seat_focus_surface(seat, NULL);
 		return;
 	}
@@ -97,6 +107,7 @@ desktop_focus_and_activate_view(struct seat *seat, struct view *view)
 		return;
 	}
 
+	view_close_popups(view);
 	view_set_activated(view);
 	seat_focus_surface(seat, view->surface);
 }
@@ -188,6 +199,9 @@ desktop_cycle_view(struct server *server, struct view *start_view,
 			return start_view;  /* may be NULL */
 		}
 	}
+
+	view_close_popups(start_view);
+
 	struct view *view = start_view;
 	struct wlr_scene_node *node = &view->scene_tree->node;
 

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -96,6 +96,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 	server->grab_y = seat->cursor->y;
 	server->grab_box = geometry;
 	server->resize_edges = edges;
+	view_close_popups(view);
 }
 
 /* Returns true if view was snapped to any edge */

--- a/src/view.c
+++ b/src/view.c
@@ -162,6 +162,14 @@ view_close(struct view *view)
 }
 
 void
+view_close_popups(struct view *view)
+{
+	if (view->impl->close_popups) {
+		view->impl->close_popups(view);
+	}
+}
+
+void
 view_move(struct view *view, int x, int y)
 {
 	assert(view);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -296,6 +296,16 @@ xdg_toplevel_view_close(struct view *view)
 }
 
 static void
+xdg_toplevel_view_close_popups(struct view *view)
+{
+	struct wlr_xdg_toplevel *toplevel = xdg_toplevel_from_view(view);
+	struct wlr_xdg_popup *popup, *next;
+	wl_list_for_each_safe(popup, next, &toplevel->base->popups, link) {
+		wlr_xdg_popup_destroy(popup);
+	}
+}
+
+static void
 xdg_toplevel_view_maximize(struct view *view, bool maximized)
 {
 	wlr_xdg_toplevel_set_maximized(xdg_toplevel_from_view(view), maximized);
@@ -446,6 +456,7 @@ xdg_toplevel_view_unmap(struct view *view)
 static const struct view_impl xdg_toplevel_view_impl = {
 	.configure = xdg_toplevel_view_configure,
 	.close = xdg_toplevel_view_close,
+	.close_popups = xdg_toplevel_view_close_popups,
 	.get_string_prop = xdg_toplevel_view_get_string_prop,
 	.map = xdg_toplevel_view_map,
 	.set_activated = xdg_toplevel_view_set_activated,


### PR DESCRIPTION
Just submitting for early thoughts/discussion.

I'm sort of puzzled that nobody has reported this before. Try opening a menu and then dragging a window, alt-tab or similar.

- [ ] close xwayland popups
- [ ] close layer-shell popups