### PR TITLE
chase(output): support fractional scaling

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -17,6 +17,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
+#include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>

--- a/src/server.c
+++ b/src/server.c
@@ -31,6 +31,7 @@
 #include "xwayland.h"
 
 #define LAB_WLR_COMPOSITOR_VERSION (5)
+#define LAB_WLR_FRACTIONAL_SCALE_MANAGER_VERSION (1)
 
 static struct wlr_compositor *compositor;
 static struct wl_event_source *sighup_source;
@@ -377,6 +378,8 @@ server_init(struct server *server)
 	wlr_data_control_manager_v1_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);
 	wlr_single_pixel_buffer_manager_v1_create(server->wl_display);
+	wlr_fractional_scale_manager_v1_create(
+		server->wl_display, LAB_WLR_FRACTIONAL_SCALE_MANAGER_VERSION);
 
 	idle_manager_create(server->wl_display, server->seat.seat);
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -125,6 +125,14 @@ handle_commit(struct wl_listener *listener, void *data)
 	}
 
 	if (update_required) {
+		wlr_fractional_scale_v1_notify_scale(
+			view->surface,
+			view->output->wlr_output->scale
+		);
+		wlr_surface_set_preferred_buffer_scale(
+			view->surface,
+			ceil(view->output->wlr_output->scale)
+		);
 		view_impl_apply_geometry(view, size.width, size.height);
 	}
 }
@@ -307,6 +315,14 @@ xdg_toplevel_view_configure(struct view *view, struct wlr_box geo)
 		 * glitches during resize, we apply the same position
 		 * adjustments here as in handle_commit().
 		 */
+		wlr_fractional_scale_v1_notify_scale(
+			view->surface,
+			view->output->wlr_output->scale
+		);
+		wlr_surface_set_preferred_buffer_scale(
+			view->surface,
+			ceil(view->output->wlr_output->scale)
+		);
 		view_impl_apply_geometry(view, view->current.width,
 			view->current.height);
 	}

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -199,6 +199,14 @@ handle_commit(struct wl_listener *listener, void *data)
 	 * reducing visual glitches.
 	 */
 	if (current->width != state->width || current->height != state->height) {
+		wlr_fractional_scale_v1_notify_scale(
+			view->surface,
+			view->output->wlr_output->scale
+		);
+		wlr_surface_set_preferred_buffer_scale(
+			view->surface,
+			ceil(view->output->wlr_output->scale)
+		);
 		view_impl_apply_geometry(view, state->width, state->height);
 	}
 }


### PR DESCRIPTION
Seems to me that the scenegraph API already [handles fractional scaling](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/d3a339a03e320c397696d3d0f49567670146a7a4/types/scene/surface.c#L18) if the plugin was registered; just have to handle some of our surfaces like XDG popups and menus. Currently fetches the intended scale from the surface's `wlr_output`.

No crashes (so far); it *appears* to work on my setup. Though, I trust with my lack of experience on wlroots that there is something I missed; please let me know :smile: