### PR TITLE
Refactor title height to use 'titlebar.height' from themerc

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -47,6 +47,10 @@ labwc-config(5).
 	Vertical padding size, used for spacing out elements in the window decorations.
 	Default is 3.
 
+*titlebar.height*
+	Window title bar height.
+	Default equals the vertical font extents of the title plus 2x padding.height.
+
 *menu.items.padding.x*
 	Horizontal padding of menu text entries in pixels.
 	Default is 7.
@@ -201,11 +205,6 @@ with the respective titlebar colors. For example: "close-active.png"
 # DEFINITIONS
 
 The handle is the window edge decoration at the bottom of the window.
-
-# DERIVED DIMENSIONS
-
-The window title bar height is equal to the vertical font extents of the title.
-Padding will be added to this later.
 
 # SEE ALSO
 

--- a/docs/themerc
+++ b/docs/themerc
@@ -9,6 +9,10 @@
 border.width: 1
 padding.height: 3
 
+# The following options has no default, but fallbacks back to
+# font-height + 2x padding.height if not set.
+# titlebar.height:
+
 # window border
 window.active.border.color: #dddad6
 window.inactive.border.color: #f6f5f4

--- a/include/theme.h
+++ b/include/theme.h
@@ -20,6 +20,7 @@ enum lab_justification {
 struct theme {
 	int border_width;
 	int padding_height;
+	int title_height;
 	int menu_overlap_x;
 	int menu_overlap_y;
 
@@ -92,7 +93,6 @@ struct theme {
 	struct lab_data_buffer *corner_top_right_inactive_normal;
 
 	/* not set in rc.xml/themerc, but derived from font & padding_height */
-	int title_height;
 	int osd_window_switcher_item_height;
 };
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -213,6 +213,7 @@ theme_builtin(struct theme *theme)
 {
 	theme->border_width = 1;
 	theme->padding_height = 3;
+	theme->title_height = INT_MIN;
 	theme->menu_overlap_x = 0;
 	theme->menu_overlap_y = 0;
 
@@ -290,6 +291,9 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match_glob(key, "padding.height")) {
 		theme->padding_height = atoi(value);
+	}
+	if (match_glob(key, "titlebar.height")) {
+		theme->title_height = atoi(value);
 	}
 	if (match_glob(key, "menu.items.padding.x")) {
 		theme->menu_item_padding_x = atoi(value);
@@ -750,8 +754,11 @@ create_corners(struct theme *theme)
 static void
 post_processing(struct theme *theme)
 {
-	theme->title_height = font_height(&rc.font_activewindow)
-		+ 2 * theme->padding_height;
+	int h = font_height(&rc.font_activewindow);
+	if (theme->title_height < h) {
+		theme->title_height = h + 2 * theme->padding_height;
+	}
+
 	theme->osd_window_switcher_item_height = font_height(&rc.font_osd)
 		+ 2 * theme->osd_window_switcher_item_padding_y
 		+ 2 * theme->osd_window_switcher_item_active_border_width;


### PR DESCRIPTION
**Description:**
Openbox and Labwc currently calculate the title size based on the font size. This can be limiting for users who want to customize the window title's appearance. For instance, if someone desires a larger title height without increasing the font size, the current system doesn't provide an solution.

**Proposed Change:**
This pull request introduces a new configuration setting in the 'themerc' configuration file: `titlebar.height`. With this setting, users can now specify the desired title height independently of the font size. If the font size specified is larger than the `titlebar.height` setting, then will use the font size.

**How to Use:**
1. Edit your 'themerc' configuration file.
2. Add or modify the `titlebar.height` setting, specifying your desired title height.
3. Save the configuration file.

**Example 'themerc' Configuration:**
```ini
# Set the title height to 24 pixels
titlebar.height = 24
```


Continuing from #1128 , the previous pull got messed up due to an editor issue. I'll now send a new pull request to get the latest changes