### PR TITLE
Fix crash when using _ToEdge actions when using the default keybinds

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -24,7 +24,7 @@ bool action_is_valid(struct action *action);
 
 void action_arg_add_str(struct action *action, const char *key, const char *value);
 
-void action_arg_from_xml_node(struct action *action, char *nodename, char *content);
+void action_arg_from_xml_node(struct action *action, const char *nodename, const char *content);
 
 bool actions_contain_toggle_keybinds(struct wl_list *action_list);
 

--- a/src/action.c
+++ b/src/action.c
@@ -159,7 +159,7 @@ action_arg_add_int(struct action *action, const char *key, int value)
 }
 
 void
-action_arg_from_xml_node(struct action *action, char *nodename, char *content)
+action_arg_from_xml_node(struct action *action, const char *nodename, const char *content)
 {
 	assert(action);
 

--- a/src/action.c
+++ b/src/action.c
@@ -257,13 +257,13 @@ action_str_from_arg(struct action_arg *arg)
 }
 
 static bool
-arg_value_exists(struct action *action, const char *key)
+arg_value_exists(struct action *action, const char *key, enum action_arg_type type)
 {
 	assert(action);
 	assert(key);
 	struct action_arg *arg;
 	wl_list_for_each(arg, &action->args, link) {
-		if (!strcasecmp(key, arg->key)) {
+		if (!strcasecmp(key, arg->key) && arg->type == type) {
 			return true;
 		}
 	}
@@ -373,6 +373,8 @@ bool
 action_is_valid(struct action *action)
 {
 	const char *arg_name = NULL;
+	enum action_arg_type arg_type = LAB_ACTION_ARG_STR;
+
 	switch (action->type) {
 	case ACTION_TYPE_EXECUTE:
 		arg_name = "command";
@@ -380,6 +382,7 @@ action_is_valid(struct action *action)
 	case ACTION_TYPE_MOVE_TO_EDGE:
 	case ACTION_TYPE_SNAP_TO_EDGE:
 		arg_name = "direction";
+		arg_type = LAB_ACTION_ARG_INT;
 		break;
 	case ACTION_TYPE_SHOW_MENU:
 		arg_name = "menu";
@@ -399,7 +402,7 @@ action_is_valid(struct action *action)
 		return true;
 	}
 
-	if (arg_value_exists(action, arg_name)) {
+	if (arg_value_exists(action, arg_name, arg_type)) {
 		return true;
 	}
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -847,7 +847,8 @@ load_default_key_bindings(void)
 		wl_list_append(&k->actions, &action->link);
 
 		if (key_combos[i].attribute && key_combos[i].value) {
-			action_arg_add_str(action, key_combos[i].attribute, key_combos[i].value);
+			action_arg_from_xml_node(action,
+				key_combos[i].attribute, key_combos[i].value);
 		}
 	}
 }
@@ -956,7 +957,8 @@ load_default_mouse_bindings(void)
 		 * slightly more sophisticated approach will be needed.
 		 */
 		if (current->attribute && current->value) {
-			action_arg_add_str(action, current->attribute, current->value);
+			action_arg_from_xml_node(action,
+				current->attribute, current->value);
 		}
 	}
 	wlr_log(WLR_DEBUG, "Loaded %u merged mousebinds", count);


### PR DESCRIPTION
This happens because of two separate bugs:
- The action validation failed to verify the data type of the argument
- When adding the fallback keybinds we add them as string but expect them being an int

This commit fixes the first bug.

Fixes 1ee8715d57ddb6b444e0b089879db6f837400539
actions: use enum for _ToEdge actions


The first commit will cause the action validation to work correctly / more strict and thus remove the keybinds.
The second commit will cause `action_arg_from_xml_node()` being used for the default mouse- and keybinds.

Sorry for everybody that might have been exposed to labwc suddenly crashing.