### PR TITLE
view: macro-ize signal/listener connection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,12 +228,12 @@ We have a very small, modest API and encourage you to use it.
 4. `wl_array_len()` to get number of elements in a `wl_array` [common/array.h]
 
 5. `ARRAY_SIZE()` to get number of elements in visible array
-   [common/array-size.h]
+   [common/macros.h]
 
 [common/mem.h]: https://github.com/labwc/labwc/blob/master/include/common/mem.h
 [common/list.h]: https://github.com/labwc/labwc/blob/master/include/common/list.h
 [common/array.h]: https://github.com/labwc/labwc/blob/master/include/common/array.h
-[common/array-size.h]: https://github.com/labwc/labwc/blob/master/include/common/array-size.h
+[common/macros.h]: https://github.com/labwc/labwc/blob/master/include/common/macros.h
 
 ### The Use of glib
 

--- a/include/common/macros.h
+++ b/include/common/macros.h
@@ -32,4 +32,22 @@
 	(dest)->name.notify = handle_##name; \
 	wl_signal_add(&(src)->events.name, &(dest)->name)
 
+/**
+ * MIN() - Minimum of two values.
+ *
+ * @note Arguments may be evaluated twice.
+ */
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+/**
+ * MAX() - Maximum of two values.
+ *
+ * @note Arguments may be evaluated twice.
+ */
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
 #endif /* LABWC_MACROS_H */

--- a/include/common/macros.h
+++ b/include/common/macros.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef LABWC_ARRAY_SIZE_H
-#define LABWC_ARRAY_SIZE_H
+#ifndef LABWC_MACROS_H
+#define LABWC_MACROS_H
 
 /**
  * ARRAY_SIZE() - Get the number of elements in array.
@@ -16,4 +16,4 @@
  */
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
-#endif /* LABWC_ARRAY_SIZE_H */
+#endif /* LABWC_MACROS_H */

--- a/include/common/macros.h
+++ b/include/common/macros.h
@@ -16,4 +16,20 @@
  */
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
+/**
+ * CONNECT_SIGNAL() - Connect a signal handler function to a wl_signal.
+ *
+ * @param src Signal emitter (struct containing wl_signal)
+ * @param dest Signal receiver (struct containing wl_listener)
+ * @param name Signal name
+ *
+ * This assumes that the common pattern is followed where:
+ *   - the wl_signal is (*src).events.<name>
+ *   - the wl_listener is (*dest).<name>
+ *   - the signal handler function is named handle_<name>
+ */
+#define CONNECT_SIGNAL(src, dest, name) \
+	(dest)->name.notify = handle_##name; \
+	wl_signal_add(&(src)->events.name, &(dest)->name)
+
 #endif /* LABWC_MACROS_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -57,14 +57,6 @@
 #define XCURSOR_DEFAULT "left_ptr"
 #define XCURSOR_SIZE 24
 
-#ifndef MIN
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-#endif
-
-#ifndef MAX
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#endif
-
 enum input_mode {
 	LAB_INPUT_STATE_PASSTHROUGH = 0,
 	LAB_INPUT_STATE_MOVE,

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -3,7 +3,7 @@
 #define LABWC_SSD_INTERNAL_H
 
 #include <wlr/util/box.h>
-#include "common/array-size.h"
+#include "common/macros.h"
 #include "ssd.h"
 
 #define FOR_EACH(tmp, ...) \

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -20,7 +20,7 @@ struct xwayland_unmanaged {
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
-	struct wl_listener override_redirect;
+	struct wl_listener set_override_redirect;
 };
 
 struct xwayland_view {
@@ -30,9 +30,9 @@ struct xwayland_view {
 	/* Events unique to XWayland views */
 	struct wl_listener request_activate;
 	struct wl_listener request_configure;
-	struct wl_listener set_app_id;		/* TODO: s/set_app_id/class/ */
+	struct wl_listener set_class;
 	struct wl_listener set_decorations;
-	struct wl_listener override_redirect;
+	struct wl_listener set_override_redirect;
 
 	/* Not (yet) implemented */
 /*	struct wl_listener set_role; */

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -64,6 +64,7 @@ my @ignore = (
 	"PREFER_FALLTHROUGH",
 	"INITIALISED_STATIC",
 	"UNNECESSARY_ELSE",
+	"MACRO_ARG_PRECEDENCE",
 );
 my $help = 0;
 my $configuration_file = ".checkpatch.conf";

--- a/src/action.c
+++ b/src/action.c
@@ -7,7 +7,7 @@
 #include <unistd.h>
 #include <wlr/util/log.h>
 #include "action.h"
-#include "common/array-size.h"
+#include "common/macros.h"
 #include "common/list.h"
 #include "common/mem.h"
 #include "common/parse-bool.h"

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -17,6 +17,7 @@
 #include <wlr/util/log.h>
 #include "action.h"
 #include "common/list.h"
+#include "common/macros.h"
 #include "common/mem.h"
 #include "common/nodename.h"
 #include "common/parse-bool.h"

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -7,7 +7,7 @@
 #include <wlr/types/wlr_primary_selection.h>
 #include <wlr/util/region.h>
 #include "action.h"
-#include "common/array-size.h"
+#include "common/macros.h"
 #include "common/mem.h"
 #include "common/scene-helpers.h"
 #include "config/mousebind.h"

--- a/src/layers.c
+++ b/src/layers.c
@@ -14,7 +14,7 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/util/log.h>
-#include "common/array-size.h"
+#include "common/macros.h"
 #include "common/list.h"
 #include "common/mem.h"
 #include "config/rcxml.h"

--- a/src/output.c
+++ b/src/output.c
@@ -16,7 +16,7 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/region.h>
 #include <wlr/util/log.h>
-#include "common/array-size.h"
+#include "common/macros.h"
 #include "common/mem.h"
 #include "labwc.h"
 #include "layers.h"

--- a/src/ssd/resize_indicator.c
+++ b/src/ssd/resize_indicator.c
@@ -3,6 +3,7 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
+#include "common/macros.h"
 #include "common/scaled_font_buffer.h"
 #include "labwc.h"
 #include "resize_indicator.h"

--- a/src/theme.c
+++ b/src/theme.c
@@ -19,7 +19,7 @@
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
 #include <strings.h>
-#include "common/array-size.h"
+#include "common/macros.h"
 #include "common/dir.h"
 #include "common/font.h"
 #include "common/graphic-helpers.h"

--- a/src/view.c
+++ b/src/view.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <strings.h>
+#include "common/macros.h"
 #include "common/match.h"
 #include "common/mem.h"
 #include "common/scene-helpers.h"

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <assert.h>
+#include "common/macros.h"
 #include "common/mem.h"
 #include "decorations.h"
 #include "labwc.h"
@@ -38,7 +39,7 @@ xdg_toplevel_from_view(struct view *view)
 }
 
 static void
-handle_new_xdg_popup(struct wl_listener *listener, void *data)
+handle_new_popup(struct wl_listener *listener, void *data)
 {
 	struct xdg_toplevel_view *xdg_toplevel_view =
 		wl_container_of(listener, xdg_toplevel_view, new_popup);
@@ -694,34 +695,21 @@ xdg_surface_new(struct wl_listener *listener, void *data)
 	/* In support of xdg popups */
 	xdg_surface->surface->data = tree;
 
-	view->map.notify = handle_map;
-	wl_signal_add(&xdg_surface->events.map, &view->map);
-	view->unmap.notify = handle_unmap;
-	wl_signal_add(&xdg_surface->events.unmap, &view->unmap);
-	view->destroy.notify = handle_destroy;
-	wl_signal_add(&xdg_surface->events.destroy, &view->destroy);
+	CONNECT_SIGNAL(xdg_surface, view, map);
+	CONNECT_SIGNAL(xdg_surface, view, unmap);
+	CONNECT_SIGNAL(xdg_surface, view, destroy);
 
 	struct wlr_xdg_toplevel *toplevel = xdg_surface->toplevel;
-	view->request_move.notify = handle_request_move;
-	wl_signal_add(&toplevel->events.request_move, &view->request_move);
-	view->request_resize.notify = handle_request_resize;
-	wl_signal_add(&toplevel->events.request_resize, &view->request_resize);
-	view->request_minimize.notify = handle_request_minimize;
-	wl_signal_add(&toplevel->events.request_minimize, &view->request_minimize);
-	view->request_maximize.notify = handle_request_maximize;
-	wl_signal_add(&toplevel->events.request_maximize, &view->request_maximize);
-	view->request_fullscreen.notify = handle_request_fullscreen;
-	wl_signal_add(&toplevel->events.request_fullscreen, &view->request_fullscreen);
-
-	view->set_title.notify = handle_set_title;
-	wl_signal_add(&toplevel->events.set_title, &view->set_title);
+	CONNECT_SIGNAL(toplevel, view, request_move);
+	CONNECT_SIGNAL(toplevel, view, request_resize);
+	CONNECT_SIGNAL(toplevel, view, request_minimize);
+	CONNECT_SIGNAL(toplevel, view, request_maximize);
+	CONNECT_SIGNAL(toplevel, view, request_fullscreen);
+	CONNECT_SIGNAL(toplevel, view, set_title);
 
 	/* Events specific to XDG toplevel views */
-	xdg_toplevel_view->set_app_id.notify = handle_set_app_id;
-	wl_signal_add(&toplevel->events.set_app_id, &xdg_toplevel_view->set_app_id);
-
-	xdg_toplevel_view->new_popup.notify = handle_new_xdg_popup;
-	wl_signal_add(&xdg_surface->events.new_popup, &xdg_toplevel_view->new_popup);
+	CONNECT_SIGNAL(toplevel, xdg_toplevel_view, set_app_id);
+	CONNECT_SIGNAL(xdg_surface, xdg_toplevel_view, new_popup);
 
 	wl_list_insert(&server->views, &view->link);
 }


### PR DESCRIPTION
@Consolatis mentioned this as an idea in #814. It seems worth pursuing to me, since it makes the code a bit more readable IMHO (and forces us to be consistent with event handler function names).

No functional change.