### PR TITLE
various: stop using data argument of wlroots event callbacks

### DIFF
--- a/src/dnd.c
+++ b/src/dnd.c
@@ -14,7 +14,7 @@ static void
 handle_icon_map(struct wl_listener *listener, void *data)
 {
 	struct drag_icon *self = wl_container_of(listener, self, events.map);
-	struct wlr_drag_icon *icon = data;
+	struct wlr_drag_icon *icon = self->icon;
 	if (icon->data) {
 		struct wlr_scene_tree *surface_tree = icon->data;
 		wlr_scene_node_set_enabled(&surface_tree->node, true);
@@ -40,7 +40,7 @@ static void
 handle_icon_unmap(struct wl_listener *listener, void *data)
 {
 	struct drag_icon *self = wl_container_of(listener, self, events.unmap);
-	struct wlr_drag_icon *icon = data;
+	struct wlr_drag_icon *icon = self->icon;
 	struct wlr_scene_tree *surface_tree = icon->data;
 	if (surface_tree) {
 		wlr_scene_node_set_enabled(&surface_tree->node, false);

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -153,11 +153,12 @@ static void
 unmanaged_handle_request_activate(struct wl_listener *listener, void *data)
 {
 	wlr_log(WLR_DEBUG, "handle unmanaged request_activate");
-	struct wlr_xwayland_surface *xsurface = data;
+	struct xwayland_unmanaged *unmanaged =
+		wl_container_of(listener, unmanaged, request_activate);
+	struct wlr_xwayland_surface *xsurface = unmanaged->xwayland_surface;
 	if (!xsurface->mapped) {
 		return;
 	}
-	struct xwayland_unmanaged *unmanaged = xsurface->data;
 	struct server *server = unmanaged->server;
 	struct seat *seat = &server->seat;
 


### PR DESCRIPTION
These are a couple of commits authored by @Consolatis that are cherry-picked from #626. They are for wlroots 0.17 compatibility, but have no negative side effects with wlroots 0.16 either. So I think we might as well merge them in now.