### PR TITLE
view.h: changed the type of tiled in struct view to enum view_edge

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -141,7 +141,7 @@ struct view {
 	bool minimized;
 	enum view_axis maximized;
 	bool fullscreen;
-	uint32_t tiled;  /* private, enum view_edge in src/view.c */
+	enum view_edge tiled;
 	bool inhibits_keybinds;
 
 	/* Pointer to an output owned struct region, may be NULL */


### PR DESCRIPTION
The type enum view_edge used to be defined in a .c file, so a structure member 'tiled' in struct view had to be defined to use another type.

Later (2023-08-02, commit 1ee8715) the definition of enum view_edge was moved to view.h, so now 'tiled' can be defined to use that type.