### PR TITLE
key-state: rename function for consistency

### DIFF
--- a/include/key-state.h
+++ b/include/key-state.h
@@ -20,7 +20,7 @@ void key_state_set_pressed(uint32_t keycode, bool ispressed);
 void key_state_store_pressed_keys_as_bound(void);
 bool key_state_corresponding_press_event_was_bound(uint32_t keycode);
 void key_state_bound_key_remove(uint32_t keycode);
-int key_state_nr_keys(void);
+int key_state_nr_bound_keys(void);
 int key_state_nr_pressed_keys(void);
 
 #endif /* LABWC_KEY_STATE_H */

--- a/src/key-state.c
+++ b/src/key-state.c
@@ -98,7 +98,7 @@ key_state_bound_key_remove(uint32_t keycode)
 }
 
 int
-key_state_nr_keys(void)
+key_state_nr_bound_keys(void)
 {
 	return bound.nr_keys;
 }

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -68,7 +68,7 @@ keyboard_modifiers_notify(struct wl_listener *listener, void *data)
 			|| seat->workspace_osd_shown_by_modifier) {
 		if (!keyboard_any_modifiers_pressed(wlr_keyboard))  {
 			if (server->osd_state.cycle_view) {
-				if (key_state_nr_keys()) {
+				if (key_state_nr_bound_keys()) {
 					should_cancel_cycling_on_next_key_release = true;
 				} else {
 					end_cycling(server);


### PR DESCRIPTION
...with the equivalent function that returns the number of pressed keys.

s/key_state_nr_keys/key_state_nr_bound_keys/