### PR TITLE
[WIP] Implement cursor-shape-v1 protocol

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -175,6 +175,7 @@ struct seat {
 	struct wl_listener swipe_end;
 
 	struct wl_listener request_cursor;
+	struct wl_listener request_set_shape;
 	struct wl_listener request_set_selection;
 	struct wl_listener request_set_primary_selection;
 

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -16,6 +16,7 @@ wayland_scanner_server = generator(
 server_protocols = [
 	wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
 	wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
+	wl_protocol_dir / 'staging/cursor-shape/cursor-shape-v1.xml',
 	wl_protocol_dir / 'staging/drm-lease/drm-lease-v1.xml',
 	'wlr-layer-shell-unstable-v1.xml',
 	'wlr-input-inhibitor-unstable-v1.xml',

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -142,7 +142,7 @@ request_cursor_notify(struct wl_listener *listener, void *data)
 		seat->seat->pointer_state.focused_client;
 
 	/*
-	 * This can be sent by any client, so we check to make sure this one is
+	 * This can be sent by any client, so we check to make sure this one
 	 * actually has pointer focus first.
 	 */
 	if (focused_client == event->seat_client) {


### PR DESCRIPTION
This protocol allows Wayland clients to request a buffer for a cursor shape from a compositor.

Tested with foot.