### PR TITLE
followMouse: add followMouseRequiresMovement

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -116,6 +116,14 @@ The rest of this man page describes configuration options.
 	Make focus follow mouse, i.e. focus is given to window under mouse
 	cursor. Default is no.
 
+*<focus><followMouseRequiresMovement>* [yes|no]
+	Requires cursor movement if followMouse is enabled. It is the same
+	as the "underMouse" setting in Openbox. If set to "no", labwc will
+	additionally focus the window under the cursor in all situations
+	which change the position of a window (e.g. switching workspaces,
+	opening/closing windows). Focusing a different window via A-Tab is
+	still possible, even with this setting set to "no". Default is yes.
+
 *<focus><raiseOnFocus>* [yes|no]
 	Raise window to top when focused. Default is no.
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -53,6 +53,7 @@
 
   <focus>
     <followMouse>no</followMouse>
+    <followMouseRequiresMovement>yes</followMouseRequiresMovement>
     <raiseOnFocus>no</raiseOnFocus>
   </focus>
 

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -35,6 +35,7 @@ struct rcxml {
 
 	/* focus */
 	bool focus_follow_mouse;
+	bool focus_follow_mouse_requires_movement;
 	bool raise_on_focus;
 
 	/* theme */

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -531,6 +531,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		fill_font(nodename, content, font_place);
 	} else if (!strcasecmp(nodename, "followMouse.focus")) {
 		set_bool(content, &rc.focus_follow_mouse);
+	} else if (!strcasecmp(nodename, "followMouseRequiresMovement.focus")) {
+		set_bool(content, &rc.focus_follow_mouse_requires_movement);
 	} else if (!strcasecmp(nodename, "raiseOnFocus.focus")) {
 		set_bool(content, &rc.raise_on_focus);
 	} else if (!strcasecmp(nodename, "doubleClickTime.mouse")) {
@@ -720,11 +722,16 @@ rcxml_init(void)
 	init_font_defaults(&rc.font_menuitem);
 	init_font_defaults(&rc.font_osd);
 
+	rc.focus_follow_mouse = false;
+	rc.focus_follow_mouse_requires_movement = true;
+	rc.raise_on_focus = false;
+
 	rc.doubleclick_time = 500;
 	rc.scroll_factor = 1.0;
 	rc.repeat_rate = 25;
 	rc.repeat_delay = 600;
 	rc.screen_edge_strength = 20;
+
 	rc.snap_edge_range = 1;
 	rc.snap_top_maximize = true;
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -519,8 +519,10 @@ _cursor_update_focus(struct server *server)
 	/* Focus surface under cursor if it isn't already focused */
 	struct cursor_context ctx = get_cursor_context(server);
 
-	if (ctx.view && rc.focus_follow_mouse && !server->osd_state.cycle_view) {
-		/* Prevent changing keyboard focus during A-Tab */
+	if (ctx.view && rc.focus_follow_mouse
+			&& !rc.focus_follow_mouse_requires_movement
+			&& !server->osd_state.cycle_view) {
+		/* Prevents changing keyboard focus during A-Tab */
 		desktop_focus_and_activate_view(&server->seat, ctx.view);
 		if (rc.raise_on_focus) {
 			view_move_to_front(ctx.view);


### PR DESCRIPTION
This implements the same config option as `underMouse` in Openbox.

Fixes #862

---
The implementation uses a different name for the config than Openbox (`followMouseRequiresMovement` vs `underMouse` which I hope is easier to understand and doesn't require looking it up in the docs). The default of the new config is set to `yes` to restore the previous behavior of `followMouse`.

If set to `no`, this PR currently prevents focusing new windows even if the cursor is at the place the new window spawns, I am not quite sure why that is. It also wasn't really tested in depth so draft for now. Practical testing (with reports including the tested variant of `yes`/`no`) welcome.

CC @bi4k8 @jech

Ref:
- #830
- #862