### PR TITLE
view: only focus topmost view if unmapped view was focused

### DIFF
--- a/include/view-impl-common.h
+++ b/include/view-impl-common.h
@@ -19,6 +19,7 @@ void view_impl_move_to_front(struct view *view);
 void view_impl_move_to_back(struct view *view);
 void view_impl_move_sub_views(struct view *parent, enum z_direction z_direction);
 void view_impl_map(struct view *view);
+void view_impl_unmap(struct view *view);
 
 /*
  * Updates view geometry at commit based on current position/size,

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -75,6 +75,15 @@ view_impl_map(struct view *view)
 		view_get_string_prop(view, "title"));
 }
 
+void
+view_impl_unmap(struct view *view)
+{
+	struct seat *seat = &view->server->seat;
+	if (seat->seat->keyboard_state.focused_surface == view->surface) {
+		desktop_focus_topmost_view(view->server);
+	}
+}
+
 static bool
 resizing_edge(struct view *view, uint32_t edge)
 {

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -554,7 +554,7 @@ xdg_toplevel_view_unmap(struct view *view, bool client_request)
 		view->mapped = false;
 		wlr_scene_node_set_enabled(&view->scene_tree->node, false);
 		wl_list_remove(&view->commit.link);
-		desktop_focus_topmost_view(view->server);
+		view_impl_unmap(view);
 	}
 }
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -531,7 +531,7 @@ xwayland_view_unmap(struct view *view, bool client_request)
 	view->mapped = false;
 	wl_list_remove(&view->commit.link);
 	wlr_scene_node_set_enabled(&view->scene_tree->node, false);
-	desktop_focus_topmost_view(view->server);
+	view_impl_unmap(view);
 
 	/*
 	 * If the view was explicitly unmapped by the client (rather


### PR DESCRIPTION
The `unmap()` handlers should only call `desktop_focus_topmost_view()` if the unmapped view was the focused view. Unmapping a view that was not focused should not change the focus.

I expect this rarely had any effect in practice; it would only matter in a focus-follows-mouse config where some view other than the one on top was focused. But it still seems better to fix.

Rather than repeating the logic in two places, create a small `view_impl_unmap()` helper. Perhaps more common "unmap" logic could be moved there in future.