### PR TITLE
keyboard: fix shifted keystroke delay

### DIFF
--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -84,7 +84,6 @@ keyboard_modifiers_notify(struct wl_listener *listener, void *data)
 			}
 		}
 	}
-	wlr_seat_set_keyboard(seat->seat, wlr_keyboard);
 	wlr_seat_keyboard_notify_modifiers(seat->seat, &wlr_keyboard->modifiers);
 }
 


### PR DESCRIPTION
Remove wlr_seat_set_keyboard() from `keyboard_modifiers_notify()` but leave it in `keyboard_key_notify()`

Fixes regression introduced in 984aeb0

Reported-by: @jlindgren90

Fixes: #1238