### PR TITLE
action: support {Go,Send}ToDesktop 'wrap' option

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -91,20 +91,26 @@ Actions are used in menus and keyboard/mouse bindings.
 	to the center of the window. If the given output does not contain
 	any windows, the cursor is centered on the given output.
 
-*<action name="GoToDesktop" to="value" />*
+*<action name="GoToDesktop" to="value" wrap="yes" />*
 	Switch to workspace.
 
 	*to* The workspace to switch to. Supported values are "last", "left",
 	"right" or the full name of a workspace or its index (starting at 1)
 	as configured in rc.xml.
 
-*<action name="SendToDesktop" to="value" follow="yes" />*
+	*wrap* [yes|no] Wrap around from last desktop to first, and vice
+	versa. Default yes.
+
+*<action name="SendToDesktop" to="value" follow="yes" wrap="yes" />*
 	Send active window to workspace.
 
 	*to* The workspace to send the window to. Supported values are the same
 	as for GoToDesktop.
 
 	*follow* [yes|no] Also switch to the specified workspace. Default yes.
+
+	*wrap* [yes|no] Wrap around from last desktop to first, and vice
+	versa. Default yes.
 
 *<action name="None">*
 	If used as the only action for a binding: clear an earlier defined binding.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -340,10 +340,10 @@
         <action name="ShowMenu" menu="root-menu" />
       </mousebind>
       <mousebind direction="Up" action="Scroll">
-        <action name="GoToDesktop" to="left" />
+        <action name="GoToDesktop" to="left" wrap="yes" />
       </mousebind>
       <mousebind direction="Down" action="Scroll">
-        <action name="GoToDesktop" to="right" />
+        <action name="GoToDesktop" to="right" wrap="yes" />
       </mousebind>
     </context>
 

--- a/include/workspaces.h
+++ b/include/workspaces.h
@@ -23,6 +23,7 @@ void workspaces_init(struct server *server);
 void workspaces_switch_to(struct workspace *target);
 void workspaces_destroy(struct server *server);
 void workspaces_osd_hide(struct seat *seat);
-struct workspace *workspaces_find(struct workspace *anchor, const char *name);
+struct workspace *workspaces_find(struct workspace *anchor, const char *name,
+	bool wrap);
 
 #endif /* LABWC_WORKSPACES_H */

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -172,22 +172,30 @@ add_workspace(struct server *server, const char *name)
 }
 
 static struct workspace *
-get_prev(struct workspace *current, struct wl_list *workspaces)
+get_prev(struct workspace *current, struct wl_list *workspaces, bool wrap)
 {
 	struct wl_list *target_link = current->link.prev;
 	if (target_link == workspaces) {
-		/* Current workspace is the first one, roll over */
+		/* Current workspace is the first one */
+		if (!wrap) {
+			return NULL;
+		}
+		/* Roll over */
 		target_link = target_link->prev;
 	}
 	return wl_container_of(target_link, current, link);
 }
 
 static struct workspace *
-get_next(struct workspace *current, struct wl_list *workspaces)
+get_next(struct workspace *current, struct wl_list *workspaces, bool wrap)
 {
 	struct wl_list *target_link = current->link.next;
 	if (target_link == workspaces) {
-		/* Current workspace is the last one, roll over */
+		/* Current workspace is the last one */
+		if (!wrap) {
+			return NULL;
+		}
+		/* Roll over */
 		target_link = target_link->next;
 	}
 	return wl_container_of(target_link, current, link);
@@ -304,7 +312,7 @@ workspaces_osd_hide(struct seat *seat)
 }
 
 struct workspace *
-workspaces_find(struct workspace *anchor, const char *name)
+workspaces_find(struct workspace *anchor, const char *name, bool wrap)
 {
 	assert(anchor);
 	if (!name) {
@@ -324,9 +332,9 @@ workspaces_find(struct workspace *anchor, const char *name)
 	} else if (!strcasecmp(name, "last")) {
 		return anchor->server->workspace_last;
 	} else if (!strcasecmp(name, "left")) {
-		return get_prev(anchor, workspaces);
+		return get_prev(anchor, workspaces, wrap);
 	} else if (!strcasecmp(name, "right")) {
-		return get_next(anchor, workspaces);
+		return get_next(anchor, workspaces, wrap);
 	} else {
 		wl_list_for_each(target, workspaces, link) {
 			if (!strcasecmp(target->name, name)) {


### PR DESCRIPTION
Make wrap 'true' by default for both GoToDesktop and SendToDesktop, in order to default the current behaviour.

For GoToDesktop OpenBox defaults to wrap="yes", but I don't know whether OpenBox SendToDesktop does the same.

Note: this is an interface change.