### PR TITLE
Allow XWayland views with WM_HINTS.input = false to be focused again

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -375,6 +375,18 @@ void foreign_toplevel_update_outputs(struct view *view);
  *              cannot assume this means that the window actually has keyboard
  *              or pointer focus, in this compositor are they called together.
  */
+
+/**
+ * desktop_focus_view() - do multiple things to make a view "active" and
+ * ready to use:
+ *  - unminimize
+ *  - switch to the workspace it's on
+ *  - give input (keyboard) focus
+ *  - optionally raise above other views
+ *
+ * It's okay to call this function even if the view isn't mapped or the
+ * session is locked/input is inhibited; it will simply do nothing.
+ */
 void desktop_focus_view(struct view *view, bool raise);
 void desktop_arrange_all_views(struct server *server);
 void desktop_focus_output(struct output *output);
@@ -393,6 +405,15 @@ enum lab_cycle_dir {
  */
 struct view *desktop_cycle_view(struct server *server, struct view *start_view,
 	enum lab_cycle_dir dir);
+
+/**
+ * desktop_focus_topmost_view() - focus the topmost view on the current
+ * workspace, skipping views that claim not to want focus (those can
+ * still be focused by explicit request, e.g. by clicking in them).
+ *
+ * This function is typically called when the focused view is hidden
+ * (closes, is minimized, etc.) to focus the "next" view underneath.
+ */
 void desktop_focus_topmost_view(struct server *server);
 
 void keyboard_cancel_keybind_repeat(struct keyboard *keyboard);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -73,6 +73,13 @@ desktop_focus_view(struct view *view, bool raise)
 		workspaces_switch_to(view->workspace, /*update_focus*/ false);
 	}
 
+	/*
+	 * Give input focus, even if the view claims not to want it (see
+	 * view->impl->wants_focus). This is a workaround for so-called
+	 * "globally active" X11 views (MATLAB known to be one such)
+	 * that expect to be able to control focus themselves, but can't
+	 * under labwc since it's disallowed at the wlroots level.
+	 */
 	struct seat *seat = &server->seat;
 	if (view->surface != seat->seat->keyboard_state.focused_surface) {
 		seat_focus_surface(seat, view->surface);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -38,16 +38,13 @@ void
 desktop_focus_view(struct view *view, bool raise)
 {
 	assert(view);
-	if (!view_isfocusable(view)) {
-		return;
-	}
-
 	/*
 	 * Guard against views with no mapped surfaces when handling
 	 * 'request_activate' and 'request_minimize'.
-	 * view_isfocusable() should return false for those views.
 	 */
-	assert(view->surface);
+	if (!view->surface) {
+		return;
+	}
 
 	struct server *server = view->server;
 	if (input_inhibit_blocks_surface(&server->seat, view->surface->resource)
@@ -64,11 +61,9 @@ desktop_focus_view(struct view *view, bool raise)
 		return;
 	}
 
-	/*
-	 * view_isfocusable() should return false for any views that are
-	 * neither mapped nor minimized.
-	 */
-	assert(view->mapped);
+	if (!view->mapped) {
+		return;
+	}
 
 	/*
 	 * Switch workspace if necessary to make the view visible

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -49,7 +49,8 @@ xwayland_view_wants_focus(struct view *view)
 	 * Clients that use XSetInputFocus() to explicitly set the input
 	 * focus should set the WM_TAKE_FOCUS atom in WM_PROTOCOLS.
 	 * Currently, labwc does not support this method of taking focus
-	 * and thus makes no use of WM_TAKE_FOCUS.
+	 * and thus ignores WM_TAKE_FOCUS. These views can still be
+	 * focused by explicit user action (e.g. clicking in them).
 	 */
 	return (bool)hints->input;
 }


### PR DESCRIPTION
Revert "desktop: try harder to avoid focusing unfocusable views"
    
Some X11 applications (MATLAB is known to be one) apparently still use
the outdated "globally active" input focus model, in which they declare
they don't want the window manager to give them input focus, but expect
to be able to take it explicitly themselves via XSetInputFocus().

Such applications are not a good fit for the Wayland world, and may have
issues even with remotely modern X11 window managers that prevent such
"focus stealing". Labwc certainly doesn't (and won't) allow it. However,
to avoid breaking such applications entirely, let's still allow the user
to give focus by clicking in the window.

For the sake of applications that legitimately don't want to be given
input focus (such as taskbars or other "panels"), we still don't give
focus to them automatically when another view is closed, and they aren't
shown in Alt-Tab.

This reverts commit cae96b0cce441dd9f1981c312ae0108b3b4e42c9.

Along with the revert (1st commit), add some comments to try to clarify
this whole mess (2nd commit).

This undoes half of #1103 and should half-fix #1130. As mentioned in
#1130, it's a compromise that probably won't make everyone 100% happy.