### PR TITLE
Add window rules and actions for `pcmanfm-qt --desktop`

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -80,6 +80,13 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="ToggleAlwaysOnTop">*
 	Toggle always-on-top of focused window.
 
+*<action name="ToggleAlwaysOnBottom">*
+	Toggle bewteen layers 'always-on-bottom' and 'normal'. When a window is
+	in the 'always-on-bottom' layer, it is rendered below all other
+	top-level windows. It is anticipated that this action will be useful
+	when defining window-rules for desktop-management tools that do not
+	support the wlr-layer-shell protocol.
+
 *<action name="ToggleKeybinds">*
 	Stop handling keybinds other than ToggleKeybinds itself.
 	This can be used to allow A-Tab and similar keybinds to be delivered

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -430,6 +430,15 @@ situation.
 	*serverDecoration* over-rules any other setting for server-side window
 	decoration on first map.
 
+*<windowRules><windowRule skipTaskbar="">* [yes|no|default]
+	*skipTaskbar* removes window foreign-toplevel protocol handle so that
+	it does not appear in clients such as panels and taskbars using that
+	protocol.
+
+*<windowRules><windowRule skipWindowSwitcher="">* [yes|no|default]
+	*skipWindowSwitcher* removes window from the Window Switcher (alt-tab
+	on-screen-display)
+
 ## ENVIRONMENT VARIABLES
 
 *XCURSOR_THEME* and *XCURSOR_SIZE* are supported to set cursor theme

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -263,6 +263,7 @@ struct server {
 
 	/* Tree for all non-layer xdg/xwayland-shell surfaces with always-on-top/below */
 	struct wlr_scene_tree *view_tree_always_on_top;
+	struct wlr_scene_tree *view_tree_always_on_bottom;
 #if HAVE_XWAYLAND
 	/* Tree for unmanaged xsurfaces without initialized view (usually popups) */
 	struct wlr_scene_tree *unmanaged_tree;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -254,7 +254,14 @@ struct server {
 
 	/* Tree for all non-layer xdg/xwayland-shell surfaces */
 	struct wlr_scene_tree *view_tree;
-	/* Tree for all non-layer xdg/xwayland-shell surfaces with always-on-top */
+
+	/*
+	 * Popups need to be rendered above always-on-top views, so we reparent
+	 * them to this dedicated tree
+	 */
+	struct wlr_scene_tree *xdg_popup_tree;
+
+	/* Tree for all non-layer xdg/xwayland-shell surfaces with always-on-top/below */
 	struct wlr_scene_tree *view_tree_always_on_top;
 #if HAVE_XWAYLAND
 	/* Tree for unmanaged xsurfaces without initialized view (usually popups) */

--- a/include/view.h
+++ b/include/view.h
@@ -171,8 +171,11 @@ void view_maximize(struct view *view, bool maximize,
 void view_set_fullscreen(struct view *view, bool fullscreen);
 void view_toggle_maximize(struct view *view);
 void view_toggle_decorations(struct view *view);
-void view_toggle_always_on_top(struct view *view);
+
 bool view_is_always_on_top(struct view *view);
+void view_toggle_always_on_top(struct view *view);
+void view_toggle_always_on_bottom(struct view *view);
+
 bool view_is_tiled(struct view *view);
 bool view_is_floating(struct view *view);
 void view_move_to_workspace(struct view *view, struct workspace *workspace);

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -26,6 +26,8 @@ struct window_rule {
 	struct wl_list actions;
 
 	enum property server_decoration;
+	enum property skip_taskbar;
+	enum property skip_window_switcher;
 
 	struct wl_list link; /* struct rcxml.window_rules */
 };

--- a/src/action.c
+++ b/src/action.c
@@ -61,6 +61,7 @@ enum action_type {
 	ACTION_TYPE_TOGGLE_FULLSCREEN,
 	ACTION_TYPE_TOGGLE_DECORATIONS,
 	ACTION_TYPE_TOGGLE_ALWAYS_ON_TOP,
+	ACTION_TYPE_TOGGLE_ALWAYS_ON_BOTTOM,
 	ACTION_TYPE_FOCUS,
 	ACTION_TYPE_ICONIFY,
 	ACTION_TYPE_MOVE,
@@ -93,6 +94,7 @@ const char *action_names[] = {
 	"ToggleFullscreen",
 	"ToggleDecorations",
 	"ToggleAlwaysOnTop",
+	"ToggleAlwaysOnBottom",
 	"Focus",
 	"Iconify",
 	"Move",
@@ -513,6 +515,11 @@ actions_run(struct view *activator, struct server *server,
 		case ACTION_TYPE_TOGGLE_ALWAYS_ON_TOP:
 			if (view) {
 				view_toggle_always_on_top(view);
+			}
+			break;
+		case ACTION_TYPE_TOGGLE_ALWAYS_ON_BOTTOM:
+			if (view) {
+				view_toggle_always_on_bottom(view);
 			}
 			break;
 		case ACTION_TYPE_FOCUS:

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -110,6 +110,10 @@ fill_window_rule(char *nodename, char *content)
 	/* Properties */
 	} else if (!strcasecmp(nodename, "serverDecoration")) {
 		set_property(content, &current_window_rule->server_decoration);
+	} else if (!strcasecmp(nodename, "skipTaskbar")) {
+		set_property(content, &current_window_rule->skip_taskbar);
+	} else if (!strcasecmp(nodename, "skipWindowSwitcher")) {
+		set_property(content, &current_window_rule->skip_window_switcher);
 
 	/* Actions */
 	} else if (!strcmp(nodename, "name.action")) {

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -9,6 +9,7 @@
 #include "node.h"
 #include "ssd.h"
 #include "view.h"
+#include "window-rules.h"
 #include "workspaces.h"
 #include "xwayland.h"
 
@@ -191,7 +192,9 @@ desktop_cycle_view(struct server *server, struct view *start_view,
 			continue;
 		}
 		view = node_view_from_node(node);
-		if (isfocusable(view)) {
+
+		enum property skip = window_rules_get_property(view, "skipWindowSwitcher");
+		if (isfocusable(view) && skip != LAB_PROP_TRUE) {
 			return view;
 		}
 	} while (view != start_view);

--- a/src/osd.c
+++ b/src/osd.c
@@ -15,6 +15,7 @@
 #include "theme.h"
 #include "node.h"
 #include "view.h"
+#include "window-rules.h"
 #include "workspaces.h"
 
 #define OSD_ITEM_HEIGHT (20)
@@ -69,7 +70,8 @@ get_osd_height(struct wl_list *node_list)
 			continue;
 		}
 		view = node_view_from_node(node);
-		if (!isfocusable(view)) {
+		enum property skip = window_rules_get_property(view, "skipWindowSwitcher");
+		if (!isfocusable(view) || skip == LAB_PROP_TRUE) {
 			continue;
 		}
 		height += OSD_ITEM_HEIGHT;
@@ -344,7 +346,8 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 			continue;
 		}
 		struct view *view = node_view_from_node(node);
-		if (!isfocusable(view)) {
+		enum property skip = window_rules_get_property(view, "skipWindowSwitcher");
+		if (!isfocusable(view) || skip == LAB_PROP_TRUE) {
 			continue;
 		}
 

--- a/src/server.c
+++ b/src/server.c
@@ -285,8 +285,31 @@ server_init(struct server *server)
 		wlr_log(WLR_ERROR, "unable to create scene");
 		exit(EXIT_FAILURE);
 	}
+
+	/*
+	 * The order in which the scene-trees below are created determines the
+	 * z-order for nodes which cover the whole work-area.  For per-output
+	 * scene-trees, see new_output_notify() in src/output.c
+	 *
+	 * | Type              | Scene Tree       | Per Output | Example
+	 * | ----------------- | ---------------- | ---------- | -------
+	 * | ext-session       | lock-screen      | Yes        | swaylock
+	 * | layer-shell       | layer-popups     | Yes        |
+	 * | layer-shell       | overlay-layer    | Yes        |
+	 * | layer-shell       | top-layer        | Yes        | waybar
+	 * | server            | labwc-menus      | No         |
+	 * | xwayland-OR       | unmanaged        | No         | dmenu
+	 * | xdg-popups        | xdg-popups       | No         |
+	 * | toplevels windows | always-on-top    | No         |
+	 * | toplevels windows | normal           | No         | firefox
+	 * | toplevels windows | always-on-bottom | No         | pcmanfm-qt --desktop
+	 * | layer-shell       | bottom-layer     | Yes        | waybar
+	 * | layer-shell       | background-layer | Yes        | swaybg
+	 */
+
 	server->view_tree = wlr_scene_tree_create(&server->scene->tree);
 	server->view_tree_always_on_top = wlr_scene_tree_create(&server->scene->tree);
+	server->xdg_popup_tree = wlr_scene_tree_create(&server->scene->tree);
 #if HAVE_XWAYLAND
 	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->tree);
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -307,6 +307,7 @@ server_init(struct server *server)
 	 * | layer-shell       | background-layer | Yes        | swaybg
 	 */
 
+	server->view_tree_always_on_bottom = wlr_scene_tree_create(&server->scene->tree);
 	server->view_tree = wlr_scene_tree_create(&server->scene->tree);
 	server->view_tree_always_on_top = wlr_scene_tree_create(&server->scene->tree);
 	server->xdg_popup_tree = wlr_scene_tree_create(&server->scene->tree);

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -34,6 +34,22 @@ view_impl_map(struct view *view)
 	if (!view->been_mapped) {
 		window_rules_apply(view, LAB_WINDOW_RULE_EVENT_ON_FIRST_MAP);
 	}
+
+	/*
+	 * It's tempting to just never create the foreign-toplevel handle in the
+	 * map handlers, but the app_id/title might not have been set at that
+	 * point, so it's safer to process the property here
+	 */
+	enum property ret = window_rules_get_property(view, "skipTaskbar");
+	if (ret == LAB_PROP_TRUE) {
+		if (view->toplevel.handle) {
+			wlr_foreign_toplevel_handle_v1_destroy(view->toplevel.handle);
+		}
+	}
+
+	wlr_log(WLR_DEBUG, "[map] identifier=%s, title=%s\n",
+		view_get_string_prop(view, "app_id"),
+		view_get_string_prop(view, "title"));
 }
 
 static bool

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -27,13 +27,13 @@ view_impl_move_to_back(struct view *view)
 void
 view_impl_map(struct view *view)
 {
-	if (!view->been_mapped) {
-		window_rules_apply(view, LAB_WINDOW_RULE_EVENT_ON_FIRST_MAP);
-	}
 	desktop_focus_and_activate_view(&view->server->seat, view);
 	view_move_to_front(view);
 	view_update_title(view);
 	view_update_app_id(view);
+	if (!view->been_mapped) {
+		window_rules_apply(view, LAB_WINDOW_RULE_EVENT_ON_FIRST_MAP);
+	}
 }
 
 static bool

--- a/src/view.c
+++ b/src/view.c
@@ -627,6 +627,28 @@ view_toggle_always_on_top(struct view *view)
 	}
 }
 
+static bool
+view_is_always_on_bottom(struct view *view)
+{
+	assert(view);
+	return view->scene_tree->node.parent ==
+		view->server->view_tree_always_on_bottom;
+}
+
+void
+view_toggle_always_on_bottom(struct view *view)
+{
+	assert(view);
+	if (view_is_always_on_bottom(view)) {
+		view->workspace = view->server->workspace_current;
+		wlr_scene_node_reparent(&view->scene_tree->node,
+			view->workspace->tree);
+	} else {
+		wlr_scene_node_reparent(&view->scene_tree->node,
+			view->server->view_tree_always_on_bottom);
+	}
+}
+
 void
 view_move_to_workspace(struct view *view, struct workspace *workspace)
 {

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -81,10 +81,17 @@ window_rules_get_property(struct view *view, const char *property)
 		 * for.
 		 */
 		if (view_matches_criteria(rule, view)) {
-			if (!strcasecmp(property, "serverDecoration")) {
-				if (rule->server_decoration) {
-					return rule->server_decoration;
-				}
+			if (rule->server_decoration
+					&& !strcasecmp(property, "serverDecoration")) {
+				return rule->server_decoration;
+			}
+			if (rule->skip_taskbar
+					&& !strcasecmp(property, "skipTaskbar")) {
+				return rule->skip_taskbar;
+			}
+			if (rule->skip_window_switcher
+					&& !strcasecmp(property, "skipWindowSwitcher")) {
+				return rule->skip_window_switcher;
 			}
 		}
 	}

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -85,8 +85,18 @@ xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup)
 	 * provide the proper parent scene node of the xdg popup. To enable
 	 * this, we always set the user data field of xdg_surfaces to the
 	 * corresponding scene node.
+	 *
+	 * xdg-popups live in server->xdg_popup_tree so that they can be
+	 * rendered above always-on-top windows
 	 */
-	struct wlr_scene_tree *parent_tree = parent->surface->data;
+	struct wlr_scene_tree *parent_tree = NULL;
+	if (parent->role == WLR_XDG_SURFACE_ROLE_POPUP) {
+		parent_tree = parent->surface->data;
+	} else {
+		parent_tree = view->server->xdg_popup_tree;
+		wlr_scene_node_set_position(&view->server->xdg_popup_tree->node,
+			view->current.x, view->current.y);
+	}
 	wlr_popup->base->surface->data =
 		wlr_scene_xdg_surface_create(parent_tree, wlr_popup->base);
 	node_descriptor_create(wlr_popup->base->surface->data,


### PR DESCRIPTION
Add
- ~~ToggleAlwaysBelow~~ `ToggleAlwaysOnBottom`
- `skipTaskar`
- `skipWindowSwitcher` (which isn't really needed for this because window-switcher doesn't show views in always-below-tree, but it seems more complete to include it here anyway in case we change the window-switcher behavior later)

Try it with (--EDITED--):

```
  <windowRules>
    <windowRule title="pcmanfm-desktop*" skipTaskbar="yes" skipWindowSwitcher="yes">
      <action name="ToggleAlwaysOnBottom"/>
    </windowRule>
  </windowRules>
```

This example is not output-centered like a layer-shell implementation would be, but rather works across the whole work area.

In `pcmanfm-qt` desktop-preferences the following settings are useful:
- `Background` - individual wallpapers for each monitor. This looks better if you have outputs of different size.
- `General` - margins of work area (use this to allow for layer-shell panels and the like)