### PR TITLE
keyboard: allow back by arrow-up or arrow-left in cycle view OSD

### DIFF
--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -354,8 +354,17 @@ handle_cycle_view_key(struct server *server, struct keyinfo *keyinfo)
 	}
 
 	/* cycle to next */
-	bool backwards = keyinfo->modifiers & WLR_MODIFIER_SHIFT;
 	if (!keyinfo->is_modifier) {
+		bool back_key = false;
+		for (int i = 0; i < keyinfo->translated.nr_syms; i++) {
+			if (keyinfo->translated.syms[i] == XKB_KEY_Up
+					|| keyinfo->translated.syms[i] == XKB_KEY_Left) {
+				back_key = true;
+				break;
+			}
+		}
+		bool backwards = (keyinfo->modifiers & WLR_MODIFIER_SHIFT) || back_key;
+
 		enum lab_cycle_dir dir = backwards
 			? LAB_CYCLE_DIR_BACKWARD
 			: LAB_CYCLE_DIR_FORWARD;


### PR DESCRIPTION
All non-modifier keys cycle forward in the cycle view OSD which makes sense for e.g. tab but is not very intuitive for arrow-up or arrow-left. Handle those keys separately to provide a feel of navigation by arrow keys in the cycle view.

Sometimes I need a while to find the window in the OSD I want to focus to. Being used to navigate by arrow keys, I got slightly confused that both arrow-down and arrow-up cycle forward. This patch proposes to allow cycling backwards also by arrow-up or arrow-left, next to shift + any-key.

PS: This is no 0.6.6 material imho.