### PR TITLE
labwc-theme(5): describe color alpha value

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -27,10 +27,10 @@ labwc-config(5).
 
 # DATA TYPES
 
-*color RGB values*
-	Colors can be specified by hexadecimal RGB values in the format #rrggbb.
-	Other formats will be supported later for better openbox theme
-	compatibility.
+*color*
+	Colors can be specified by either of the following:
+	- #rrggbb (hexadecimal RGB values)
+	- #rrggbb aaa (same but with decimal alpha value)
 
 *justification*
 	Justification determines the horizontal alignment of text. Valid options


### PR DESCRIPTION
...which has been supported for a long time but not been reflected in the man page.  Colors can be parsed as `#rrggbb aaa` with aaa representing a decimal alpha value. This could be used to hide a button, for example:

    window.active.button.menu.unpressed.image.color: #000000 0
    window.inactive.button.menu.unpressed.image.color: #000000 0

We could add a note on the web-site tips & tricks about this.

I have a feeling there is even an issue against this somewhere.