### PR TITLE
xwayland: Add mapped argument to xwayland_view_create()

### DIFF
--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -43,8 +43,8 @@ struct xwayland_view {
 void xwayland_unmanaged_create(struct server *server,
 	struct wlr_xwayland_surface *xsurface, bool mapped);
 
-struct xwayland_view *xwayland_view_create(struct server *server,
-	struct wlr_xwayland_surface *xsurface);
+void xwayland_view_create(struct server *server,
+	struct wlr_xwayland_surface *xsurface, bool mapped);
 
 struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
 

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -146,13 +146,7 @@ unmanaged_handle_override_redirect(struct wl_listener *listener, void *data)
 	unmanaged_handle_destroy(&unmanaged->destroy, NULL);
 	xsurface->data = NULL;
 
-	struct xwayland_view *xwayland_view = xwayland_view_create(server, xsurface);
-	if (mapped) {
-		struct view *view = &xwayland_view->base;
-		if (view->impl->map) {
-			view->impl->map(view);
-		}
-	}
+	xwayland_view_create(server, xsurface, mapped);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -608,8 +608,9 @@ static const struct view_impl xwayland_view_impl = {
 	.move_to_back = xwayland_view_move_to_back,
 };
 
-struct xwayland_view *
-xwayland_view_create(struct server *server, struct wlr_xwayland_surface *xsurface)
+void
+xwayland_view_create(struct server *server,
+		struct wlr_xwayland_surface *xsurface, bool mapped)
 {
 	struct xwayland_view *xwayland_view = znew(*xwayland_view);
 	struct view *view = &xwayland_view->base;
@@ -669,7 +670,10 @@ xwayland_view_create(struct server *server, struct wlr_xwayland_surface *xsurfac
 	wl_signal_add(&xsurface->events.set_override_redirect, &xwayland_view->override_redirect);
 
 	wl_list_insert(&view->server->views, &view->link);
-	return xwayland_view;
+
+	if (mapped) {
+		xwayland_view_map(view);
+	}
 }
 
 static void
@@ -686,9 +690,9 @@ handle_new_surface(struct wl_listener *listener, void *data)
 	 */
 	if (xsurface->override_redirect) {
 		xwayland_unmanaged_create(server, xsurface, /* mapped */ false);
-		return;
+	} else {
+		xwayland_view_create(server, xsurface, /* mapped */ false);
 	}
-	xwayland_view_create(server, xsurface);
 }
 
 static void


### PR DESCRIPTION
This is a trivial cleanup to make `xwayland_view_create()` symmetrical with `xwayland_unmanaged_create()`, and avoid the need to access `view->impl` from xwayland-unmanaged.c.

The return value of `xwayland_view_create()` is no longer used, so return `void`.

No functional change.