### PR TITLE
xwayland: fix some issues with initially maximized GTK apps

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -337,6 +337,8 @@ void view_move(struct view *view, int x, int y);
 void view_move_to_cursor(struct view *view);
 void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
+bool view_compute_centered_position(struct view *view,
+	const struct wlr_box *ref, int w, int h, int *x, int *y);
 void view_store_natural_geometry(struct view *view);
 
 /**

--- a/src/view.c
+++ b/src/view.c
@@ -539,7 +539,7 @@ view_minimize(struct view *view, bool minimized)
 	minimize_sub_views(root, minimized);
 }
 
-static bool
+bool
 view_compute_centered_position(struct view *view, const struct wlr_box *ref,
 		int w, int h, int *x, int *y)
 {


### PR DESCRIPTION
X11 clients may request to be initially fullscreen or maximized by setting hints in the _NET_WM_STATE property. For some reason, we are currently only honoring fullscreen requests but not maximize.

The fixes issues with GTK apps (notably Firefox, but others as well) not starting maximized. (Qt apps seem to send a separate maximize request and weren't affected.)
    
Additionally (2nd commit), for views that are initially maximized or fullscreen and have no explicitly specified position, we need to center the stored natural geometry, or the view may end up partially offscreen once unmaximized/unfullscreened.
