### PR TITLE
CI: limit workflow runs to 20 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     name: Build
     needs: codestyle
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This prevents the FreeBSD runner to run for 6 hours in a bootloop.

Ref:
- https://github.com/vmactions/freebsd-vm/issues/74