### PR TITLE
output: Make the session lock layer the topmost

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -191,6 +191,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 	/*
 	 * Set the z-positions to achieve the following order (from top to
 	 * bottom):
+	 *	- session lock layer
 	 *	- layer-shell popups
 	 *	- overlay layer
 	 *	- top layer
@@ -203,6 +204,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 	wlr_scene_node_raise_to_top(&output->layer_tree[2]->node);
 	wlr_scene_node_raise_to_top(&output->layer_tree[3]->node);
 	wlr_scene_node_raise_to_top(&output->layer_popup_tree->node);
+	wlr_scene_node_raise_to_top(&output->session_lock_tree->node);
 
 	if (rc.adaptive_sync) {
 		wlr_log(WLR_INFO, "enable adaptive sync on %s", wlr_output->name);


### PR DESCRIPTION
Make sure that only the session lock layer is visible to a user. Fixes the issue with mako notifications being rendered above the swaylock window.