### PR TITLE
xwayland: do not re-set deocrations on unminimize

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -530,7 +530,9 @@ xwayland_view_map(struct view *view)
 	 *   3. set maximized (geometry depends on decorations)
 	 */
 	view_set_fullscreen(view, xwayland_surface->fullscreen);
-	view_set_decorations(view, want_deco(xwayland_surface));
+	if (!view->been_mapped) {
+		view_set_decorations(view, want_deco(xwayland_surface));
+	}
 	enum view_axis axis = VIEW_AXIS_NONE;
 	if (xwayland_surface->maximized_horz) {
 		axis |= VIEW_AXIS_HORIZONTAL;


### PR DESCRIPTION
Reproduce issue by:

1. Run an XWayland client
2. ToggleDecorations twice to hide deco
3. Minimize/unminimize from panel
4. Observe that deco is back

Reported-by: @Consolatis