### PR TITLE
view: Add view_move_to_front/back() with _no_focus variant

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -367,8 +367,6 @@ void foreign_toplevel_update_outputs(struct view *view);
  *              cannot assume this means that the window actually has keyboard
  *              or pointer focus, in this compositor are they called together.
  */
-void desktop_move_to_front(struct view *view);
-void desktop_move_to_back(struct view *view);
 void desktop_focus_and_activate_view(struct seat *seat, struct view *view);
 void desktop_arrange_all_views(struct server *server);
 void desktop_focus_output(struct output *output);

--- a/include/view.h
+++ b/include/view.h
@@ -184,6 +184,10 @@ void view_snap_to_edge(struct view *view, const char *direction,
 	bool store_natural_geometry);
 void view_snap_to_region(struct view *view, struct region *region,
 	bool store_natural_geometry);
+
+void view_move_to_front(struct view *view);
+void view_move_to_back(struct view *view);
+
 const char *view_get_string_prop(struct view *view, const char *prop);
 void view_update_title(struct view *view);
 void view_update_app_id(struct view *view);

--- a/src/action.c
+++ b/src/action.c
@@ -439,12 +439,12 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_RAISE:
 			if (view) {
-				desktop_move_to_front(view);
+				view_move_to_front(view);
 			}
 			break;
 		case ACTION_TYPE_LOWER:
 			if (view) {
-				desktop_move_to_back(view);
+				view_move_to_back(view);
 			}
 			break;
 		case ACTION_TYPE_RESIZE:

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -13,30 +13,6 @@
 #include "xwayland.h"
 
 void
-desktop_move_to_front(struct view *view)
-{
-	if (!view) {
-		return;
-	}
-	if (view->impl->move_to_front) {
-		view->impl->move_to_front(view);
-		cursor_update_focus(view->server);
-	}
-}
-
-void
-desktop_move_to_back(struct view *view)
-{
-	if (!view) {
-		return;
-	}
-	if (view->impl->move_to_back) {
-		view->impl->move_to_back(view);
-		cursor_update_focus(view->server);
-	}
-}
-
-void
 desktop_arrange_all_views(struct server *server)
 {
 	/*
@@ -267,7 +243,9 @@ desktop_focus_topmost_mapped_view(struct server *server)
 {
 	struct view *view = topmost_mapped_view(server);
 	desktop_focus_and_activate_view(&server->seat, view);
-	desktop_move_to_front(view);
+	if (view) {
+		view_move_to_front(view);
+	}
 }
 
 void

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -38,7 +38,7 @@ handle_request_activate(struct wl_listener *listener, void *data)
 		workspaces_switch_to(view->workspace);
 	}
 	desktop_focus_and_activate_view(&view->server->seat, view);
-	desktop_move_to_front(view);
+	view_move_to_front(view);
 }
 
 static void

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -40,7 +40,9 @@ static void
 end_cycling(struct server *server)
 {
 	desktop_focus_and_activate_view(&server->seat, server->osd_state.cycle_view);
-	desktop_move_to_front(server->osd_state.cycle_view);
+	if (server->osd_state.cycle_view) {
+		view_move_to_front(server->osd_state.cycle_view);
+	}
 
 	/* osd_finish() additionally resets cycle_view to NULL */
 	osd_finish(server);

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -27,7 +27,7 @@ void
 view_impl_map(struct view *view)
 {
 	desktop_focus_and_activate_view(&view->server->seat, view);
-	desktop_move_to_front(view);
+	view_move_to_front(view);
 	view_update_title(view);
 	view_update_app_id(view);
 }

--- a/src/view.c
+++ b/src/view.c
@@ -982,6 +982,26 @@ view_snap_to_region(struct view *view, struct region *region,
 	view_apply_region_geometry(view);
 }
 
+void
+view_move_to_front(struct view *view)
+{
+	assert(view);
+	if (view->impl->move_to_front) {
+		view->impl->move_to_front(view);
+		cursor_update_focus(view->server);
+	}
+}
+
+void
+view_move_to_back(struct view *view)
+{
+	assert(view);
+	if (view->impl->move_to_back) {
+		view->impl->move_to_back(view);
+		cursor_update_focus(view->server);
+	}
+}
+
 const char *
 view_get_string_prop(struct view *view, const char *prop)
 {

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -495,7 +495,7 @@ xdg_activation_handle_request(struct wl_listener *listener, void *data)
 		workspaces_switch_to(view->workspace);
 	}
 	desktop_focus_and_activate_view(&view->server->seat, view);
-	desktop_move_to_front(view);
+	view_move_to_front(view);
 }
 
 /*

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -270,7 +270,7 @@ handle_request_activate(struct wl_listener *listener, void *data)
 		wl_container_of(listener, xwayland_view, request_activate);
 	struct view *view = &xwayland_view->base;
 	desktop_focus_and_activate_view(&view->server->seat, view);
-	desktop_move_to_front(view);
+	view_move_to_front(view);
 }
 
 static void


### PR DESCRIPTION
This avoids calling `view->impl` functions from `cursor.c` and `desktop.c`.

No functional change intended.