### PR TITLE
includes: identifier consistency in include guards

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_ACTION_H
-#define __LABWC_ACTION_H
+#ifndef LABWC_ACTION_H
+#define LABWC_ACTION_H
 
 #include <wayland-util.h>
 
@@ -30,4 +30,4 @@ void actions_run(struct view *activator, struct server *server,
 	struct wl_list *actions, uint32_t resize_edges);
 void action_list_free(struct wl_list *action_list);
 
-#endif /* __LABWC_ACTION_H */
+#endif /* LABWC_ACTION_H */

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -23,8 +23,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef __LABWC_BUFFER_H
-#define __LABWC_BUFFER_H
+#ifndef LABWC_BUFFER_H
+#define LABWC_BUFFER_H
 
 #include <cairo.h>
 #include <wlr/types/wlr_buffer.h>
@@ -49,4 +49,4 @@ struct lab_data_buffer *buffer_create_cairo(uint32_t width, uint32_t height,
 struct lab_data_buffer *buffer_create_wrap(void *pixel_data, uint32_t width,
 	uint32_t height, uint32_t stride, bool free_on_destroy);
 
-#endif /* __LABWC_BUFFER_H */
+#endif /* LABWC_BUFFER_H */

--- a/include/common/buf.h
+++ b/include/common/buf.h
@@ -5,8 +5,8 @@
  * Copyright Johan Malm 2020
  */
 
-#ifndef __LABWC_BUF_H
-#define __LABWC_BUF_H
+#ifndef LABWC_BUF_H
+#define LABWC_BUF_H
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,4 +39,4 @@ void buf_init(struct buf *s);
  */
 void buf_add(struct buf *s, const char *data);
 
-#endif /* __LABWC_BUF_H */
+#endif /* LABWC_BUF_H */

--- a/include/common/dir.h
+++ b/include/common/dir.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_DIR_H
-#define __LABWC_DIR_H
+#ifndef LABWC_DIR_H
+#define LABWC_DIR_H
 
 char *config_dir(void);
 
@@ -10,4 +10,4 @@ char *config_dir(void);
  */
 char *theme_dir(const char *theme_name);
 
-#endif /* __LABWC_DIR_H */
+#endif /* LABWC_DIR_H */

--- a/include/common/fd_util.h
+++ b/include/common/fd_util.h
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_FD_UTIL_H
-#define __LABWC_FD_UTIL_H
+#ifndef LABWC_FD_UTIL_H
+#define LABWC_FD_UTIL_H
 
 void increase_nofile_limit(void);
 void restore_nofile_limit(void);
 
-#endif /* __LABWC_FD_UTIL_H */
+#endif /* LABWC_FD_UTIL_H */

--- a/include/common/font.h
+++ b/include/common/font.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_FONT_H
-#define __LABWC_FONT_H
+#ifndef LABWC_FONT_H
+#define LABWC_FONT_H
 
 struct lab_data_buffer;
 
@@ -54,4 +54,4 @@ void font_buffer_create(struct lab_data_buffer **buffer, int max_width,
  */
 void font_finish(void);
 
-#endif /* __LABWC_FONT_H */
+#endif /* LABWC_FONT_H */

--- a/include/common/grab-file.h
+++ b/include/common/grab-file.h
@@ -5,8 +5,8 @@
  * Copyright Johan Malm 2020
  */
 
-#ifndef __LABWC_GRAB_FILE_H
-#define __LABWC_GRAB_FILE_H
+#ifndef LABWC_GRAB_FILE_H
+#define LABWC_GRAB_FILE_H
 
 /**
  * grab_file - read file into memory buffer
@@ -15,4 +15,4 @@
  */
 char *grab_file(const char *filename);
 
-#endif /* __LABWC_GRAB_FILE_H */
+#endif /* LABWC_GRAB_FILE_H */

--- a/include/common/graphic-helpers.h
+++ b/include/common/graphic-helpers.h
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_GRAPHIC_HELPERS_H
+#define LABWC_GRAPHIC_HELPERS_H
 
 #include <cairo.h>
 #include <wayland-server-core.h>
@@ -44,3 +46,5 @@ void set_cairo_color(cairo_t *cairo, float *color);
 /* Draws a border with a specified line width */
 void draw_cairo_border(cairo_t *cairo, double width, double height,
 		double line_width);
+
+#endif /* LABWC_GRAPHIC_HELPERS_H */

--- a/include/common/list.h
+++ b/include/common/list.h
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_LIST_H
+#define LABWC_LIST_H
 #include <wayland-server-core.h>
 
 /**
@@ -17,3 +19,5 @@ wl_list_append(struct wl_list *list, struct wl_list *elm)
 {
 	wl_list_insert(list->prev, elm);
 }
+
+#endif /* LABWC_LIST_H */

--- a/include/common/match.h
+++ b/include/common/match.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_MATCH_H
-#define __LABWC_MATCH_H
+#ifndef LABWC_MATCH_H
+#define LABWC_MATCH_H
 #include <glib.h>
 
 /**
@@ -11,4 +11,4 @@
  */
 bool match_glob(const gchar *pattern, const gchar *string);
 
-#endif /* __LABWC_MATCH_H */
+#endif /* LABWC_MATCH_H */

--- a/include/common/mem.h
+++ b/include/common/mem.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_MEM_H
-#define __LABWC_MEM_H
+#ifndef LABWC_MEM_H
+#define LABWC_MEM_H
 
 #include <stdlib.h>
 
@@ -52,4 +52,4 @@ char *xstrdup(const char *str);
 	free(ptr); (ptr) = NULL; \
 } while (0)
 
-#endif /* __LABWC_MEM_H */
+#endif /* LABWC_MEM_H */

--- a/include/common/nodename.h
+++ b/include/common/nodename.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_NODENAME_H
-#define __LABWC_NODENAME_H
+#ifndef LABWC_NODENAME_H
+#define LABWC_NODENAME_H
 
 #include <libxml/parser.h>
 #include <libxml/tree.h>
@@ -17,4 +17,4 @@
  */
 char *nodename(xmlNode * node, char *buf, int len);
 
-#endif /* __LABWC_NODENAME_H */
+#endif /* LABWC_NODENAME_H */

--- a/include/common/parse-bool.h
+++ b/include/common/parse-bool.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_PARSE_BOOL_H
-#define __LABWC_PARSE_BOOL_H
+#ifndef LABWC_PARSE_BOOL_H
+#define LABWC_PARSE_BOOL_H
 #include <stdbool.h>
 
 /**
@@ -21,4 +21,4 @@ int parse_bool(const char *str, int default_value);
 void set_bool(const char *str, bool *variable);
 void set_bool_as_int(const char *str, int *variable);
 
-#endif /* __LABWC_PARSE_BOOL_H */
+#endif /* LABWC_PARSE_BOOL_H */

--- a/include/common/scaled_font_buffer.h
+++ b/include/common/scaled_font_buffer.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LAB_COMMON_SCALED_FONT_BUFFER_H
-#define __LAB_COMMON_SCALED_FONT_BUFFER_H
+#ifndef LABWC_SCALED_FONT_BUFFER_H
+#define LABWC_SCALED_FONT_BUFFER_H
 
 #include "common/font.h"
 
@@ -56,4 +56,4 @@ void scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text
  */
 void scaled_font_buffer_set_max_width(struct scaled_font_buffer *self, int max_width);
 
-#endif /* __LAB_COMMON_SCALED_FONT_BUFFER_H */
+#endif /* LABWC_SCALED_FONT_BUFFER_H */

--- a/include/common/scaled_scene_buffer.h
+++ b/include/common/scaled_scene_buffer.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LAB_COMMON_SCALED_SCENE_BUFFER_H
-#define __LAB_COMMON_SCALED_SCENE_BUFFER_H
+#ifndef LABWC_SCALED_SCENE_BUFFER_H
+#define LABWC_SCALED_SCENE_BUFFER_H
 
 #define LAB_SCALED_BUFFER_MAX_CACHE 2
 
@@ -66,4 +66,4 @@ struct scaled_scene_buffer_cache_entry {
 	double scale;
 };
 
-#endif /* __LAB_COMMON_SCALED_SCENE_BUFFER_H */
+#endif /* LABWC_SCALED_SCENE_BUFFER_H */

--- a/include/common/scene-helpers.h
+++ b/include/common/scene-helpers.h
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_SCENE_HELPERS_H
+#define LABWC_SCENE_HELPERS_H
 
 struct wlr_scene_node;
 struct wlr_scene_rect;
@@ -15,3 +17,5 @@ struct wlr_surface *lab_wlr_surface_from_node(struct wlr_scene_node *node);
  * Return NULL if previous link is list-head which means node is bottom-most
  */
 struct wlr_scene_node *lab_wlr_scene_get_prev_node(struct wlr_scene_node *node);
+
+#endif /* LABWC_SCENE_HELPERS_H */

--- a/include/common/spawn.h
+++ b/include/common/spawn.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_SPAWN_H
-#define __LABWC_SPAWN_H
+#ifndef LABWC_SPAWN_H
+#define LABWC_SPAWN_H
 
 /**
  * spawn_async_no_shell - execute asyncronously
@@ -8,4 +8,4 @@
  */
 void spawn_async_no_shell(char const *command);
 
-#endif /* __LABWC_SPAWN_H */
+#endif /* LABWC_SPAWN_H */

--- a/include/common/string-helpers.h
+++ b/include/common/string-helpers.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_STRING_HELPERS_H
-#define __LABWC_STRING_HELPERS_H
+#ifndef LABWC_STRING_HELPERS_H
+#define LABWC_STRING_HELPERS_H
 
 /**
  * string_strip - strip white space left and right
@@ -16,4 +16,4 @@ char *string_strip(char *s);
  */
 void string_truncate_at_pattern(char *buf, const char *pattern);
 
-#endif /* __LABWC_STRING_HELPERS_H */
+#endif /* LABWC_STRING_HELPERS_H */

--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_KEYBIND_H
-#define __LABWC_KEYBIND_H
+#ifndef LABWC_KEYBIND_H
+#define LABWC_KEYBIND_H
 
 #include <wlr/types/wlr_keyboard.h>
 #include <xkbcommon/xkbcommon.h>
@@ -30,4 +30,4 @@ uint32_t parse_modifier(const char *symname);
 
 bool keybind_the_same(struct keybind *a, struct keybind *b);
 
-#endif /* __LABWC_KEYBIND_H */
+#endif /* LABWC_KEYBIND_H */

--- a/include/config/libinput.h
+++ b/include/config/libinput.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_LIBINPUT_H
-#define __LABWC_LIBINPUT_H
+#ifndef LABWC_LIBINPUT_H
+#define LABWC_LIBINPUT_H
 
 #include <libinput.h>
 #include <string.h>
@@ -30,4 +30,4 @@ enum device_type get_device_type(const char *s);
 struct libinput_category *libinput_category_create(void);
 struct libinput_category *libinput_category_get_default(void);
 
-#endif /* __LABWC_LIBINPUT_H */
+#endif /* LABWC_LIBINPUT_H */

--- a/include/config/mousebind.h
+++ b/include/config/mousebind.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_MOUSEBIND_H
-#define __LABWC_MOUSEBIND_H
+#ifndef LABWC_MOUSEBIND_H
+#define LABWC_MOUSEBIND_H
 
 #include <wayland-util.h>
 #include "ssd.h"
@@ -50,4 +50,4 @@ enum direction mousebind_direction_from_str(const char *str, uint32_t *modifiers
 struct mousebind *mousebind_create(const char *context);
 bool mousebind_the_same(struct mousebind *a, struct mousebind *b);
 
-#endif /* __LABWC_MOUSEBIND_H */
+#endif /* LABWC_MOUSEBIND_H */

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_RCXML_H
-#define __LABWC_RCXML_H
+#ifndef LABWC_RCXML_H
+#define LABWC_RCXML_H
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -91,4 +91,4 @@ void rcxml_parse_xml(struct buf *b);
 void rcxml_read(const char *filename);
 void rcxml_finish(void);
 
-#endif /* __LABWC_RCXML_H */
+#endif /* LABWC_RCXML_H */

--- a/include/config/session.h
+++ b/include/config/session.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_SESSION_H
-#define __LABWC_SESSION_H
+#ifndef LABWC_SESSION_H
+#define LABWC_SESSION_H
 
 /**
  * session_environment_init - set enrivonment variables based on <key>=<value>
@@ -17,4 +17,4 @@ void session_environment_init(const char *dir);
  */
 void session_autostart_init(const char *dir);
 
-#endif /* __LABWC_SESSION_H */
+#endif /* LABWC_SESSION_H */

--- a/include/cursor.h
+++ b/include/cursor.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_CURSOR_H
-#define __LABWC_CURSOR_H
+#ifndef LABWC_CURSOR_H
+#define LABWC_CURSOR_H
 
 #include <wlr/util/edges.h>
 #include "ssd.h"
@@ -119,4 +119,4 @@ void cursor_update_image(struct seat *seat);
 void cursor_init(struct seat *seat);
 void cursor_finish(struct seat *seat);
 
-#endif /* __LABWC_CURSOR_H */
+#endif /* LABWC_CURSOR_H */

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __DEBUG_H
-#define __DEBUG_H
+#ifndef LABWC_DEBUG_H
+#define LABWC_DEBUG_H
 
 struct server;
 
 void debug_dump_scene(struct server *server);
 
-#endif /* __DEBUG_H */
+#endif /* LABWC_DEBUG_H */

--- a/include/decorations.h
+++ b/include/decorations.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LAB_DECORATIONS_H
-#define __LAB_DECORATIONS_H
+#ifndef LABWC_DECORATIONS_H
+#define LABWC_DECORATIONS_H
 
 struct server;
 struct view;
@@ -12,4 +12,4 @@ void xdg_server_decoration_init(struct server *server);
 void kde_server_decoration_update_default(void);
 void kde_server_decoration_set_view(struct view *view, struct wlr_surface *surface);
 
-#endif /* __LAB_DECORATIONS_H */
+#endif /* LABWC_DECORATIONS_H */

--- a/include/dnd.h
+++ b/include/dnd.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LAB_DND_H
-#define __LAB_DND_H
+#ifndef LABWC_DND_H
+#define LABWC_DND_H
 
 #include <wayland-server-core.h>
 
@@ -24,4 +24,4 @@ void dnd_icons_show(struct seat *seat, bool show);
 void dnd_icons_move(struct seat *seat, double x, double y);
 void dnd_finish(struct seat *seat);
 
-#endif /* __LAB_DND_H */
+#endif /* LABWC_DND_H */

--- a/include/key-state.h
+++ b/include/key-state.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_KEY_STATE_H
-#define __LABWC_KEY_STATE_H
+#ifndef LABWC_KEY_STATE_H
+#define LABWC_KEY_STATE_H
 
 /*
  * All keycodes in these functions are (Linux) libinput evdev scancodes which is
@@ -22,4 +22,4 @@ bool key_state_corresponding_press_event_was_bound(uint32_t keycode);
 void key_state_bound_key_remove(uint32_t keycode);
 int key_state_nr_keys(void);
 
-#endif /* __LABWC_KEY_STATE_H */
+#endif /* LABWC_KEY_STATE_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_H
-#define __LABWC_H
+#ifndef LABWC_H
+#define LABWC_H
 #include "config.h"
 #include <getopt.h>
 #include <stdbool.h>
@@ -455,4 +455,4 @@ void create_constraint(struct wl_listener *listener, void *data);
 void constrain_cursor(struct server *server, struct wlr_pointer_constraint_v1
 	*constraint);
 
-#endif /* __LABWC_H */
+#endif /* LABWC_H */

--- a/include/layers.h
+++ b/include/layers.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_LAYERS_H
-#define __LABWC_LAYERS_H
+#ifndef LABWC_LAYERS_H
+#define LABWC_LAYERS_H
 #include <wayland-server.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 
@@ -36,4 +36,4 @@ void layers_init(struct server *server);
 
 void layers_arrange(struct output *output);
 
-#endif /* __LABWC_LAYERS_H */
+#endif /* LABWC_LAYERS_H */

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_MENU_H
-#define __LABWC_MENU_H
+#ifndef LABWC_MENU_H
+#define LABWC_MENU_H
 
 #include <wayland-server.h>
 
@@ -115,4 +115,4 @@ void menu_close_root(struct server *server);
 /* menu_reconfigure - reload theme and content */
 void menu_reconfigure(struct server *server);
 
-#endif /* __LABWC_MENU_H */
+#endif /* LABWC_MENU_H */

--- a/include/node.h
+++ b/include/node.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_NODE_DESCRIPTOR_H
-#define __LABWC_NODE_DESCRIPTOR_H
+#ifndef LABWC_NODE_DESCRIPTOR_H
+#define LABWC_NODE_DESCRIPTOR_H
 #include <wlr/types/wlr_scene.h>
 
 struct view;
@@ -79,4 +79,4 @@ struct menuitem *node_menuitem_from_node(
 struct ssd_button *node_ssd_button_from_node(
 	struct wlr_scene_node *wlr_scene_node);
 
-#endif /* __LABWC_NODE_DESCRIPTOR_H */
+#endif /* LABWC_NODE_DESCRIPTOR_H */

--- a/include/regions.h
+++ b/include/regions.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_REGIONS_H
-#define __LABWC_REGIONS_H
+#ifndef LABWC_REGIONS_H
+#define LABWC_REGIONS_H
 
 #include <wlr/util/box.h>
 
@@ -76,4 +76,4 @@ struct region *regions_from_name(const char *region_name, struct output *output)
 void regions_show_overlay(struct view *view, struct seat *seat, struct region *region);
 void regions_hide_overlay(struct seat *seat);
 
-#endif /* __LABWC_REGIONS_H */
+#endif /* LABWC_REGIONS_H */

--- a/include/resistance.h
+++ b/include/resistance.h
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __RESISTANCE_H
-#define __RESISTANCE_H
+#ifndef LABWC_RESISTANCE_H
+#define LABWC_RESISTANCE_H
 #include "labwc.h"
 
 void resistance_move_apply(struct view *view, double *x, double *y);
 void resistance_resize_apply(struct view *view, struct wlr_box *new_view_geo);
 
-#endif /* __RESISTANCE_H */
+#endif /* LABWC_RESISTANCE_H */

--- a/include/session-lock.h
+++ b/include/session-lock.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LAB_SESSION_LOCK_H
-#define __LAB_SESSION_LOCK_H
+#ifndef LABWC_SESSION_LOCK_H
+#define LABWC_SESSION_LOCK_H
 
 #include <wlr/types/wlr_session_lock_v1.h>
 
@@ -19,4 +19,4 @@ struct session_lock {
 void session_lock_init(struct server *server);
 void session_lock_output_create(struct session_lock *lock, struct output *output);
 
-#endif /* __LAB_SESSION_LOCK_H */
+#endif /* LABWC_SESSION_LOCK_H */

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_SSD_INTERNAL_H
-#define __LABWC_SSD_INTERNAL_H
+#ifndef LABWC_SSD_INTERNAL_H
+#define LABWC_SSD_INTERNAL_H
 
 #include <wlr/util/box.h>
 #include "ssd.h"
@@ -136,4 +136,4 @@ void ssd_extents_create(struct ssd *ssd);
 void ssd_extents_update(struct ssd *ssd);
 void ssd_extents_destroy(struct ssd *ssd);
 
-#endif /* __LABWC_SSD_INTERNAL_H */
+#endif /* LABWC_SSD_INTERNAL_H */

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_SSD_H
-#define __LABWC_SSD_H
+#ifndef LABWC_SSD_H
+#define LABWC_SSD_H
 
 #include <wayland-server-core.h>
 
@@ -95,4 +95,4 @@ bool ssd_debug_is_root_node(const struct ssd *ssd, struct wlr_scene_node *node);
 const char *ssd_debug_get_node_name(const struct ssd *ssd,
 	struct wlr_scene_node *node);
 
-#endif /* __LABWC_SSD_H */
+#endif /* LABWC_SSD_H */

--- a/include/theme.h
+++ b/include/theme.h
@@ -5,8 +5,8 @@
  * Copyright Johan Malm 2020-2021
  */
 
-#ifndef __LABWC_THEME_H
-#define __LABWC_THEME_H
+#ifndef LABWC_THEME_H
+#define LABWC_THEME_H
 
 #include <stdio.h>
 #include <wlr/render/wlr_renderer.h>
@@ -100,4 +100,4 @@ void theme_init(struct theme *theme, const char *theme_name);
  */
 void theme_finish(struct theme *theme);
 
-#endif /* __LABWC_THEME_H */
+#endif /* LABWC_THEME_H */

--- a/include/view-impl-common.h
+++ b/include/view-impl-common.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_VIEW_IMPL_COMMON_H
-#define __LABWC_VIEW_IMPL_COMMON_H
+#ifndef LABWC_VIEW_IMPL_COMMON_H
+#define LABWC_VIEW_IMPL_COMMON_H
 /*
  * Common code for view->impl functions
  *
@@ -20,4 +20,4 @@ void view_impl_map(struct view *view);
  */
 void view_impl_apply_geometry(struct view *view, int w, int h);
 
-#endif /* __LABWC_VIEW_IMPL_COMMON_H */
+#endif /* LABWC_VIEW_IMPL_COMMON_H */

--- a/include/view.h
+++ b/include/view.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_VIEW_H
-#define __LABWC_VIEW_H
+#ifndef LABWC_VIEW_H
+#define LABWC_VIEW_H
 
 #include "config.h"
 #include <stdbool.h>
@@ -202,4 +202,4 @@ void view_destroy(struct view *view);
 /* xdg.c */
 struct wlr_xdg_surface *xdg_surface_from_view(struct view *view);
 
-#endif /* __LABWC_VIEW_H */
+#endif /* LABWC_VIEW_H */

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __WINDOW_RULES_H
-#define __WINDOW_RULES_H
+#ifndef LABWC_WINDOW_RULES_H
+#define LABWC_WINDOW_RULES_H
 
 enum window_rule_event {
 	LAB_WINDOW_RULE_EVENT_ON_FIRST_MAP = 0,
@@ -35,4 +35,4 @@ struct view;
 void window_rules_apply(struct view *view, enum window_rule_event event);
 enum property window_rules_get_property(struct view *view, const char *property);
 
-#endif /* __WINDOW_RULES_H */
+#endif /* LABWC_WINDOW_RULES_H */

--- a/include/workspaces.h
+++ b/include/workspaces.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_WORKSPACES_H
-#define __LABWC_WORKSPACES_H
+#ifndef LABWC_WORKSPACES_H
+#define LABWC_WORKSPACES_H
 
 struct seat;
 struct view;
@@ -25,4 +25,4 @@ void workspaces_destroy(struct server *server);
 void workspaces_osd_hide(struct seat *seat);
 struct workspace *workspaces_find(struct workspace *anchor, const char *name);
 
-#endif /* __LABWC_WORKSPACES_H */
+#endif /* LABWC_WORKSPACES_H */

--- a/include/xbm/parse.h
+++ b/include/xbm/parse.h
@@ -5,8 +5,8 @@
  * Copyright Johan Malm 2020
  */
 
-#ifndef __LABWC_PARSE_H
-#define __LABWC_PARSE_H
+#ifndef LABWC_PARSE_H
+#define LABWC_PARSE_H
 
 #include "xbm/tokenize.h"
 #include <stdint.h>
@@ -35,4 +35,4 @@ struct pixmap parse_xbm_tokens(struct token *tokens);
  */
 struct pixmap parse_xbm_builtin(const char *button, int size);
 
-#endif /* __LABWC_PARSE_H */
+#endif /* LABWC_PARSE_H */

--- a/include/xbm/tokenize.h
+++ b/include/xbm/tokenize.h
@@ -5,8 +5,8 @@
  * Copyright Johan Malm 2020
  */
 
-#ifndef __LABWC_TOKENIZE_H
-#define __LABWC_TOKENIZE_H
+#ifndef LABWC_TOKENIZE_H
+#define LABWC_TOKENIZE_H
 
 enum token_type {
 	TOKEN_NONE = 0,
@@ -31,4 +31,4 @@ struct token {
  */
 struct token *tokenize_xbm(char *buffer);
 
-#endif /* __LABWC_TOKENIZE_H */
+#endif /* LABWC_TOKENIZE_H */

--- a/include/xbm/xbm.h
+++ b/include/xbm/xbm.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_XBM_H
-#define __LABWC_XBM_H
+#ifndef LABWC_XBM_H
+#define LABWC_XBM_H
 
 #include <wlr/render/wlr_renderer.h>
 
@@ -11,4 +11,4 @@
  */
 void xbm_load(struct theme *theme);
 
-#endif /* __LABWC_XBM_H */
+#endif /* LABWC_XBM_H */

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef __LABWC_XWAYLAND_H
-#define __LABWC_XWAYLAND_H
+#ifndef LABWC_XWAYLAND_H
+#define LABWC_XWAYLAND_H
 #include "config.h"
 #if HAVE_XWAYLAND
 #include "view.h"
@@ -55,4 +55,4 @@ void xwayland_server_init(struct server *server,
 void xwayland_server_finish(struct server *server);
 
 #endif /* HAVE_XWAYLAND */
-#endif /* __LABWC_XWAYLAND_H */
+#endif /* LABWC_XWAYLAND_H */


### PR DESCRIPTION
Made all header files to have LABWC_ prefix in include guard identifers.

Converted from __LABWC_ in 35 include/ files.
Converted from __LAB_ in 5 include/ files.
Added LABWC prefix to 3 include/ files.
Added include guards to 3 include/ files.