### PR TITLE
seat: use focus_change event to update focused/active view

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -167,6 +167,7 @@ struct seat {
 	struct wl_client *active_client_while_inhibited;
 	struct wl_list inputs;
 	struct wl_listener new_input;
+	struct wl_listener focus_change;
 
 	struct wl_listener cursor_motion;
 	struct wl_listener cursor_motion_absolute;
@@ -247,11 +248,8 @@ struct server {
 
 	/* SSD state */
 	/*
-	 * Currently focused view (cached value). This pointer is used
-	 * primarily to track which view is being drawn with "active"
-	 * SSD coloring. We consider it a bug if this gets out of sync
-	 * with the actual keyboard focus (according to wlroots). See
-	 * also desktop_focused_view().
+	 * Currently focused view. Updated with each "focus change"
+	 * event. This view is drawn with "active" SSD coloring.
 	 */
 	struct view *focused_view;
 	struct ssd_hover_state *ssd_hover_state;
@@ -395,14 +393,6 @@ enum lab_cycle_dir {
  */
 struct view *desktop_cycle_view(struct server *server, struct view *start_view,
 	enum lab_cycle_dir dir);
-/**
- * desktop_focused_view - return the view that is currently focused
- * (determined on-the-fly from the wlroots keyboard focus). The return
- * value should ideally match server->focused_view (we consider it a
- * bug otherwise) but is guaranteed to be up-to-date even if
- * server->focused_view gets out of sync.
- */
-struct view *desktop_focused_view(struct server *server);
 void desktop_focus_topmost_mapped_view(struct server *server);
 
 void keyboard_cancel_keybind_repeat(struct keyboard *keyboard);

--- a/include/view.h
+++ b/include/view.h
@@ -187,6 +187,12 @@ enum lab_view_criteria {
 };
 
 /**
+ * view_from_wlr_surface() - returns the view associated with a
+ * wlr_surface, or NULL if the surface has no associated view.
+ */
+struct view *view_from_wlr_surface(struct wlr_surface *surface);
+
+/**
  * for_each_view() - iterate over all views which match criteria
  * @view: Iterator.
  * @head: Head of list to iterate over.
@@ -257,8 +263,7 @@ bool view_isfocusable(struct view *view);
 bool view_inhibits_keybinds(struct view *view);
 void view_toggle_keybinds(struct view *view);
 
-void view_focus(struct view *view);
-void view_defocus(struct view *view);
+void view_set_activated(struct view *view, bool activated);
 void view_set_output(struct view *view, struct output *output);
 void view_close(struct view *view);
 

--- a/src/action.c
+++ b/src/action.c
@@ -503,7 +503,7 @@ view_for_action(struct view *activator, struct server *server,
 		return ctx.view;
 	}
 	default:
-		return desktop_focused_view(server);
+		return server->focused_view;
 	}
 }
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -602,7 +602,7 @@ create_constraint(struct wl_listener *listener, void *data)
 	constraint->destroy.notify = destroy_constraint;
 	wl_signal_add(&wlr_constraint->events.destroy, &constraint->destroy);
 
-	struct view *view = desktop_focused_view(server);
+	struct view *view = server->focused_view;
 	if (view && view->surface == wlr_constraint->surface) {
 		constrain_cursor(server, wlr_constraint);
 	}

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -94,7 +94,7 @@ handle_keybinding(struct server *server, uint32_t modifiers, xkb_keysym_t sym, x
 			continue;
 		}
 		if (server->seat.nr_inhibited_keybind_views
-				&& view_inhibits_keybinds(desktop_focused_view(server))
+				&& view_inhibits_keybinds(server->focused_view)
 				&& !actions_contain_toggle_keybinds(&keybind->actions)) {
 			continue;
 		}

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -287,7 +287,7 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	 * Only refocus if the focus is not already on an always-on-top view.
 	 */
 	if (update_focus) {
-		struct view *view = desktop_focused_view(server);
+		struct view *view = server->focused_view;
 		if (!view || !view_is_always_on_top(view)) {
 			desktop_focus_topmost_mapped_view(server);
 		}


### PR DESCRIPTION
- Connect to `wlr_seat_keyboard_state`'s `focus_change` event.
- Add `view_from_wlr_surface()`, which does what the name says.
- Use `focus_change` event along with `view_from_wlr_surface()` to update `server->focused_view` and set SSD states via `view_set_activated()`.
- Eliminate `desktop_focused_view()` since `server->focused_view` should be reliably up-to-date now.
- Eliminate `view_focus/defocus()` since we can now just call seat_focus_surface() directly.