### PR TITLE
[wip] Add dmabuf feedback

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -209,6 +209,7 @@ struct server {
 		char pending_output_name[4096];
 	} headless;
 	struct wlr_session *session;
+	struct wlr_linux_dmabuf_v1 *linux_dmabuf;
 
 	struct wlr_xdg_shell *xdg_shell;
 	struct wlr_layer_shell_v1 *layer_shell;


### PR DESCRIPTION
Fixes
- #1268

This turned out to be a bit more complex because the `wlr_renderer_init_wl_display()` call we used to do does not store or return the `wlr_linux_dmabuf_v1` pointer anywhere (which we need to supply to `wlr_scene_set_linux_dmabuf_v1()`).

So instead of using `wlr_renderer_init_wl_display()` we just do it manually. This is also what the the sway scene graph [patches](https://github.com/swaywm/sway/pull/6844/commits/9c04a1894d5989a52d6e0541a3fd04e44b479709) do. We could also just use both but that causes duplicated globals warnings in wlroots which might cause further hard to detect / debug issues.

As for how to actually test this.. I have no idea.

Todo:
- [ ] remove logging
- [ ] find a way to actually test this