### PR TITLE
view: update focused surface and activated view together

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -257,7 +257,7 @@ bool view_isfocusable(struct view *view);
 bool view_inhibits_keybinds(struct view *view);
 void view_toggle_keybinds(struct view *view);
 
-void view_set_activated(struct view *view);
+void view_set_focused(struct view *view, bool focused);
 void view_set_output(struct view *view, struct output *output);
 void view_close(struct view *view);
 

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -69,16 +69,7 @@ desktop_focus_and_activate_view(struct seat *seat, struct view *view)
 		return;
 	}
 
-	struct wlr_surface *prev_surface;
-	prev_surface = seat->seat->keyboard_state.focused_surface;
-
-	/* Do not re-focus an already focused surface. */
-	if (prev_surface == view->surface) {
-		return;
-	}
-
-	view_set_activated(view);
-	seat_focus_surface(seat, view->surface);
+	view_set_focused(view, true);
 }
 
 static struct wl_list *


### PR DESCRIPTION
When minimizing the last/only focusable view, its "activated" state is set to false, and `server->focused_view` is cleared, but at the wlroots level the focused surface is not cleared (`seat_focus_surface()` is not called).

When attempting to unminimize, `desktop_focus_and_activate_view()` sees that `view->surface` is still focused, and returns without setting the activated state of the view; `server->focused_view` also remains `NULL`.

To try and keep everything in sync better, replace `view_set_activated()` with `view_set_focused()`, which allows setting or clearing both the focus and the activated state of the view. Then use the new function in both `view_minimize()` and `desktop_focus_and_activate_view()`.

~~This is a pre-existing issue, but (at least in my setup) is much easier to encounter after https://github.com/labwc/labwc/pull/1103, because it's easier to minimize the last focusable view.~~

edit: It appears I may have actually caused the particular issue in https://github.com/labwc/labwc/pull/1103 by removing a `seat_focus_surface(seat, NULL)` from `desktop_focus_and_activate_view()`. I think this is still a good cleanup though.