### PR TITLE
desktop.c: prevent switching workspaces for always-on-bottom windows

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -323,6 +323,7 @@ void view_toggle_maximize(struct view *view);
 void view_toggle_decorations(struct view *view);
 
 bool view_is_always_on_top(struct view *view);
+bool view_is_always_on_bottom(struct view *view);
 void view_toggle_always_on_top(struct view *view);
 void view_toggle_always_on_bottom(struct view *view);
 

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -67,9 +67,9 @@ desktop_focus_view(struct view *view, bool raise)
 
 	/*
 	 * Switch workspace if necessary to make the view visible
-	 * (unnecessary for "always on top" views).
+	 * (unnecessary for "always on {top,bottom}" views).
 	 */
-	if (!view_is_always_on_top(view)) {
+	if (!view_is_always_on_top(view) && !view_is_always_on_bottom(view)) {
 		workspaces_switch_to(view->workspace, /*update_focus*/ false);
 	}
 

--- a/src/view.c
+++ b/src/view.c
@@ -872,7 +872,7 @@ view_toggle_always_on_top(struct view *view)
 	}
 }
 
-static bool
+bool
 view_is_always_on_bottom(struct view *view)
 {
 	assert(view);


### PR DESCRIPTION
Fixes:
- #1170

Reported-by: @stefonarch
Reported-by: @tsujan

Testing would be appreciated.