### PR TITLE
Keep xwayland stacking order in sync when switching workspaces

### DIFF
--- a/include/common/array.h
+++ b/include/common/array.h
@@ -30,4 +30,15 @@ wl_array_len(struct wl_array *array)
 	return array->size / sizeof(const char *);
 }
 
+/**
+ * Iterates in reverse over an array.
+ * @pos: pointer that each array element will be assigned to
+ * @array: wl_array to iterate over
+ */
+#define wl_array_for_each_reverse(pos, array)                                          \
+	for (pos = !(array)->data ? NULL                                               \
+		: (void *)((const char *)(array)->data + (array)->size - sizeof(pos)); \
+		pos && (const char *)pos >= (const char *)(array)->data;               \
+		(pos)--)
+
 #endif /* LABWC_ARRAY_H */

--- a/include/view.h
+++ b/include/view.h
@@ -222,12 +222,24 @@ struct xdg_toplevel_view {
 	struct wl_listener new_popup;
 };
 
+/* All criteria is applied in AND logic */
 enum lab_view_criteria {
+	/* No filter -> all focusable views */
 	LAB_VIEW_CRITERIA_NONE = 0,
-	LAB_VIEW_CRITERIA_CURRENT_WORKSPACE = 1 << 0,
-	LAB_VIEW_CRITERIA_FULLSCREEN = 1 << 1,
-	LAB_VIEW_CRITERIA_NO_ALWAYS_ON_TOP = 1 << 2,
-	LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER = 1 << 3,
+
+	/*
+	 * Includes always-on-top views, e.g.
+	 * what is visible on the current workspace
+	 */
+	LAB_VIEW_CRITERIA_CURRENT_WORKSPACE       = 1 << 0,
+
+	/* Positive criteria */
+	LAB_VIEW_CRITERIA_FULLSCREEN              = 1 << 1,
+	LAB_VIEW_CRITERIA_ALWAYS_ON_TOP           = 1 << 2,
+
+	/* Negative criteria */
+	LAB_VIEW_CRITERIA_NO_ALWAYS_ON_TOP        = 1 << 6,
+	LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER = 1 << 7,
 };
 
 /**

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -46,6 +46,8 @@ void xwayland_unmanaged_create(struct server *server,
 void xwayland_view_create(struct server *server,
 	struct wlr_xwayland_surface *xsurface, bool mapped);
 
+void xwayland_adjust_stacking_order(struct server *server);
+
 struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
 
 void xwayland_server_init(struct server *server,

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -5531,6 +5531,7 @@ sub process {
 			#
 			if ($starts_with_if_while_etc && !length($s)
 					&& $filename ne "include/view.h"
+					&& $filename ne "include/common/array.h"
 					&& $filename ne "include/ssd-internal.h") {
 				CHK("BRACES", "[labwc-custom] open brace { expected after if/while/for/switch - even with single statement blocks");
 			}

--- a/src/view.c
+++ b/src/view.c
@@ -105,6 +105,11 @@ matches_criteria(struct view *view, enum lab_view_criteria criteria)
 			return false;
 		}
 	}
+	if (criteria & LAB_VIEW_CRITERIA_ALWAYS_ON_TOP) {
+		if (!view_is_always_on_top(view)) {
+			return false;
+		}
+	}
 	if (criteria & LAB_VIEW_CRITERIA_NO_ALWAYS_ON_TOP) {
 		if (view_is_always_on_top(view)) {
 			return false;

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include "config.h"
 #include "buffer.h"
 #include "common/font.h"
 #include "common/graphic-helpers.h"
@@ -16,6 +17,7 @@
 #include "labwc.h"
 #include "view.h"
 #include "workspaces.h"
+#include "xwayland.h"
 
 /* Internal helpers */
 static size_t
@@ -297,6 +299,10 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	/* And finally show the OSD */
 	_osd_show(server);
 
+#if HAVE_XWAYLAND
+	/* Ensure xwayland internal stacking order corresponds to the current workspace  */
+	xwayland_adjust_stacking_order(server);
+#endif
 	/*
 	 * Make sure we are not carrying around a
 	 * cursor image from the previous desktop


### PR DESCRIPTION
Until we expose the workspaces to xwayland we need a way to
ensure that xwayland views on the current workspace are always
stacked above xwayland views on other workspaces.

If we fail to do so, issues arise in scenarios where we change
the mouse focus but do not change the (xwayland) stacking order.

Reproducer:
- If followMouse is enabled, raiseOnFocus must be disabled
- Open at least two xwayland windows which allow scrolling
  (some X11 terminal with `man man` for example)
- Switch to another workspace, open another xwayland window
  which allows scrolling and maximize it
- Switch back to the previous workspace with the two windows
- Move the mouse to the xwayland window that does <b>not</b> have
  focus
- Start scrolling
- All scroll events should end up on the maximized window on
  the other workspace

This patch fixes the issue by simply raising all windows from
the current workspace again in their original stacking order
when switching workspaces.

Reported-by: Domo via IRC (thanks!)