### PR TITLE
keyboard: fix release event bug after session lock

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -233,18 +233,6 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	}
 
 	/*
-	 * Ignore labwc keybindings if input is inhibited
-	 * It's important to do this after key_state_set_pressed() to ensure
-	 * _all_ key press/releases are registered
-	 */
-	if (seat->active_client_while_inhibited) {
-		return false;
-	}
-	if (seat->server->session_lock) {
-		return false;
-	}
-
-	/*
 	 * If a user lets go of the modifier (e.g. alt) before the 'normal' key
 	 * (e.g. tab) when window-cycling, we do not end the cycling until both
 	 * keys have been released.  If we end the window-cycling on release of
@@ -267,6 +255,18 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 			&& event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
 		key_state_bound_key_remove(event->keycode);
 		return true;
+	}
+
+	/*
+	 * Ignore labwc keybindings if input is inhibited
+	 * It's important to do this after key_state_set_pressed() to ensure
+	 * _all_ key press/releases are registered
+	 */
+	if (seat->active_client_while_inhibited) {
+		return false;
+	}
+	if (seat->server->session_lock) {
+		return false;
 	}
 
 	uint32_t modifiers = wlr_keyboard_get_modifiers(wlr_keyboard);


### PR DESCRIPTION
Do not withhold the release event associated with a keybind which executes a keyboard-input-inhibiting client like swaylock.

In other words, make release-events of absorbed keys (those used up by a keybind) de-register as such even though session-lock or input-inhibit is in-force.

Fixes: issue #1114

Helped-by: @Consolatis