### PR TITLE
keybinds: add support for Meta and Hyper modifiers

### DIFF
--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -15,14 +15,19 @@
 uint32_t
 parse_modifier(const char *symname)
 {
+	/* Mod2 == NumLock */
 	if (!strcmp(symname, "S")) {
 		return WLR_MODIFIER_SHIFT;
 	} else if (!strcmp(symname, "C")) {
 		return WLR_MODIFIER_CTRL;
-	} else if (!strcmp(symname, "A")) {
+	} else if (!strcmp(symname, "A") || !strcmp(symname, "Mod1")) {
 		return WLR_MODIFIER_ALT;
-	} else if (!strcmp(symname, "W")) {
+	} else if (!strcmp(symname, "W") || !strcmp(symname, "Mod4")) {
 		return WLR_MODIFIER_LOGO;
+	} else if (!strcmp(symname, "M") || !strcmp(symname, "Mod5")) {
+		return WLR_MODIFIER_MOD5;
+	} else if (!strcmp(symname, "H") || !strcmp(symname, "Mod3")) {
+		return WLR_MODIFIER_MOD3;
 	} else {
 		return 0;
 	}

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -130,7 +130,10 @@ static bool is_modifier_key(xkb_keysym_t sym)
 		|| sym == XKB_KEY_Control_L
 		|| sym == XKB_KEY_Control_R
 		|| sym == XKB_KEY_Super_L
-		|| sym == XKB_KEY_Super_R;
+		|| sym == XKB_KEY_Super_R
+		/* Right hand Alt key for Mod5 */
+		|| sym == XKB_KEY_Mode_switch
+		|| sym == XKB_KEY_ISO_Level3_Shift;
 }
 
 struct keysyms {

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -133,7 +133,9 @@ static bool is_modifier_key(xkb_keysym_t sym)
 		|| sym == XKB_KEY_Super_R
 		/* Right hand Alt key for Mod5 */
 		|| sym == XKB_KEY_Mode_switch
-		|| sym == XKB_KEY_ISO_Level3_Shift;
+		|| sym == XKB_KEY_ISO_Level3_Shift
+		/* Prevents storing layout change notifier in pressed */
+		|| sym == XKB_KEY_ISO_Next_Group;
 }
 
 struct keysyms {


### PR DESCRIPTION
<b>keybinds: add support for Meta and Hyper modifiers</b>

The modifiers can be used in keybinds via `M-key` and `H-key`

Additionally adds support for:
- `Mod1` (same as `A`)
- `Mod3` (same as `H`)
- `Mod4` (same as `W`)
- `Mod5` (same as `M`)

This is compatible with the format used by Openbox.
(http://openbox.org/wiki/Help:Bindings#Syntax)

`Mod2` (`NumLock`) and `Caps` are still not supported due
to their locking behavior but could theoretically be added.

Fixes:
- #1061

This patch does not support the same changes for mousebinds.

----

<b>keyboard: prevent storing synthetic layout change key event</b>

Before this patch, we were storing the key in our pressed set
and didn't remove it which in turn caused all further keybinds
to fail. The behavior was dependent on the exact flow of press
and release events and was most obvious when using
`XKB_DEFAULT_OPTIONS=grp:alt_shift_toggle`

We now simply treat it as a modifier and thus do not store it
in the pressed set.

Fixes:
- #1129