### PR TITLE
Small refactor to use newer wlroots 0.17 features 

### DIFF
--- a/include/common/scene-helpers.h
+++ b/include/common/scene-helpers.h
@@ -5,13 +5,9 @@
 #include <stdbool.h>
 
 struct wlr_scene_node;
-struct wlr_scene_rect;
-struct wlr_scene_tree;
 struct wlr_surface;
 struct wlr_scene_output;
 
-struct wlr_scene_rect *lab_wlr_scene_get_rect(struct wlr_scene_node *node);
-struct wlr_scene_tree *lab_scene_tree_from_node(struct wlr_scene_node *node);
 struct wlr_surface *lab_wlr_surface_from_node(struct wlr_scene_node *node);
 
 /**

--- a/include/dnd.h
+++ b/include/dnd.h
@@ -5,19 +5,6 @@
 #include <wayland-server-core.h>
 
 struct seat;
-struct wlr_drag_icon;
-struct wlr_scene_tree;
-
-struct drag_icon {
-	struct wlr_scene_tree *icon_tree;
-	struct wlr_drag_icon *icon;
-	struct {
-		struct wl_listener map;
-		struct wl_listener commit;
-		struct wl_listener unmap;
-		struct wl_listener destroy;
-	} events;
-};
 
 void dnd_init(struct seat *seat);
 void dnd_icons_show(struct seat *seat, bool show);

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -6,20 +6,6 @@
 #include <wlr/util/log.h>
 #include "common/scene-helpers.h"
 
-struct wlr_scene_rect *
-lab_wlr_scene_get_rect(struct wlr_scene_node *node)
-{
-	assert(node->type == WLR_SCENE_NODE_RECT);
-	return (struct wlr_scene_rect *)node;
-}
-
-struct wlr_scene_tree *
-lab_scene_tree_from_node(struct wlr_scene_node *node)
-{
-	assert(node->type == WLR_SCENE_NODE_TREE);
-	return (struct wlr_scene_tree *)node;
-}
-
 struct wlr_surface *
 lab_wlr_surface_from_node(struct wlr_scene_node *node)
 {

--- a/src/debug.c
+++ b/src/debug.c
@@ -170,7 +170,7 @@ dump_tree(struct server *server, struct wlr_scene_node *node,
 
 	if (node->type == WLR_SCENE_NODE_TREE) {
 		struct wlr_scene_node *child;
-		struct wlr_scene_tree *tree = lab_scene_tree_from_node(node);
+		struct wlr_scene_tree *tree = wlr_scene_tree_from_node(node);
 		wl_list_for_each(child, &tree->children, link) {
 			dump_tree(server, child, pos + INDENT_SIZE,
 				x + child->x, y + child->y);

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -87,19 +87,19 @@ menu_update_width(struct menu *menu)
 	/* Update all items for the new size */
 	wl_list_for_each(item, &menu->menuitems, link) {
 		wlr_scene_rect_set_size(
-			lab_wlr_scene_get_rect(item->normal.background),
+			wlr_scene_rect_from_node(item->normal.background),
 			menu->size.width, item->height);
 
 		if (!item->selected.background) {
 			/* This is a separator. They don't have a selected background. */
 			wlr_scene_rect_set_size(
-				lab_wlr_scene_get_rect(item->normal.text),
+				wlr_scene_rect_from_node(item->normal.text),
 				menu->size.width - 2 * theme->menu_separator_padding_width,
 				theme->menu_separator_line_thickness);
 		} else {
 			/* Usual menu item */
 			wlr_scene_rect_set_size(
-				lab_wlr_scene_get_rect(item->selected.background),
+				wlr_scene_rect_from_node(item->selected.background),
 				menu->size.width, item->height);
 			if (item->native_width > max_width || item->submenu) {
 				scaled_font_buffer_set_max_width(item->normal.buffer,

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -339,7 +339,7 @@ ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable)
 		: rc.theme->window_active_border_color;
 
 	struct ssd_part *part = ssd_get_part(&ssd->border.active.parts, LAB_SSD_PART_TOP);
-	struct wlr_scene_rect *rect = lab_wlr_scene_get_rect(part->node);
+	struct wlr_scene_rect *rect = wlr_scene_rect_from_node(part->node);
 	wlr_scene_rect_set_color(rect, color);
 }
 

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -91,7 +91,7 @@ ssd_border_update(struct ssd *ssd)
 	struct ssd_sub_tree *subtree;
 	FOR_EACH_STATE(ssd, subtree) {
 		wl_list_for_each(part, &subtree->parts, link) {
-			rect = lab_wlr_scene_get_rect(part->node);
+			rect = wlr_scene_rect_from_node(part->node);
 			switch (part->type) {
 			case LAB_SSD_PART_LEFT:
 				wlr_scene_rect_set_size(rect,

--- a/src/ssd/ssd_extents.c
+++ b/src/ssd/ssd_extents.c
@@ -138,7 +138,7 @@ ssd_extents_update(struct ssd *ssd)
 
 	struct wlr_box *target;
 	wl_list_for_each(part, &ssd->extents.parts, link) {
-		rect = lab_wlr_scene_get_rect(part->node);
+		rect = wlr_scene_rect_from_node(part->node);
 		target = part->geometry;
 		switch (part->type) {
 		case LAB_SSD_PART_TOP:

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -110,7 +110,7 @@ set_squared_corners(struct ssd *ssd, bool enable)
 			struct ssd_button *button = node_ssd_button_from_node(part->node);
 
 			/* Toggle background between invisible and titlebar background color */
-			struct wlr_scene_rect *rect = lab_wlr_scene_get_rect(button->background);
+			struct wlr_scene_rect *rect = wlr_scene_rect_from_node(button->background);
 			wlr_scene_rect_set_color(rect, !enable ? (float[4]) {0, 0, 0, 0} : (
 				subtree == &ssd->titlebar.active
 					? rc.theme->window_active_title_bg_color
@@ -149,7 +149,7 @@ ssd_titlebar_update(struct ssd *ssd)
 			switch (part->type) {
 			case LAB_SSD_PART_TITLEBAR:
 				wlr_scene_rect_set_size(
-					lab_wlr_scene_get_rect(part->node),
+					wlr_scene_rect_from_node(part->node),
 					width - SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT,
 					theme->title_height);
 				continue;


### PR DESCRIPTION
- Removal of `lab_wlr_scene_get_rect` and `lab_scene_tree_from_node`
- Replacing `struct drag_icon` in `dnd` with `wlr_scene_drag_icon_create`

Manual testing of DnD on my setup appears to work fine, and I can't find any particular regressions.