### PR TITLE
window-rules: support title criteria

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -347,7 +347,7 @@ defined as shown below.
 <windowRules>
 
   <!-- Action -->
-  <windowRule identifier="">
+  <windowRule identifier="" title="">
     <action name=""/>
   </windowRule>
 
@@ -359,14 +359,17 @@ defined as shown below.
 
 *Actions*
 
-*<windowRules><windowRule identifier="">*
+*<windowRules><windowRule identifier="" title="">*
 	Define a window rule for any window which matches the criteria defined
-	by the attribute *identifier*. Matching against patterns with '\*'
-	(wildcard) and '?' (joker) is supported. Pattern matching is
-	case-insensitive.
+	by the attributes *identifier* or *title*. If both are defined, AND
+	logic is used, so both have to match.
+	Matching against patterns with '\*' (wildcard) and '?' (joker) is
+	supported. Pattern matching is case-insensitive.
 
 	*identifier* relates to app_id for native Wayland windows and WM_CLASS
 	for XWayland clients.
+
+	*title* is the title of the window.
 
 *Properties*
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -376,11 +376,19 @@
   </libinput>
 
   <!--
+    Window Rules
+      - Criteria can consist of 'identifier' or 'title' or both (in which case
+        AND logic is used).
+      - 'identifier' relates to app_id for native Wayland windows and WM_CLASS
+        for XWayland clients.
+      - Matching against patterns with '*' (wildcard) and '?' (joker) is
+        supported. Pattern matching is case-insensitive.
+
   <windowRules>
-    <windowRule identifier="*">
-      <action name="Maximize" />
-    </windowRule>
-    <windowRule identifier="some-application" serverDecoration="yes" />
+    <windowRule identifier="*"><action name="Maximize"/></windowRule>
+    <windowRule identifier="foo" serverDecoration="yes"/>
+    <windowRule title="bar" serverDecoration="yes"/>
+    <windowRule identifier="baz" title="quax" serverDecoration="yes"/>
   </windowRules>
   -->
 

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -20,6 +20,7 @@ enum property {
  */
 struct window_rule {
 	char *identifier;
+	char *title;
 
 	enum window_rule_event event;
 	struct wl_list actions;


### PR DESCRIPTION
Example config:

```
<windowRules>
  <windowRule identifier="foot" title="foo"><action name="Maximize"/></windowRule>
</windowRules>
```

Observe that:

- `foot -T foo` starts maximized
- `xterm -T foo` starts normal