### PR TITLE
src/common/spawn.c: Restore SIGPIPE default handler before exec

### DIFF
--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -46,6 +46,8 @@ spawn_async_no_shell(char const *command)
 		sigset_t set;
 		sigemptyset(&set);
 		sigprocmask(SIG_SETMASK, &set, NULL);
+		/* Restore ignored signals */
+		signal(SIGPIPE, SIG_DFL);
 		grandchild = fork();
 		if (grandchild == 0) {
 			execvp(argv[0], argv);


### PR DESCRIPTION
See the following issue for further information:
- #1209

Reported-by: @bdantas

