### PR TITLE
keyboard: set numlock automatically

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -276,6 +276,10 @@ this is for compatibility with Openbox.
 
 ## KEYBOARD
 
+*<keyboard><numlock>* [on|off]
+	When recognizing a new keyboard enable or disable Num Lock.
+	Default is on.
+
 *<keyboard><keybind key="" layoutDependent="">*
 	Define a *key* binding in the format *modifier-key*, where supported
 	modifiers include S (shift); C (control); A (alt); W (super). Unlike

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -141,6 +141,7 @@
     your favourite terminal or application launcher. See rc.xml for an example.
   -->
   <keyboard>
+    <numlock>on</numlock>
     <repeatRate>25</repeatRate>
     <repeatDelay>600</repeatDelay>
     <keybind key="A-Tab">

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -62,6 +62,7 @@ struct rcxml {
 	/* keyboard */
 	int repeat_rate;
 	int repeat_delay;
+	bool kb_numlock_enable;
 	struct wl_list keybinds;   /* struct keybind.link */
 
 	/* mouse */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -419,6 +419,7 @@ void desktop_focus_topmost_view(struct server *server);
 void keyboard_cancel_keybind_repeat(struct keyboard *keyboard);
 void keyboard_key_notify(struct wl_listener *listener, void *data);
 void keyboard_modifiers_notify(struct wl_listener *listener, void *data);
+void keyboard_set_numlock(struct wlr_keyboard *keyboard);
 void keyboard_init(struct seat *seat);
 bool keyboard_any_modifiers_pressed(struct wlr_keyboard *keyboard);
 void keyboard_finish(struct seat *seat);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -732,6 +732,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.repeat_rate = atoi(content);
 	} else if (!strcasecmp(nodename, "repeatDelay.keyboard")) {
 		rc.repeat_delay = atoi(content);
+	} else if (!strcasecmp(nodename, "numlock.keyboard")) {
+		set_bool(content, &rc.kb_numlock_enable);
 	} else if (!strcasecmp(nodename, "screenEdgeStrength.resistance")) {
 		rc.screen_edge_strength = atoi(content);
 	} else if (!strcasecmp(nodename, "range.snapping")) {
@@ -949,6 +951,7 @@ rcxml_init(void)
 	rc.scroll_factor = 1.0;
 	rc.repeat_rate = 25;
 	rc.repeat_delay = 600;
+	rc.kb_numlock_enable = true;
 	rc.screen_edge_strength = 20;
 
 	rc.snap_edge_range = 1;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <wlr/backend/multi.h>
 #include <wlr/backend/session.h>
+#include <wlr/interfaces/wlr_keyboard.h>
 #include "action.h"
 #include "idle.h"
 #include "key-state.h"
@@ -481,6 +482,33 @@ keyboard_key_notify(struct wl_listener *listener, void *data)
 		wlr_seat_keyboard_notify_key(wlr_seat, event->time_msec,
 			event->keycode, event->state);
 	}
+}
+
+void
+keyboard_set_numlock(struct wlr_keyboard *keyboard)
+{
+	xkb_mod_index_t num_idx =
+		xkb_map_mod_get_index(keyboard->keymap, XKB_MOD_NAME_NUM);
+	if (num_idx == XKB_MOD_INVALID) {
+		wlr_log(WLR_INFO, "Failed to set Num Lock: not found in keymap");
+		return;
+	}
+
+	xkb_mod_mask_t locked = keyboard->modifiers.locked;
+	if (rc.kb_numlock_enable) {
+		locked |= (xkb_mod_mask_t)1 << num_idx;
+	} else {
+		locked &= ~((xkb_mod_mask_t)1 << num_idx);
+	}
+
+	/*
+	 * This updates the xkb-state + kb->modifiers and also triggers the
+	 * keyboard->events.modifiers signal (the signal has no effect in
+	 * current labwc usage since the keyboard is not part of a
+	 * keyboard-group yet).
+	 */
+	wlr_keyboard_notify_modifiers(keyboard, keyboard->modifiers.depressed,
+		keyboard->modifiers.latched, locked, keyboard->modifiers.group);
 }
 
 void

--- a/src/seat.c
+++ b/src/seat.c
@@ -211,6 +211,14 @@ new_keyboard(struct seat *seat, struct wlr_input_device *device, bool virtual)
 
 	wlr_keyboard_set_keymap(kb, seat->keyboard_group->keyboard.keymap);
 
+	/*
+	 * This needs to be before wlr_keyboard_group_add_keyboard().
+	 * For some reason, wlroots takes the modifier state from the
+	 * new keyboard and syncs it to the others in the group, rather
+	 * than the other way around.
+	 */
+	keyboard_set_numlock(kb);
+
 	if (!virtual) {
 		wlr_keyboard_group_add_keyboard(seat->keyboard_group, kb);
 	}


### PR DESCRIPTION
This should get us most of the way to solving #637. I haven't coded up the bits to hook it up to rc.xml; help with that would be welcome.

A minor surprise is that the initial NumLock state is re-applied (to all keyboards) if a new keyboard is hot-plugged. It's wlroots doing this behind our back, though with a little more code we could prevent it. In my opinion, it's a pretty minor issue (but then, I basically never turn off NumLock).