### PR TITLE
Support pipemenus

### DIFF
--- a/docs/labwc-menu.5.scd
+++ b/docs/labwc-menu.5.scd
@@ -33,16 +33,21 @@ The menu file must be entirely enclosed within <openbox_menu> and
     ...some content...
   </menu>
 
+  <!-- Pipemenu -->
+  <menu id="" label="" execute="COMMAND"/>
+
 </menu>
 ```
 
-*menu.id*
-	Each menu must be given an id, which is a unique identifier of the menu.
-	This id is used to refer to the menu in a ShowMenu action.
-	Default identifiers are "client-menu" for the titlebar context menu and
-	"root-menu" for the root window context menu.
-	Available localisation for the default "client-menu" is
-	only shown if no "client-menu" is present in menu.xml.
+*menu.id* (when at toplevel)
+	Define a menu tree. Each menu must be given an id, which is a unique
+	identifier of the menu. This id is used to refer to the menu in a
+	ShowMenu action. Default identifiers are
+		- "root-menu" for the root window context menu
+		- "client-menu" for a window's titlebar context menu
+
+*menu.id* (when nested under other *<menu>* element)
+	Link to a submenu defined elsewhere (by a *<menu id="">* at toplevel)
 
 *menu.label*
 	The title of the menu, shown in its parent. A label must be given when
@@ -57,6 +62,48 @@ The menu file must be entirely enclosed within <openbox_menu> and
 
 *menu.separator*
 	Horizontal line.
+
+*menu.execute*
+	Command to execute for pipe menu. See details below.
+
+# PIPE MENUS
+
+Pipe menus are menus generated dynamically based on output of scripts or
+binaries. They are so-called because the output of the executable is piped to
+the labwc menu.
+
+For any *<menu id="" label="" execute="COMMAND"/>* entry in menu.xml, the
+COMMAND will be executed the first time the item is selected (for example by
+cursor or keyboard input). The XML output of the command will be parsed and
+shown as a submenu. The content of pipemenus is cached until the whole menu
+(not just the pipemenu) is closed.
+
+The content of the output must be entirely enclosed within *<openbox_pipe_menu>*
+tags. Inside these, menus are specified in the same way as static (normal)
+menus, for example:
+
+```
+<openbox_pipe_menu>
+  <item label="Terminal">
+    <action name="Execute" command="xterm"/>
+  </item>
+</openbox_pipe_menu>
+```
+
+Inline submenus and nested pipemenus are supported.
+
+Note that it is the responsibility of the pipemenu executable to ensure that
+ID attributes are unique. Duplicates are ignored.
+
+When writing pipe menu scripts, make sure to escape XML special characters such
+as "&" ("&amp;"), "<" ("&lt;"), and ">" ("&gt;").
+
+
+# LOCALISATION
+
+Available localisation for the default "client-menu" is only shown if no
+"client-menu" is present in menu.xml. Any menu definition in menu.xml is
+interpreted as a user-override.
 
 # SEE ALSO
 

--- a/include/common/spawn.h
+++ b/include/common/spawn.h
@@ -2,10 +2,34 @@
 #ifndef LABWC_SPAWN_H
 #define LABWC_SPAWN_H
 
+#include <sys/types.h>
+
 /**
  * spawn_async_no_shell - execute asynchronously
  * @command: command to be executed
  */
 void spawn_async_no_shell(char const *command);
+
+/**
+ * spawn_piped - execute asyncronously
+ * @command: command to be executed
+ * @pipe_fd: set to the read end of a pipe
+ *           connected to stdout of the command
+ *
+ * Notes:
+ * The returned pid_t has to be waited for to
+ * not produce zombies and the pipe_fd has to
+ * be closed. spawn_piped_close() can be used
+ * to ensure both.
+ */
+pid_t spawn_piped(const char *command, int *pipe_fd);
+
+/**
+ * spawn_piped_close - clean up a previous
+ *                     spawn_piped() process
+ * @pid: will be waitpid()'d for
+ * @pipe_fd: will be close()'d
+ */
+void spawn_piped_close(pid_t pid, int pipe_fd);
 
 #endif /* LABWC_SPAWN_H */

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -29,6 +29,8 @@ struct menu_scene {
 
 struct menuitem {
 	struct wl_list actions;
+	char *execute;
+	char *id; /* needed for pipemenus */
 	struct menu *parent;
 	struct menu *submenu;
 	bool selectable;
@@ -46,6 +48,7 @@ struct menu {
 	char *label;
 	int item_height;
 	struct menu *parent;
+
 	struct {
 		int width;
 		int height;
@@ -57,6 +60,8 @@ struct menu {
 		struct menuitem *item;
 	} selection;
 	struct wlr_scene_tree *scene_tree;
+	bool is_pipemenu;
+	enum menu_align align;
 
 	/* Used to match a window-menu to the view that triggered it. */
 	struct view *triggered_by_view;  /* may be NULL */

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -81,14 +81,14 @@ void menu_finish(struct server *server);
 struct menu *menu_get_by_id(struct server *server, const char *id);
 
 /**
- * menu_open - open menu on position (x, y)
+ * menu_open_root - open menu on position (x, y)
  *
  * This function will close server->menu_current, open the
  * new menu and assign @menu to server->menu_current.
  *
  * Additionally, server->input_mode wil be set to LAB_INPUT_STATE_MENU.
  */
-void menu_open(struct menu *menu, int x, int y);
+void menu_open_root(struct menu *menu, int x, int y);
 
 /**
  * menu_process_cursor_motion

--- a/src/action.c
+++ b/src/action.c
@@ -605,7 +605,7 @@ show_menu(struct server *server, struct view *view,
 
 	/* Replaced by next show_menu() or cleaned on view_destroy() */
 	menu->triggered_by_view = view;
-	menu_open(menu, x, y);
+	menu_open_root(menu, x, y);
 }
 
 static struct view *

--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
+#include <fcntl.h>
 #include <glib.h>
 #include <signal.h>
 #include <stdio.h>
@@ -10,6 +11,26 @@
 #include <wlr/util/log.h>
 #include "common/spawn.h"
 #include "common/fd_util.h"
+
+static void
+reset_signals_and_limits(void)
+{
+	restore_nofile_limit();
+
+	sigset_t set;
+	sigemptyset(&set);
+	sigprocmask(SIG_SETMASK, &set, NULL);
+
+	/* Restore ignored signals */
+	signal(SIGPIPE, SIG_DFL);
+}
+
+static void
+set_cloexec(int fd)
+{
+	int flags = fcntl(fd, F_GETFD);
+	fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
 
 void
 spawn_async_no_shell(char const *command)
@@ -39,14 +60,9 @@ spawn_async_no_shell(char const *command)
 		wlr_log(WLR_ERROR, "unable to fork()");
 		goto out;
 	case 0:
-		restore_nofile_limit();
+		reset_signals_and_limits();
 
 		setsid();
-		sigset_t set;
-		sigemptyset(&set);
-		sigprocmask(SIG_SETMASK, &set, NULL);
-		/* Restore ignored signals */
-		signal(SIGPIPE, SIG_DFL);
 		grandchild = fork();
 		if (grandchild == 0) {
 			execvp(argv[0], argv);
@@ -63,3 +79,76 @@ out:
 	g_strfreev(argv);
 }
 
+pid_t
+spawn_piped(const char *command, int *pipe_fd)
+{
+	assert(command);
+
+	int pipe_rw[2];
+	if (pipe(pipe_rw) != 0) {
+		wlr_log(WLR_ERROR, "unable to pipe()");
+		return -1;
+	}
+
+	pid_t pid = fork();
+	if (pid < 0) {
+		close(pipe_rw[0]);
+		close(pipe_rw[1]);
+		wlr_log(WLR_ERROR, "unable to fork()");
+		return pid;
+	}
+
+	if (pid == 0) {
+		/* child */
+		reset_signals_and_limits();
+
+		/*
+		 * replace stdin and stderr with /dev/null
+		 * and stdout with the write end of the pipe
+		 */
+		dup2(pipe_rw[1], STDOUT_FILENO);
+		close(pipe_rw[0]);
+		close(pipe_rw[1]);
+
+		int dev_null = open("/dev/null", O_RDWR);
+		if (dev_null < 0) {
+			wlr_log_errno(WLR_ERROR, "opening /dev/null failed");
+			/*
+			 * Just close stdin and stderr and
+			 * hope $command can deal with that.
+			 */
+			close(STDIN_FILENO);
+			close(STDERR_FILENO);
+		} else {
+			dup2(dev_null, STDIN_FILENO);
+			dup2(dev_null, STDERR_FILENO);
+			close(dev_null);
+		}
+
+		execl("/bin/sh", "sh", "-c", command, NULL);
+		/*
+		 * Our stderr points to /dev/null or is closed
+		 * at this point so logging is pretty useless.
+		 */
+		_exit(1);
+	}
+
+	/* labwc */
+	close(pipe_rw[1]);
+
+	/*
+	 * Prevent leaking the read end of the pipe to further
+	 * children forked during the lifetime of the descriptor.
+	 */
+	set_cloexec(pipe_rw[0]);
+
+	*pipe_fd = pipe_rw[0];
+	return pid;
+}
+
+void
+spawn_piped_close(pid_t pid, int pipe_fd)
+{
+	close(pipe_fd);
+	/* waitpid() is done in a generic SIGCHLD handler in src/server.c */
+}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -593,6 +593,25 @@ menu_get_full_width(struct menu *menu)
 	return width + max_child_width;
 }
 
+static struct wlr_box
+get_submenu_position(struct menuitem *item, enum menu_align align)
+{
+	struct wlr_box pos = { 0 };
+	struct menu *menu = item->parent;
+	struct theme *theme = menu->server->theme;
+	int lx = menu->scene_tree->node.x;
+	int ly = menu->scene_tree->node.y;
+
+	if (align & LAB_MENU_OPEN_RIGHT) {
+		pos.x = lx + menu->size.width - theme->menu_overlap_x;
+	} else {
+		pos.x = lx;
+	}
+	int rel_y = item->tree->node.y;
+	pos.y = ly + rel_y - theme->menu_overlap_y;
+	return pos;
+}
+
 static void
 menu_configure(struct menu *menu, int lx, int ly, enum menu_align align)
 {
@@ -650,14 +669,8 @@ menu_configure(struct menu *menu, int lx, int ly, enum menu_align align)
 		if (!item->submenu) {
 			continue;
 		}
-		if (align & LAB_MENU_OPEN_RIGHT) {
-			new_lx = lx + menu->size.width - theme->menu_overlap_x;
-		} else {
-			new_lx = lx;
-		}
-		rel_y = item->tree->node.y;
-		new_ly = ly + rel_y - theme->menu_overlap_y;
-		menu_configure(item->submenu, new_lx, new_ly, align);
+		struct wlr_box pos = get_submenu_position(item, align);
+		menu_configure(item->submenu, pos.x, pos.y, align);
 	}
 }
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -874,6 +874,13 @@ menu_process_item_selection(struct menuitem *item)
 {
 	assert(item);
 
+	/* Do not keep selecting the same item */
+	static struct menuitem *last;
+	if (item == last) {
+		return;
+	}
+	last = item;
+
 	if (!item->selectable) {
 		return;
 	}
@@ -1042,12 +1049,6 @@ menu_process_cursor_motion(struct wlr_scene_node *node)
 {
 	assert(node && node->data);
 	struct menuitem *item = node_menuitem_from_node(node);
-
-	if (item->selectable && node == &item->selected.tree->node) {
-		/* We are on an already selected item */
-		return;
-	}
-
 	menu_process_item_selection(item);
 }
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -842,7 +842,7 @@ menu_close(struct menu *menu)
 }
 
 void
-menu_open(struct menu *menu, int x, int y)
+menu_open_root(struct menu *menu, int x, int y)
 {
 	assert(menu);
 	if (menu->server->menu_current) {


### PR DESCRIPTION
http://openbox.org/wiki/Help:Menus#Pipe_menus

Before merge
- [x] Remove logging marked `XXX`
- [x] Decide whether or not to insist on an `id` attribute in `<menu label="" id="" execute=""/>`. ~~Openbox requires it, but it isn't actually needed in my opinion.~~ Decided to require `id` to stay consistent with Openbox and to make pipemenu-generators responsible for unique id (rather than labwc having to uniquify them which might become quite hard).

There is lots of stuff that needs to be done with menus in general (e.g. making sure we don't have duplicate menu ids, positioning big menus better within usable areas, handling `nr_items * item_height > usable_area->height`)... but let's leave that for separate PRs.