### PR TITLE
Use the GTK+ 3 notebook header color as the default active title color

### DIFF
--- a/docs/themerc
+++ b/docs/themerc
@@ -14,14 +14,14 @@ padding.height: 3
 # titlebar.height:
 
 # window border
-window.active.border.color: #dddad6
+window.active.border.color: #e1dedb
 window.inactive.border.color: #f6f5f4
 
 # ToggleKeybinds status indicator
 window.active.indicator.toggled-keybind.color: #ff0000
 
 # window titlebar background
-window.active.title.bg.color: #dddad6
+window.active.title.bg.color: #e1dedb
 window.inactive.title.bg.color: #f6f5f4
 
 # window titlebar text
@@ -45,7 +45,7 @@ menu.width.min: 20
 menu.width.max: 200
 menu.items.bg.color: #fcfbfa
 menu.items.text.color: #000000
-menu.items.active.bg.color: #dddad6
+menu.items.active.bg.color: #e1dedb
 menu.items.active.text.color: #000000
 menu.items.padding.x: 7
 menu.items.padding.y: 4

--- a/src/theme.c
+++ b/src/theme.c
@@ -217,12 +217,12 @@ theme_builtin(struct theme *theme)
 	theme->menu_overlap_x = 0;
 	theme->menu_overlap_y = 0;
 
-	parse_hexstr("#dddad6", theme->window_active_border_color);
+	parse_hexstr("#e1dedb", theme->window_active_border_color);
 	parse_hexstr("#f6f5f4", theme->window_inactive_border_color);
 
 	parse_hexstr("#ff0000", theme->window_toggled_keybinds_color);
 
-	parse_hexstr("#dddad6", theme->window_active_title_bg_color);
+	parse_hexstr("#e1dedb", theme->window_active_title_bg_color);
 	parse_hexstr("#f6f5f4", theme->window_inactive_title_bg_color);
 
 	parse_hexstr("#000000", theme->window_active_label_text_color);
@@ -248,7 +248,7 @@ theme_builtin(struct theme *theme)
 
 	parse_hexstr("#fcfbfa", theme->menu_items_bg_color);
 	parse_hexstr("#000000", theme->menu_items_text_color);
-	parse_hexstr("#dddad6", theme->menu_items_active_bg_color);
+	parse_hexstr("#e1dedb", theme->menu_items_active_bg_color);
 	parse_hexstr("#000000", theme->menu_items_active_text_color);
 
 	theme->menu_item_padding_x = 7;


### PR DESCRIPTION
The current light gray color is very very very close to the pavucontrol notebook header color, but not enough for "seamless" appearance.

Before:

![before](https://github.com/labwc/labwc/assets/1471149/19fbc897-0def-46ea-b72c-ff7098732714)

After:

![after](https://github.com/labwc/labwc/assets/1471149/15f8c10c-f6c3-4b34-8d7b-22760604269d)
