### PR TITLE
xwayland: set _NET_WORKAREA property based on usable area

### DIFF
--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -58,5 +58,7 @@ void xwayland_server_init(struct server *server,
 	struct wlr_compositor *compositor);
 void xwayland_server_finish(struct server *server);
 
+void xwayland_update_workarea(struct server *server);
+
 #endif /* HAVE_XWAYLAND */
 #endif /* LABWC_XWAYLAND_H */

--- a/src/output.c
+++ b/src/output.c
@@ -24,6 +24,7 @@
 #include "node.h"
 #include "regions.h"
 #include "view.h"
+#include "xwayland.h"
 
 static void
 output_frame_notify(struct wl_listener *listener, void *data)
@@ -610,6 +611,9 @@ output_update_usable_area(struct output *output)
 {
 	if (update_usable_area(output)) {
 		regions_update_geometry(output);
+#if HAVE_XWAYLAND
+		xwayland_update_workarea(output->server);
+#endif
 		desktop_arrange_all_views(output->server);
 	}
 }
@@ -629,6 +633,9 @@ output_update_all_usable_areas(struct server *server, bool layout_changed)
 		}
 	}
 	if (usable_area_changed || layout_changed) {
+#if HAVE_XWAYLAND
+		xwayland_update_workarea(server);
+#endif
 		desktop_arrange_all_views(server);
 	}
 }


### PR DESCRIPTION
XWayland clients use the _NET_WORKAREA root window property to determine how much of the screen is not covered by panels/docks. The property is used for example by Qt to determine areas of the screen that popup menus should not overlap (see `QScreen::availableVirtualGeometry`).

Depends on wlroots MR (merged for 0.17):
https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4406