### PR TITLE
cursor: fix layer subsurface focus bug

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -915,7 +915,14 @@ cursor_button_press(struct seat *seat, struct wlr_pointer_button_event *event)
 		}
 	}
 	if (ctx.type == LAB_SSD_LAYER_SUBSURFACE) {
-		seat_focus_surface(seat, ctx.surface);
+		struct wlr_surface *top = get_toplevel(ctx.surface);
+		if (top) {
+			struct wlr_layer_surface_v1 *layer =
+				wlr_layer_surface_v1_from_wlr_surface(top);
+			if (layer->current.keyboard_interactive) {
+				seat_set_focus_layer(seat, layer);
+			}
+		}
 	}
 
 	if (ctx.type != LAB_SSD_CLIENT && ctx.type != LAB_SSD_LAYER_SUBSURFACE


### PR DESCRIPTION
...by checking keyboard-interactivity before giving layer-subsurface focus on button press.

Before this patch, waybar's raise-minimize did not work because keyboard focus was given to waybar layer-shell subsurfaces without checking for their keyboard interactivity setting.  Clicking on a waybar task-button gave keyboard focus to that button which removed it from the client and therefore confused the panel logic.

Fixes: issue #1131

Have tested with `waybar` and `gtk-layer-demo`. Seems to work fine.