### PR TITLE
src/cursor.c: fix invisible cursor on output loss / restore

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -260,6 +260,16 @@ cursor_update_image(struct seat *seat)
 {
 	enum lab_cursors cursor = seat->server_cursor;
 	if (cursor == LAB_CURSOR_CLIENT) {
+		/*
+		 * When we loose the output cursor while over a client
+		 * surface (e.g. output was destroyed and we now deal with
+		 * a new output instance), we have to force a re-enter of
+		 * the surface so the client sets its own cursor again.
+		 */
+		if (seat->seat->pointer_state.focused_surface) {
+			seat->server_cursor = LAB_CURSOR_DEFAULT;
+			cursor_update_focus(seat->server);
+		}
 		return;
 	}
 	wlr_xcursor_manager_set_cursor_image(

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1176,6 +1176,9 @@ cursor_init(struct seat *seat)
 		cursor_names = cursors_x11;
 	}
 
+	/* Set the initial cursor image so the cursor is visible right away */
+	cursor_set(seat, LAB_CURSOR_DEFAULT);
+
 	dnd_init(seat);
 
 	seat->cursor_motion.notify = cursor_motion;


### PR DESCRIPTION
Previously, the cursor image was only updated on output loss when the cursor was on a labwc owned surface. This patch forces a re-enter of a client surface in the remaining case of cursor being over a non-labwc surface which causes the client to re-set its own cursor image.

This fixes a regression caused by 4dc99e2f3856650f3b61778f015a823cfae978d2.
Thanks to @Flrian for finding the root cause of the issue.

Fixes #820

Reported-by: @Flrian
Tested-by: @Flrian