### PR TITLE
followMouse: allow focus switching via A-Tab

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -509,7 +509,8 @@ cursor_update_focus(struct server *server)
 	/* Focus surface under cursor if it isn't already focused */
 	struct cursor_context ctx = get_cursor_context(server);
 
-	if (ctx.view && rc.focus_follow_mouse) {
+	if (ctx.view && rc.focus_follow_mouse && !server->osd_state.cycle_view) {
+		/* Prevent changing keyboard focus during A-Tab */
 		desktop_focus_and_activate_view(&server->seat, ctx.view);
 		if (rc.raise_on_focus) {
 			/*

--- a/src/osd.c
+++ b/src/osd.c
@@ -164,7 +164,6 @@ osd_on_view_destroy(struct view *view)
 void
 osd_finish(struct server *server)
 {
-	server->osd_state.cycle_view = NULL;
 	server->osd_state.preview_node = NULL;
 	server->osd_state.preview_anchor = NULL;
 
@@ -181,6 +180,15 @@ osd_finish(struct server *server)
 
 	/* Hiding OSD may need a cursor change */
 	cursor_update_focus(server);
+
+	/*
+	 * We delay resetting cycle_view until after cursor_update_focus()
+	 * has been called to allow A-Tab keyboard focus switching even if
+	 * followMouse has been configured and the cursor is on a different
+	 * surface. Otherwise cursor_update_focus() would automatically
+	 * refocus the surface the cursor is currently on.
+	 */
+	server->osd_state.cycle_view = NULL;
 }
 
 void


### PR DESCRIPTION
Fixes a regression caused by the recent enhancement of followMouse behavior.

Fixes: #849
Reported-by: mitigate via IRC