### PR TITLE
view: raise/lower sub-view correctly relative to other sub-views

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -349,14 +349,20 @@ static void
 xdg_toplevel_view_move_to_front(struct view *view)
 {
 	struct view *root = xdg_toplevel_view_get_root(view);
+	/* FIXME: this exact code is repeated in xwayland.c */
 	view_impl_move_to_front(root);
 	view_impl_move_sub_views(root, LAB_TO_FRONT);
+	/* make sure view is in front of other sub-views */
+	if (view != root) {
+		view_impl_move_to_front(view);
+	}
 }
 
 static void
 xdg_toplevel_view_move_to_back(struct view *view)
 {
 	struct view *root = xdg_toplevel_view_get_root(view);
+	/* FIXME: this exact code is repeated in xwayland.c */
 	view_impl_move_sub_views(root, LAB_TO_BACK);
 	view_impl_move_to_back(root);
 }

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -614,14 +614,20 @@ static void
 xwayland_view_move_to_front(struct view *view)
 {
 	struct view *root = xwayland_view_get_root(view);
+	/* FIXME: this exact code is repeated in xdg.c */
 	view_impl_move_to_front(root);
 	view_impl_move_sub_views(root, LAB_TO_FRONT);
+	/* make sure view is in front of other sub-views */
+	if (view != root) {
+		view_impl_move_to_front(view);
+	}
 }
 
 static void
 xwayland_view_move_to_back(struct view *view)
 {
 	struct view *root = xwayland_view_get_root(view);
+	/* FIXME: this exact code is repeated in xdg.c */
 	view_impl_move_sub_views(root, LAB_TO_BACK);
 	view_impl_move_to_back(root);
 }


### PR DESCRIPTION
When a parent view has multiple sub-views (dialogs) visible, focusing one sub-view ought to raise it above the others. This doesn't currently happen -- focusing a sub-view raises the whole group of views together, but has no effect on the relative stacking order between them.

I thought I saw an issue ticket for this recently, but I can't find it now.

Anyway, this seems like a simple oversight in the `view->impl->move_to_front()` functions that's pretty easy to fix. `move_to_back()` appears to need similar logic, so add it there too.

Tested with HomeBank: the Import dialog pops up an additional Open File dialog, which before this change appears behind the Import dialog (and clicking on it does not raise it to the front). After this change, the Open File dialog appears in front as expected.

Only after implementing the fix for xwayland did I notice that xdg has identical logic in its `move_to_front/back()` impl functions. I don't know why we even have `view->impl->move_to_front/back()`, since the logic is identical (except for calling different `get_root()` functions, which is easily abstracted by just calling `view_get_root()`).

So the second commit deduplicates the logic by putting it directly in `view_move_to_front/back()`. This way, we can fix the bug in one place.