### PR TITLE
keyboard: make keybind match stricter

### DIFF
--- a/include/key-state.h
+++ b/include/key-state.h
@@ -21,5 +21,6 @@ void key_state_store_pressed_keys_as_bound(void);
 bool key_state_corresponding_press_event_was_bound(uint32_t keycode);
 void key_state_bound_key_remove(uint32_t keycode);
 int key_state_nr_keys(void);
+int key_state_nr_pressed_keys(void);
 
 #endif /* LABWC_KEY_STATE_H */

--- a/src/key-state.c
+++ b/src/key-state.c
@@ -102,3 +102,9 @@ key_state_nr_keys(void)
 {
 	return bound.nr_keys;
 }
+
+int
+key_state_nr_pressed_keys(void)
+{
+	return pressed.nr_keys;
+}


### PR DESCRIPTION
...and avoid failing to send release events to clients for any keys that were not absorbed by a keybind.

Do not match keybinds if there are other non-modifier keys (not part of any defined bind) pressed at the same time.

Only store non-modifier keycodes in the key-state.c 'pressed' array. This makes the call to wlr_seat_keyboard_notify_enter() in seat_focus() consistent with the equivalent in sway (in seat_keyboard_notify_enter()).

Fixes: issue #1091