### PR TITLE
Allow snap to window in MoveToEdge; Add GrowToEdge, ShrinkToEdge

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -39,9 +39,14 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="Move" />*
 	Begin interactive move of window under cursor
 
-*<action name="MoveToEdge" direction="value" />*
-	Move window to edge of outputs. Understands directions "left", "up",
-	"right" and "down".
+*<action name="MoveToEdge" direction="value" snapWindows="value" />*
+	Move window until it hits the next edge.
+
+	*direction* [left|up|right|down] Direction in which to move.
+
+	*snapWindows* [yes|no] Move window until it hits an edge of
+	another window or screen edge. If set to "no", only move to
+	the next screen edge. Default is yes.
 
 *<action name="Resize" />*
 	Begin interactive resize of window under cursor

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -56,6 +56,17 @@ Actions are used in menus and keyboard/mouse bindings.
 	top or bottom tell how much to resize on that edge of window,
 	positive values grow window, negative shrink window.
 
+*<action name="GrowToEdge" direction="value" />*
+	Resize window to fill the space between its edge and any other
+	window edge.
+
+	*direction* [left|up|right|down] Direction in which to grow.
+
+*<action name="ShrinkToEdge" direction="value" />*
+	Reverse of GrowToEdge. Shrinks by a maximum of 50%.
+
+	*direction* [left|up|right|down] Direction in which to shrink.
+
 *<action name="MoveTo" x="" y="" />*
 	Move to position (x, y)
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -460,6 +460,7 @@ bool output_is_usable(struct output *output);
 void output_update_usable_area(struct output *output);
 void output_update_all_usable_areas(struct server *server, bool layout_changed);
 struct wlr_box output_usable_area_in_layout_coords(struct output *output);
+struct wlr_box output_usable_area_scaled(struct output *output);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
 

--- a/include/snap.h
+++ b/include/snap.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_SNAP_H
+#define LABWC_SNAP_H
+
+#include "common/border.h"
+#include "view.h"
+
+struct wlr_box;
+
+struct border snap_get_max_distance(struct view *view);
+
+void snap_vector_to_next_edge(struct view *view, enum view_edge direction, int *dx, int *dy);
+int snap_distance_to_next_edge(struct view *view, enum view_edge direction);
+void snap_grow_to_next_edge(struct view *view, enum view_edge direction, struct wlr_box *geo);
+void snap_shrink_to_next_edge(struct view *view, enum view_edge direction, struct wlr_box *geo);
+
+#endif /* LABWC_SNAP_H */

--- a/include/view.h
+++ b/include/view.h
@@ -371,6 +371,8 @@ void view_set_decorations(struct view *view, bool decorations);
 void view_toggle_fullscreen(struct view *view);
 void view_adjust_for_layout_change(struct view *view);
 void view_move_to_edge(struct view *view, enum view_edge direction, bool snap_to_windows);
+void view_grow_to_edge(struct view *view, enum view_edge direction);
+void view_shrink_to_edge(struct view *view, enum view_edge direction);
 void view_snap_to_edge(struct view *view, enum view_edge direction, bool store_natural_geometry);
 void view_snap_to_region(struct view *view, struct region *region, bool store_natural_geometry);
 

--- a/include/view.h
+++ b/include/view.h
@@ -8,6 +8,9 @@
 #include <wayland-util.h>
 #include <wlr/util/box.h>
 
+#define LAB_MIN_VIEW_WIDTH  100
+#define LAB_MIN_VIEW_HEIGHT  60
+
 /*
  * In labwc, a view is a container for surfaces which can be moved around by
  * the user. In practice this means XDG toplevel and XWayland windows.

--- a/include/view.h
+++ b/include/view.h
@@ -370,7 +370,7 @@ void view_move_to_workspace(struct view *view, struct workspace *workspace);
 void view_set_decorations(struct view *view, bool decorations);
 void view_toggle_fullscreen(struct view *view);
 void view_adjust_for_layout_change(struct view *view);
-void view_move_to_edge(struct view *view, enum view_edge direction);
+void view_move_to_edge(struct view *view, enum view_edge direction, bool snap_to_windows);
 void view_snap_to_edge(struct view *view, enum view_edge direction, bool store_natural_geometry);
 void view_snap_to_region(struct view *view, struct region *region, bool store_natural_geometry);
 

--- a/src/action.c
+++ b/src/action.c
@@ -266,6 +266,11 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 		}
 		break;
 	case ACTION_TYPE_MOVE_TO_EDGE:
+		if (!strcasecmp(argument, "snapWindows")) {
+			action_arg_add_bool(action, argument, parse_bool(content, true));
+			goto cleanup;
+		}
+		/* Falls through */
 	case ACTION_TYPE_SNAP_TO_EDGE:
 		if (!strcmp(argument, "direction")) {
 			enum view_edge edge = view_edge_parse(content);
@@ -638,7 +643,8 @@ actions_run(struct view *activator, struct server *server,
 			if (view) {
 				/* Config parsing makes sure that direction is a valid direction */
 				enum view_edge edge = action_get_int(action, "direction", 0);
-				view_move_to_edge(view, edge);
+				bool snap_to_windows = action_get_bool(action, "snapWindows", true);
+				view_move_to_edge(view, edge, snap_to_windows);
 			}
 			break;
 		case ACTION_TYPE_SNAP_TO_EDGE:

--- a/src/action.c
+++ b/src/action.c
@@ -66,6 +66,8 @@ enum action_type {
 	ACTION_TYPE_EXIT,
 	ACTION_TYPE_MOVE_TO_EDGE,
 	ACTION_TYPE_SNAP_TO_EDGE,
+	ACTION_TYPE_GROW_TO_EDGE,
+	ACTION_TYPE_SHRINK_TO_EDGE,
 	ACTION_TYPE_NEXT_WINDOW,
 	ACTION_TYPE_PREVIOUS_WINDOW,
 	ACTION_TYPE_RECONFIGURE,
@@ -105,6 +107,8 @@ const char *action_names[] = {
 	"Exit",
 	"MoveToEdge",
 	"SnapToEdge",
+	"GrowToEdge",
+	"ShrinkToEdge",
 	"NextWindow",
 	"PreviousWindow",
 	"Reconfigure",
@@ -272,6 +276,8 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 		}
 		/* Falls through */
 	case ACTION_TYPE_SNAP_TO_EDGE:
+	case ACTION_TYPE_GROW_TO_EDGE:
+	case ACTION_TYPE_SHRINK_TO_EDGE:
 		if (!strcmp(argument, "direction")) {
 			enum view_edge edge = view_edge_parse(content);
 			if ((edge == VIEW_EDGE_CENTER && action->type != ACTION_TYPE_SNAP_TO_EDGE)
@@ -411,6 +417,8 @@ action_is_valid(struct action *action)
 		break;
 	case ACTION_TYPE_MOVE_TO_EDGE:
 	case ACTION_TYPE_SNAP_TO_EDGE:
+	case ACTION_TYPE_GROW_TO_EDGE:
+	case ACTION_TYPE_SHRINK_TO_EDGE:
 		arg_name = "direction";
 		arg_type = LAB_ACTION_ARG_INT;
 		break;
@@ -652,6 +660,20 @@ actions_run(struct view *activator, struct server *server,
 				/* Config parsing makes sure that direction is a valid direction */
 				enum view_edge edge = action_get_int(action, "direction", 0);
 				view_snap_to_edge(view, edge, /*store_natural_geometry*/ true);
+			}
+			break;
+		case ACTION_TYPE_GROW_TO_EDGE:
+			if (view) {
+				/* Config parsing makes sure that direction is a valid direction */
+				enum view_edge edge = action_get_int(action, "direction", 0);
+				view_grow_to_edge(view, edge);
+			}
+			break;
+		case ACTION_TYPE_SHRINK_TO_EDGE:
+			if (view) {
+				/* Config parsing makes sure that direction is a valid direction */
+				enum view_edge edge = action_get_int(action, "direction", 0);
+				view_shrink_to_edge(view, edge);
 			}
 			break;
 		case ACTION_TYPE_NEXT_WINDOW:

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ labwc_sources = files(
   'seat.c',
   'server.c',
   'session-lock.c',
+  'snap.c',
   'touch.c',
   'theme.c',
   'view.c',

--- a/src/output.c
+++ b/src/output.c
@@ -565,6 +565,24 @@ output_usable_area_in_layout_coords(struct output *output)
 	return box;
 }
 
+struct wlr_box
+output_usable_area_scaled(struct output *output)
+{
+	if (!output) {
+		return (struct wlr_box){0};
+	}
+	struct wlr_box usable = output_usable_area_in_layout_coords(output);
+	if (usable.height == output->wlr_output->height
+			&& output->wlr_output->scale != 1) {
+		usable.height /= output->wlr_output->scale;
+	}
+	if (usable.width == output->wlr_output->width
+			&& output->wlr_output->scale != 1) {
+		usable.width /= output->wlr_output->scale;
+	}
+	return usable;
+}
+
 void
 handle_output_power_manager_set_mode(struct wl_listener *listener, void *data)
 {

--- a/src/snap.c
+++ b/src/snap.c
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <assert.h>
+#include <strings.h>
+#include <wlr/util/box.h>
+#include "labwc.h"
+#include "snap.h"
+#include "view.h"
+#include "workspaces.h"
+
+/* We cannot use MIN/MAX macros, as they may call functions twice, and
+ * can be overridden by previous #define.
+ */
+static inline int
+min(int a, int b) {
+	return a < b ? a : b;
+}
+
+static inline int
+max(int a, int b) {
+	return a > b ? a : b;
+}
+
+static inline int
+min3(int a, int b, int c) {
+	return min(min(a, b), c);
+}
+
+enum snap_mode {
+	SNAP_MODE_MOVE = 0,
+	SNAP_MODE_GROW,
+	SNAP_MODE_SHRINK,
+};
+
+static struct border
+snap_get_view_edge(struct view *view)
+{
+	struct border margin = ssd_get_margin(view->ssd);
+	struct border edge = {
+		.left   = view->pending.x - margin.left,
+		.top    = view->pending.y - margin.top,
+		.right  = view->pending.x + view->pending.width  + margin.right,
+		.bottom = view->pending.y + view->pending.height + margin.bottom
+	};
+	return edge;
+}
+
+struct border
+snap_get_max_distance(struct view *view)
+{
+	struct output *output = view->output;
+	struct border margin = ssd_get_margin(view->ssd);
+	struct wlr_box usable = output_usable_area_scaled(output);
+	struct border distance = {
+		.left   = usable.x + margin.left + rc.gap - view->pending.x,
+		.top    = usable.y + margin.top  + rc.gap - view->pending.y,
+		.right  = usable.x + usable.width  - view->pending.width
+			- margin.right  - rc.gap - view->pending.x,
+		.bottom = usable.y + usable.height - view->pending.height
+			- margin.bottom - rc.gap - view->pending.y
+	};
+	return distance;
+}
+
+struct snap_search {
+	const int search_dir; /* -1: left/up, 1: right/down */
+
+	const int add_view_x;
+	const int add_view_y;
+	const int add_view_width;
+	const int add_view_height;
+
+	const int add_margin_left;
+	const int add_margin_top;
+	const int add_margin_right;
+	const int add_margin_bottom;
+};
+
+/* near/far is the left, right, top or bottom border of a window,
+ * depending on the search direction:
+ *  - near_right: search to the right, snap to left  (near) border of a window.
+ *  - far_right:  search to the right, snap to right (far)  border of a window.
+ *  - near_left:  search to the left,  snap to right (near) border of a window.
+ *  - far_left:   search to the left,  snap to left  (far)  border of a window.
+ *
+ * structs below define what coordinates and margins to take into
+ * account depending near/far, and direction.
+ */
+static const struct snap_search near_left  = { -1,   1, 0, 1, 0,    0,  0,  1,  0 };
+static const struct snap_search near_up    = { -1,   0, 1, 0, 1,    0,  0,  0,  1 };
+static const struct snap_search near_right = {  1,   1, 0, 0, 0,   -1,  0,  0,  0 };
+static const struct snap_search near_down  = {  1,   0, 1, 0, 0,    0, -1,  0,  0 };
+static const struct snap_search far_left   = { -1,   1, 0, 0, 0,   -1,  0,  0,  0 };
+static const struct snap_search far_up     = { -1,   0, 1, 0, 0,    0, -1,  0,  0 };
+static const struct snap_search far_right  = {  1,   1, 0, 1, 0,    0,  0,  1,  0 };
+static const struct snap_search far_down   = {  1,   0, 1, 0, 1,    0,  0,  1,  0 };
+
+static inline int
+_snap_next_edge(struct view *view, int start_pos, const struct snap_search def, int max, int gap)
+{
+	struct output *output = view->output;
+	struct server *server = output->server;
+	struct view *v;
+	int p = max;
+	for_each_view(v, &server->views, LAB_VIEW_CRITERIA_CURRENT_WORKSPACE) {
+		if (v == view || v->output != output || v->minimized || v->maximized) {
+			continue;
+		}
+
+		struct border margin = ssd_get_margin(v->ssd);
+		int vp = -start_pos;
+		vp += def.add_margin_left   * margin.left;
+		vp += def.add_margin_top    * margin.top;
+		vp += def.add_margin_right  * margin.right;
+		vp += def.add_margin_bottom * margin.bottom;
+		vp += def.add_view_x        * v->pending.x;
+		vp += def.add_view_y        * v->pending.y;
+		vp += def.add_view_width    * v->pending.width;
+		vp += def.add_view_height   * v->pending.height;
+		vp += gap;
+
+		if (def.search_dir * vp > 0 && def.search_dir * (vp - p) < 0) {
+			p = vp;
+		}
+	}
+	return p;
+}
+
+static void
+_snap_move_resize_to_edge(struct view *view, enum view_edge direction, enum snap_mode mode,
+		struct wlr_box *delta)
+{
+	struct border edge = snap_get_view_edge(view);
+	struct border dmax;
+	if (mode == SNAP_MODE_SHRINK) {
+		/* limit to half of current size */
+		int width_max_dx  = max(view->pending.width  - LAB_MIN_VIEW_WIDTH,  0);
+		int height_max_dy = max(view->pending.height - LAB_MIN_VIEW_HEIGHT, 0);
+		dmax.right  = min(width_max_dx,  view->pending.width  / 2);
+		dmax.bottom = min(height_max_dy, view->pending.height / 2);
+		dmax.left   = -dmax.right;
+		dmax.top    = -dmax.bottom;
+	} else {
+		dmax = snap_get_max_distance(view);
+	}
+
+	switch (direction) {
+	case VIEW_EDGE_LEFT:
+		if (mode == SNAP_MODE_MOVE) {
+			delta->x += max(
+				/* left edge to left/right edges */
+				_snap_next_edge(view, edge.left, near_left, dmax.left, rc.gap),
+				_snap_next_edge(view, edge.left, far_left,  dmax.left, 0)
+			);
+		} else if (mode == SNAP_MODE_GROW) {
+			int dx = max(
+				/* left edge to left/right edges */
+				_snap_next_edge(view, edge.left, near_left, dmax.left, rc.gap),
+				_snap_next_edge(view, edge.left, far_left,  dmax.left, 0)
+			);
+			delta->x     +=  dx;
+			delta->width += -dx;
+		} else if (mode == SNAP_MODE_SHRINK) {
+			delta->width += max(
+				/* right edge to left/right edges */
+				_snap_next_edge(view, edge.right, near_left, dmax.left, 0),
+				_snap_next_edge(view, edge.right, far_left,  dmax.left, -rc.gap)
+			);
+		}
+		break;
+	case VIEW_EDGE_UP:
+		if (mode == SNAP_MODE_MOVE) {
+			delta->y += max(
+				/* top edge to top/bottom edges */
+				_snap_next_edge(view, edge.top, near_up, dmax.top, rc.gap),
+				_snap_next_edge(view, edge.top, far_up,  dmax.top, 0)
+			);
+		} else if (mode == SNAP_MODE_GROW) {
+			int dy = max(
+				/* top edge to top/bottom edges */
+				_snap_next_edge(view, edge.top, near_up, dmax.top, rc.gap),
+				_snap_next_edge(view, edge.top, far_up,  dmax.top, 0)
+			);
+			delta->y      +=  dy;
+			delta->height += -dy;
+		} else if (mode == SNAP_MODE_SHRINK) {
+			delta->height += max(
+				/* bottom edge to top/bottom edges */
+				_snap_next_edge(view, edge.bottom, near_up, dmax.top, 0),
+				_snap_next_edge(view, edge.bottom, far_up,  dmax.top, -rc.gap)
+			);
+		}
+		break;
+	case VIEW_EDGE_RIGHT:
+		if (mode == SNAP_MODE_MOVE) {
+			delta->x += min3(
+				/* left edge to left/right edges */
+				_snap_next_edge(view, edge.left, near_right, dmax.right, 0),
+				_snap_next_edge(view, edge.left, far_right,  dmax.right, rc.gap),
+				/* right edge to left edge */
+				_snap_next_edge(view, edge.right, near_right, dmax.right, -rc.gap)
+			);
+		} else if (mode == SNAP_MODE_GROW) {
+			delta->width += min(
+				/* right edge to left/right edges */
+				_snap_next_edge(view, edge.right, near_right, dmax.right, -rc.gap),
+				_snap_next_edge(view, edge.right, far_right,  dmax.right, 0)
+			);
+		} else if (mode == SNAP_MODE_SHRINK) {
+			delta->x += min(
+				/* left edge to left/right edges */
+				_snap_next_edge(view, edge.left, near_right, dmax.right, 0),
+				_snap_next_edge(view, edge.left, far_right,  dmax.right, rc.gap)
+			);
+			delta->width += -(delta->x);
+		}
+		break;
+	case VIEW_EDGE_DOWN:
+		if (mode == SNAP_MODE_MOVE) {
+			delta->y += min3(
+				/* top edge to top/bottom edges */
+				_snap_next_edge(view, edge.top, near_down, dmax.bottom, 0),
+				_snap_next_edge(view, edge.top, far_down,  dmax.bottom, rc.gap),
+				/* bottom edge to top edge */
+				_snap_next_edge(view, edge.bottom, near_down, dmax.bottom, -rc.gap)
+			);
+		} else if (mode == SNAP_MODE_GROW) {
+			delta->height += min(
+				/* bottom edge to top/bottom edges */
+				_snap_next_edge(view, edge.bottom, near_down, dmax.bottom, -rc.gap),
+				_snap_next_edge(view, edge.bottom, far_down,  dmax.bottom, 0)
+			);
+		} else if (mode == SNAP_MODE_SHRINK) {
+			delta->y += min(
+				/* top edge to top/bottom edges */
+				_snap_next_edge(view, edge.top, near_down, dmax.bottom, 0),
+				_snap_next_edge(view, edge.top, far_down,  dmax.bottom, rc.gap)
+			);
+			delta->height += -(delta->y);
+		}
+		break;
+	default:
+		return;
+	}
+}
+
+void
+snap_vector_to_next_edge(struct view *view, enum view_edge direction, int *dx, int *dy)
+{
+	struct wlr_box delta = {0};
+	_snap_move_resize_to_edge(view, direction, SNAP_MODE_MOVE, &delta);
+	*dx = delta.x;
+	*dy = delta.y;
+}
+
+int
+snap_distance_to_next_edge(struct view *view, enum view_edge direction)
+{
+	struct wlr_box delta = {0};
+	_snap_move_resize_to_edge(view, direction, SNAP_MODE_MOVE, &delta);
+	switch (direction) {
+	case VIEW_EDGE_LEFT:  return -delta.x;
+	case VIEW_EDGE_UP:    return -delta.y;
+	case VIEW_EDGE_RIGHT: return  delta.x;
+	case VIEW_EDGE_DOWN:  return  delta.y;
+	default: return 0;
+	}
+}
+
+void
+snap_grow_to_next_edge(struct view *view, enum view_edge direction, struct wlr_box *geo)
+{
+	_snap_move_resize_to_edge(view, direction, SNAP_MODE_GROW, geo);
+}
+
+void
+snap_shrink_to_next_edge(struct view *view, enum view_edge direction, struct wlr_box *geo)
+{
+	_snap_move_resize_to_edge(view, direction, SNAP_MODE_SHRINK, geo);
+}

--- a/src/view.c
+++ b/src/view.c
@@ -208,16 +208,7 @@ static struct wlr_box
 view_get_edge_snap_box(struct view *view, struct output *output,
 		enum view_edge edge)
 {
-	struct wlr_box usable = output_usable_area_in_layout_coords(output);
-	if (usable.height == output->wlr_output->height
-			&& output->wlr_output->scale != 1) {
-		usable.height /= output->wlr_output->scale;
-	}
-	if (usable.width == output->wlr_output->width
-			&& output->wlr_output->scale != 1) {
-		usable.width /= output->wlr_output->scale;
-	}
-
+	struct wlr_box usable = output_usable_area_scaled(output);
 	int x_offset = edge == VIEW_EDGE_RIGHT
 		? (usable.width + rc.gap) / 2 : rc.gap;
 	int y_offset = edge == VIEW_EDGE_DOWN

--- a/src/view.c
+++ b/src/view.c
@@ -1162,6 +1162,40 @@ view_move_to_edge(struct view *view, enum view_edge direction, bool snap_to_wind
 	view_move(view, view->pending.x + dx, view->pending.y + dy);
 }
 
+void
+view_grow_to_edge(struct view *view, enum view_edge direction)
+{
+	assert(view);
+	if (view->fullscreen || view->maximized) {
+		return;
+	}
+	if (!output_is_usable(view->output)) {
+		wlr_log(WLR_ERROR, "view has no output, not growing view");
+		return;
+	}
+
+	struct wlr_box geo = view->pending;
+	snap_grow_to_next_edge(view, direction, &geo);
+	view_move_resize(view, geo);
+}
+
+void
+view_shrink_to_edge(struct view *view, enum view_edge direction)
+{
+	assert(view);
+	if (view->fullscreen || view->maximized) {
+		return;
+	}
+	if (!output_is_usable(view->output)) {
+		wlr_log(WLR_ERROR, "view has no output, not shrinking view");
+		return;
+	}
+
+	struct wlr_box geo = view->pending;
+	snap_shrink_to_next_edge(view, direction, &geo);
+	view_move_resize(view, geo);
+}
+
 enum view_edge
 view_edge_parse(const char *direction)
 {

--- a/src/view.c
+++ b/src/view.c
@@ -19,8 +19,6 @@
 #include <wlr/xwayland.h>
 #endif
 
-#define LAB_MIN_VIEW_WIDTH  100
-#define LAB_MIN_VIEW_HEIGHT  60
 #define LAB_FALLBACK_WIDTH  640
 #define LAB_FALLBACK_HEIGHT 480
 


### PR DESCRIPTION
I have been following your work for quite a while now (nice project, thanks a lot!), as I'm still stuck in X11 with openbox. For me there's just some small features which I'm painfully missing in order to control my window manager using the keyboard only.

A very common use case is to open a terminal "W-t", then align it to some other terminal using "W-arrow".

My rc.xml for this:
```
<!-- keyboard window placement -->
<keybind key="W-Left">
  <action name="MoveToEdge" direction="left" snap="window"/>
</keybind>
<keybind key="W-Right">
  <action name="MoveToEdge" direction="right" snap="window"/>
</keybind>
<keybind key="W-Up">
  <action name="MoveToEdge" direction="up" snap="window"/>
</keybind>
<keybind key="W-Down">
  <action name="MoveToEdge" direction="down" snap="window"/>
</keybind>
```

In addition to that, I want to align them (grow, shrink) to fill available space:
```
<keybind key="W-A-Left">
  <action name="ShrinkToEdge" direction="left"/>
</keybind>
<keybind key="W-A-Right">
  <action name="GrowToEdge" direction="right"/>
</keybind>
<keybind key="W-A-Up">
  <action name="ShrinkToEdge" direction="up"/>
</keybind>
<keybind key="W-A-Down">
  <action name="GrowToEdge" direction="down"/>
</keybind>
```

**This MR implements "GrowToEdge","ShrinkToEdge", and adds the ability to snap to next window for "MoveToEdge".**

Works nicely for me with the above config.

I will add some review comments in the code for some parts which I'm not sure about; especially we might consider adding a new compile unit for parts of the code.