### PR TITLE
OSD improvements

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -146,6 +146,17 @@ elements are not listed here, but are supported.
 *osd.label.text.color*
 	Text color of on-screen-display
 
+*osd.window-switcher.width*
+	Width of window switcher in pixels. Default is 600.
+
+*osd.window-switcher.item.padding.x*
+	Horizontal padding of window switcher entries in pixels.
+	Default is 10.
+
+*osd.window-switcher.item.padding.y*
+	Vertical padding of window switcher entries in pixels.
+	Default is 6.
+
 *border.color*
 	Set all border colors. This is obsolete, but supported for backward
 	compatibility as some themes still contain it.

--- a/docs/themerc
+++ b/docs/themerc
@@ -52,3 +52,7 @@ osd.bg.color: #dddda6
 osd.border.color: #000000
 osd.border.width: 1
 osd.label.text.color: #000000
+
+osd.window-switcher.width: 600
+osd.window-switcher.item.padding.x: 10
+osd.window-switcher.item.padding.y: 6

--- a/include/common/graphic-helpers.h
+++ b/include/common/graphic-helpers.h
@@ -7,6 +7,7 @@
 
 struct wlr_scene_tree;
 struct wlr_scene_rect;
+struct wlr_fbox;
 
 struct multi_rect {
 	struct wlr_scene_tree *tree;
@@ -44,7 +45,6 @@ void multi_rect_set_size(struct multi_rect *rect, int width, int height);
 void set_cairo_color(cairo_t *cairo, float *color);
 
 /* Draws a border with a specified line width */
-void draw_cairo_border(cairo_t *cairo, double width, double height,
-		double line_width);
+void draw_cairo_border(cairo_t *cairo, struct wlr_fbox fbox, double line_width);
 
 #endif /* LABWC_GRAPHIC_HELPERS_H */

--- a/include/theme.h
+++ b/include/theme.h
@@ -62,9 +62,14 @@ struct theme {
 	float menu_separator_color[4];
 
 	int osd_border_width;
+
 	float osd_bg_color[4];
 	float osd_border_color[4];
 	float osd_label_text_color[4];
+
+	int osd_window_switcher_width;
+	int osd_window_switcher_item_padding_x;
+	int osd_window_switcher_item_padding_y;
 
 	/* textures */
 	struct lab_data_buffer *xbm_close_active_unpressed;
@@ -84,6 +89,7 @@ struct theme {
 
 	/* not set in rc.xml/themerc, but derived from font & padding_height */
 	int title_height;
+	int osd_window_switcher_item_height;
 };
 
 /**

--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -4,6 +4,7 @@
 #include <cairo.h>
 #include <stdlib.h>
 #include <wlr/types/wlr_scene.h>
+#include <wlr/util/box.h>
 #include "common/graphic-helpers.h"
 #include "common/mem.h"
 
@@ -62,18 +63,17 @@ multi_rect_set_size(struct multi_rect *rect, int width, int height)
 
 /* Draws a border with a specified line width */
 void
-draw_cairo_border(cairo_t *cairo, double width, double height, double line_width)
+draw_cairo_border(cairo_t *cairo, struct wlr_fbox fbox, double line_width)
 {
 	cairo_save(cairo);
 
-	double x, y, w, h;
 	/* The anchor point of a line is in the center */
-	x = line_width / 2;
-	y = x;
-	w = width - line_width;
-	h = height - line_width;
+	fbox.x += line_width / 2.0;
+	fbox.y += line_width / 2.0;
+	fbox.width -= line_width;
+	fbox.height -= line_width;
 	cairo_set_line_width(cairo, line_width);
-	cairo_rectangle(cairo, x, y, w, h);
+	cairo_rectangle(cairo, fbox.x, fbox.y, fbox.width, fbox.height);
 	cairo_stroke(cairo);
 
 	cairo_restore(cairo);

--- a/src/osd.c
+++ b/src/osd.c
@@ -21,7 +21,6 @@
 #define OSD_ITEM_HEIGHT (20)
 #define OSD_ITEM_WIDTH (600)
 #define OSD_ITEM_PADDING (10)
-#define OSD_BORDER_WIDTH (6)
 
 /* is title different from app_id/class? */
 static int
@@ -76,7 +75,7 @@ get_osd_height(struct wl_list *node_list)
 		}
 		height += OSD_ITEM_HEIGHT;
 	}
-	height += 2 * OSD_BORDER_WIDTH;
+	height += 2 * rc.theme->osd_border_width;
 	return height;
 }
 
@@ -313,7 +312,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 
 	pango_cairo_update_layout(cairo, layout);
 
-	int y = OSD_BORDER_WIDTH;
+	int y = theme->osd_border_width;
 
 	/* Center text entries on the y axis */
 	int y_offset = (OSD_ITEM_HEIGHT - font_height(&rc.font_osd)) / 2;
@@ -351,7 +350,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 			continue;
 		}
 
-		int x = OSD_BORDER_WIDTH + OSD_ITEM_PADDING;
+		int x = theme->osd_border_width + OSD_ITEM_PADDING;
 		struct window_switcher_field *field;
 		wl_list_for_each(field, &rc.window_switcher.fields, link) {
 			buf.len = 0;
@@ -379,8 +378,8 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 
 		if (view == cycle_view) {
 			/* Highlight current window */
-			cairo_rectangle(cairo, OSD_BORDER_WIDTH, y - y_offset,
-				OSD_ITEM_WIDTH, OSD_ITEM_HEIGHT);
+			cairo_rectangle(cairo, theme->osd_border_width,
+				y - y_offset, OSD_ITEM_WIDTH, OSD_ITEM_HEIGHT);
 			cairo_stroke(cairo);
 		}
 
@@ -402,7 +401,7 @@ display_osd(struct output *output)
 	const char *workspace_name = server->workspace_current->name;
 
 	float scale = output->wlr_output->scale;
-	int w = OSD_ITEM_WIDTH + (2 * OSD_BORDER_WIDTH);
+	int w = OSD_ITEM_WIDTH + (2 * server->theme->osd_border_width);
 	int h = get_osd_height(node_list);
 	if (show_workspace) {
 		/* workspace indicator */

--- a/src/theme.c
+++ b/src/theme.c
@@ -140,6 +140,10 @@ theme_builtin(struct theme *theme)
 	theme->menu_separator_padding_height = 3;
 	parse_hexstr("#888888", theme->menu_separator_color);
 
+	theme->osd_window_switcher_width = 600;
+	theme->osd_window_switcher_item_padding_x = 10;
+	theme->osd_window_switcher_item_padding_y = 6;
+
 	/* inherit settings in post_processing() if not set elsewhere */
 	theme->osd_bg_color[0] = FLT_MIN;
 	theme->osd_border_width = INT_MIN;
@@ -303,6 +307,15 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match_glob(key, "osd.border.color")) {
 		parse_hexstr(value, theme->osd_border_color);
+	}
+	if (match_glob(key, "osd.window-switcher.width")) {
+		theme->osd_window_switcher_width = atoi(value);
+	}
+	if (match_glob(key, "osd.window-switcher.item.padding.x")) {
+		theme->osd_window_switcher_item_padding_x = atoi(value);
+	}
+	if (match_glob(key, "osd.window-switcher.item.padding.y")) {
+		theme->osd_window_switcher_item_padding_y = atoi(value);
 	}
 	if (match_glob(key, "osd.label.text.color")) {
 		parse_hexstr(value, theme->osd_label_text_color);
@@ -518,6 +531,8 @@ post_processing(struct theme *theme)
 {
 	theme->title_height = font_height(&rc.font_activewindow)
 		+ 2 * theme->padding_height;
+	theme->osd_window_switcher_item_height = font_height(&rc.font_osd)
+		+ 2 * theme->osd_window_switcher_item_padding_y;
 
 	if (rc.corner_radius >= theme->title_height) {
 		theme->title_height = rc.corner_radius + 1;

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -91,7 +91,11 @@ _osd_update(struct server *server)
 
 		/* Border */
 		set_cairo_color(cairo, theme->osd_border_color);
-		draw_cairo_border(cairo, width, height, theme->osd_border_width);
+		struct wlr_fbox fbox = {
+			.width = width,
+			.height = height,
+		};
+		draw_cairo_border(cairo, fbox, theme->osd_border_width);
 
 		uint16_t x = (width - marker_width) / 2;
 		wl_list_for_each(workspace, &server->workspaces, link) {


### PR DESCRIPTION
--EDIT-- This list is now managed at #968 

Based on @1qh list in issue #879

- [x] item height
- [x] item width
- [x] item vertical padding
- [x] focused item border width
- focused item background and text color
- [x] possible to hide each of 3 columns
- position of desktop name (top/bottom)
- different font size for desktop switcher and window switcher
- size of the squares in desktop switcher

TODO:

- [x] Consider `s/osd.window-switcher.item.width/osd-window-switcher.width/`
- Consider allowing window-switcher width to be specified as a percentage of output width
- Calculate window-switcher width based on item-width + padding
- ~~Take into account output->scale~~
- osd.c: simplify the get_title() helper and associated `is_title_different()`
- Cope with many `nr_items` * `item_height` > `output_height`
- Show always on-top windows
- Consider showing multiple work-spaces in window-switcher (although config might get pretty hard
- Consider showing window thumbnails :smile:

Notes:

Have used `osd.window-switcher.foo: bar` because the window-switcher is only one type of OSD and we might want to set different value for the workspace-switcher for example. If anyone wants to set them to the same, they can simply do `osd.*.foo: bar`.
