### PR TITLE
cursor: backport null check from wlroots-0.17 branch

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -910,7 +910,7 @@ cursor_button_press(struct seat *seat, struct wlr_pointer_button_event *event)
 	if (ctx.type == LAB_SSD_LAYER_SURFACE) {
 		struct wlr_layer_surface_v1 *layer =
 			wlr_layer_surface_v1_from_wlr_surface(ctx.surface);
-		if (layer->current.keyboard_interactive) {
+		if (layer && layer->current.keyboard_interactive) {
 			seat_set_focus_layer(seat, layer);
 		}
 	}


### PR DESCRIPTION
Check that `wlr_layer_surface_v1_from_wlr_surface()` doesn't return NULL. This may be unnecessary with wlroots 0.16 (not sure) but doesn't hurt and reduces the delta to the wlroots-0.17 branch.