### PR TITLE
xwayland: update stacking order in move_to_front/back()

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -238,12 +238,17 @@ struct server {
 	struct wlr_box grab_box;
 	uint32_t resize_edges;
 
-	/* SSD state */
 	/*
 	 * Currently focused view. Updated with each "focus change"
 	 * event. This view is drawn with "active" SSD coloring.
 	 */
 	struct view *focused_view;
+	/*
+	 * Most recently raised view. Used to avoid unnecessarily
+	 * raising the same view over and over.
+	 */
+	struct view *last_raised_view;
+
 	struct ssd_hover_state *ssd_hover_state;
 
 	/* Tree for all non-layer xdg/xwayland-shell surfaces */

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -55,9 +55,12 @@ view_impl_map(struct view *view)
 void
 view_impl_unmap(struct view *view)
 {
-	struct seat *seat = &view->server->seat;
-	if (seat->seat->keyboard_state.focused_surface == view->surface) {
-		desktop_focus_topmost_view(view->server);
+	struct server *server = view->server;
+	if (view == server->focused_view) {
+		desktop_focus_topmost_view(server);
+	}
+	if (view == server->last_raised_view) {
+		server->last_raised_view = NULL;
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -1345,6 +1345,7 @@ move_to_front(struct view *view)
 	if (view->impl->move_to_front) {
 		view->impl->move_to_front(view);
 	}
+	view->server->last_raised_view = view;
 }
 
 static void
@@ -1352,6 +1353,9 @@ move_to_back(struct view *view)
 {
 	if (view->impl->move_to_back) {
 		view->impl->move_to_back(view);
+	}
+	if (view == view->server->last_raised_view) {
+		view->server->last_raised_view = NULL;
 	}
 }
 
@@ -1365,6 +1369,17 @@ void
 view_move_to_front(struct view *view)
 {
 	assert(view);
+	/*
+	 * This function is called often, generally on every mouse
+	 * button press (more often for focus-follows-mouse). Avoid
+	 * unnecessarily raising the same view over and over, or
+	 * attempting to raise a root view above its own sub-view.
+	 */
+	struct view *last = view->server->last_raised_view;
+	if (view == last || (last && view == view_get_root(last))) {
+		return;
+	}
+
 	struct view *root = view_get_root(view);
 	assert(root);
 
@@ -1515,6 +1530,10 @@ view_destroy(struct view *view)
 	if (server->focused_view == view) {
 		server->focused_view = NULL;
 		need_cursor_update = true;
+	}
+
+	if (server->last_raised_view == view) {
+		server->last_raised_view = NULL;
 	}
 
 	if (server->seat.pressed.view == view) {


### PR DESCRIPTION
Currently xwayland views are restacked on top of the XWayland server stacking order when activated (i.e. focused). This is wrong because focus/raise are independent concepts (though often occurring together). The stacking order should be updated when the view is raised/lowered, not when the view is focused.
    
Work is in progress elsewhere (#1142) that will result in views more often being raised without being focused. Without this fix, those views don't get restacked properly, resulting in clicks "passing through" to views underneath.

The first commit, on its own, fixes the issue but has a side effect of increasing our traffic to the X server a bit. The second commit ("view: avoid raising same view over and over") is an optimization to reduce that traffic a bit.