### PR TITLE
Add `<margin>` and `MoveTo` in support of `lxqt-panel`

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -45,6 +45,9 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="Resize">*
 	Begin interactive resize of window under cursor
 
+*<action name="MoveTo" x="" y="" />*
+	Move to position (x, y)
+
 *<action name="SnapToEdge" direction="value" />*
 	Resize window to fill half the output in the given direction. Supports
 	directions "left", "up", "right", "down" and "center".

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -411,9 +411,9 @@ defined as shown below.
 </windowRules>
 ```
 
-*Actions*
+*Criteria*
 
-*<windowRules><windowRule identifier="" title="">*
+*<windowRules><windowRule identifier="" title="" matchOnce="">*
 	Define a window rule for any window which matches the criteria defined
 	by the attributes *identifier* or *title*. If both are defined, AND
 	logic is used, so both have to match.
@@ -424,6 +424,9 @@ defined as shown below.
 	for XWayland clients.
 
 	*title* is the title of the window.
+
+	*matchOnce* can be true|false. If true, the rule will only apply to the
+	first instance of the window with the specified identifier or title.
 
 *Properties*
 

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -235,6 +235,12 @@ Therefore, where multiple objects of the same kind are required (for example
 *<theme><font place=""><weight>*
 	Font weight (normal or bold). Default is normal.
 
+## MARGIN
+
+*<margin top="" bottom="" left="" right="" output="" />*
+	Specify the number of pixels to reserve at the edges of an output.
+	New, maximized and tiled windows will not be placed in these areas.
+
 ## KEYBOARD
 
 *<keyboard><keybind key="">*

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -89,6 +89,17 @@
     </names>
   </desktops>
 
+  <!--
+    # <margin> can be used to reserve space where new/maximized/tiled
+    # windows will not be placed. Clients using layer-shell protocol reserve
+    # space automatically, so <margin> is only intended for other, specialist
+    # cases.
+    #
+    # If output is left empty, the margin will be applied to all outputs.
+
+    <margin top="" bottom="" left="" right="" output="" />
+  -->
+
   <!-- Percent based regions based on output usable area, % char is required -->
   <!--
     <regions>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -387,20 +387,41 @@
   </libinput>
 
   <!--
-    Window Rules
-      - Criteria can consist of 'identifier' or 'title' or both (in which case
-        AND logic is used).
-      - 'identifier' relates to app_id for native Wayland windows and WM_CLASS
-        for XWayland clients.
-      - Matching against patterns with '*' (wildcard) and '?' (joker) is
-        supported. Pattern matching is case-insensitive.
+    # Window Rules
+    #   - Criteria can consist of 'identifier' or 'title' or both (in which case
+    #     AND logic is used).
+    #   - 'identifier' relates to app_id for native Wayland windows and WM_CLASS
+    #     for XWayland clients.
+    #   - Criteria can also contain `matchOnce="true"` meaning that the rule
+    #     must only apply to the first instance of the window with that
+    #     particular 'identifier' or 'title'.
+    #   - Matching against patterns with '*' (wildcard) and '?' (joker) is
+    #     supported. Pattern matching is case-insensitive.
 
-  <windowRules>
-    <windowRule identifier="*"><action name="Maximize"/></windowRule>
-    <windowRule identifier="foo" serverDecoration="yes"/>
-    <windowRule title="bar" serverDecoration="yes"/>
-    <windowRule identifier="baz" title="quax" serverDecoration="yes"/>
-  </windowRules>
+    <windowRules>
+      <windowRule identifier="*"><action name="Maximize"/></windowRule>
+      <windowRule identifier="foo" serverDecoration="yes"/>
+      <windowRule title="bar" serverDecoration="yes"/>
+      <windowRule identifier="baz" title="quax" serverDecoration="yes"/>
+    </windowRules>
+
+    # Example below for `lxqt-panel` and `pcmanfm-qt \-\-desktop`
+    # where 'matchOnce' is used to avoid applying rule to the panel configuration
+    # window with the same 'app_id'
+
+    <windowRules>
+      <windowRule identifier="lxqt-panel" matchOnce="true">
+        <skipTaskbar>yes</skipTaskbar>
+        <action name="MoveTo" x="0" y="0" />
+        <action name="ToggleAlwaysOnTop"/>
+      </windowRule>
+      <windowRule title="pcmanfm-desktop*">
+        <skipTaskbar>yes</skipTaskbar>
+        <skipWindowSwitcher>yes</skipWindowSwitcher>
+        <action name="MoveTo" x="0" y="0" />
+        <action name="ToggleAlwaysOnBottom"/>
+      </windowRule>
+    </windowRules>
   -->
 
 </labwc_config>

--- a/include/common/border.h
+++ b/include/common/border.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_BORDER_H
+#define LABWC_BORDER_H
+
+struct border {
+	int top;
+	int right;
+	int bottom;
+	int left;
+};
+
+#endif /* LABWC_BORDER_H */

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <wayland-server-core.h>
 
+#include "common/border.h"
 #include "common/buf.h"
 #include "common/font.h"
 #include "config/libinput.h"
@@ -16,6 +17,12 @@ enum window_switcher_field_content {
 	LAB_FIELD_TYPE,
 	LAB_FIELD_APP_ID,
 	LAB_FIELD_TITLE,
+};
+
+struct usable_area_override {
+	struct border margin;
+	char *output;
+	struct wl_list link; /* struct rcxml.usable_area_overrides */
 };
 
 struct window_switcher_field {
@@ -46,6 +53,9 @@ struct rcxml {
 	struct font font_osd;
 	/* Pointer to current theme */
 	struct theme *theme;
+
+	/* <margin top="" bottom="" left="" right="" output="" /> */
+	struct wl_list usable_area_overrides;
 
 	/* keyboard */
 	int repeat_rate;

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -3,6 +3,7 @@
 #define LABWC_SSD_H
 
 #include <wayland-server-core.h>
+#include "common/border.h"
 
 #define SSD_BUTTON_COUNT 4
 #define SSD_BUTTON_WIDTH 26
@@ -46,13 +47,6 @@ struct ssd_hover_state;
 struct view;
 struct wlr_scene;
 struct wlr_scene_node;
-
-struct border {
-	int top;
-	int right;
-	int bottom;
-	int left;
-};
 
 /*
  * Public SSD API

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -21,6 +21,7 @@ enum property {
 struct window_rule {
 	char *identifier;
 	char *title;
+	bool match_once;
 
 	enum window_rule_event event;
 	struct wl_list actions;

--- a/src/action.c
+++ b/src/action.c
@@ -74,6 +74,7 @@ enum action_type {
 	ACTION_TYPE_RAISE,
 	ACTION_TYPE_LOWER,
 	ACTION_TYPE_RESIZE,
+	ACTION_TYPE_MOVETO,
 	ACTION_TYPE_GO_TO_DESKTOP,
 	ACTION_TYPE_SEND_TO_DESKTOP,
 	ACTION_TYPE_SNAP_TO_REGION,
@@ -107,6 +108,7 @@ const char *action_names[] = {
 	"Raise",
 	"Lower",
 	"Resize",
+	"MoveTo",
 	"GoToDesktop",
 	"SendToDesktop",
 	"SnapToRegion",
@@ -185,6 +187,12 @@ action_arg_from_xml_node(struct action *action, char *nodename, char *content)
 	case ACTION_TYPE_SHOW_MENU:
 		if (!strcmp(argument, "menu")) {
 			action_arg_add_str(action, argument, content);
+			goto cleanup;
+		}
+		break;
+	case ACTION_TYPE_MOVETO:
+		if (!strcmp(argument, "x") || !strcmp(argument, "y")) {
+			action_arg_add_int(action, argument, atoi(content));
 			goto cleanup;
 		}
 		break;
@@ -590,6 +598,13 @@ actions_run(struct view *activator, struct server *server,
 			if (view) {
 				interactive_begin(view, LAB_INPUT_STATE_RESIZE,
 					resize_edges);
+			}
+			break;
+		case ACTION_TYPE_MOVETO:
+			if (view) {
+				int x = get_arg_value_int(action, "x", 0);
+				int y = get_arg_value_int(action, "y", 0);
+				view_move(view, x, y);
 			}
 			break;
 		case ACTION_TYPE_GO_TO_DESKTOP: {

--- a/src/action.c
+++ b/src/action.c
@@ -23,6 +23,7 @@
 enum action_arg_type {
 	LAB_ACTION_ARG_STR = 0,
 	LAB_ACTION_ARG_BOOL,
+	LAB_ACTION_ARG_INT,
 };
 
 struct action_arg {
@@ -40,6 +41,11 @@ struct action_arg_str {
 struct action_arg_bool {
 	struct action_arg base;
 	bool value;
+};
+
+struct action_arg_int {
+	struct action_arg base;
+	int value;
 };
 
 enum action_type {
@@ -127,6 +133,18 @@ action_arg_add_bool(struct action *action, char *key, bool value)
 {
 	struct action_arg_bool *arg = znew(*arg);
 	arg->base.type = LAB_ACTION_ARG_BOOL;
+	if (key) {
+		arg->base.key = xstrdup(key);
+	}
+	arg->value = value;
+	wl_list_append(&action->args, &arg->base.link);
+}
+
+static void
+action_arg_add_int(struct action *action, char *key, int value)
+{
+	struct action_arg_int *arg = znew(*arg);
+	arg->base.type = LAB_ACTION_ARG_INT;
 	if (key) {
 		arg->base.key = xstrdup(key);
 	}
@@ -242,6 +260,23 @@ get_arg_value_bool(struct action *action, const char *key, bool default_value)
 		if (!strcasecmp(key, arg->key)) {
 			assert(arg->type == LAB_ACTION_ARG_BOOL);
 			return ((struct action_arg_bool *)arg)->value;
+		}
+	}
+	return default_value;
+}
+
+static int
+get_arg_value_int(struct action *action, const char *key, int default_value)
+{
+	assert(key);
+	struct action_arg *arg;
+	wl_list_for_each(arg, &action->args, link) {
+		if (!arg->key) {
+			continue;
+		}
+		if (!strcasecmp(key, arg->key)) {
+			assert(arg->type == LAB_ACTION_ARG_INT);
+			return ((struct action_arg_int *)arg)->value;
 		}
 	}
 	return default_value;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -128,6 +128,8 @@ fill_window_rule(char *nodename, char *content)
 	} else if (!strcmp(nodename, "title")) {
 		free(current_window_rule->title);
 		current_window_rule->title = xstrdup(content);
+	} else if (!strcasecmp(nodename, "matchOnce")) {
+		set_bool(content, &current_window_rule->match_once);
 
 	/* Event */
 	} else if (!strcmp(nodename, "event")) {


### PR DESCRIPTION
Try with

```
  <margin top="32" />

  <windowRules>
    <!-- set matchOnce to avoid applying rule to panel configuration window -->
    <windowRule identifier="lxqt-panel" matchOnce="true">
      <skipTaskbar>yes</skipTaskbar>
      <action name="MoveTo" x="0" y="0" />
      <action name="ToggleAlwaysOnTop"/>
    </windowRule>
    <windowRule title="pcmanfm-desktop*">
      <skipTaskbar>yes</skipTaskbar>
      <skipWindowSwitcher>yes</skipWindowSwitcher>
      <action name="MoveTo" x="0" y="0" />
      <action name="ToggleAlwaysOnBottom"/>
    </windowRule>
  </windowRules>

```

- ~~Hide always-on-top layer when running an application in full-screen~~ Moved to first post of #941 