### PR TITLE
[wip] feature: Allow blocking wayland protocols

### DIFF
--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -31,6 +31,11 @@ struct window_switcher_field {
 	struct wl_list link; /* struct rcxml.window_switcher.fields */
 };
 
+struct blocked_protocol {
+	struct wl_list link; /* struct rcxml.blocked_protocols */
+	char *interface_name;
+};
+
 struct rcxml {
 	char *config_dir;
 
@@ -94,6 +99,7 @@ struct rcxml {
 	} window_switcher;
 
 	struct wl_list window_rules; /* struct window_rule.link */
+	struct wl_list blocked_protocols; /* struct blocked_protocol.link */
 };
 
 extern struct rcxml rc;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -37,6 +37,7 @@ static bool in_mousebind;
 static bool in_libinput_category;
 static bool in_window_switcher_field;
 static bool in_window_rules;
+static bool in_blocked_protocols;
 
 static struct usable_area_override *current_usable_area_override;
 static struct keybind *current_keybind;
@@ -163,6 +164,16 @@ fill_window_rule(char *nodename, char *content)
 			"nodename: '%s' content: '%s'", nodename, content);
 	} else {
 		action_arg_from_xml_node(current_window_rule_action, nodename, content);
+	}
+}
+
+static void
+fill_blocked_protocols(char *nodename, char *content)
+{
+	if (!strcasecmp(nodename, "name.interface.blockedProtocols")) {
+		struct blocked_protocol *proto = znew(*proto);
+		proto->interface_name = xstrdup(content);
+		wl_list_append(&rc.blocked_protocols, &proto->link);
 	}
 }
 
@@ -536,6 +547,10 @@ entry(xmlNode *node, char *nodename, char *content)
 		fill_window_rule(nodename, content);
 		return;
 	}
+	if (in_blocked_protocols) {
+		fill_blocked_protocols(nodename, content);
+		return;
+	}
 
 	/* handle nodes without content, e.g. <keyboard><default /> */
 	if (!strcmp(nodename, "default.keyboard")) {
@@ -736,6 +751,12 @@ xml_tree_walk(xmlNode *node)
 			in_window_rules = false;
 			continue;
 		}
+		if (!strcasecmp((char *)n->name, "blockedProtocols")) {
+			in_blocked_protocols = true;
+			traverse(n);
+			in_blocked_protocols = false;
+			continue;
+		}
 		traverse(n);
 	}
 }
@@ -776,6 +797,7 @@ rcxml_init(void)
 		wl_list_init(&rc.regions);
 		wl_list_init(&rc.window_switcher.fields);
 		wl_list_init(&rc.window_rules);
+		wl_list_init(&rc.blocked_protocols);
 	}
 	has_run = true;
 
@@ -1316,6 +1338,13 @@ rcxml_finish(void)
 	struct window_rule *rule, *rule_tmp;
 	wl_list_for_each_safe(rule, rule_tmp, &rc.window_rules, link) {
 		rule_destroy(rule);
+	}
+
+	struct blocked_protocol *proto, *proto_tmp;
+	wl_list_for_each_safe(proto, proto_tmp, &rc.blocked_protocols, link) {
+		wl_list_remove(&proto->link);
+		zfree(proto->interface_name);
+		zfree(proto);
 	}
 
 	/* Reset state vars for starting fresh when Reload is triggered */

--- a/src/server.c
+++ b/src/server.c
@@ -180,7 +180,15 @@ server_global_filter(const struct wl_client *client, const struct wl_global *glo
 		}
 	}
 #endif
+	struct blocked_protocol *proto;
+	wl_list_for_each(proto, &rc.blocked_protocols, link) {
+		if (!strcmp(iface->name, proto->interface_name)) {
+			wlr_log(WLR_INFO, "blocking protocol %s", proto->interface_name);
+			return false;
+		}
+	}
 
+	wlr_log(WLR_DEBUG, "protocol not blocked: %s", iface->name);
 	return true;
 }
 


### PR DESCRIPTION
Missing:
- [ ] docs (including it only applying to new windows after --reconfigure)
- [ ] discuss config naming and format
- [ ] remove "not blocked: $interface_name" debug log

Test config entry:
```xml
  <blockedProtocols>
        <interface name="zwlr_virtual_pointer_manager_v1" />
        <interface name="zwp_virtual_keyboard_manager_v1" />
        <interface name="zwlr_export_dmabuf_manager_v1" />
        <interface name="zwlr_screencopy_manager_v1" />
        <interface name="zwlr_data_control_manager_v1" />
        <interface name="zwlr_input_inhibit_manager_v1" />
        <interface name="zwlr_foreign_toplevel_manager_v1" />
        <interface name="zwlr_layer_shell_v1" />
  </blockedProtocols>
```

Related:
- https://github.com/labwc/labwc/discussions/1002