### PR TITLE
common/buf.c: do not use memcpy for overlapping regions

### DIFF
--- a/src/common/buf.c
+++ b/src/common/buf.c
@@ -41,7 +41,7 @@ strip_curly_braces(char *s)
 		return;
 	}
 	len -= 2;
-	memcpy(s, s + 1, len);
+	memmove(s, s + 1, len);
 	s[len] = 0;
 }
 


### PR DESCRIPTION
Post `0.6.5`