### PR TITLE
keyboard: allow applying keyboard layout per window

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -283,6 +283,10 @@ windows using the mouse.
 	When recognizing a new keyboard enable or disable Num Lock.
 	Default is on.
 
+*<keyboard layoutScope="">* [global|window]
+	Stores the keyboard layout either globally or per window and restores
+	it when switching back to the window. Default is global.
+
 *<keyboard><keybind key="" layoutDependent="">*
 	Define a *key* binding in the format *modifier-key*, where supported
 	modifiers are:

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -142,6 +142,7 @@
   -->
   <keyboard>
     <numlock>on</numlock>
+    <layoutScope>global</layoutScope>
     <repeatRate>25</repeatRate>
     <repeatDelay>600</repeatDelay>
     <keybind key="A-Tab">

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -63,6 +63,7 @@ struct rcxml {
 	int repeat_rate;
 	int repeat_delay;
 	bool kb_numlock_enable;
+	bool kb_layout_per_window;
 	struct wl_list keybinds;   /* struct keybind.link */
 
 	/* mouse */

--- a/include/input/keyboard.h
+++ b/include/input/keyboard.h
@@ -3,6 +3,7 @@
 #define LABWC_KEYBOARD_H
 
 #include <stdbool.h>
+#include <xkbcommon/xkbcommon.h>
 
 struct seat;
 struct keyboard;
@@ -13,6 +14,7 @@ void keyboard_finish(struct seat *seat);
 
 void keyboard_setup_handlers(struct keyboard *keyboard);
 void keyboard_set_numlock(struct wlr_keyboard *keyboard);
+void keyboard_update_layout(struct seat *seat, xkb_layout_index_t layout);
 void keyboard_cancel_keybind_repeat(struct keyboard *keyboard);
 bool keyboard_any_modifiers_pressed(struct wlr_keyboard *keyboard);
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -39,7 +39,6 @@
 #include <wlr/types/wlr_virtual_pointer_v1.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/util/log.h>
-#include <xkbcommon/xkbcommon.h>
 #include "config/keybind.h"
 #include "config/rcxml.h"
 #include "input/cursor.h"

--- a/include/view.h
+++ b/include/view.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <wayland-util.h>
 #include <wlr/util/box.h>
+#include <xkbcommon/xkbcommon.h>
 
 #define LAB_MIN_VIEW_WIDTH  100
 #define LAB_MIN_VIEW_HEIGHT  60
@@ -143,6 +144,7 @@ struct view {
 	bool fullscreen;
 	enum view_edge tiled;
 	bool inhibits_keybinds;
+	xkb_layout_index_t keyboard_layout;
 
 	/* Pointer to an output owned struct region, may be NULL */
 	struct region *tiled_region;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -735,6 +735,12 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.repeat_delay = atoi(content);
 	} else if (!strcasecmp(nodename, "numlock.keyboard")) {
 		set_bool(content, &rc.kb_numlock_enable);
+	} else if (!strcasecmp(nodename, "layoutScope.keyboard")) {
+		/*
+		 * This can be changed to an enum later on
+		 * if we decide to also support "application".
+		 */
+		rc.kb_layout_per_window = !strcasecmp(content, "window");
 	} else if (!strcasecmp(nodename, "screenEdgeStrength.resistance")) {
 		rc.screen_edge_strength = atoi(content);
 	} else if (!strcasecmp(nodename, "range.snapping")) {
@@ -953,6 +959,7 @@ rcxml_init(void)
 	rc.repeat_rate = 25;
 	rc.repeat_delay = 600;
 	rc.kb_numlock_enable = true;
+	rc.kb_layout_per_window = false;
 	rc.screen_edge_strength = 20;
 
 	rc.snap_edge_range = 1;

--- a/src/view.c
+++ b/src/view.c
@@ -6,6 +6,7 @@
 #include "common/match.h"
 #include "common/mem.h"
 #include "common/scene-helpers.h"
+#include "input/keyboard.h"
 #include "labwc.h"
 #include "menu/menu.h"
 #include "regions.h"
@@ -265,6 +266,17 @@ view_set_activated(struct view *view, bool activated)
 	if (view->toplevel.handle) {
 		wlr_foreign_toplevel_handle_v1_set_activated(
 			view->toplevel.handle, activated);
+	}
+
+	if (rc.kb_layout_per_window) {
+		if (!activated) {
+			/* Store configured keyboard layout per view */
+			view->keyboard_layout =
+				view->server->seat.keyboard_group->keyboard.modifiers.group;
+		} else {
+			/* Switch to previously stored keyboard layout */
+			keyboard_update_layout(&view->server->seat, view->keyboard_layout);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes
- #1076

Windows remember their last configured keyboard layout and restore that layout when getting focus.
New windows will use the default layout. Can be tested via something like this in `~/.config/labwc/environment` and pressing the "menu" key:
```
XKB_DEFAULT_LAYOUT=de,us
XKB_DEFAULT_OPTIONS=grp:menu_toggle,grp_led:scroll
```
Also requires enabling the feature in the first place:
```xml
<keyboard layoutScope="window">
..
</keyboard>
```

Missing:
- [x] some setting to turn this on / off
  - [ ] decide on the setting category and name, maybe Openbox has something similar?
  - [x] decide on the default setting, default-off sounds good
  - [x] docs
- [x] directly include xkb header in `view.h` and `labwc.h` due to the type alias
- [x] add example to commit message