### PR TITLE
keyboard: allow switching VT when locked

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -257,20 +257,6 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 		return true;
 	}
 
-	/*
-	 * Ignore labwc keybindings if input is inhibited
-	 * It's important to do this after key_state_set_pressed() to ensure
-	 * _all_ key press/releases are registered
-	 */
-	if (seat->active_client_while_inhibited) {
-		return false;
-	}
-	if (seat->server->session_lock) {
-		return false;
-	}
-
-	uint32_t modifiers = wlr_keyboard_get_modifiers(wlr_keyboard);
-
 	/* Catch C-A-F1 to C-A-F12 to change tty */
 	if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		for (int i = 0; i < translated.nr_syms; i++) {
@@ -286,6 +272,20 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 			}
 		}
 	}
+
+	/*
+	 * Ignore labwc keybindings if input is inhibited
+	 * It's important to do this after key_state_set_pressed() to ensure
+	 * _all_ key press/releases are registered
+	 */
+	if (seat->active_client_while_inhibited) {
+		return false;
+	}
+	if (seat->server->session_lock) {
+		return false;
+	}
+
+	uint32_t modifiers = wlr_keyboard_get_modifiers(wlr_keyboard);
 
 	if (server->input_mode == LAB_INPUT_STATE_MENU) {
 		/*


### PR DESCRIPTION
I noticed that one currently can't switch to a different VT if the labwc session is locked. It seems undesirable to have to unlock one VT session just to switch to another one (which potentially belongs to a different user).

Assuming this was unintentional, can we allow switching VTs while locked? It appears to be as simple as reordering the two logic steps in `handle_compositor_keybindings()`.