### PR TITLE
config: s/app_id/identifier/ for window-switcher field

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -143,7 +143,8 @@ Therefore, where multiple objects of the same kind are required (for example
 
 		- *type* Show view type ("xdg-shell" or "xwayland")
 
-		- *app_id* Show app_id (class for XWayland)
+		- *identifier* Show identifier (app_id for native Wayland
+		  windows and WM_CLASS for XWayland clients)
 
 		- *title* Show window title if different to app_id
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -39,10 +39,14 @@
     </font>
   </theme>
 
+  <!--
+    Just as for window-rules, 'identifier' relates to app_id for native Wayland
+    windows and WM_CLASS for XWayland clients.
+  -->
   <windowSwitcher show="yes" preview="yes" outlines="yes">
     <fields>
       <field content="type" width="25%" />
-      <field content="app_id" width="25%" />
+      <field content="identifier" width="25%" />
       <field content="title" width="50%" />
     </fields>
   </windowSwitcher>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -16,7 +16,7 @@
 enum window_switcher_field_content {
 	LAB_FIELD_NONE = 0,
 	LAB_FIELD_TYPE,
-	LAB_FIELD_APP_ID,
+	LAB_FIELD_IDENTIFIER,
 	LAB_FIELD_TITLE,
 };
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -183,8 +183,11 @@ fill_window_switcher_field(char *nodename, char *content)
 	} else if (!strcmp(nodename, "content")) {
 		if (!strcmp(content, "type")) {
 			current_field->content = LAB_FIELD_TYPE;
+		} else if (!strcmp(content, "identifier")) {
+			current_field->content = LAB_FIELD_IDENTIFIER;
 		} else if (!strcmp(content, "app_id")) {
-			current_field->content = LAB_FIELD_APP_ID;
+			wlr_log(WLR_ERROR, "window-switcher field 'app_id' is deprecated");
+			current_field->content = LAB_FIELD_IDENTIFIER;
 		} else if (!strcmp(content, "title")) {
 			current_field->content = LAB_FIELD_TITLE;
 		} else {
@@ -1054,7 +1057,7 @@ static struct {
 	int width;
 } fields[] = {
 	{ LAB_FIELD_TYPE, 25 },
-	{ LAB_FIELD_APP_ID, 25 },
+	{ LAB_FIELD_IDENTIFIER, 25 },
 	{ LAB_FIELD_TITLE, 50 },
 	{ LAB_FIELD_NONE, 0 },
 };

--- a/src/osd.c
+++ b/src/osd.c
@@ -352,7 +352,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 			case LAB_FIELD_TYPE:
 				buf_add(&buf, get_type(*view));
 				break;
-			case LAB_FIELD_APP_ID:
+			case LAB_FIELD_IDENTIFIER:
 				buf_add(&buf, get_app_id(*view));
 				break;
 			case LAB_FIELD_TITLE:


### PR DESCRIPTION
...to be consistent with window rules.

The use of 'app_id' for window-switcher fields is hereby deprecated.