### PR TITLE
src/ssd: fix tiling via keybind when maximized

### DIFF
--- a/include/ssd.h
+++ b/include/ssd.h
@@ -60,6 +60,7 @@ struct wlr_scene_node;
  */
 struct ssd *ssd_create(struct view *view, bool active);
 struct border ssd_get_margin(const struct ssd *ssd);
+void ssd_update_margin(struct ssd *ssd);
 void ssd_set_active(struct ssd *ssd, bool active);
 void ssd_update_title(struct ssd *ssd);
 void ssd_update_geometry(struct ssd *ssd);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -196,6 +196,15 @@ ssd_get_margin(const struct ssd *ssd)
 }
 
 void
+ssd_update_margin(struct ssd *ssd)
+{
+	if (!ssd) {
+		return;
+	}
+	ssd->margin = ssd_thickness(ssd->view);
+}
+
+void
 ssd_update_geometry(struct ssd *ssd)
 {
 	if (!ssd) {
@@ -209,6 +218,10 @@ ssd_update_geometry(struct ssd *ssd)
 			/* Dynamically resize extents based on position and usable_area */
 			ssd_extents_update(ssd);
 			ssd->state.geometry = current;
+		}
+		if (ssd->state.squared_corners != ssd->view->maximized) {
+			ssd_border_update(ssd);
+			ssd_titlebar_update(ssd);
 		}
 		return;
 	}

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -52,6 +52,10 @@ ssd_border_create(struct ssd *ssd)
 			theme->border_width + SSD_BUTTON_WIDTH,
 			-(ssd->titlebar.height + theme->border_width), color);
 	} FOR_EACH_END
+
+	if (view->maximized) {
+		wlr_scene_node_set_enabled(&ssd->border.tree->node, false);
+	}
 }
 
 void

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -17,6 +17,8 @@
 	&(ssd)->titlebar.active, \
 	&(ssd)->titlebar.inactive)
 
+static void set_squared_corners(struct ssd *ssd, bool enable);
+
 void
 ssd_titlebar_create(struct ssd *ssd)
 {
@@ -81,7 +83,12 @@ ssd_titlebar_create(struct ssd *ssd)
 			corner_top_right, close_button_unpressed,
 			width - SSD_BUTTON_WIDTH * 1, view);
 	} FOR_EACH_END
+
 	ssd_update_title(ssd);
+
+	if (view->maximized) {
+		set_squared_corners(ssd, view->maximized);
+	}
 }
 
 static bool

--- a/src/view.c
+++ b/src/view.c
@@ -648,6 +648,13 @@ set_maximized(struct view *view, bool maximized)
 			view->toplevel.handle, maximized);
 	}
 	view->maximized = maximized;
+
+	/*
+	 * Ensure that follow-up actions like SnapToEdge / SnapToRegion
+	 * use up-to-date SSD margin information. Otherwise we will end
+	 * up using an outdated ssd->margin to calculate offsets.
+	 */
+	ssd_update_margin(view->ssd);
 }
 
 /*


### PR DESCRIPTION
The previous PR introduced an issue with tiling based actions like SnapToEdge and SnapToRegion using outdated SSD margin values when called via keybind while maximized. That resulted in wrong offsets for the tiled windows.

This commit restores the functionality by forcing a re-calculation of the SSD margin when changing the maximized state.

Thanks to @Flrian for reporting the issue via IRC.