### PR TITLE
ssd: use `view->pending` for size calculations to avoid the titlebar being out-of-sync with the view size

### DIFF
--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -62,10 +62,10 @@ ssd_max_extents(struct view *view)
 	assert(view);
 	struct border border = ssd_thickness(view);
 	return (struct wlr_box){
-		.x = view->current.x - border.left,
-		.y = view->current.y - border.top,
-		.width = view->current.width + border.left + border.right,
-		.height = view->current.height + border.top + border.bottom,
+		.x = view->pending.x - border.left,
+		.y = view->pending.y - border.top,
+		.width = view->pending.width + border.left + border.right,
+		.height = view->pending.height + border.top + border.bottom,
 	};
 }
 
@@ -191,7 +191,7 @@ ssd_create(struct view *view, bool active)
 	ssd->margin = ssd_thickness(view);
 	ssd_set_active(ssd, active);
 	ssd_enable_keybind_inhibit_indicator(ssd, view->inhibits_keybinds);
-	ssd->state.geometry = view->current;
+	ssd->state.geometry = view->pending;
 
 	return ssd;
 }
@@ -219,12 +219,12 @@ ssd_update_geometry(struct ssd *ssd)
 	}
 
 	struct wlr_box cached = ssd->state.geometry;
-	struct wlr_box current = ssd->view->current;
-	if (current.width == cached.width && current.height == cached.height) {
-		if (current.x != cached.x || current.y != cached.y) {
+	struct wlr_box pending = ssd->view->pending;
+	if (pending.width == cached.width && pending.height == cached.height) {
+		if (pending.x != cached.x || pending.y != cached.y) {
 			/* Dynamically resize extents based on position and usable_area */
 			ssd_extents_update(ssd);
-			ssd->state.geometry = current;
+			ssd->state.geometry = pending;
 		}
 		if (ssd->state.squared_corners != ssd->view->maximized) {
 			ssd_border_update(ssd);
@@ -235,7 +235,7 @@ ssd_update_geometry(struct ssd *ssd)
 	ssd_extents_update(ssd);
 	ssd_border_update(ssd);
 	ssd_titlebar_update(ssd);
-	ssd->state.geometry = current;
+	ssd->state.geometry = pending;
 }
 
 void

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -19,8 +19,8 @@ ssd_border_create(struct ssd *ssd)
 
 	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
-	int width = view->current.width;
-	int height = view->current.height;
+	int width = view->pending.width;
+	int height = view->pending.height;
 	int full_width = width + 2 * theme->border_width;
 
 	float *color;
@@ -81,8 +81,8 @@ ssd_border_update(struct ssd *ssd)
 
 	struct theme *theme = view->server->theme;
 
-	int width = view->current.width;
-	int height = view->current.height;
+	int width = view->pending.width;
+	int height = view->pending.height;
 	int full_width = width + 2 * theme->border_width;
 
 	struct ssd_part *part;

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -108,8 +108,8 @@ ssd_extents_update(struct ssd *ssd)
 
 	struct theme *theme = view->server->theme;
 
-	int width = view->current.width;
-	int height = view->current.height;
+	int width = view->pending.width;
+	int height = view->pending.height;
 	int full_height = height + theme->border_width * 2 + ssd->titlebar.height;
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = SSD_EXTENDED_AREA;

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -24,7 +24,7 @@ ssd_titlebar_create(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
-	int width = view->current.width;
+	int width = view->pending.width;
 
 	float *color;
 	struct wlr_scene_tree *parent;
@@ -130,7 +130,7 @@ void
 ssd_titlebar_update(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
-	int width = view->current.width;
+	int width = view->pending.width;
 	struct theme *theme = view->server->theme;
 
 	if (view->maximized != ssd->state.squared_corners) {
@@ -218,7 +218,7 @@ ssd_update_title_positions(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
-	int width = view->current.width;
+	int width = view->pending.width;
 	int title_bg_width = width - SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT;
 
 	int x, y;
@@ -286,7 +286,7 @@ ssd_update_title(struct ssd *ssd)
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
 	struct ssd_state_title_width *dstate;
-	int title_bg_width = view->current.width
+	int title_bg_width = view->pending.width
 		- SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT;
 
 	FOR_EACH_STATE(ssd, subtree) {


### PR DESCRIPTION
@tsujan - testing welcome (I can't reproduce the bug, so can't verify that this fixes it)