### PR TITLE
Add view_array_append() and for_each_view()

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -160,6 +160,36 @@ struct xdg_toplevel_view {
 	struct wl_listener new_popup;
 };
 
+enum lab_view_criteria {
+	LAB_VIEW_CRITERIA_ALL = 0,
+	LAB_VIEW_CRITERIA_CURRENT_WORKSPACE = 1 << 0,
+	LAB_VIEW_CRITERIA_NO_ALWAYS_ON_TOP = 1 << 1,
+	LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER = 1 << 2,
+};
+
+/**
+ * view_array_append - append views that match criteria to array
+ * @server: server context
+ * @views: arrays to append to
+ * @criteria: criteria to match against
+ *
+ * Note: This array has a very short shelf-life so it is intended to be used
+ *       with a single-use-throw-away approach.
+ *
+ * Example usage:
+ *
+ *	struct view **view;
+ *	struct wl_array views;
+ *	wl_array_init(&views);
+ *	view_array_append(server, &views, LAB_VIEW_CRITERIA_CURRENT_WORKSPACE);
+ *	wl_array_for_each(view, &views) {
+ *		// Do something with *view
+ *	}
+ *	wl_array_release(&views);
+ */
+void view_array_append(struct server *server, struct wl_array *views,
+	enum lab_view_criteria criteria);
+
 bool view_inhibits_keybinds(struct view *view);
 void view_toggle_keybinds(struct view *view);
 

--- a/include/view.h
+++ b/include/view.h
@@ -161,23 +161,54 @@ struct xdg_toplevel_view {
 };
 
 enum lab_view_criteria {
-	LAB_VIEW_CRITERIA_ALL = 0,
+	LAB_VIEW_CRITERIA_NONE = 0,
 	LAB_VIEW_CRITERIA_CURRENT_WORKSPACE = 1 << 0,
 	LAB_VIEW_CRITERIA_NO_ALWAYS_ON_TOP = 1 << 1,
 	LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER = 1 << 2,
 };
 
 /**
- * view_array_append - append views that match criteria to array
+ * for_each_view() - iterate over all views which match criteria
+ * @view: Iterator.
+ * @head: Head of list to iterate over.
+ * @criteria: Criteria to match against.
+ * Example:
+ *	struct view *view;
+ *	for_each_view(view, &server->views, LAB_VIEW_CRITERIA_NONE) {
+ *		printf("%s\n", view_get_string_prop(view, "app_id"));
+ *	}
+ */
+#define for_each_view(view, head, criteria)		\
+	for (view = view_next(head, NULL, criteria);	\
+	     view;					\
+	     view = view_next(head, view, criteria))
+
+/**
+ * view_next() - Get next view which matches criteria.
+ * @head: Head of list to iterate over.
+ * @view: Current view from which to find the next one. If NULL is provided as
+ *	  the view argument, the start of the list will be used.
+ * @criteria: Criteria to match against.
+ *
+ * Returns NULL if there are no views matching the criteria.
+ */
+struct view *view_next(struct wl_list *head, struct view *view,
+	enum lab_view_criteria criteria);
+
+/**
+ * view_array_append() - Append views that match criteria to array
  * @server: server context
  * @views: arrays to append to
  * @criteria: criteria to match against
+ *
+ * This function is useful in cases where the calling function may change the
+ * stacking order or where it needs to iterate over the views multiple times,
+ * for example to get the number of views before processing them.
  *
  * Note: This array has a very short shelf-life so it is intended to be used
  *       with a single-use-throw-away approach.
  *
  * Example usage:
- *
  *	struct view **view;
  *	struct wl_array views;
  *	wl_array_init(&views);

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -5526,10 +5526,11 @@ sub process {
 			# because (as opposed to Linux coding style) we use
 			# braces for single statement blocks.
 			#
-			# include/ssd-internal.h contains a macro that we can't
-			# deal with, so ignore that
+			# We ignore a couple of header-files which contain
+			# macros that we cannot deal with.
 			#
 			if ($starts_with_if_while_etc && !length($s)
+					&& $filename ne "include/view.h"
 					&& $filename ne "include/ssd-internal.h") {
 				CHK("BRACES", "[labwc-custom] open brace { expected after if/while/for/switch - even with single statement blocks");
 			}

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -435,3 +435,4 @@ get_cursor_context(struct server *server)
 	wlr_log(WLR_ERROR, "Unknown node detected");
 	return ret;
 }
+

--- a/src/osd.c
+++ b/src/osd.c
@@ -392,21 +392,6 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 	cairo_surface_flush(surf);
 }
 
-static int
-get_osd_height(struct server *server, struct wl_array *views)
-{
-	int height = 0;
-
-	/* Includes item border width */
-	size_t len = views->size / sizeof(struct view *);
-	height += len * rc.theme->osd_window_switcher_item_height;
-
-	/* Add OSD border width */
-	height += 2 * rc.theme->osd_border_width;
-	height += 2 * rc.theme->osd_window_switcher_padding;
-	return height;
-}
-
 static void
 display_osd(struct output *output)
 {
@@ -426,7 +411,9 @@ display_osd(struct output *output)
 
 	float scale = output->wlr_output->scale;
 	int w = theme->osd_window_switcher_width;
-	int h = get_osd_height(server, &views);
+	int h = views.size / sizeof(struct view *) * rc.theme->osd_window_switcher_item_height
+		+ 2 * rc.theme->osd_border_width
+		+ 2 * rc.theme->osd_window_switcher_padding;
 	if (show_workspace) {
 		/* workspace indicator */
 		h += theme->osd_window_switcher_item_height;

--- a/src/view.c
+++ b/src/view.c
@@ -18,44 +18,63 @@
 #define LAB_FALLBACK_WIDTH  640
 #define LAB_FALLBACK_HEIGHT 480
 
+static bool
+matches_criteria(struct view *view, enum lab_view_criteria criteria)
+{
+	if (!isfocusable(view)) {
+		return false;
+	}
+	if (criteria & LAB_VIEW_CRITERIA_CURRENT_WORKSPACE) {
+		/*
+		 * Always-on-top views are always on the current desktop and are
+		 * special in that they live in a different tree.
+		 */
+		struct server *server = view->server;
+		if (view->scene_tree->node.parent != server->workspace_current->tree
+				&& !view_is_always_on_top(view)) {
+			return false;
+		}
+	}
+	if (criteria & LAB_VIEW_CRITERIA_NO_ALWAYS_ON_TOP) {
+		if (view_is_always_on_top(view)) {
+			return false;
+		}
+	}
+	if (criteria & LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER) {
+		if (window_rules_get_property(view, "skipWindowSwitcher") == LAB_PROP_TRUE) {
+			return false;
+		}
+	}
+	return true;
+}
+
+struct view *
+view_next(struct wl_list *head, struct view *view, enum lab_view_criteria criteria)
+{
+	assert(head);
+
+	struct wl_list *elm = view ? &view->link : head;
+
+	for (elm = elm->next; elm != head; elm = elm->next) {
+		view = wl_container_of(elm, view, link);
+		if (matches_criteria(view, criteria)) {
+			return view;
+		}
+	}
+	return NULL;
+}
+
 void
 view_array_append(struct server *server, struct wl_array *views,
 		enum lab_view_criteria criteria)
 {
 	struct view *view;
-	wl_list_for_each(view, &server->views, link)
-	{
-		if (!isfocusable(view)) {
+	for_each_view(view, &server->views, criteria) {
+		struct view **entry = wl_array_add(views, sizeof(*entry));
+		if (!entry) {
+			wlr_log(WLR_ERROR, "wl_array_add(): out of memory");
 			continue;
 		}
-
-		if (criteria & LAB_VIEW_CRITERIA_CURRENT_WORKSPACE) {
-			/*
-			 * Always-on-top views are always on the current
-			 * desktop and are special in that they live in a
-			 * different tree.
-			 */
-			if (view_is_always_on_top(view)) {
-				goto next;
-			}
-			if (view->scene_tree->node.parent != server->workspace_current->tree) {
-				continue;
-			}
-		}
-next:
-		if (criteria & LAB_VIEW_CRITERIA_NO_ALWAYS_ON_TOP) {
-			if (view_is_always_on_top(view)) {
-				continue;
-			}
-		}
-		if (criteria & LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER) {
-			if (window_rules_get_property(view, "skipWindowSwitcher")
-					== LAB_PROP_TRUE) {
-				continue;
-			}
-		}
-
-		struct view **entry = wl_array_add(views, sizeof(*entry));
 		*entry = view;
 	}
 }

--- a/src/view.c
+++ b/src/view.c
@@ -18,6 +18,48 @@
 #define LAB_FALLBACK_WIDTH  640
 #define LAB_FALLBACK_HEIGHT 480
 
+void
+view_array_append(struct server *server, struct wl_array *views,
+		enum lab_view_criteria criteria)
+{
+	struct view *view;
+	wl_list_for_each(view, &server->views, link)
+	{
+		if (!isfocusable(view)) {
+			continue;
+		}
+
+		if (criteria & LAB_VIEW_CRITERIA_CURRENT_WORKSPACE) {
+			/*
+			 * Always-on-top views are always on the current
+			 * desktop and are special in that they live in a
+			 * different tree.
+			 */
+			if (view_is_always_on_top(view)) {
+				goto next;
+			}
+			if (view->scene_tree->node.parent != server->workspace_current->tree) {
+				continue;
+			}
+		}
+next:
+		if (criteria & LAB_VIEW_CRITERIA_NO_ALWAYS_ON_TOP) {
+			if (view_is_always_on_top(view)) {
+				continue;
+			}
+		}
+		if (criteria & LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER) {
+			if (window_rules_get_property(view, "skipWindowSwitcher")
+					== LAB_PROP_TRUE) {
+				continue;
+			}
+		}
+
+		struct view **entry = wl_array_add(views, sizeof(*entry));
+		*entry = view;
+	}
+}
+
 /**
  * All view_apply_xxx_geometry() functions must *not* modify
  * any state besides repositioning or resizing the view.
@@ -1260,3 +1302,4 @@ view_destroy(struct view *view)
 		cursor_update_focus(server);
 	}
 }
+


### PR DESCRIPTION
...to reduce code duplication.

The function populates an array with views which meet any set of critera from:

  - current-workspace
  - no-always-on-top
  - no-skipWindowSwitcher (window-rule)

Make src/osd.c use this new interface. Note that always-on-top views are still filtered out from the window-switcher and that desktop_cycle_view() needs to be re-worked before always-on-top views can be opted in.