### PR TITLE
docs: fix some typos

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -81,7 +81,7 @@ Actions are used in menus and keyboard/mouse bindings.
 	Toggle always-on-top of focused window.
 
 *<action name="ToggleAlwaysOnBottom">*
-	Toggle bewteen layers 'always-on-bottom' and 'normal'. When a window is
+	Toggle between layers 'always-on-bottom' and 'normal'. When a window is
 	in the 'always-on-bottom' layer, it is rendered below all other
 	top-level windows. It is anticipated that this action will be useful
 	when defining window-rules for desktop-management tools that do not

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -34,9 +34,9 @@ that the environment file is treated differently by openbox where it is simply
 sourced prior to running openbox.
 
 The *menu.xml* file defines the context/root-menus and is described in
-labwc-menu(5)
+labwc-menu(5).
 
-There is a small <theme> section in rc.xml, for example to set rouned corners,
+There is a small <theme> section in rc.xml, for example to set rounded corners,
 but the remainder of the theme specification and associated files are described
 in labwc-theme(5).
 
@@ -177,7 +177,7 @@ Therefore, where multiple objects of the same kind are required (for example
 ## WINDOW SNAPPING
 
 *<snapping><range>*
-	The distance in pixels from the edge of an ouput for window Move
+	The distance in pixels from the edge of an output for window Move
 	operations to trigger SnapToEdge. A range of 0 disables window snapping.
 	Default is 1.
 
@@ -242,7 +242,8 @@ Therefore, where multiple objects of the same kind are required (for example
 	modifiers include S (shift); C (control); A (alt); W (super). Unlike
 	Openbox, multiple space-separated key combinations and key-chains are
 	not supported. The application "wev" (wayland event viewer) is packaged
-	in a lot of distributions and can be used to view all available keynames.
+	in a lot of distributions and can be used to view all available
+	keynames.
 
 *<keyboard><keybind key=""><action name="">*
 	Keybind action. See labwc-action(5)

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -79,16 +79,16 @@ labwc-config(5).
 	Border color of inactive window
 
 *window.active.title.bg.color*
-	Background color for the focussed window's titlebar
+	Background color for the focused window's titlebar
 
 *window.inactive.title.bg.color*
-	Background color for non-focussed windows' titlebars
+	Background color for non-focused windows' titlebars
 
 *window.active.label.text.color*
-	Text color for the focussed window's titlebar
+	Text color for the focused window's titlebar
 
 *window.inactive.label.text.color*
-	Text color non-focussed windows' titlebars
+	Text color non-focused windows' titlebars
 
 *window.label.text.justify*
 	Specifies how window titles are aligned in the titlebar for both


### PR DESCRIPTION
Between, output, rounded and focused.

Added one inconsistently missing trailing period.

Inserted newline before last word in one line in
labwc-actions.5.scd in order to keep that line from passing 80-column boundary.