### PR TITLE
src/ssd: disable border and un-round corners on maximize

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -62,7 +62,7 @@ struct ssd {
 
 	/* Borders allow resizing as well */
 	struct {
-		/* struct wlr_scene_tree *tree;      unused for now */
+		struct wlr_scene_tree *tree;
 		struct ssd_sub_tree active;
 		struct ssd_sub_tree inactive;
 	} border;

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -17,6 +17,7 @@ struct ssd_button {
 	struct view *view;
 	enum ssd_part_type type;
 	struct wlr_scene_node *hover;
+	struct wlr_scene_node *background;
 
 	struct wl_listener destroy;
 };
@@ -41,6 +42,7 @@ struct ssd {
 	 * don't update things we don't have to.
 	 */
 	struct {
+		bool squared_corners;   /* To un-round corner buttons on maximize */
 		struct wlr_box geometry;
 		struct ssd_state_title {
 			char *text;

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -27,6 +27,15 @@ ssd_thickness(struct view *view)
 	}
 
 	struct theme *theme = view->server->theme;
+
+	if (view->maximized) {
+		struct border thickness = { 0 };
+		if (!ssd_titlebar_is_hidden(view->ssd)) {
+			thickness.top += theme->title_height;
+		}
+		return thickness;
+	}
+
 	struct border thickness = {
 		.top = theme->title_height + theme->border_width,
 		.bottom = theme->border_width,

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -152,7 +152,7 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 	wlr_scene_node_set_position(button_root->node, x, 0);
 
 	/* Background */
-	add_scene_rect(part_list, type, parent,
+	struct ssd_part *bg_rect = add_scene_rect(part_list, type, parent,
 		SSD_BUTTON_WIDTH, rc.theme->title_height, 0, 0, bg_color);
 
 	/* Icon */
@@ -175,6 +175,7 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 	button->type = type;
 	button->view = view;
 	button->hover = hover;
+	button->background = bg_rect->node;
 	return button_root;
 }
 


### PR DESCRIPTION
Partly addresses
- #1044

Main issues with this PR:
- [x] the borders of the rounded corners leak into neighboring screens
- [ ] no config setting to enable / disable the new feature

Regarding the corner button leakage.. I am not sure how to tackle this.
If wlroots 0.16 would already provide the scissor support for scene nodes we could just cut the border away from the buttons. There are two other options I see:
- create an additional no-border variant for every corner button (active / inactive, left / right, border / no-border)
- combine this with the long standing `unround-corners-on-maximize` issue and use a scene graph rect for the background of the corner buttons when maximized

Regarding the config setting: not sure if we need / want one or if we just disable borders / unround corner buttons on maximize