### PR TITLE
Show modal dialog above parent window

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -45,6 +45,8 @@ struct view_impl {
 	void (*minimize)(struct view *view, bool minimize);
 	void (*move_to_front)(struct view *view);
 	void (*move_to_back)(struct view *view);
+	struct view *(*get_root)(struct view *self);
+	void (*append_children)(struct view *self, struct wl_array *children);
 };
 
 struct view {
@@ -203,6 +205,8 @@ void view_snap_to_region(struct view *view, struct region *region,
 
 void view_move_to_front(struct view *view);
 void view_move_to_back(struct view *view);
+struct view *view_get_root(struct view *view);
+void view_append_children(struct view *view, struct wl_array *children);
 
 const char *view_get_string_prop(struct view *view, const char *prop);
 void view_update_title(struct view *view);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -369,20 +369,35 @@ move_sub_views(struct view *parent, enum z_direction z_direction)
 	}
 }
 
+/* Return the most senior parent (=root) view */
+static struct view *
+root_view_of_view(struct view *view)
+{
+	struct wlr_xdg_toplevel *root = top_parent_of(view);
+	struct wlr_xdg_surface *surface = (struct wlr_xdg_surface *)root->base;
+	return (struct view *)surface->data;
+}
+
+/*
+ * In the view_move_to_{front,back} functions, a modal dialog is always shown
+ * above its parent window, and the two always move together, so other window
+ * cannot come between them.
+ * This is consistent with GTK3/Qt5 applications on mutter and openbox.
+ */
 static void
 xdg_toplevel_view_move_to_front(struct view *view)
 {
-	view_impl_move_to_front(view);
-
-	/* Show modal dialog above parent window */
-	move_sub_views(view, LAB_TO_FRONT);
+	struct view *root = root_view_of_view(view);
+	view_impl_move_to_front(root);
+	move_sub_views(root, LAB_TO_FRONT);
 }
 
 static void
 xdg_toplevel_view_move_to_back(struct view *view)
 {
-	view_impl_move_to_back(view);
-	move_sub_views(view, LAB_TO_BACK);
+	struct view *root = root_view_of_view(view);
+	view_impl_move_to_back(root);
+	move_sub_views(root, LAB_TO_BACK);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -555,18 +555,27 @@ move_sub_views(struct view *parent, enum z_direction z_direction)
 	}
 }
 
+static struct view *
+root_view_of_view(struct view *view)
+{
+	struct wlr_xwayland_surface *root = top_parent_of(view);
+	return (struct view *)root->data;
+}
+
 static void
 xwayland_view_move_to_front(struct view *view)
 {
-	view_impl_move_to_front(view);
-	move_sub_views(view, LAB_TO_FRONT);
+	struct view *root = root_view_of_view(view);
+	view_impl_move_to_front(root);
+	move_sub_views(root, LAB_TO_FRONT);
 }
 
 static void
 xwayland_view_move_to_back(struct view *view)
 {
-	view_impl_move_to_back(view);
-	move_sub_views(view, LAB_TO_BACK);
+	struct view *root = root_view_of_view(view);
+	view_impl_move_to_back(root);
+	move_sub_views(root, LAB_TO_BACK);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -413,14 +413,23 @@ top_left_edge_boundary_check(struct view *view)
 static void
 xwayland_view_map(struct view *view)
 {
+	struct wlr_xwayland_surface *xwayland_surface = xwayland_surface_from_view(view);
 	if (view->mapped) {
+		return;
+	}
+	if (!xwayland_surface->surface) {
+		/*
+		 * We may get here if a user minimizes an xwayland dialog at the
+		 * same time as the client requests unmap, which xwayland
+		 * clients sometimes do without actually requesting destroy
+		 * even if they don't intend to use that view/surface anymore
+		 */
+		wlr_log(WLR_DEBUG, "Cannot map view without wlr_surface");
 		return;
 	}
 	view->mapped = true;
 	ensure_initial_geometry_and_output(view);
 	wlr_scene_node_set_enabled(&view->scene_tree->node, true);
-	struct wlr_xwayland_surface *xwayland_surface =
-		xwayland_surface_from_view(view);
 	if (!view->fullscreen && xwayland_surface->fullscreen) {
 		view_set_fullscreen(view, true);
 	}

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -530,6 +530,10 @@ enum z_direction {
 	LAB_TO_BACK,
 };
 
+/*
+ * TODO: Combine append_children() and move_sub_views() as much as possible.
+ * https://github.com/labwc/labwc/pull/998#discussion_r1284085575
+ */
 static void
 move_sub_views(struct view *parent, enum z_direction z_direction)
 {
@@ -566,7 +570,7 @@ move_sub_views(struct view *parent, enum z_direction z_direction)
 }
 
 static struct view *
-root_view_of_view(struct view *view)
+xwayland_view_get_root(struct view *view)
 {
 	struct wlr_xwayland_surface *root = top_parent_of(view);
 	return (struct view *)root->data;
@@ -575,7 +579,7 @@ root_view_of_view(struct view *view)
 static void
 xwayland_view_move_to_front(struct view *view)
 {
-	struct view *root = root_view_of_view(view);
+	struct view *root = xwayland_view_get_root(view);
 	view_impl_move_to_front(root);
 	move_sub_views(root, LAB_TO_FRONT);
 }
@@ -583,9 +587,41 @@ xwayland_view_move_to_front(struct view *view)
 static void
 xwayland_view_move_to_back(struct view *view)
 {
-	struct view *root = root_view_of_view(view);
+	struct view *root = xwayland_view_get_root(view);
 	view_impl_move_to_back(root);
 	move_sub_views(root, LAB_TO_BACK);
+}
+
+static void
+xwayland_view_append_children(struct view *self, struct wl_array *children)
+{
+	struct wlr_xwayland_surface *surface = xwayland_surface_from_view(self);
+	struct view *view;
+
+	wl_list_for_each_reverse(view, &self->server->views, link)
+	{
+		if (view == self) {
+			continue;
+		}
+		if (view->type != LAB_XWAYLAND_VIEW) {
+			continue;
+		}
+		/*
+		 * This happens when a view has never been mapped or when a
+		 * client has requested a `handle_unmap`.
+		 */
+		if (!view->surface) {
+			continue;
+		}
+		if (!view->mapped && !view->minimized) {
+			continue;
+		}
+		if (top_parent_of(view) != surface) {
+			continue;
+		}
+		struct view **child = wl_array_add(children, sizeof(*child));
+		*child = view;
+	}
 }
 
 static void
@@ -631,6 +667,8 @@ static const struct view_impl xwayland_view_impl = {
 	.minimize = xwayland_view_minimize,
 	.move_to_front = xwayland_view_move_to_front,
 	.move_to_back = xwayland_view_move_to_back,
+	.get_root = xwayland_view_get_root,
+	.append_children = xwayland_view_append_children,
 };
 
 void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -492,7 +492,7 @@ static void
 xwayland_view_unmap(struct view *view, bool client_request)
 {
 	if (!view->mapped) {
-		return;
+		goto out;
 	}
 	view->mapped = false;
 	wl_list_remove(&view->commit.link);
@@ -504,6 +504,7 @@ xwayland_view_unmap(struct view *view, bool client_request)
 	 * than just minimized), destroy the foreign toplevel handle so
 	 * the unmapped view doesn't show up in panels and the like.
 	 */
+out:
 	if (client_request && view->toplevel.handle) {
 		wlr_foreign_toplevel_handle_v1_destroy(view->toplevel.handle);
 		view->toplevel.handle = NULL;


### PR DESCRIPTION
This behaviour is consistent with that of mutter and openbox.

Tested with mousepad's 'about' dialog

Fixes: issue #823 