### PR TITLE
cursor: allow re-focusing xwayland-unmanaged surfaces

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -382,6 +382,14 @@ void foreign_toplevel_update_outputs(struct view *view);
  * session is locked/input is inhibited; it will simply do nothing.
  */
 void desktop_focus_view(struct view *view, bool raise);
+
+/**
+ * desktop_focus_view_or_surface() - like desktop_focus_view() but can
+ * also focus other (e.g. xwayland-unmanaged) surfaces
+ */
+void desktop_focus_view_or_surface(struct seat *seat, struct view *view,
+	struct wlr_surface *surface, bool raise);
+
 void desktop_arrange_all_views(struct server *server);
 void desktop_focus_output(struct output *output);
 struct view *desktop_topmost_focusable_view(struct server *server);


### PR DESCRIPTION
We already allow some xwayland-unmanaged surfaces to take focus on map, if indicated by `wlr_xwayland_or_surface_wants_focus()`. But once these surfaces lose focus, they never regain it again.

Add `desktop_focus_view_or_surface()` and call it in the appropriate places to allow these views to regain focus in the usual ways (e.g. clicking on them or focus-follows-mouse).

Fixes #1217.