### PR TITLE
view: add client_request flag to view->impl->unmap()

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -34,7 +34,13 @@ struct view_impl {
 	void (*map)(struct view *view);
 	void (*set_activated)(struct view *view, bool activated);
 	void (*set_fullscreen)(struct view *view, bool fullscreen);
-	void (*unmap)(struct view *view);
+	/*
+	 * client_request is true if the client unmapped its own
+	 * surface; false if we are just minimizing the view. The two
+	 * cases are similar but have subtle differences (e.g., when
+	 * minimizing we don't destroy the foreign toplevel handle).
+	 */
+	void (*unmap)(struct view *view, bool client_request);
 	void (*maximize)(struct view *view, bool maximize);
 	void (*minimize)(struct view *view, bool minimize);
 	void (*move_to_front)(struct view *view);

--- a/src/view.c
+++ b/src/view.c
@@ -246,7 +246,7 @@ view_minimize(struct view *view, bool minimized)
 	}
 	view->minimized = minimized;
 	if (minimized) {
-		view->impl->unmap(view);
+		view->impl->unmap(view, /* client_request */ false);
 		_view_set_activated(view, false);
 		if (view == view->server->focused_view) {
 			/*

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -151,7 +151,7 @@ static void
 handle_unmap(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, unmap);
-	view->impl->unmap(view);
+	view->impl->unmap(view, /* client_request */ true);
 }
 
 static void
@@ -452,7 +452,7 @@ xdg_toplevel_view_map(struct view *view)
 }
 
 static void
-xdg_toplevel_view_unmap(struct view *view)
+xdg_toplevel_view_unmap(struct view *view, bool client_request)
 {
 	if (view->mapped) {
 		view->mapped = false;


### PR DESCRIPTION
This makes explicit the subtle behavioral difference between `xwayland_view_unmap()` and `handle_unmap()`.

With this change, the XDG and XWayland versions of `handle_map/unmap()` are now identical, which will make further refactoring possible.