### PR TITLE
window-rules: add ignoreFocusRequest property

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -482,6 +482,9 @@ situation.
 	*skipWindowSwitcher* removes window from the Window Switcher (alt-tab
 	on-screen-display)
 
+*<windowRules><windowRule ignoreFocusRequest="">* [yes|no|default]
+	*ignoreFocusRequest* prevent window to activate itself.
+
 ## ENVIRONMENT VARIABLES
 
 *XCURSOR_THEME* and *XCURSOR_SIZE* are supported to set cursor theme

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -29,6 +29,7 @@ struct window_rule {
 	enum property server_decoration;
 	enum property skip_taskbar;
 	enum property skip_window_switcher;
+	enum property ignore_focus_request;
 
 	struct wl_list link; /* struct rcxml.window_rules */
 };

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -150,6 +150,8 @@ fill_window_rule(char *nodename, char *content)
 		set_property(content, &current_window_rule->skip_taskbar);
 	} else if (!strcasecmp(nodename, "skipWindowSwitcher")) {
 		set_property(content, &current_window_rule->skip_window_switcher);
+	} else if (!strcasecmp(nodename, "ignoreFocusRequest")) {
+		set_property(content, &current_window_rule->ignore_focus_request);
 
 	/* Actions */
 	} else if (!strcmp(nodename, "name.action")) {

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -124,6 +124,10 @@ window_rules_get_property(struct view *view, const char *property)
 					&& !strcasecmp(property, "skipWindowSwitcher")) {
 				return rule->skip_window_switcher;
 			}
+			if (rule->ignore_focus_request
+					&& !strcasecmp(property, "ignoreFocusRequest")) {
+				return rule->ignore_focus_request;
+			}
 		}
 	}
 	return LAB_PROP_UNSPECIFIED;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -590,6 +590,11 @@ xdg_activation_handle_request(struct wl_listener *listener, void *data)
 	 * for the seat / serial being correct and then allow the request.
 	 */
 
+	if (window_rules_get_property(view, "ignoreFocusRequest") == LAB_PROP_TRUE) {
+		wlr_log(WLR_INFO, "Ignoring focus request due to window rule configuration");
+		return;
+	}
+
 	/*
 	 * TODO: This is the exact same code as used in foreign.c.
 	 *       Refactor it into a public helper function somewhere.

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -285,6 +285,12 @@ handle_request_activate(struct wl_listener *listener, void *data)
 	struct xwayland_view *xwayland_view =
 		wl_container_of(listener, xwayland_view, request_activate);
 	struct view *view = &xwayland_view->base;
+
+	if (window_rules_get_property(view, "ignoreFocusRequest") == LAB_PROP_TRUE) {
+		wlr_log(WLR_INFO, "Ignoring focus request due to window rule configuration");
+		return;
+	}
+
 	desktop_focus_and_activate_view(&view->server->seat, view);
 	view_move_to_front(view);
 }


### PR DESCRIPTION
This PR allows to use window rules to block self-activation requests from xwayland and wayland native windows.
It is different from preventing focus completely, e.g. manually selecting the window via `A-Tab` or similar still allows interaction with the window.

Example config:
```xml
<windowRules>
	<windowRule identifier="*firefox*" ignoreFocusRequest="yes" />
</windowRule>
```

I have not tested this PR at all as I'd need to set up some testing environment which supports the xdg_activation protocol. It would take much longer than creating this patch in the first place, so testing would be much appreciated.

Outstanding questions / issues:
- [ ] unmanaged xwayland surfaces are not handled as it might break context menus, I am not sure about this.
  Support for them could be added pretty easily though because we already fetch the topmost mapped view in `unmanaged_handle_request_activate()` due to `->pid` checks.
- [x] I didn't check if Openbox supports something similar which we can implement instead of this PR