### PR TITLE
key-state: make nr-pressed-keys check more accurate

### DIFF
--- a/include/key-state.h
+++ b/include/key-state.h
@@ -21,6 +21,6 @@ void key_state_store_pressed_keys_as_bound(void);
 bool key_state_corresponding_press_event_was_bound(uint32_t keycode);
 void key_state_bound_key_remove(uint32_t keycode);
 int key_state_nr_bound_keys(void);
-int key_state_nr_pressed_keys(void);
+bool key_state_multiple_normal_keys_pressed(void);
 
 #endif /* LABWC_KEY_STATE_H */

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -361,7 +361,7 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	 * avoids false positive matches where 'other' keys were pressed at the
 	 * same time.
 	 */
-	if (key_state_nr_pressed_keys() > 1) {
+	if (key_state_multiple_normal_keys_pressed()) {
 		return false;
 	}
 


### PR DESCRIPTION
@jlindgren90 @Consolatis Maybe not the tidiest, but just a quick proof of concept to go with our discussion in issue #1208 
