### PR TITLE
actions: Prevent env var expansion for subshells like `$()`

### DIFF
--- a/src/common/buf.c
+++ b/src/common/buf.c
@@ -33,6 +33,13 @@ buf_expand_shell_variables(struct buf *s)
 				++p;
 			}
 			*p = '\0';
+
+			/* Don't expand single $ (as used by subshells) */
+			if (!strlen(environment_variable.buf)) {
+				buf_add(&new, "$");
+				continue;
+			}
+
 			i += strlen(environment_variable.buf);
 			strip_curly_braces(environment_variable.buf);
 			p = getenv(environment_variable.buf);


### PR DESCRIPTION
We currently expand Execute action commands like
`sh -c 'echo $(date) >> /tmp/foo'` to
`sh -c 'echo (date) >> /tmp/foo'`

This obviously breaks the subshell. This patch fixes it by preventing single `$` being replaced with nothing.

The more general question is if we actually want to run the env var expansion for Execute command arguments in the first place: It allows for things like `nautilus $HOME` or `nautilus ~` but causes real issues for `sh -c` constructs by replacing all $variables showing up there with (potentially empty) env vars.

An example would be `sh -c 'foo=test; echo $foo'`