### PR TITLE
view: fix some inconsistencies in view_ functions

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -271,7 +271,7 @@ void view_array_append(struct server *server, struct wl_array *views,
 	enum lab_view_criteria criteria);
 
 /**
- * view_isfocusable() - Check whether or not a view can be focused
+ * view_is_focusable() - Check whether or not a view can be focused
  * @view: view to be checked
  *
  * The purpose of this test is to filter out views (generally Xwayland) which
@@ -282,9 +282,8 @@ void view_array_append(struct server *server, struct wl_array *views,
  * The only views that are allowed to be focusd are those that have a surface
  * and have been mapped at some point since creation.
  */
-bool view_isfocusable(struct view *view);
+bool view_is_focusable(struct view *view);
 
-bool view_inhibits_keybinds(struct view *view);
 void view_toggle_keybinds(struct view *view);
 
 void view_set_activated(struct view *view, bool activated);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -114,7 +114,7 @@ first_view(struct server *server)
 			continue;
 		}
 		struct view *view = node_view_from_node(node);
-		if (view_isfocusable(view)) {
+		if (view_is_focusable(view)) {
 			return view;
 		}
 	}
@@ -186,7 +186,7 @@ desktop_cycle_view(struct server *server, struct view *start_view,
 		view = node_view_from_node(node);
 
 		enum property skip = window_rules_get_property(view, "skipWindowSwitcher");
-		if (view_isfocusable(view) && skip != LAB_PROP_TRUE) {
+		if (view_is_focusable(view) && skip != LAB_PROP_TRUE) {
 			return view;
 		}
 	} while (view != start_view);
@@ -208,7 +208,7 @@ desktop_topmost_focusable_view(struct server *server)
 			continue;
 		}
 		view = node_view_from_node(node);
-		if (view->mapped && view_isfocusable(view)) {
+		if (view->mapped && view_is_focusable(view)) {
 			return view;
 		}
 	}
@@ -247,7 +247,7 @@ desktop_focus_output(struct output *output)
 			continue;
 		}
 		view = node_view_from_node(node);
-		if (!view_isfocusable(view)) {
+		if (!view_is_focusable(view)) {
 			continue;
 		}
 		if (wlr_output_layout_intersects(layout,

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -94,7 +94,8 @@ handle_keybinding(struct server *server, uint32_t modifiers, xkb_keysym_t sym, x
 			continue;
 		}
 		if (server->seat.nr_inhibited_keybind_views
-				&& view_inhibits_keybinds(server->focused_view)
+				&& server->focused_view
+				&& server->focused_view->inhibits_keybinds
 				&& !actions_contain_toggle_keybinds(&keybind->actions)) {
 			continue;
 		}

--- a/src/osd.c
+++ b/src/osd.c
@@ -479,7 +479,7 @@ osd_update(struct server *server)
 
 	/* Outline current window */
 	if (rc.window_switcher.outlines) {
-		if (view_isfocusable(server->osd_state.cycle_view)) {
+		if (view_is_focusable(server->osd_state.cycle_view)) {
 			osd_update_preview_outlines(server->osd_state.cycle_view);
 		}
 	}


### PR DESCRIPTION
... especially regarding whether a `(view *)` parameter may be `NULL`. It's confusing when some functions accept `NULL` and others don't, and could trip someone up.

I'm partly to blame for the inconsistency, since (if memory serves) I added `view_is_tiled()` and `view_is_floating()`, which do accept `NULL`.

In detail:

- Make `view_is_tiled()` and `view_is_floating()` no longer accept `NULL`.
- Rename `view_isfocusable` -> `view_is_focusable` for consistency with other `view_is_` functions.
- Eliminate `view_inhibits_keybinds()` as it only existed to safely accept `NULL` and check a single flag, which can be checked directly.
- Add `assert(view)` to remaining public `view_` functions to catch accidentally passing `NULL`.
- Inline `inhibit_keybinds()` into `view_toggle_keybinds()`. It is closely related and not called from anywhere else; inlining it allows eliminating an extra `assert()` which is now impossible.