### PR TITLE
More robust action argument parsing

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -20,6 +20,8 @@ struct action {
 
 struct action *action_create(const char *action_name);
 
+bool action_is_valid(struct action *action);
+
 void action_arg_add_str(struct action *action, const char *key, const char *value);
 
 void action_arg_from_xml_node(struct action *action, char *nodename, char *content);

--- a/include/action.h
+++ b/include/action.h
@@ -30,6 +30,8 @@ bool actions_contain_toggle_keybinds(struct wl_list *action_list);
 
 void actions_run(struct view *activator, struct server *server,
 	struct wl_list *actions, uint32_t resize_edges);
+
+void action_free(struct action *action);
 void action_list_free(struct wl_list *action_list);
 
 #endif /* LABWC_ACTION_H */

--- a/include/action.h
+++ b/include/action.h
@@ -20,7 +20,7 @@ struct action {
 
 struct action *action_create(const char *action_name);
 
-void action_arg_add_str(struct action *action, char *key, const char *value);
+void action_arg_add_str(struct action *action, const char *key, const char *value);
 
 void action_arg_from_xml_node(struct action *action, char *nodename, char *content);
 

--- a/src/action.c
+++ b/src/action.c
@@ -122,38 +122,38 @@ const char *action_names[] = {
 };
 
 void
-action_arg_add_str(struct action *action, char *key, const char *value)
+action_arg_add_str(struct action *action, const char *key, const char *value)
 {
+	assert(action);
+	assert(key);
 	assert(value && "Tried to add NULL action string argument");
 	struct action_arg_str *arg = znew(*arg);
 	arg->base.type = LAB_ACTION_ARG_STR;
-	if (key) {
-		arg->base.key = xstrdup(key);
-	}
+	arg->base.key = xstrdup(key);
 	arg->value = xstrdup(value);
 	wl_list_append(&action->args, &arg->base.link);
 }
 
 static void
-action_arg_add_bool(struct action *action, char *key, bool value)
+action_arg_add_bool(struct action *action, const char *key, bool value)
 {
+	assert(action);
+	assert(key);
 	struct action_arg_bool *arg = znew(*arg);
 	arg->base.type = LAB_ACTION_ARG_BOOL;
-	if (key) {
-		arg->base.key = xstrdup(key);
-	}
+	arg->base.key = xstrdup(key);
 	arg->value = value;
 	wl_list_append(&action->args, &arg->base.link);
 }
 
 static void
-action_arg_add_int(struct action *action, char *key, int value)
+action_arg_add_int(struct action *action, const char *key, int value)
 {
+	assert(action);
+	assert(key);
 	struct action_arg_int *arg = znew(*arg);
 	arg->base.type = LAB_ACTION_ARG_INT;
-	if (key) {
-		arg->base.key = xstrdup(key);
-	}
+	arg->base.key = xstrdup(key);
 	arg->value = value;
 	wl_list_append(&action->args, &arg->base.link);
 }
@@ -252,12 +252,10 @@ action_str_from_arg(struct action_arg *arg)
 static const char *
 get_arg_value_str(struct action *action, const char *key, const char *default_value)
 {
+	assert(action);
 	assert(key);
 	struct action_arg *arg;
 	wl_list_for_each(arg, &action->args, link) {
-		if (!arg->key) {
-			continue;
-		}
 		if (!strcasecmp(key, arg->key)) {
 			return action_str_from_arg(arg);
 		}
@@ -268,12 +266,10 @@ get_arg_value_str(struct action *action, const char *key, const char *default_va
 static bool
 get_arg_value_bool(struct action *action, const char *key, bool default_value)
 {
+	assert(action);
 	assert(key);
 	struct action_arg *arg;
 	wl_list_for_each(arg, &action->args, link) {
-		if (!arg->key) {
-			continue;
-		}
 		if (!strcasecmp(key, arg->key)) {
 			assert(arg->type == LAB_ACTION_ARG_BOOL);
 			return ((struct action_arg_bool *)arg)->value;
@@ -285,12 +281,10 @@ get_arg_value_bool(struct action *action, const char *key, bool default_value)
 static int
 get_arg_value_int(struct action *action, const char *key, int default_value)
 {
+	assert(action);
 	assert(key);
 	struct action_arg *arg;
 	wl_list_for_each(arg, &action->args, link) {
-		if (!arg->key) {
-			continue;
-		}
 		if (!strcasecmp(key, arg->key)) {
 			assert(arg->type == LAB_ACTION_ARG_INT);
 			return ((struct action_arg_int *)arg)->value;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -808,28 +808,28 @@ rcxml_init(void)
 }
 
 static struct {
-	const char *binding, *action, *command;
+	const char *binding, *action, *attribute, *value;
 } key_combos[] = {
-	{ "A-Tab", "NextWindow", NULL },
-	{ "W-Return", "Execute", "alacritty" },
-	{ "A-F3", "Execute", "bemenu-run" },
-	{ "A-F4", "Close", NULL },
-	{ "W-a", "ToggleMaximize", NULL },
-	{ "A-Left", "MoveToEdge", "left" },
-	{ "A-Right", "MoveToEdge", "right" },
-	{ "A-Up", "MoveToEdge", "up" },
-	{ "A-Down", "MoveToEdge", "down" },
-	{ "W-Left", "SnapToEdge", "left" },
-	{ "W-Right", "SnapToEdge", "right" },
-	{ "W-Up", "SnapToEdge", "up" },
-	{ "W-Down", "SnapToEdge", "down" },
-	{ "A-Space", "ShowMenu", "client-menu"},
-	{ "XF86_AudioLowerVolume", "Execute", "amixer sset Master 5%-" },
-	{ "XF86_AudioRaiseVolume", "Execute", "amixer sset Master 5%+" },
-	{ "XF86_AudioMute", "Execute", "amixer sset Master toggle" },
-	{ "XF86_MonBrightnessUp", "Execute", "brightnessctl set +10%" },
-	{ "XF86_MonBrightnessDown", "Execute", "brightnessctl set 10%-" },
-	{ NULL, NULL, NULL },
+	{ "A-Tab", "NextWindow", NULL, NULL },
+	{ "W-Return", "Execute", "command", "alacritty" },
+	{ "A-F3", "Execute", "command", "bemenu-run" },
+	{ "A-F4", "Close", NULL, NULL },
+	{ "W-a", "ToggleMaximize", NULL, NULL },
+	{ "A-Left", "MoveToEdge", "direction", "left" },
+	{ "A-Right", "MoveToEdge", "direction", "right" },
+	{ "A-Up", "MoveToEdge", "direction", "up" },
+	{ "A-Down", "MoveToEdge", "direction", "down" },
+	{ "W-Left", "SnapToEdge", "direction", "left" },
+	{ "W-Right", "SnapToEdge", "direction", "right" },
+	{ "W-Up", "SnapToEdge", "direction", "up" },
+	{ "W-Down", "SnapToEdge", "direction", "down" },
+	{ "A-Space", "ShowMenu", "menu", "client-menu"},
+	{ "XF86_AudioLowerVolume", "Execute", "command", "amixer sset Master 5%-" },
+	{ "XF86_AudioRaiseVolume", "Execute", "command", "amixer sset Master 5%+" },
+	{ "XF86_AudioMute", "Execute", "command", "amixer sset Master toggle" },
+	{ "XF86_MonBrightnessUp", "Execute", "command", "brightnessctl set +10%" },
+	{ "XF86_MonBrightnessDown", "Execute", "command", "brightnessctl set 10%-" },
+	{ NULL, NULL, NULL, NULL },
 };
 
 static void
@@ -846,8 +846,8 @@ load_default_key_bindings(void)
 		action = action_create(key_combos[i].action);
 		wl_list_append(&k->actions, &action->link);
 
-		if (key_combos[i].command) {
-			action_arg_add_str(action, NULL, key_combos[i].command);
+		if (key_combos[i].attribute && key_combos[i].value) {
+			action_arg_add_str(action, key_combos[i].attribute, key_combos[i].value);
 		}
 	}
 }
@@ -956,7 +956,7 @@ load_default_mouse_bindings(void)
 		 * slightly more sophisticated approach will be needed.
 		 */
 		if (current->attribute && current->value) {
-			action_arg_add_str(action, (char *)current->attribute, current->value);
+			action_arg_add_str(action, current->attribute, current->value);
 		}
 	}
 	wlr_log(WLR_DEBUG, "Loaded %u merged mousebinds", count);

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -128,6 +128,30 @@ post_processing(struct server *server)
 	}
 }
 
+static void
+validate_menu(struct menu *menu)
+{
+	struct menuitem *item;
+	struct action *action, *action_tmp;
+	wl_list_for_each(item, &menu->menuitems, link) {
+		wl_list_for_each_safe(action, action_tmp, &item->actions, link) {
+			if (!action_is_valid(action)) {
+				wl_list_remove(&action->link);
+				action_free(action);
+				wlr_log(WLR_ERROR, "Removed invalid menu action");
+			}
+		}
+	}
+}
+
+static void
+validate(struct server *server)
+{
+	for (int i = 0; i < nr_menus; ++i) {
+		validate_menu(menus + i);
+	}
+}
+
 static struct menuitem *
 item_create(struct menu *menu, const char *text, bool show_arrow)
 {
@@ -730,6 +754,7 @@ menu_init(struct server *server)
 	init_rootmenu(server);
 	init_windowmenu(server);
 	post_processing(server);
+	validate(server);
 }
 
 void


### PR DESCRIPTION
And assign argument names.

Missing:
- [x] add asserts() for the argument name in `action_arg_add_*()`
- [x] remove `if (!arg->key)` check in `get_arg_value_*()`
- [x] potentially use `string_truncate_at_pattern()` on the original `nodename` argument
- [x] verify that all action and argument combinations have been properly defined here
- [x] add `bool action_valid()` to verify that all required arguments exist for the given action and call it from the `validate()` hook in `rcxml.c`
- [x] same for `menu.c`
- [x] same for window rules
- [x] remove checks for required arguments when running actions as we now do that at config load time

Fixes:
- #894