### PR TITLE
desktop: move scene-tree node in move-to-back

### DIFF
--- a/include/view-impl-common.h
+++ b/include/view-impl-common.h
@@ -10,6 +10,7 @@
 struct view;
 
 void view_impl_move_to_front(struct view *view);
+void view_impl_move_to_back(struct view *view);
 void view_impl_map(struct view *view);
 
 /*

--- a/include/view.h
+++ b/include/view.h
@@ -37,6 +37,7 @@ struct view_impl {
 	void (*unmap)(struct view *view);
 	void (*maximize)(struct view *view, bool maximize);
 	void (*move_to_front)(struct view *view);
+	void (*move_to_back)(struct view *view);
 };
 
 struct view {

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -30,8 +30,10 @@ desktop_move_to_back(struct view *view)
 	if (!view) {
 		return;
 	}
-	wl_list_remove(&view->link);
-	wl_list_append(&view->server->views, &view->link);
+	if (view->impl->move_to_back) {
+		view->impl->move_to_back(view);
+		cursor_update_focus(view->server);
+	}
 }
 
 void

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -2,6 +2,7 @@
 /* view-impl-common.c: common code for shell view->impl functions */
 #include <stdio.h>
 #include <strings.h>
+#include "common/list.h"
 #include "labwc.h"
 #include "view.h"
 #include "view-impl-common.h"
@@ -12,6 +13,14 @@ view_impl_move_to_front(struct view *view)
 	wl_list_remove(&view->link);
 	wl_list_insert(&view->server->views, &view->link);
 	wlr_scene_node_raise_to_top(&view->scene_tree->node);
+}
+
+void
+view_impl_move_to_back(struct view *view)
+{
+	wl_list_remove(&view->link);
+	wl_list_append(&view->server->views, &view->link);
+	wlr_scene_node_lower_to_bottom(&view->scene_tree->node);
 }
 
 void

--- a/src/view.c
+++ b/src/view.c
@@ -232,7 +232,6 @@ view_minimize(struct view *view, bool minimized)
 	view->minimized = minimized;
 	if (minimized) {
 		view->impl->unmap(view);
-		desktop_move_to_back(view);
 		_view_set_activated(view, false);
 		if (view == view->server->focused_view) {
 			/*

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -455,6 +455,7 @@ static const struct view_impl xdg_toplevel_view_impl = {
 	.unmap = xdg_toplevel_view_unmap,
 	.maximize = xdg_toplevel_view_maximize,
 	.move_to_front = view_impl_move_to_front,
+	.move_to_back = view_impl_move_to_back,
 };
 
 void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -497,8 +497,13 @@ xwayland_view_maximize(struct view *view, bool maximized)
 		maximized);
 }
 
+enum z_direction {
+	LAB_TO_FRONT,
+	LAB_TO_BACK,
+};
+
 static void
-move_sub_views_to_front(struct view *parent)
+move_sub_views(struct view *parent, enum z_direction z_direction)
 {
 	assert(parent);
 
@@ -524,7 +529,11 @@ move_sub_views_to_front(struct view *parent)
 		if (top_parent_of(view) != parent_xwayland_surface) {
 			continue;
 		}
-		view_impl_move_to_front(view);
+		if (z_direction == LAB_TO_FRONT) {
+			view_impl_move_to_front(view);
+		} else if (z_direction == LAB_TO_BACK) {
+			view_impl_move_to_back(view);
+		}
 	}
 }
 
@@ -532,7 +541,14 @@ static void
 xwayland_view_move_to_front(struct view *view)
 {
 	view_impl_move_to_front(view);
-	move_sub_views_to_front(view);
+	move_sub_views(view, LAB_TO_FRONT);
+}
+
+static void
+xwayland_view_move_to_back(struct view *view)
+{
+	view_impl_move_to_back(view);
+	move_sub_views(view, LAB_TO_BACK);
 }
 
 static void
@@ -576,6 +592,7 @@ static const struct view_impl xwayland_view_impl = {
 	.unmap = xwayland_view_unmap,
 	.maximize = xwayland_view_maximize,
 	.move_to_front = xwayland_view_move_to_front,
+	.move_to_back = xwayland_view_move_to_back,
 };
 
 static void


### PR DESCRIPTION
@Consolatis @jech How about this as a pre-commit for PR #829 

`view_minimize()` does not need to call `desktop_move_to_back()` because the stacking order is not changed and the windowSwitcher uses the scene-tree nodes anyway.

I thought of not keeping `server->views` in sync with view z-order, but xwayland sub-views still relies on it.