### PR TITLE
[wip] Keybinds: keyboard layout agnostic keybinds

### DIFF
--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -6,11 +6,16 @@
 #include <xkbcommon/xkbcommon.h>
 
 #define MAX_KEYSYMS 32
+#define MAX_KEYCODES 16
+
+struct server;
 
 struct keybind {
 	uint32_t modifiers;
 	xkb_keysym_t *keysyms;
 	size_t keysyms_len;
+	xkb_keycode_t keycodes[MAX_KEYCODES];
+	size_t keycodes_len;
 	struct wl_list actions;  /* struct action.link */
 	struct wl_list link;     /* struct rcxml.keybinds */
 };
@@ -30,4 +35,5 @@ uint32_t parse_modifier(const char *symname);
 
 bool keybind_the_same(struct keybind *a, struct keybind *b);
 
+void keybind_update_keycodes(struct server *server);
 #endif /* LABWC_KEYBIND_H */

--- a/src/server.c
+++ b/src/server.c
@@ -57,6 +57,7 @@ reload_config_and_theme(void)
 	regions_reconfigure(g_server);
 	resize_indicator_reconfigure(g_server);
 	kde_server_decoration_update_default();
+	keybind_update_keycodes(g_server);
 }
 
 static int


### PR DESCRIPTION
This is an initial implementation of keyboard layout agnostic keybinds.
Background:
- #1069
- various other issues in the past

The gist of the PR is:
- we add keycodes (of physical keys) to the keybinds
- we prefer keycodes over keysyms
- if no keycode matches, we fall back to keysyms, e.g. exactly the same as what we are doing without the PR

To decide on our way forward with this, these are the goals the implementation should solve from a user perspective IMO:
- in a single layout situation nothing should change at all
- in a multi layout situation, by default keybinds should work independent of the currently active layout
- the ordering of the layout config should not matter, e.g. `us,de` vs `de,us`
- we should allow binding keys that are not available in the English layout like `W-ö` or `W-я`
- the user should still be able to optionally define specific keybinds that only work if that keysym is available in the currently active layout

The initial implementation should mostly [1] solve all but the last goal. However, the details are important here:

A single physical key usually means two different things in the two layouts (examples compared to the "us" layout: in the German layout `ö` is mapped to `;`, in the Russian layout `я` is mapped to `z`). To account for that we get the actual keycode for the physical key of a keybind for all configured layouts when initializing. Problems start to arise when a key is available in both layouts but the keycode differs (e.g. it is on a different physical key). An example for that is `z` and `y` in the German layout which are interchanged. If we now get the keycodes for `z` in a "us,de" situation it results in both the physical keys for `z` and `y` being stored for `<keybind key="W-z" />` (one variant for each layout). Thus both physical keys are now suddenly bound to the action.

We could allow users to work around that issue by adding a further optional flag for keybinds which causes us to simply not store any keycodes. That would then make a `<keybind key="W-z" sym_only="yes" />` work only for the physical key that aligns with the currently active layout (which is the current situation in master). So the physical key to trigger the keybind would change along with the layout.

Another option would be to search for an "English" layout and only search for keycodes in that layout. But that would prevent the possibility to use keys that are not available in the "us" layout like `W-ö` or `W-я` if the "us" layout is currently active. They would still work via the keysym fallback in the other layout though.

So I am not sure how to proceed here, I prefer the optional `sym_only` (name itself up for discussion as usual) argument for keybinds given the available options. As that one allows keys like `W-ö` to work independently of the layout but allows manually marking keys like `W-z` as `sym_only`. But maybe there is another option that I missed? Or are there other goals I missed or should the goals be different?

[1]
There is still an issue that keypad keys only work via the fallback keysym path as we don't go over all the possible modifiers (which includes `NumLock`) when trying to get the keycodes for a given keysym. This should be fine though because the keycode list would then just be empty and thus we fall back to the keysym one.

Outstanding work items:
- depending on further discussion outcome: optional `sym_only` keybind argument
- doc update
- silence debug logging