### PR TITLE
Set untiled in ResizeRelative and maybe other fixes

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -629,9 +629,10 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_MOVE_RELATIVE:
-			if (view) {
+			if (view && !view->fullscreen) {
 				int x = get_arg_value_int(action, "x", 0);
 				int y = get_arg_value_int(action, "y", 0);
+				view_maximize(view, false, false);
 				view_move(view, view->pending.x + x, view->pending.y + y);
 			}
 			break;

--- a/src/view.c
+++ b/src/view.c
@@ -206,12 +206,15 @@ view_move_resize(struct view *view, struct wlr_box geo)
 void
 view_resize_relative(struct view *view, int left, int right, int top, int bottom)
 {
+	if (view->fullscreen || view->maximized)
+		return;
 	struct wlr_box newgeo = view->pending;
 	newgeo.x -= left;
 	newgeo.width += left + right;
 	newgeo.y -= top;
 	newgeo.height += top + bottom;
 	view_move_resize(view, newgeo);
+	view_set_untiled(view);
 }
 
 void


### PR DESCRIPTION
I noticed that if window is snapped to edge, resized with ResizeRelative, then moved with mouse it returns to size it was before snap to edge. Can be fixed by adding view_set_untiled.

Also both MoveRelative and ResizeRelative don't check if view is fullscreen or maximized, should we change that? I think they should be disabled at least for fullscreen.