### PR TITLE
src/keyboard.c: always try to remove keys from the pressed set on release

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -241,9 +241,16 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 		is_layout_switch |= translated.syms[i] == XKB_KEY_ISO_Next_Group;
 	}
 
-	if (!is_modifier && !is_layout_switch) {
-		key_state_set_pressed(event->keycode,
-			event->state == WL_KEYBOARD_KEY_STATE_PRESSED);
+	/*
+	 * An earlier press event from a key that causes a layout change event
+	 * might have been added already without us knowing that it actually was
+	 * a XKB_KEY_ISO_Next_Group sym. Thus we always try to remove the current
+	 * key from the set of pressed keys on release.
+	 */
+	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
+		key_state_set_pressed(event->keycode, false);
+	} else if (!is_modifier && !is_layout_switch) {
+		key_state_set_pressed(event->keycode, true);
 	}
 
 	/*


### PR DESCRIPTION
Fixes:
- #1200

Reported-by: @kyak

<details><summary>Technical nitty gritty details</summary>
The following logs are based on a work-in-progress patch but are good enough to explain the earlier issues:

- #1129
`XKB_DEFAULT_OPTIONS=grp:alt_shift_toggle`
```
00:15:07.138 [../src/keyboard.c:242] Got new key event: 50 (press) modifier: yes
00:15:07.138 [../src/keyboard.c:264]    Translated:
00:15:07.138 [../src/keyboard.c:269]            0xffe1 (Shift_L)
00:15:07.138 [../src/keyboard.c:271]    Raw:
00:15:07.138 [../src/keyboard.c:276]            0xffe1 (Shift_L)
00:15:07.874 [../src/keyboard.c:242] Got new key event: 64 (press) modifier: no
00:15:07.874 [../src/keyboard.c:264]    Translated:
00:15:07.874 [../src/keyboard.c:269]            0xfe08 (ISO_Next_Group)
00:15:07.874 [../src/keyboard.c:271]    Raw:
00:15:07.874 [../src/keyboard.c:276]            0xffe9 (Alt_L)
00:15:08.266 [../src/keyboard.c:242] Got new key event: 50 (release) modifier: no
00:15:08.266 [../src/keyboard.c:264]    Translated:
00:15:08.266 [../src/keyboard.c:269]            0xfe08 (ISO_Next_Group)
00:15:08.266 [../src/keyboard.c:271]    Raw:
00:15:08.266 [../src/keyboard.c:276]            0xffe1 (Shift_L)
00:15:08.754 [../src/keyboard.c:242] Got new key event: 64 (release) modifier: yes
00:15:08.755 [../src/keyboard.c:264]    Translated:
00:15:08.755 [../src/keyboard.c:269]            0xffe9 (Alt_L)
00:15:08.755 [../src/keyboard.c:271]    Raw:
00:15:08.755 [../src/keyboard.c:276]            0xffe9 (Alt_L)
```

In this case
- we were adding key `64` to key_state because it was not detected as a modifier (via translated sym)
- we were *not* removing key `64` from key_state because now it had been detected as a modifier
- the result was that all keybinds stopped working because there was still a `Alt_L` key stuck in the key_state

To fix that we started to treat `ISO_Next_Group` the same as the modifiers (and thus prevent it from getting added to the key_state). While this fix indeed prevented the issue, it also created a second (very similar) bug where the layout toggle was set to a key that is *not* a modifier itself (or rather, we don't treat it that way such as `CapsLock` or `Menu`).

- #1200
Meet `XKB_DEFAULT_OPTIONS=grp:caps_toggle` with the previously mentioned fix applied:
```
00:00:02.478 [../src/keyboard.c:242] Got new key event: 50 (press) modifier: yes
00:00:02.478 [../src/keyboard.c:264]    Translated:
00:00:02.478 [../src/keyboard.c:269]            0xffe1 (Shift_L)
00:00:02.478 [../src/keyboard.c:271]    Raw:
00:00:02.478 [../src/keyboard.c:276]            0xffe1 (Shift_L)
00:00:03.134 [../src/keyboard.c:242] Got new key event: 66 (press) modifier: no
00:00:03.134 [../src/keyboard.c:264]    Translated:
00:00:03.134 [../src/keyboard.c:269]            0xffe5 (Caps_Lock)
00:00:03.134 [../src/keyboard.c:271]    Raw:
00:00:03.134 [../src/keyboard.c:276]            0xfe08 (ISO_Next_Group)
00:00:03.494 [../src/keyboard.c:242] Got new key event: 50 (release) modifier: yes
00:00:03.494 [../src/keyboard.c:264]    Translated:
00:00:03.494 [../src/keyboard.c:269]            0xffe1 (Shift_L)
00:00:03.494 [../src/keyboard.c:271]    Raw:
00:00:03.494 [../src/keyboard.c:276]            0xffe1 (Shift_L)
00:00:03.894 [../src/keyboard.c:242] Got new key event: 66 (release) modifier: no
00:00:03.894 [../src/keyboard.c:264]    Translated:
00:00:03.894 [../src/keyboard.c:269]            0xfe08 (ISO_Next_Group)
00:00:03.894 [../src/keyboard.c:271]    Raw:
00:00:03.894 [../src/keyboard.c:276]            0xfe08 (ISO_Next_Group)
```

In this case
- we were adding key `66` to key_state because it was neither a modifier nor a layout_change (via translated sym)
- we were *not* removing key `66` from key_state because now it had been detected as a layout change
- the result was that all keybinds stopped working because there was still a `Caps_Lock` key stuck in the key_state

So where do we end up with this and how could we fix it (hopefully for good for the usual use-cases this time):
- On `release` events we *always* try to remove the key from the key_state, regardless of the syms.
  This would have prevented both of the issues (but still would have caused keybinds which contain the layout toggle key to break)
- We keep treating `ISO_Next_Group` similar to a modifier.
  Otherwise we would break all keybinds which contain the layout switching key(s) (example: `grp:lwin_toggle` and a keybind like `W-t` or `W-S-t` or `grp:alt_shift_toggle` and a keybind like `A-S-t`) [0]
  (Although this is not the best configuration anyway because libxkb does switch the layout each time the key is pressed, regardless of how many other keys are pressed as well)
- We may need to look into the other dynamic xkb syms at some point [1]

[0]
```
00:00:05.041 [../src/keyboard.c:242] Got new key event: 133 (press) modifier: no
00:00:05.041 [../src/keyboard.c:264]    Translated:
00:00:05.041 [../src/keyboard.c:269]            0xfe08 (ISO_Next_Group)
00:00:05.041 [../src/keyboard.c:271]    Raw:
00:00:05.041 [../src/keyboard.c:276]            0xfe08 (ISO_Next_Group)
00:00:05.265 [../src/keyboard.c:242] Got new key event: 133 (release) modifier: no
00:00:05.265 [../src/keyboard.c:264]    Translated:
00:00:05.265 [../src/keyboard.c:269]            0xfe08 (ISO_Next_Group)
00:00:05.265 [../src/keyboard.c:271]    Raw:
00:00:05.265 [../src/keyboard.c:276]            0xfe08 (ISO_Next_Group)
```
Thus, no way to detect this actually being the `Super_L` modifier.

[1]
```
#define XKB_KEY_ISO_Lock                      0xfe01
#define XKB_KEY_ISO_Level2_Latch              0xfe02
#define XKB_KEY_ISO_Level3_Shift              0xfe03
#define XKB_KEY_ISO_Level3_Latch              0xfe04
#define XKB_KEY_ISO_Level3_Lock               0xfe05
#define XKB_KEY_ISO_Level5_Shift              0xfe11
#define XKB_KEY_ISO_Level5_Latch              0xfe12
#define XKB_KEY_ISO_Level5_Lock               0xfe13
#define XKB_KEY_ISO_Group_Shift               0xff7e  /* Alias for mode_switch */
#define XKB_KEY_ISO_Group_Latch               0xfe06
#define XKB_KEY_ISO_Group_Lock                0xfe07
#define XKB_KEY_ISO_Next_Group                0xfe08
#define XKB_KEY_ISO_Next_Group_Lock           0xfe09
#define XKB_KEY_ISO_Prev_Group                0xfe0a
#define XKB_KEY_ISO_Prev_Group_Lock           0xfe0b
#define XKB_KEY_ISO_First_Group               0xfe0c
#define XKB_KEY_ISO_First_Group_Lock          0xfe0d
#define XKB_KEY_ISO_Last_Group                0xfe0e
#define XKB_KEY_ISO_Last_Group_Lock           0xfe0f
```
From `/usr/include/xkbcommon/xkbcommon-keysyms.h`
</details>

Testing for broken keybinds with different layout change configurations would be appreciated @kyak @stefonarch 