### PR TITLE
src/ssd: use view->ssd_titlebar_hidden for ssd_thickness calculations

### DIFF
--- a/include/ssd.h
+++ b/include/ssd.h
@@ -65,7 +65,6 @@ void ssd_set_active(struct ssd *ssd, bool active);
 void ssd_update_title(struct ssd *ssd);
 void ssd_update_geometry(struct ssd *ssd);
 void ssd_destroy(struct ssd *ssd);
-bool ssd_titlebar_is_hidden(struct ssd *ssd);
 void ssd_titlebar_hide(struct ssd *ssd);
 
 void ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable);

--- a/src/view.c
+++ b/src/view.c
@@ -740,9 +740,13 @@ view_toggle_decorations(struct view *view)
 {
 	assert(view);
 	if (rc.ssd_keep_border && view->ssd_enabled && view->ssd
-			&& !ssd_titlebar_is_hidden(view->ssd)) {
-		ssd_titlebar_hide(view->ssd);
+			&& !view->ssd_titlebar_hidden) {
+		/*
+		 * ssd_titlebar_hidden has to be set before calling
+		 * ssd_titlebar_hide() to make ssd_thickness() happy.
+		 */
 		view->ssd_titlebar_hidden = true;
+		ssd_titlebar_hide(view->ssd);
 		if (!view_is_floating(view)) {
 			view_apply_special_geometry(view);
 		}


### PR DESCRIPTION
Before this patch we were using the internal .enabled flag of the titlebar tree node. This failed due to ssd_thickness() not having view->ssd assigned when initially called. Instead of assigning view->ssd within ssd_create() we just always use the view boolean flag directly. This fixes an issue where a border-only view that has been snapped to an edge or region would have a gap in the size of the titlebar on top after a Reconfigure.

Fixes
- #1083