### PR TITLE
config: support <libinput><device category=""><tapAndDrag> & <dragLock>

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -407,6 +407,14 @@ Therefore, where multiple objects of the same kind are required (for example
 	left button, right button, and middle button, respectively (lrm) (the
 	default), or to left button, middle button, and right button (lmr).
 
+*<libinput><device category=""><tapAndDrag>* [yes|no]
+	Enable or disable tap-and-drag for this category. Tap-and-drag processes
+	a tap immediately followed by a finger down as the start of a drag.
+
+*<libinput><device category=""><dragLock>* [yes|no]
+	Enable or disable drag lock for this category. Drag lock ignores a
+	momentary release of a finger during tap-and-dragging.
+
 *<libinput><device category=""><middleEmulation>* [yes|no]
 	Enable or disable middle button emulation for this category. Middle
 	emulation processes a simultaneous left and right click as a press of

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -392,6 +392,8 @@
       <accelProfile></accelProfile>
       <tap>yes</tap>
       <tapButtonMap></tapButtonMap>
+      <tapAndDrag></tapAndDrag>
+      <dragLock></dragLock>
       <middleEmulation></middleEmulation>
       <disableWhileTyping></disableWhileTyping>
     </device>

--- a/include/config/libinput.h
+++ b/include/config/libinput.h
@@ -21,6 +21,8 @@ struct libinput_category {
 	int left_handed;
 	enum libinput_config_tap_state tap;
 	enum libinput_config_tap_button_map tap_button_map;
+	enum libinput_config_drag_state tap_and_drag;
+	enum libinput_config_drag_lock_state drag_lock;
 	enum libinput_config_accel_profile accel_profile;
 	enum libinput_config_middle_emulation_state middle_emu;
 	enum libinput_config_dwt_state dwt;

--- a/include/config/libinput.h
+++ b/include/config/libinput.h
@@ -21,11 +21,11 @@ struct libinput_category {
 	int left_handed;
 	enum libinput_config_tap_state tap;
 	enum libinput_config_tap_button_map tap_button_map;
-	enum libinput_config_drag_state tap_and_drag;
-	enum libinput_config_drag_lock_state drag_lock;
-	enum libinput_config_accel_profile accel_profile;
-	enum libinput_config_middle_emulation_state middle_emu;
-	enum libinput_config_dwt_state dwt;
+	int tap_and_drag; /* -1 or libinput_config_drag_state */
+	int drag_lock; /* -1 or libinput_config_drag_lock_state */
+	int accel_profile; /* -1 or libinput_config_accel_profile */
+	int middle_emu; /* -1 or libinput_config_middle_emulation_state */
+	int dwt; /* -1 or libinput_config_dwt_state */
 };
 
 enum device_type get_device_type(const char *s);

--- a/src/config/libinput.c
+++ b/src/config/libinput.c
@@ -16,6 +16,8 @@ libinput_category_init(struct libinput_category *l)
 	l->left_handed = -1;
 	l->tap = LIBINPUT_CONFIG_TAP_ENABLED;
 	l->tap_button_map = LIBINPUT_CONFIG_TAP_MAP_LRM;
+	l->tap_and_drag = -1;
+	l->drag_lock = -1;
 	l->accel_profile = -1;
 	l->middle_emu = -1;
 	l->dwt = -1;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -408,6 +408,22 @@ fill_libinput_category(char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "invalid tapButtonMap");
 		}
+	} else if (!strcasecmp(nodename, "tapAndDrag")) {
+		int ret = parse_bool(content, -1);
+		if (ret < 0) {
+			return;
+		}
+		current_libinput_category->tap_and_drag = ret
+			? LIBINPUT_CONFIG_DRAG_ENABLED
+			: LIBINPUT_CONFIG_DRAG_DISABLED;
+	} else if (!strcasecmp(nodename, "dragLock")) {
+		int ret = parse_bool(content, -1);
+		if (ret < 0) {
+			return;
+		}
+		current_libinput_category->drag_lock = ret
+			? LIBINPUT_CONFIG_DRAG_LOCK_ENABLED
+			: LIBINPUT_CONFIG_DRAG_LOCK_DISABLED;
 	} else if (!strcasecmp(nodename, "accelProfile")) {
 		current_libinput_category->accel_profile =
 			get_accel_profile(content);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -339,11 +339,11 @@ fill_mousebind(char *nodename, char *content)
 	}
 }
 
-static enum libinput_config_accel_profile
+static int
 get_accel_profile(const char *s)
 {
 	if (!s) {
-		return LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT;
+		return -1;
 	}
 	if (!strcasecmp(s, "flat")) {
 		return LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT;
@@ -351,7 +351,7 @@ get_accel_profile(const char *s)
 	if (!strcasecmp(s, "adaptive")) {
 		return LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE;
 	}
-	return LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT;
+	return -1;
 }
 
 static void

--- a/src/seat.c
+++ b/src/seat.c
@@ -96,7 +96,7 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	}
 
 	if (libinput_device_config_scroll_has_natural_scroll(libinput_dev) <= 0
-		|| dc->natural_scroll < 0) {
+			|| dc->natural_scroll < 0) {
 		wlr_log(WLR_INFO, "natural scroll not configured");
 	} else {
 		wlr_log(WLR_INFO, "natural scroll configured");
@@ -105,7 +105,7 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	}
 
 	if (libinput_device_config_left_handed_is_available(libinput_dev) <= 0
-		|| dc->left_handed < 0) {
+			|| dc->left_handed < 0) {
 		wlr_log(WLR_INFO, "left-handed mode not configured");
 	} else {
 		wlr_log(WLR_INFO, "left-handed mode configured");
@@ -137,7 +137,7 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	}
 
 	if (libinput_device_config_dwt_is_available(libinput_dev) == 0
-		|| dc->dwt < 0) {
+			|| dc->dwt < 0) {
 		wlr_log(WLR_INFO, "dwt not configured");
 	} else {
 		wlr_log(WLR_INFO, "dwt configured");

--- a/src/seat.c
+++ b/src/seat.c
@@ -95,6 +95,24 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			dc->tap_button_map);
 	}
 
+	if (libinput_device_config_tap_get_finger_count(libinput_dev) <= 0
+			|| dc->tap_and_drag < 0) {
+		wlr_log(WLR_INFO, "tap-and-drag not configured");
+	} else {
+		wlr_log(WLR_INFO, "tap-and-drag configured");
+		libinput_device_config_tap_set_drag_enabled(
+			libinput_dev, dc->tap_and_drag);
+	}
+
+	if (libinput_device_config_tap_get_finger_count(libinput_dev) <= 0
+			|| dc->drag_lock < 0) {
+		wlr_log(WLR_INFO, "drag lock not configured");
+	} else {
+		wlr_log(WLR_INFO, "drag lock configured");
+		libinput_device_config_tap_set_drag_lock_enabled(
+			libinput_dev, dc->drag_lock);
+	}
+
 	if (libinput_device_config_scroll_has_natural_scroll(libinput_dev) <= 0
 			|| dc->natural_scroll < 0) {
 		wlr_log(WLR_INFO, "natural scroll not configured");


### PR DESCRIPTION
Addresses #1064 with tap-and-drag support.

This PR also fixes a problem that enums initialized with -1 are bigger than 0 because gcc uses unsigned int as default backing type of enum.

This is my first time sending a PR to OSS, so excuse me if I made silly mistakes.