### PR TITLE
interactive: Make window snapping with mouse more intuitive

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -388,7 +388,8 @@ void view_adjust_for_layout_change(struct view *view);
 void view_move_to_edge(struct view *view, enum view_edge direction, bool snap_to_windows);
 void view_grow_to_edge(struct view *view, enum view_edge direction);
 void view_shrink_to_edge(struct view *view, enum view_edge direction);
-void view_snap_to_edge(struct view *view, enum view_edge direction, bool store_natural_geometry);
+void view_snap_to_edge(struct view *view, enum view_edge direction,
+	bool across_outputs, bool store_natural_geometry);
 void view_snap_to_region(struct view *view, struct region *region, bool store_natural_geometry);
 
 void view_move_to_front(struct view *view);

--- a/src/action.c
+++ b/src/action.c
@@ -674,7 +674,9 @@ actions_run(struct view *activator, struct server *server,
 			if (view) {
 				/* Config parsing makes sure that direction is a valid direction */
 				enum view_edge edge = action_get_int(action, "direction", 0);
-				view_snap_to_edge(view, edge, /*store_natural_geometry*/ true);
+				view_snap_to_edge(view, edge,
+					/*across_outputs*/ true,
+					/*store_natural_geometry*/ true);
 			}
 			break;
 		case ACTION_TYPE_GROW_TO_EDGE:

--- a/src/view.c
+++ b/src/view.c
@@ -1322,7 +1322,8 @@ view_edge_parse(const char *direction)
 }
 
 void
-view_snap_to_edge(struct view *view, enum view_edge edge, bool store_natural_geometry)
+view_snap_to_edge(struct view *view, enum view_edge edge,
+			bool across_outputs, bool store_natural_geometry)
 {
 	assert(view);
 	if (view->fullscreen) {
@@ -1334,7 +1335,7 @@ view_snap_to_edge(struct view *view, enum view_edge edge, bool store_natural_geo
 		return;
 	}
 
-	if (view->tiled == edge && view->maximized == VIEW_AXIS_NONE) {
+	if (across_outputs && view->tiled == edge && view->maximized == VIEW_AXIS_NONE) {
 		/* We are already tiled for this edge and thus should switch outputs */
 		struct wlr_output *new_output = NULL;
 		struct wlr_output *current_output = output->wlr_output;
@@ -1375,13 +1376,6 @@ view_snap_to_edge(struct view *view, enum view_edge edge, bool store_natural_geo
 			 * state because the window might have been moved away
 			 * (and thus got untiled) and then snapped back to the
 			 * original edge.
-			 *
-			 * TODO: The described pattern will cause another bug
-			 *       in multi monitor setups: it will snap the
-			 *       window to the inverted edge of the nearest
-			 *       output. This is the desired behavior when
-			 *       caused by a keybind but doesn't make sense
-			 *       when caused by mouse movement.
 			 */
 			view_apply_tiled_geometry(view);
 			return;


### PR DESCRIPTION
In current implementation, window snapping triggered with mouse has some counter-intuitive behaviors in my (vertically aligned) dual monitor setup:

(a) Cannot snap a tiled window into another output
<img src="https://github.com/labwc/labwc/assets/22029524/638e0218-0e90-4109-859d-216efeb7fc0e" width=200>

(b) Dragging a tiled window into another output forces snapping (related to (a))
<img src="https://github.com/labwc/labwc/assets/22029524/15ac886e-a651-404f-a2c5-fdd663cdd1f2" width=200>

(c) Snapping is triggered when the center of the window is in another output, even if the cursor is not on the edge.
<img src="https://github.com/labwc/labwc/assets/22029524/103511e2-e2e4-4755-896b-9e928e035ea8" width=200>

(d) Snapping a tiled window to the same direction moves the window into the adjacent output and inverts its direction (mentioned in ![comment](https://github.com/labwc/labwc/blob/d2bcb94bae336c5ce9eb53e87c0cdfe1218d7733/src/view.c#L1379))
<img src="https://github.com/labwc/labwc/assets/22029524/ee38d681-b8c4-4fd1-8318-891c625df041" width=200>



(a)-(c) occur because the cursor position relative to the output **the view belongs to** is used to determine if and in which direction the snapping is triggered. So this PR changes it to use the output that **contains the cursor** instead.

(d) is addressed by simply adding `across_outputs` parameter to `view_snap_to_edge()`.

I'm testing my commit and it's working fine so far.