### PR TITLE
view: try to reduce confusion in focused_view tracking

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -246,6 +246,13 @@ struct server {
 	uint32_t resize_edges;
 
 	/* SSD state */
+	/*
+	 * Currently focused view (cached value). This pointer is used
+	 * primarily to track which view is being drawn with "active"
+	 * SSD coloring. We consider it a bug if this gets out of sync
+	 * with the actual keyboard focus (according to wlroots). See
+	 * also desktop_focused_view().
+	 */
 	struct view *focused_view;
 	struct ssd_hover_state *ssd_hover_state;
 
@@ -370,7 +377,7 @@ void foreign_toplevel_update_outputs(struct view *view);
  *              cannot assume this means that the window actually has keyboard
  *              or pointer focus, in this compositor are they called together.
  */
-void desktop_focus_and_activate_view(struct seat *seat, struct view *view);
+void desktop_focus_view(struct view *view);
 void desktop_arrange_all_views(struct server *server);
 void desktop_focus_output(struct output *output);
 struct view *desktop_topmost_mapped_view(struct server *server);
@@ -388,6 +395,13 @@ enum lab_cycle_dir {
  */
 struct view *desktop_cycle_view(struct server *server, struct view *start_view,
 	enum lab_cycle_dir dir);
+/**
+ * desktop_focused_view - return the view that is currently focused
+ * (determined on-the-fly from the wlroots keyboard focus). The return
+ * value should ideally match server->focused_view (we consider it a
+ * bug otherwise) but is guaranteed to be up-to-date even if
+ * server->focused_view gets out of sync.
+ */
 struct view *desktop_focused_view(struct server *server);
 void desktop_focus_topmost_mapped_view(struct server *server);
 

--- a/include/view.h
+++ b/include/view.h
@@ -257,7 +257,8 @@ bool view_isfocusable(struct view *view);
 bool view_inhibits_keybinds(struct view *view);
 void view_toggle_keybinds(struct view *view);
 
-void view_set_activated(struct view *view);
+void view_focus(struct view *view);
+void view_defocus(struct view *view);
 void view_set_output(struct view *view, struct output *output);
 void view_close(struct view *view);
 

--- a/src/action.c
+++ b/src/action.c
@@ -634,7 +634,7 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_FOCUS:
 			if (view) {
-				desktop_focus_and_activate_view(&server->seat, view);
+				desktop_focus_view(view);
 			}
 			break;
 		case ACTION_TYPE_ICONIFY:

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -478,7 +478,7 @@ process_cursor_motion(struct server *server, uint32_t time)
 	}
 
 	if (ctx.view && rc.focus_follow_mouse) {
-		desktop_focus_and_activate_view(seat, ctx.view);
+		desktop_focus_view(ctx.view);
 		if (rc.raise_on_focus) {
 			view_move_to_front(ctx.view);
 		}
@@ -522,7 +522,7 @@ _cursor_update_focus(struct server *server)
 			&& !rc.focus_follow_mouse_requires_movement
 			&& !server->osd_state.cycle_view) {
 		/* Prevents changing keyboard focus during A-Tab */
-		desktop_focus_and_activate_view(&server->seat, ctx.view);
+		desktop_focus_view(ctx.view);
 		if (rc.raise_on_focus) {
 			view_move_to_front(ctx.view);
 		}

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -37,7 +37,7 @@ handle_request_activate(struct wl_listener *listener, void *data)
 	if (view->workspace != view->server->workspace_current) {
 		workspaces_switch_to(view->workspace);
 	}
-	desktop_focus_and_activate_view(&view->server->seat, view);
+	desktop_focus_view(view);
 	view_move_to_front(view);
 }
 

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -41,8 +41,8 @@ keyboard_any_modifiers_pressed(struct wlr_keyboard *keyboard)
 static void
 end_cycling(struct server *server)
 {
-	desktop_focus_and_activate_view(&server->seat, server->osd_state.cycle_view);
 	if (server->osd_state.cycle_view) {
+		desktop_focus_view(server->osd_state.cycle_view);
 		view_move_to_front(server->osd_state.cycle_view);
 	}
 

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -51,7 +51,7 @@ view_impl_move_sub_views(struct view *parent, enum z_direction z_direction)
 void
 view_impl_map(struct view *view)
 {
-	desktop_focus_and_activate_view(&view->server->seat, view);
+	desktop_focus_view(view);
 	view_move_to_front(view);
 	view_update_title(view);
 	view_update_app_id(view);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -615,7 +615,7 @@ xdg_activation_handle_request(struct wl_listener *listener, void *data)
 	if (view->workspace != view->server->workspace_current) {
 		workspaces_switch_to(view->workspace);
 	}
-	desktop_focus_and_activate_view(&view->server->seat, view);
+	desktop_focus_view(view);
 	view_move_to_front(view);
 }
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -256,7 +256,7 @@ handle_request_activate(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	desktop_focus_and_activate_view(&view->server->seat, view);
+	desktop_focus_view(view);
 	view_move_to_front(view);
 }
 


### PR DESCRIPTION
Our current approach to handling the focused/active view is a bit confusing. In particular, it's hard to be sure when `server->focused_view` is or isn't in sync with the real wlroots keyboard focus.

Try to clean things up a bit. In particular:

- Add comments to `server->focused_view` and `desktop_focused_view()` to clarify that they should match, but it's not guaranteed.
- `desktop_focused_view()` now prints a warning if it detects that `server->focused_view` is out of sync. We should keep an eye out for this warning, and if we see it, try to figure out why it happened.
- For consistency, use only "focus/defocus" as the verbs in function names rather than "activate". This is a bit arbitrary, but the idea is that focus is the primary action while the active/inactive state is a side effect.
- `view_focus/defocus()` replace `view_set_activated()` and now update both focus and active/inactive state, to try to keep them in sync.
- Add comments at `view_focus/defocus()` to warn against calling them directly (we should generally call the desktop.c functions).
- `desktop_focus_view(NULL)` is now forbidden and is no longer handled as a special case to clear the focus. This was (at least to me) a surprising behavior and caused trouble when working on another change.
- To maintain existing behavior, `desktop_focus_topmost_mapped_view()` now explicitly clears the focus if there are no mapped views.

There should be no behavioral change here.

Supersedes #1107.