### PR TITLE
keyboard: avoid stuck keys due to keybindings (alternate approach)

### DIFF
--- a/include/input/key-state.h
+++ b/include/input/key-state.h
@@ -19,7 +19,7 @@
 uint32_t *key_state_pressed_sent_keycodes(void);
 int key_state_nr_pressed_sent_keycodes(void);
 
-void key_state_set_pressed(uint32_t keycode, bool ispressed);
+void key_state_set_pressed(uint32_t keycode, bool is_pressed, bool is_modifier);
 void key_state_store_pressed_key_as_bound(uint32_t keycode);
 bool key_state_corresponding_press_event_was_bound(uint32_t keycode);
 void key_state_bound_key_remove(uint32_t keycode);

--- a/include/input/key-state.h
+++ b/include/input/key-state.h
@@ -2,6 +2,9 @@
 #ifndef LABWC_KEY_STATE_H
 #define LABWC_KEY_STATE_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 /*
  * All keycodes in these functions are (Linux) libinput evdev scancodes which is
  * what 'wlr_keyboard' uses (e.g. 'seat->keyboard_group->keyboard->keycodes').
@@ -17,7 +20,7 @@ uint32_t *key_state_pressed_sent_keycodes(void);
 int key_state_nr_pressed_sent_keycodes(void);
 
 void key_state_set_pressed(uint32_t keycode, bool ispressed);
-void key_state_store_pressed_keys_as_bound(void);
+void key_state_store_pressed_key_as_bound(uint32_t keycode);
 bool key_state_corresponding_press_event_was_bound(uint32_t keycode);
 void key_state_bound_key_remove(uint32_t keycode);
 int key_state_nr_bound_keys(void);

--- a/src/input/key-state.c
+++ b/src/input/key-state.c
@@ -79,10 +79,9 @@ key_state_set_pressed(uint32_t keycode, bool ispressed)
 }
 
 void
-key_state_store_pressed_keys_as_bound(void)
+key_state_store_pressed_key_as_bound(uint32_t keycode)
 {
-	memcpy(bound.keys, pressed.keys, MAX_PRESSED_KEYS * sizeof(uint32_t));
-	bound.nr_keys = pressed.nr_keys;
+	add_key(&bound, keycode);
 }
 
 bool

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -360,19 +360,6 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	}
 
 	/*
-	 * A keybind is not considered valid if other keys are pressed at the
-	 * same time.
-	 *
-	 * In labwc, a keybind is defined by one/many modifier keys + _one_
-	 * non-modifier key. Returning early on >1 pressed non-modifier keys
-	 * avoids false positive matches where 'other' keys were pressed at the
-	 * same time.
-	 */
-	if (key_state_nr_pressed_keys() > 1) {
-		return false;
-	}
-
-	/*
 	 * Handle compositor keybinds
 	 *
 	 * When matching against keybinds, we process the input keys in the

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -230,25 +230,14 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	 */
 
 	bool is_modifier = false;
-	bool is_layout_switch = false;
 	uint32_t modifiers = wlr_keyboard_get_modifiers(wlr_keyboard);
 
 	for (int i = 0; i < translated.nr_syms; i++) {
 		is_modifier |= is_modifier_key(translated.syms[i]);
-		is_layout_switch |= translated.syms[i] == XKB_KEY_ISO_Next_Group;
 	}
 
-	/*
-	 * An earlier press event from a key that causes a layout change event
-	 * might have been added already without us knowing that it actually was
-	 * a XKB_KEY_ISO_Next_Group sym. Thus we always try to remove the current
-	 * key from the set of pressed keys on release.
-	 */
-	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
-		key_state_set_pressed(event->keycode, false);
-	} else if (!is_modifier && !is_layout_switch) {
-		key_state_set_pressed(event->keycode, true);
-	}
+	key_state_set_pressed(event->keycode,
+		event->state == WL_KEYBOARD_KEY_STATE_PRESSED);
 
 	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
 		/*

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -237,7 +237,7 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	}
 
 	key_state_set_pressed(event->keycode,
-		event->state == WL_KEYBOARD_KEY_STATE_PRESSED);
+		event->state == WL_KEYBOARD_KEY_STATE_PRESSED, is_modifier);
 
 	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
 		/*


### PR DESCRIPTION
For discussion/consideration along with #1212 (not mutually exclusive) for solving #1208.

Before commit e77330bc3fe7, there were issues with keys becoming "stuck" if other keys were pressed at the time a keybinding was matched, because those other keys were included in the "bound" set and the release events were incorrectly eaten by labwc.

Commit e77330bc3fe7 solved that issue with the "big hammer" approach of preventing keybindings from working at all if other keys were pressed:

        if (key_state_nr_pressed_keys() > 1) {
                return false;
        }

This is an alternate approach to solving the original problem, by (1) not including those other keys in the "bound" set and (2) making sure we always forward release events for un-bound keys to clients (even if a menu or OSD is displayed).

Details:

- Since we only ever want to store the single matched keycode as bound, `key_state_store_pressed_keys_as_bound()` doesn't really make sense in the plural, so rename it to `key_state_store_pressed_key_as_bound()` and pass in the keycode.

- The calls to `key_state_store_pressed_keys_as_bound()` within `handle_keybinding()` appear to be redundant since it is also called from the parent function (`handle_compositor_keybindings()`). So remove these calls.

- Finally, rework the logic for handling key-release events so that we always forward release events for keys not in the "bound" set.

This PR does not remove the `key_state_nr_pressed_keys() > 1` check, and because of that should not result in any functional change. It should however make it possible to relax or remove that check in future.