### PR TITLE
menu: use wl_list instead of array

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -320,6 +320,7 @@ struct server {
 	struct theme *theme;
 
 	struct menu *menu_current;
+	struct wl_list menus;
 };
 
 #define LAB_NR_LAYERS (4)

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -60,6 +60,7 @@ struct menu {
 
 	/* Used to match a window-menu to the view that triggered it. */
 	struct view *triggered_by_view;  /* may be NULL */
+	struct wl_list link; /* server.menus */
 };
 
 /* For keyboard support */
@@ -70,14 +71,14 @@ void menu_submenu_leave(struct server *server);
 bool menu_call_selected_actions(struct server *server);
 
 void menu_init(struct server *server);
-void menu_finish(void);
+void menu_finish(struct server *server);
 
 /**
  * menu_get_by_id - get menu by id
  *
  * @id id string defined in menu.xml like "root-menu"
  */
-struct menu *menu_get_by_id(const char *id);
+struct menu *menu_get_by_id(struct server *server, const char *id);
 
 /**
  * menu_open - open menu on position (x, y)

--- a/src/action.c
+++ b/src/action.c
@@ -493,7 +493,7 @@ show_menu(struct server *server, struct view *view, const char *menu_name)
 	}
 
 	bool force_menu_top_left = false;
-	struct menu *menu = menu_get_by_id(menu_name);
+	struct menu *menu = menu_get_by_id(server, menu_name);
 	if (!menu) {
 		return;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -180,7 +180,7 @@ main(int argc, char *argv[])
 
 	server_finish(&server);
 
-	menu_finish();
+	menu_finish(&server);
 	theme_finish(&theme);
 	rcxml_finish();
 	font_finish();

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -33,22 +33,14 @@ static struct action *current_item_action;
 static int menu_level;
 static struct menu *current_menu;
 
-/* vector for <menu id="" label=""> elements */
-static struct menu *menus;
-static int nr_menus, alloc_menus;
-
 /* TODO: split this whole file into parser.c and actions.c*/
 
 static struct menu *
 menu_create(struct server *server, const char *id, const char *label)
 {
-	if (nr_menus == alloc_menus) {
-		alloc_menus = (alloc_menus + 16) * 2;
-		menus = xrealloc(menus, alloc_menus * sizeof(struct menu));
-	}
-	struct menu *menu = menus + nr_menus;
-	memset(menu, 0, sizeof(*menu));
-	nr_menus++;
+	struct menu *menu = znew(*menu);
+	wl_list_append(&server->menus, &menu->link);
+
 	wl_list_init(&menu->menuitems);
 	menu->id = xstrdup(id);
 	menu->label = xstrdup(label ? label : id);
@@ -62,14 +54,13 @@ menu_create(struct server *server, const char *id, const char *label)
 }
 
 struct menu *
-menu_get_by_id(const char *id)
+menu_get_by_id(struct server *server, const char *id)
 {
 	if (!id) {
 		return NULL;
 	}
 	struct menu *menu;
-	for (int i = 0; i < nr_menus; ++i) {
-		menu = menus + i;
+	wl_list_for_each(menu, &server->menus, link) {
 		if (!strcmp(menu->id, id)) {
 			return menu;
 		}
@@ -124,8 +115,7 @@ static void
 post_processing(struct server *server)
 {
 	struct menu *menu;
-	for (int i = 0; i < nr_menus; ++i) {
-		menu = menus + i;
+	wl_list_for_each(menu, &server->menus, link) {
 		menu_update_width(menu);
 	}
 }
@@ -149,8 +139,9 @@ validate_menu(struct menu *menu)
 static void
 validate(struct server *server)
 {
-	for (int i = 0; i < nr_menus; ++i) {
-		validate_menu(menus + i);
+	struct menu *menu;
+	wl_list_for_each(menu, &server->menus, link) {
+		validate_menu(menu);
 	}
 }
 
@@ -473,7 +464,7 @@ handle_menu_element(xmlNode *n, struct server *server)
 		 * <menu id=""> creates an entry which points to a menu
 		 * defined elsewhere
 		 */
-		struct menu *menu = menu_get_by_id(id);
+		struct menu *menu = menu_get_by_id(server, id);
 		if (menu) {
 			current_item = item_create(current_menu, menu->label, true);
 			if (current_item) {
@@ -654,15 +645,14 @@ menu_configure(struct menu *menu, int lx, int ly, enum menu_align align)
 }
 
 static void
-menu_hide_submenu(const char *id)
+menu_hide_submenu(struct server *server, const char *id)
 {
 	struct menu *menu, *hide_menu;
-	hide_menu = menu_get_by_id(id);
+	hide_menu = menu_get_by_id(server, id);
 	if (!hide_menu) {
 		return;
 	}
-	for (int i = 0; i < nr_menus; ++i) {
-		menu = menus + i;
+	wl_list_for_each(menu, &server->menus, link) {
 		bool should_reposition = false;
 		struct menuitem *item, *next;
 		wl_list_for_each_safe(item, next, &menu->menuitems, link) {
@@ -688,7 +678,7 @@ menu_hide_submenu(const char *id)
 static void
 init_rootmenu(struct server *server)
 {
-	struct menu *menu = menu_get_by_id("root-menu");
+	struct menu *menu = menu_get_by_id(server, "root-menu");
 
 	/* Default menu if no menu.xml found */
 	if (!menu) {
@@ -706,7 +696,7 @@ init_rootmenu(struct server *server)
 static void
 init_windowmenu(struct server *server)
 {
-	struct menu *menu = menu_get_by_id("client-menu");
+	struct menu *menu = menu_get_by_id(server, "client-menu");
 
 	/* Default menu if no menu.xml found */
 	if (!menu) {
@@ -745,13 +735,14 @@ init_windowmenu(struct server *server)
 	}
 
 	if (wl_list_length(&rc.workspace_config.workspaces) == 1) {
-		menu_hide_submenu("workspaces");
+		menu_hide_submenu(server, "workspaces");
 	}
 }
 
 void
 menu_init(struct server *server)
 {
+	wl_list_init(&server->menus);
 	parse_xml("menu.xml", server);
 	init_rootmenu(server);
 	init_windowmenu(server);
@@ -760,11 +751,10 @@ menu_init(struct server *server)
 }
 
 void
-menu_finish(void)
+menu_finish(struct server *server)
 {
-	struct menu *menu;
-	for (int i = 0; i < nr_menus; ++i) {
-		menu = menus + i;
+	struct menu *menu, *tmp_menu;
+	wl_list_for_each_safe(menu, tmp_menu, &server->menus, link) {
 		struct menuitem *item, *next;
 		wl_list_for_each_safe(item, next, &menu->menuitems, link) {
 			item_destroy(item);
@@ -774,10 +764,9 @@ menu_finish(void)
 		 * including node descriptors and scaled_font_buffers.
 		 */
 		wlr_scene_node_destroy(&menu->scene_tree->node);
+		wl_list_remove(&menu->link);
+		zfree(menu);
 	}
-	zfree(menus);
-	alloc_menus = 0;
-	nr_menus = 0;
 }
 
 /* Sets selection (or clears selection if passing NULL) */
@@ -1040,7 +1029,7 @@ menu_close_root(struct server *server)
 void
 menu_reconfigure(struct server *server)
 {
-	menu_finish();
+	menu_finish(server);
 	server->menu_current = NULL;
 	menu_init(server);
 }


### PR DESCRIPTION
...to make it easier to split menu.c into smaller chunks without exposing nr_menus variable.