### PR TITLE
view: account for base size in resize indicator

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -37,6 +37,17 @@ enum view_edge {
 };
 
 struct view;
+
+/* Basic size hints (subset of XSizeHints from X11) */
+struct view_size_hints {
+	int min_width;
+	int min_height;
+	int width_inc;
+	int height_inc;
+	int base_width;
+	int base_height;
+};
+
 struct view_impl {
 	void (*configure)(struct view *view, struct wlr_box geo);
 	void (*close)(struct view *view);
@@ -57,7 +68,7 @@ struct view_impl {
 	void (*move_to_back)(struct view *view);
 	struct view *(*get_root)(struct view *self);
 	void (*append_children)(struct view *self, struct wl_array *children);
-	void (*fill_size_hints)(struct view *self, struct wlr_box *box);
+	struct view_size_hints (*get_size_hints)(struct view *self);
 };
 
 struct view {
@@ -306,6 +317,7 @@ void view_update_title(struct view *view);
 void view_update_app_id(struct view *view);
 void view_reload_ssd(struct view *view);
 
+struct view_size_hints view_get_size_hints(struct view *view);
 void view_adjust_size(struct view *view, int *w, int *h);
 
 void view_evacuate_region(struct view *view);

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -48,8 +48,6 @@ void xwayland_view_create(struct server *server,
 
 struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
 
-bool xwayland_apply_size_hints(struct view *view, int *w, int *h);
-
 void xwayland_server_init(struct server *server,
 	struct wlr_compositor *compositor);
 void xwayland_server_finish(struct server *server);

--- a/src/ssd/resize_indicator.c
+++ b/src/ssd/resize_indicator.c
@@ -49,18 +49,6 @@ resize_indicator_init(struct view *view)
 	resize_indicator_reconfigure_view(indicator);
 }
 
-static struct wlr_box
-get_size_hints(struct view *view)
-{
-	assert(view);
-
-	struct wlr_box hints = { 0 };
-	if (view->impl->fill_size_hints) {
-		view->impl->fill_size_hints(view, &hints);
-	}
-	return hints;
-}
-
 static bool
 wants_indicator(struct view *view)
 {
@@ -70,8 +58,8 @@ wants_indicator(struct view *view)
 		if (view->server->input_mode != LAB_INPUT_STATE_RESIZE) {
 			return false;
 		}
-		struct wlr_box size_hints = get_size_hints(view);
-		if (size_hints.width && size_hints.height) {
+		struct view_size_hints hints = view_get_size_hints(view);
+		if (hints.width_inc && hints.height_inc) {
 			return true;
 		}
 	}
@@ -173,10 +161,12 @@ resize_indicator_update(struct view *view)
 	switch (view->server->input_mode) {
 	case LAB_INPUT_STATE_RESIZE:
 		; /* works around "a label can only be part of a statement" */
-		struct wlr_box size_hints = get_size_hints(view);
+		struct view_size_hints hints = view_get_size_hints(view);
 		snprintf(text, sizeof(text), "%d x %d",
-			view->current.width / MAX(1, size_hints.width),
-			view->current.height / MAX(1, size_hints.height));
+			MAX(0, view->current.width - hints.base_width)
+				/ MAX(1, hints.width_inc),
+			MAX(0, view->current.height - hints.base_height)
+				/ MAX(1, hints.height_inc));
 		break;
 	case LAB_INPUT_STATE_MOVE:
 		; /* works around "a label can only be part of a statement" */


### PR DESCRIPTION
For views with a non-pixel size increment (e.g. X11 terminals), it's helpful to subtract the base size of the window (typically including menu bar, scrollbars, etc.) before computing the number of size increments (e.g. cells/characters). This way, the displayed size will exactly match the terminal grid (e.g. 80x25 or whatever).

`wlr_box` isn't really the best fit for size hints, so let's define a `struct view_size_hints` and a nice `view_get_size_hints()` function, wrapping `view->impl->get_size_hints()`.

This also seems like a great opportunity to make `view_adjust_size()` window-system-agnostic and eliminate `xwayland_apply_size_hints()`.