### PR TITLE
session-lock: reconfigure for output layout changes

### DIFF
--- a/include/session-lock.h
+++ b/include/session-lock.h
@@ -4,6 +4,9 @@
 
 #include <wlr/types/wlr_session_lock_v1.h>
 
+struct output;
+struct server;
+
 struct session_lock {
 	struct wlr_session_lock_v1 *lock;
 	struct wlr_surface *focused;
@@ -18,5 +21,6 @@ struct session_lock {
 
 void session_lock_init(struct server *server);
 void session_lock_output_create(struct session_lock *lock, struct output *output);
+void session_lock_update_for_layout_change(void);
 
 #endif /* LABWC_SESSION_LOCK_H */

--- a/src/output.c
+++ b/src/output.c
@@ -272,6 +272,7 @@ static void
 output_update_for_layout_change(struct server *server)
 {
 	output_update_all_usable_areas(server, /*layout_changed*/ true);
+	session_lock_update_for_layout_change();
 
 	/*
 	 * "Move" each wlr_output_cursor (in per-output coordinates) to


### PR DESCRIPTION
Currently, if the output layout changes while the session is locked, the lock surfaces may end up wrongly positioned, which looks bad and may reveal some of the user's workspace underneath.

As an example, this is what my desktop looks like after docking my laptop:
![image](https://github.com/labwc/labwc/assets/1244737/90df249e-e470-49a9-b021-599975748c19)

To prevent this, reposition the session-lock scene trees and reconfigure the lock surfaces when the output layout changes.

P.S. It may also make sense to disable/destroy the lock surfaces for disabled outputs. I think the black rectangle in the picture was originally meant for the laptop display, which turns off when docked. (It's not visible after this change - maybe just hidden behind one of the other lock surfaces.)