### PR TITLE
rc, layers: Add ignoreExclusiveArea

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -102,6 +102,7 @@ Therefore, where multiple objects of the same kind are required (for example
   <gap>0</gap>
   <adaptiveSync>no</adaptiveSync>
   <reuseOutputMode>no</reuseOutputMode>
+  <ignoreExclusiveArea>no</ignoreExclusiveArea>
 </core>
 ```
 
@@ -122,6 +123,10 @@ Therefore, where multiple objects of the same kind are required (for example
 	This may prevent unnecessary screenblank delays when starting labwc
 	(also known as flicker free boot). If the existing output mode can not
 	be used with labwc the preferred mode of the monitor is used instead.
+	Default is no.
+
+*<core><ignoreExclusiveArea>* [yes|no]
+	Ignore the exclusive area provided by wlr_layer clients.
 	Default is no.
 
 ## WINDOW SWITCHER

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -12,6 +12,7 @@
     <gap>0</gap>
     <adaptiveSync>no</adaptiveSync>
     <reuseOutputMode>no</reuseOutputMode>
+    <ignoreExclusiveArea>no</ignoreExclusiveArea>
   </core>
 
   <!-- <font><theme> can be defined without an attribute to set all places -->

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -39,6 +39,7 @@ struct rcxml {
 	int gap;
 	bool adaptive_sync;
 	bool reuse_output_mode;
+	bool ignore_exclusive_area;
 
 	/* focus */
 	bool focus_follow_mouse;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -569,6 +569,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.gap = atoi(content);
 	} else if (!strcasecmp(nodename, "adaptiveSync.core")) {
 		set_bool(content, &rc.adaptive_sync);
+	} else if (!strcasecmp(nodename, "ignoreExclusiveArea.core")) {
+		set_bool(content, &rc.ignore_exclusive_area);
 	} else if (!strcasecmp(nodename, "reuseOutputMode.core")) {
 		set_bool(content, &rc.reuse_output_mode);
 	} else if (!strcmp(nodename, "name.theme")) {

--- a/src/layers.c
+++ b/src/layers.c
@@ -93,6 +93,9 @@ layers_arrange(struct output *output)
 			scene_output->y);
 	}
 
+	if (rc.ignore_exclusive_area)
+		usable_area = full_area;
+
 	output->usable_area = usable_area;
 }
 


### PR DESCRIPTION
Adds a config option to ignore the exclusive area for wl_layer clients such as waybar, allowing windows and their titlebars to appear in the same space.