### PR TITLE
Add features to make window header icons more like those in Openbox

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -197,6 +197,16 @@ file within a particular theme. The following xbm buttons are supported:
 - iconify.xbm
 - close.xbm
 - menu.xbm
+- max_toggled.xbm
+
+Additional icons can be defined to be shown when the mouse pointer is hovering
+over the button in question:
+
+- max_hover.xbm
+- iconify_hover.xbm
+- close_hover.xbm
+- menu_hover.xbm
+- max_hover_toggled.xbm
 
 One advantage of xbm buttons over other formats is that they change color based
 on the theme. Other formats use the suffices "-active" and "-inactive" to align

--- a/include/button/button-xbm.h
+++ b/include/button/button-xbm.h
@@ -5,7 +5,7 @@
 struct lab_data_buffer;
 
 /* button_xbm_load - Convert xbm file to buffer with cairo surface */
-void button_xbm_load(const char *button_name, struct lab_data_buffer **buffer,
-	char *fallback_button, float *rgba);
+void button_xbm_load(const char *button_name, const char *alt_name,
+	struct lab_data_buffer **buffer, char *fallback_button, float *rgba);
 
 #endif /* LABWC_BUTTON_XBM_H */

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -101,7 +101,7 @@ struct ssd_hover_state {
 	struct view *view;
 	struct wlr_scene_node *node;
 	struct wlr_scene_node *old_node;
-	enum view_axis maximized;
+	int maximized;
 };
 
 struct wlr_buffer;

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -122,8 +122,10 @@ struct ssd_part *add_scene_button(
 	struct wl_list *part_list, enum ssd_part_type type,
 	struct wlr_scene_tree *parent, float *bg_color,
 	struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer,
-	struct wlr_buffer *alticon_buffer, struct wlr_buffer *althover_buffer,
 	int x, struct view *view);
+void
+add_alt_button(struct wl_list *part_list, enum ssd_part_type type,
+		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer);
 struct ssd_part *add_scene_button_corner(
 	struct wl_list *part_list, enum ssd_part_type type,
 	enum ssd_part_type corner_type, struct wlr_scene_tree *parent,

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -5,6 +5,7 @@
 #include <wlr/util/box.h>
 #include "common/macros.h"
 #include "ssd.h"
+#include "view.h"
 
 #define FOR_EACH(tmp, ...) \
 { \
@@ -17,7 +18,10 @@
 struct ssd_button {
 	struct view *view;
 	enum ssd_part_type type;
+	struct wlr_scene_node *icon;
 	struct wlr_scene_node *hover;
+	struct wlr_scene_node *alticon;
+	struct wlr_scene_node *althover;
 	struct wlr_scene_node *background;
 
 	struct wl_listener destroy;
@@ -96,6 +100,8 @@ struct ssd_part {
 struct ssd_hover_state {
 	struct view *view;
 	struct wlr_scene_node *node;
+	struct wlr_scene_node *old_node;
+	enum view_axis maximized;
 };
 
 struct wlr_buffer;
@@ -115,7 +121,9 @@ struct ssd_part *add_scene_buffer(
 struct ssd_part *add_scene_button(
 	struct wl_list *part_list, enum ssd_part_type type,
 	struct wlr_scene_tree *parent, float *bg_color,
-	struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer, int x, struct view *view);
+	struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer,
+	struct wlr_buffer *alticon_buffer, struct wlr_buffer *althover_buffer,
+	int x, struct view *view);
 struct ssd_part *add_scene_button_corner(
 	struct wl_list *part_list, enum ssd_part_type type,
 	enum ssd_part_type corner_type, struct wlr_scene_tree *parent,

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -18,10 +18,10 @@
 struct ssd_button {
 	struct view *view;
 	enum ssd_part_type type;
-	struct wlr_scene_node *icon;
+	struct wlr_scene_node *normal;
 	struct wlr_scene_node *hover;
-	struct wlr_scene_node *alticon;
-	struct wlr_scene_node *althover;
+	struct wlr_scene_node *toggled;
+	struct wlr_scene_node *toggled_hover;
 	struct wlr_scene_node *background;
 
 	struct wl_listener destroy;
@@ -124,7 +124,7 @@ struct ssd_part *add_scene_button(
 	struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer,
 	int x, struct view *view);
 void
-add_alt_icon(struct wl_list *part_list, enum ssd_part_type type,
+add_toggled_icon(struct wl_list *part_list, enum ssd_part_type type,
 		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer);
 struct ssd_part *add_scene_button_corner(
 	struct wl_list *part_list, enum ssd_part_type type,

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -115,11 +115,11 @@ struct ssd_part *add_scene_buffer(
 struct ssd_part *add_scene_button(
 	struct wl_list *part_list, enum ssd_part_type type,
 	struct wlr_scene_tree *parent, float *bg_color,
-	struct wlr_buffer *icon_buffer, int x, struct view *view);
+	struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer, int x, struct view *view);
 struct ssd_part *add_scene_button_corner(
 	struct wl_list *part_list, enum ssd_part_type type,
 	enum ssd_part_type corner_type, struct wlr_scene_tree *parent,
-	struct wlr_buffer *corner_buffer, struct wlr_buffer *icon_buffer,
+	struct wlr_buffer *corner_buffer, struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer,
 	int x, struct view *view);
 
 /* SSD internal helpers */

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -129,8 +129,8 @@ add_alt_icon(struct wl_list *part_list, enum ssd_part_type type,
 struct ssd_part *add_scene_button_corner(
 	struct wl_list *part_list, enum ssd_part_type type,
 	enum ssd_part_type corner_type, struct wlr_scene_tree *parent,
-	struct wlr_buffer *corner_buffer, struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer,
-	int x, struct view *view);
+	struct wlr_buffer *corner_buffer, struct wlr_buffer *icon_buffer,
+	struct wlr_buffer *hover_buffer, int x, struct view *view);
 
 /* SSD internal helpers */
 struct ssd_part *ssd_get_part(

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -124,7 +124,7 @@ struct ssd_part *add_scene_button(
 	struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer,
 	int x, struct view *view);
 void
-add_alt_button(struct wl_list *part_list, enum ssd_part_type type,
+add_alt_icon(struct wl_list *part_list, enum ssd_part_type type,
 		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer);
 struct ssd_part *add_scene_button_corner(
 	struct wl_list *part_list, enum ssd_part_type type,

--- a/include/theme.h
+++ b/include/theme.h
@@ -87,6 +87,16 @@ struct theme {
 	struct lab_data_buffer *button_iconify_inactive_unpressed;
 	struct lab_data_buffer *button_menu_inactive_unpressed;
 
+	struct lab_data_buffer *button_close_active_hover;
+	struct lab_data_buffer *button_maximize_active_hover;
+	struct lab_data_buffer *button_iconify_active_hover;
+	struct lab_data_buffer *button_menu_active_hover;
+
+	struct lab_data_buffer *button_close_inactive_hover;
+	struct lab_data_buffer *button_maximize_inactive_hover;
+	struct lab_data_buffer *button_iconify_inactive_hover;
+	struct lab_data_buffer *button_menu_inactive_hover;
+
 	struct lab_data_buffer *corner_top_left_active_normal;
 	struct lab_data_buffer *corner_top_right_active_normal;
 	struct lab_data_buffer *corner_top_left_inactive_normal;

--- a/include/theme.h
+++ b/include/theme.h
@@ -79,21 +79,25 @@ struct theme {
 	/* textures */
 	struct lab_data_buffer *button_close_active_unpressed;
 	struct lab_data_buffer *button_maximize_active_unpressed;
+	struct lab_data_buffer *button_restore_active_unpressed;
 	struct lab_data_buffer *button_iconify_active_unpressed;
 	struct lab_data_buffer *button_menu_active_unpressed;
 
 	struct lab_data_buffer *button_close_inactive_unpressed;
 	struct lab_data_buffer *button_maximize_inactive_unpressed;
+	struct lab_data_buffer *button_restore_inactive_unpressed;
 	struct lab_data_buffer *button_iconify_inactive_unpressed;
 	struct lab_data_buffer *button_menu_inactive_unpressed;
 
 	struct lab_data_buffer *button_close_active_hover;
 	struct lab_data_buffer *button_maximize_active_hover;
+	struct lab_data_buffer *button_restore_active_hover;
 	struct lab_data_buffer *button_iconify_active_hover;
 	struct lab_data_buffer *button_menu_active_hover;
 
 	struct lab_data_buffer *button_close_inactive_hover;
 	struct lab_data_buffer *button_maximize_inactive_hover;
+	struct lab_data_buffer *button_restore_inactive_hover;
 	struct lab_data_buffer *button_iconify_inactive_hover;
 	struct lab_data_buffer *button_menu_inactive_hover;
 

--- a/src/button/button-xbm.c
+++ b/src/button/button-xbm.c
@@ -259,8 +259,8 @@ parse_xbm_builtin(const char *button, int size)
 }
 
 void
-button_xbm_load(const char *button_name, struct lab_data_buffer **buffer,
-		char *fallback_button, float *rgba)
+button_xbm_load(const char *button_name, const char *alt_name,
+	struct lab_data_buffer **buffer, char *fallback_button, float *rgba)
 {
 	struct pixmap pixmap = {0};
 	if (*buffer) {
@@ -280,6 +280,18 @@ button_xbm_load(const char *button_name, struct lab_data_buffer **buffer,
 		pixmap = parse_xbm_tokens(tokens);
 		if (tokens) {
 			free(tokens);
+		}
+	}
+	if (!pixmap.data && *alt_name) {
+		button_filename(alt_name, filename, sizeof(filename));
+		char *token_buffer = grab_file(filename);
+		if (token_buffer) {
+			struct token *tokens = tokenize_xbm(token_buffer);
+			free(token_buffer);
+			pixmap = parse_xbm_tokens(tokens);
+			if (tokens) {
+				free(tokens);
+			}
 		}
 	}
 	if (!pixmap.data) {

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -190,7 +190,7 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 }
 
 void
-add_alt_button(struct wl_list *part_list, enum ssd_part_type type,
+add_alt_icon(struct wl_list *part_list, enum ssd_part_type type,
 		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer)
 {
 	struct ssd_part *part = ssd_get_part(part_list, type);

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <assert.h>
-#include "common/scene-helpers.h"
 #include "common/list.h"
 #include "common/mem.h"
 #include "labwc.h"
@@ -181,21 +180,21 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 	struct ssd_button *button = ssd_button_descriptor_create(button_root->node);
 	button->type = type;
 	button->view = view;
-	button->icon = icon_part->node;
+	button->normal = icon_part->node;
 	button->hover = hover_part->node;
 	button->background = bg_rect->node;
-	button->alticon = NULL;
-	button->althover = NULL;
+	button->toggled = NULL;
+	button->toggled_hover = NULL;
 	return button_root;
 }
 
 void
-add_alt_icon(struct wl_list *part_list, enum ssd_part_type type,
+add_toggled_icon(struct wl_list *part_list, enum ssd_part_type type,
 		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer)
 {
 	struct ssd_part *part = ssd_get_part(part_list, type);
 	struct ssd_button *button = node_ssd_button_from_node(part->node);
-	struct wlr_scene_tree *parent = lab_scene_tree_from_node(part->node);
+	struct wlr_scene_tree *parent = wlr_scene_tree_from_node(part->node);
 
 	/* Alternate icon */
 	struct wlr_box icon_geo = get_scale_box(icon_buffer,
@@ -221,8 +220,8 @@ add_alt_icon(struct wl_list *part_list, enum ssd_part_type type,
 
 	wlr_scene_node_set_enabled(althover_part->node, false);
 
-	button->alticon = alticon_part->node;
-	button->althover = althover_part->node;
+	button->toggled = alticon_part->node;
+	button->toggled_hover = althover_part->node;
 }
 
 struct ssd_part *

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <assert.h>
+#include "common/scene-helpers.h"
 #include "common/list.h"
 #include "common/mem.h"
 #include "labwc.h"
 #include "node.h"
 #include "ssd-internal.h"
-#include "common/scene-helpers.h"
 
 /* Internal helpers */
 static void

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -108,7 +108,7 @@ add_scene_button_corner(struct wl_list *part_list, enum ssd_part_type type,
 		-offset_x, -rc.theme->border_width);
 
 	/* Finally just put a usual theme button on top, using an invisible hitbox */
-	add_scene_button(part_list, type, parent, invisible, icon_buffer, hover_buffer, 0, view);
+	add_scene_button(part_list, type, parent, invisible, icon_buffer, hover_buffer, NULL, NULL, 0, view);
 	return button_root;
 }
 
@@ -141,10 +141,10 @@ get_scale_box(struct wlr_buffer *buffer, double container_width,
 struct ssd_part *
 add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 		struct wlr_scene_tree *parent, float *bg_color,
-		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer, int x, struct view *view)
+		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer,
+		struct wlr_buffer *alticon_buffer, struct wlr_buffer *althover_buffer,
+		int x, struct view *view)
 {
-	struct wlr_scene_node *hover;
-
 	struct ssd_part *button_root = add_scene_part(part_list, type);
 	parent = wlr_scene_tree_create(parent);
 	button_root->node = &parent->node;
@@ -178,9 +178,34 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 
 	wlr_scene_node_set_enabled(hover_part->node, false);
 
+	/* Alternate icon */
+	struct ssd_part *alticon_part, *althover_part;
+	if (alticon_buffer)
+	{
+		alticon_part = add_scene_buffer(part_list, type,
+			parent, alticon_buffer, icon_geo.x, icon_geo.y);
+
+		wlr_scene_buffer_set_dest_size(
+			wlr_scene_buffer_from_node(alticon_part->node),
+			icon_geo.width, icon_geo.height);
+
+		wlr_scene_node_set_enabled(alticon_part->node, false);
+
+		althover_part = add_scene_buffer(part_list, type,
+			parent, althover_buffer, hover_geo.x, hover_geo.y);
+
+		wlr_scene_buffer_set_dest_size(
+			wlr_scene_buffer_from_node(althover_part->node),
+			hover_geo.width, hover_geo.height);
+
+		wlr_scene_node_set_enabled(althover_part->node, false);
+	}
 	struct ssd_button *button = ssd_button_descriptor_create(button_root->node);
 	button->type = type;
 	button->view = view;
+	button->icon = icon_part->node;
+	button->alticon = alticon_buffer ? alticon_part->node : NULL;
+	button->althover = alticon_buffer ? althover_part->node : NULL;
 	button->hover = hover_part->node;
 	button->background = bg_rect->node;
 	return button_root;

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -194,8 +194,8 @@ add_alt_icon(struct wl_list *part_list, enum ssd_part_type type,
 		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer)
 {
 	struct ssd_part *part = ssd_get_part(part_list, type);
-	struct ssd_button *button = node_ssd_button_from_node (part->node);
-	struct wlr_scene_tree *parent = lab_scene_tree_from_node (part->node);
+	struct ssd_button *button = node_ssd_button_from_node(part->node);
+	struct wlr_scene_tree *parent = lab_scene_tree_from_node(part->node);
 
 	/* Alternate icon */
 	struct wlr_box icon_geo = get_scale_box(icon_buffer,

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -36,6 +36,11 @@ ssd_titlebar_create(struct ssd *ssd)
 	struct wlr_buffer *maximize_button_unpressed;
 	struct wlr_buffer *close_button_unpressed;
 
+	struct wlr_buffer *menu_button_hover;
+	struct wlr_buffer *iconify_button_hover;
+	struct wlr_buffer *maximize_button_hover;
+	struct wlr_buffer *close_button_hover;
+
 	ssd->titlebar.tree = wlr_scene_tree_create(ssd->tree);
 
 	struct ssd_sub_tree *subtree;
@@ -51,6 +56,10 @@ ssd_titlebar_create(struct ssd *ssd)
 			iconify_button_unpressed = &theme->button_iconify_active_unpressed->base;
 			close_button_unpressed = &theme->button_close_active_unpressed->base;
 			maximize_button_unpressed = &theme->button_maximize_active_unpressed->base;
+			menu_button_hover = &theme->button_menu_active_hover->base;
+			iconify_button_hover = &theme->button_iconify_active_hover->base;
+			close_button_hover = &theme->button_close_active_hover->base;
+			maximize_button_hover = &theme->button_maximize_active_hover->base;
 		} else {
 			color = theme->window_inactive_title_bg_color;
 			corner_top_left = &theme->corner_top_left_inactive_normal->base;
@@ -60,6 +69,10 @@ ssd_titlebar_create(struct ssd *ssd)
 			maximize_button_unpressed =
 				&theme->button_maximize_inactive_unpressed->base;
 			close_button_unpressed = &theme->button_close_inactive_unpressed->base;
+			menu_button_hover = &theme->button_menu_inactive_hover->base;
+			iconify_button_hover = &theme->button_iconify_inactive_hover->base;
+			close_button_hover = &theme->button_close_inactive_hover->base;
+			maximize_button_hover = &theme->button_maximize_inactive_hover->base;
 			wlr_scene_node_set_enabled(&parent->node, false);
 		}
 		wl_list_init(&subtree->parts);
@@ -71,16 +84,16 @@ ssd_titlebar_create(struct ssd *ssd)
 		/* Buttons */
 		add_scene_button_corner(&subtree->parts,
 			LAB_SSD_BUTTON_WINDOW_MENU, LAB_SSD_PART_CORNER_TOP_LEFT, parent,
-			corner_top_left, menu_button_unpressed, 0, view);
+			corner_top_left, menu_button_unpressed, menu_button_hover, 0, view);
 		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_ICONIFY, parent,
-			color, iconify_button_unpressed,
+			color, iconify_button_unpressed, iconify_button_hover,
 			width - SSD_BUTTON_WIDTH * 3, view);
 		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE, parent,
-			color, maximize_button_unpressed,
+			color, maximize_button_unpressed, maximize_button_hover,
 			width - SSD_BUTTON_WIDTH * 2, view);
 		add_scene_button_corner(&subtree->parts,
 			LAB_SSD_BUTTON_CLOSE, LAB_SSD_PART_CORNER_TOP_RIGHT, parent,
-			corner_top_right, close_button_unpressed,
+			corner_top_right, close_button_unpressed, close_button_hover,
 			width - SSD_BUTTON_WIDTH * 1, view);
 	} FOR_EACH_END
 

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -184,7 +184,7 @@ ssd_titlebar_update(struct ssd *ssd)
 				if (is_direct_child(part->node, subtree)) {
 					wlr_scene_node_set_position(part->node,
 						width - SSD_BUTTON_WIDTH * 2, 0);
-					struct ssd_button *button = 
+					struct ssd_button *button =
 						node_ssd_button_from_node(part->node);
 					if (button->alticon) {
 						wlr_scene_node_set_enabled(button->icon,

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -184,13 +184,17 @@ ssd_titlebar_update(struct ssd *ssd)
 				if (is_direct_child(part->node, subtree)) {
 					wlr_scene_node_set_position(part->node,
 						width - SSD_BUTTON_WIDTH * 2, 0);
-					struct ssd_button *button = node_ssd_button_from_node(part->node);
-					if (button->alticon)
-					{
-						wlr_scene_node_set_enabled (button->icon, !maximized);
-						wlr_scene_node_set_enabled (button->alticon, maximized);
-						wlr_scene_node_set_enabled (button->hover, false);
-						wlr_scene_node_set_enabled (button->althover, false);
+					struct ssd_button *button = 
+						node_ssd_button_from_node(part->node);
+					if (button->alticon) {
+						wlr_scene_node_set_enabled(button->icon,
+							!maximized);
+						wlr_scene_node_set_enabled(button->alticon,
+							maximized);
+						wlr_scene_node_set_enabled(button->hover,
+							false);
+						wlr_scene_node_set_enabled(button->althover,
+							false);
 					}
 				}
 				continue;
@@ -394,20 +398,24 @@ ssd_update_button_hover(struct wlr_scene_node *node,
 disable_old_hover:
 	if (hover_state->node) {
 		wlr_scene_node_set_enabled(hover_state->node, false);
-		if (hover_state->maximized == (int) hover_state->view->maximized || hover_state->maximized == -1)
-			wlr_scene_node_set_enabled (hover_state->old_node, true);
+		if (hover_state->maximized == (int)hover_state->view->maximized
+			|| hover_state->maximized == -1) {
+			wlr_scene_node_set_enabled(hover_state->old_node, true);
+		}
 		hover_state->view = NULL;
 		hover_state->node = NULL;
 	}
 	if (button) {
 		bool maximized = button->view->maximized;
-		if (maximized && !button->alticon) maximized = false;
-		wlr_scene_node_set_enabled (maximized ? button->althover : button->hover, true);
+		if (maximized && !button->alticon) {
+			maximized = false;
+		}
+		wlr_scene_node_set_enabled(maximized ? button->althover : button->hover, true);
 		hover_state->view = button->view;
 		hover_state->node = maximized ? button->althover : button->hover;
 		hover_state->old_node = maximized ? button->alticon : button->icon;
-		hover_state->maximized = button->alticon ? (int) button->view->maximized : -1;
-		wlr_scene_node_set_enabled (maximized ? button->alticon : button->icon, false);
+		hover_state->maximized = button->alticon ? (int)button->view->maximized : -1;
+		wlr_scene_node_set_enabled(maximized ? button->alticon : button->icon, false);
 	}
 }
 

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -92,12 +92,13 @@ ssd_titlebar_create(struct ssd *ssd)
 			LAB_SSD_BUTTON_WINDOW_MENU, LAB_SSD_PART_CORNER_TOP_LEFT, parent,
 			corner_top_left, menu_button_unpressed, menu_button_hover, 0, view);
 		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_ICONIFY, parent,
-			color, iconify_button_unpressed, iconify_button_hover, NULL, NULL,
+			color, iconify_button_unpressed, iconify_button_hover,
 			width - SSD_BUTTON_WIDTH * 3, view);
 		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE, parent,
 			color, maximize_button_unpressed, maximize_button_hover,
-			restore_button_unpressed, restore_button_hover,
 			width - SSD_BUTTON_WIDTH * 2, view);
+		add_alt_button(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE,
+			restore_button_unpressed, restore_button_hover);
 		add_scene_button_corner(&subtree->parts,
 			LAB_SSD_BUTTON_CLOSE, LAB_SSD_PART_CORNER_TOP_RIGHT, parent,
 			corner_top_right, close_button_unpressed, close_button_hover,
@@ -184,10 +185,13 @@ ssd_titlebar_update(struct ssd *ssd)
 					wlr_scene_node_set_position(part->node,
 						width - SSD_BUTTON_WIDTH * 2, 0);
 					struct ssd_button *button = node_ssd_button_from_node(part->node);
-					wlr_scene_node_set_enabled (button->icon, !maximized);
-					wlr_scene_node_set_enabled (button->alticon, maximized);
-					wlr_scene_node_set_enabled (button->hover, false);
-					wlr_scene_node_set_enabled (button->althover, false);
+					if (button->alticon)
+					{
+						wlr_scene_node_set_enabled (button->icon, !maximized);
+						wlr_scene_node_set_enabled (button->alticon, maximized);
+						wlr_scene_node_set_enabled (button->hover, false);
+						wlr_scene_node_set_enabled (button->althover, false);
+					}
 				}
 				continue;
 			case LAB_SSD_PART_CORNER_TOP_RIGHT:

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -97,7 +97,7 @@ ssd_titlebar_create(struct ssd *ssd)
 		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE, parent,
 			color, maximize_button_unpressed, maximize_button_hover,
 			width - SSD_BUTTON_WIDTH * 2, view);
-		add_alt_icon(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE,
+		add_toggled_icon(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE,
 			restore_button_unpressed, restore_button_hover);
 		add_scene_button_corner(&subtree->parts,
 			LAB_SSD_BUTTON_CLOSE, LAB_SSD_PART_CORNER_TOP_RIGHT, parent,
@@ -186,14 +186,14 @@ ssd_titlebar_update(struct ssd *ssd)
 						width - SSD_BUTTON_WIDTH * 2, 0);
 					struct ssd_button *button =
 						node_ssd_button_from_node(part->node);
-					if (button->alticon) {
-						wlr_scene_node_set_enabled(button->icon,
+					if (button->toggled) {
+						wlr_scene_node_set_enabled(button->normal,
 							!maximized);
-						wlr_scene_node_set_enabled(button->alticon,
+						wlr_scene_node_set_enabled(button->toggled,
 							maximized);
 						wlr_scene_node_set_enabled(button->hover,
 							false);
-						wlr_scene_node_set_enabled(button->althover,
+						wlr_scene_node_set_enabled(button->toggled_hover,
 							false);
 					}
 				}
@@ -407,15 +407,15 @@ disable_old_hover:
 	}
 	if (button) {
 		bool maximized = button->view->maximized;
-		if (maximized && !button->alticon) {
+		if (maximized && !button->toggled) {
 			maximized = false;
 		}
-		wlr_scene_node_set_enabled(maximized ? button->althover : button->hover, true);
+		wlr_scene_node_set_enabled(maximized ? button->toggled_hover : button->hover, true);
 		hover_state->view = button->view;
-		hover_state->node = maximized ? button->althover : button->hover;
-		hover_state->old_node = maximized ? button->alticon : button->icon;
-		hover_state->maximized = button->alticon ? (int)button->view->maximized : -1;
-		wlr_scene_node_set_enabled(maximized ? button->alticon : button->icon, false);
+		hover_state->node = maximized ? button->toggled_hover : button->hover;
+		hover_state->old_node = maximized ? button->toggled : button->normal;
+		hover_state->maximized = button->toggled ? (int)button->view->maximized : -1;
+		wlr_scene_node_set_enabled(maximized ? button->toggled : button->normal, false);
 	}
 }
 

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -97,7 +97,7 @@ ssd_titlebar_create(struct ssd *ssd)
 		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE, parent,
 			color, maximize_button_unpressed, maximize_button_hover,
 			width - SSD_BUTTON_WIDTH * 2, view);
-		add_alt_button(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE,
+		add_alt_icon(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE,
 			restore_button_unpressed, restore_button_hover);
 		add_scene_button_corner(&subtree->parts,
 			LAB_SSD_BUTTON_CLOSE, LAB_SSD_PART_CORNER_TOP_RIGHT, parent,

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -394,7 +394,7 @@ ssd_update_button_hover(struct wlr_scene_node *node,
 disable_old_hover:
 	if (hover_state->node) {
 		wlr_scene_node_set_enabled(hover_state->node, false);
-		if (hover_state->maximized == hover_state->view->maximized)
+		if (hover_state->maximized == (int) hover_state->view->maximized || hover_state->maximized == -1)
 			wlr_scene_node_set_enabled (hover_state->old_node, true);
 		hover_state->view = NULL;
 		hover_state->node = NULL;
@@ -406,7 +406,7 @@ disable_old_hover:
 		hover_state->view = button->view;
 		hover_state->node = maximized ? button->althover : button->hover;
 		hover_state->old_node = maximized ? button->alticon : button->icon;
-		hover_state->maximized = button->view->maximized;
+		hover_state->maximized = button->alticon ? (int) button->view->maximized : -1;
 		wlr_scene_node_set_enabled (maximized ? button->alticon : button->icon, false);
 	}
 }

--- a/src/theme.c
+++ b/src/theme.c
@@ -107,6 +107,54 @@ load_buttons(struct theme *theme)
 				theme->window_inactive_button_close_unpressed_image_color,
 			},
 		},
+		{
+			"menu_hover",
+			{ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
+			{
+				&theme->button_menu_active_hover,
+				theme->window_active_button_menu_unpressed_image_color,
+			},
+			{
+				&theme->button_menu_inactive_hover,
+				theme->window_inactive_button_menu_unpressed_image_color,
+			},
+		},
+		{
+			"iconify_hover",
+			{ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
+			{
+				&theme->button_iconify_active_hover,
+				theme->window_active_button_iconify_unpressed_image_color,
+			},
+			{
+				&theme->button_iconify_inactive_hover,
+				theme->window_inactive_button_iconify_unpressed_image_color,
+			},
+		},
+		{
+			"max_hover",
+			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+			{
+				&theme->button_maximize_active_hover,
+				theme->window_active_button_max_unpressed_image_color,
+			},
+			{
+				&theme->button_maximize_inactive_hover,
+				theme->window_inactive_button_max_unpressed_image_color,
+			},
+		},
+		{
+			"close_hover",
+			{ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
+			{
+				&theme->button_close_active_hover,
+				theme->window_active_button_close_unpressed_image_color,
+			},
+			{
+				&theme->button_close_inactive_hover,
+				theme->window_inactive_button_close_unpressed_image_color,
+			},
+		},
 	};
 
 	char filename[4096] = {0};

--- a/src/theme.c
+++ b/src/theme.c
@@ -96,6 +96,18 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
+			"max_toggled",
+			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+			{
+				&theme->button_restore_active_unpressed,
+				theme->window_active_button_max_unpressed_image_color,
+			},
+			{
+				&theme->button_restore_inactive_unpressed,
+				theme->window_inactive_button_max_unpressed_image_color,
+			},
+		},
+		{
 			"close",
 			{ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
 			{
@@ -140,6 +152,18 @@ load_buttons(struct theme *theme)
 			},
 			{
 				&theme->button_maximize_inactive_hover,
+				theme->window_inactive_button_max_unpressed_image_color,
+			},
+		},
+		{
+			"max_hover_toggled",
+			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+			{
+				&theme->button_restore_active_hover,
+				theme->window_active_button_max_unpressed_image_color,
+			},
+			{
+				&theme->button_restore_inactive_hover,
 				theme->window_inactive_button_max_unpressed_image_color,
 			},
 		},

--- a/src/theme.c
+++ b/src/theme.c
@@ -39,6 +39,7 @@
 
 struct button {
 	const char *name;
+	const char *alt_name;
 	char fallback_button[6];	/* built-in 6x6 button */
 	struct {
 		struct lab_data_buffer **buffer;
@@ -60,7 +61,7 @@ load_buttons(struct theme *theme)
 {
 	struct button buttons[] = {
 		{
-			"menu",
+			"menu", NULL,
 			{ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
 			{
 				&theme->button_menu_active_unpressed,
@@ -72,7 +73,7 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
-			"iconify",
+			"iconify", NULL,
 			{ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
 			{
 				&theme->button_iconify_active_unpressed,
@@ -84,7 +85,7 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
-			"max",
+			"max", NULL,
 			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
 			{
 				&theme->button_maximize_active_unpressed,
@@ -96,7 +97,7 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
-			"max_toggled",
+			"max_toggled", NULL,
 			{ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
 			{
 				&theme->button_restore_active_unpressed,
@@ -108,7 +109,7 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
-			"close",
+			"close", NULL,
 			{ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
 			{
 				&theme->button_close_active_unpressed,
@@ -120,7 +121,7 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
-			"menu_hover",
+			"menu_hover", NULL,
 			{ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
 			{
 				&theme->button_menu_active_hover,
@@ -132,7 +133,7 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
-			"iconify_hover",
+			"iconify_hover", NULL,
 			{ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
 			{
 				&theme->button_iconify_active_hover,
@@ -144,7 +145,7 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
-			"max_hover",
+			"max_hover", NULL,
 			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
 			{
 				&theme->button_maximize_active_hover,
@@ -156,7 +157,7 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
-			"max_hover_toggled",
+			"max_hover_toggled", "max_toggled_hover",
 			{ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
 			{
 				&theme->button_restore_active_hover,
@@ -168,7 +169,7 @@ load_buttons(struct theme *theme)
 			},
 		},
 		{
-			"close_hover",
+			"close_hover", NULL,
 			{ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
 			{
 				&theme->button_close_active_hover,
@@ -182,6 +183,7 @@ load_buttons(struct theme *theme)
 	};
 
 	char filename[4096] = {0};
+	char alt_filename[4096] = {0};
 	for (size_t i = 0; i < ARRAY_SIZE(buttons); ++i) {
 		struct button *b = &buttons[i];
 
@@ -191,8 +193,16 @@ load_buttons(struct theme *theme)
 		/* Try png icon first */
 		snprintf(filename, sizeof(filename), "%s-active.png", b->name);
 		button_png_load(filename, b->active.buffer);
+		if (!*b->active.buffer && b->alt_name) {
+			snprintf(filename, sizeof(filename), "%s-active.png", b->alt_name);
+			button_png_load(filename, b->active.buffer);
+		}
 		snprintf(filename, sizeof(filename), "%s-inactive.png", b->name);
 		button_png_load(filename, b->inactive.buffer);
+		if (!*b->inactive.buffer && b->alt_name) {
+			snprintf(filename, sizeof(filename), "%s-inactive.png", b->alt_name);
+			button_png_load(filename, b->inactive.buffer);
+		}
 
 #if HAVE_RSVG
 		/* Then try svg icon */
@@ -201,20 +211,31 @@ load_buttons(struct theme *theme)
 			snprintf(filename, sizeof(filename), "%s-active.svg", b->name);
 			button_svg_load(filename, b->active.buffer, size);
 		}
+		if (!*b->active.buffer && b->alt_name) {
+			snprintf(filename, sizeof(filename), "%s-active.svg", b->alt_name);
+			button_svg_load(filename, b->active.buffer, size);
+		}
 		if (!*b->inactive.buffer) {
 			snprintf(filename, sizeof(filename), "%s-inactive.svg", b->name);
+			button_svg_load(filename, b->inactive.buffer, size);
+		}
+		if (!*b->active.buffer && b->alt_name) {
+			snprintf(filename, sizeof(filename), "%s-inactive.svg", b->alt_name);
 			button_svg_load(filename, b->inactive.buffer, size);
 		}
 #endif
 
 		/* If there were no png/svg buttons, use xbm */
 		snprintf(filename, sizeof(filename), "%s.xbm", b->name);
+		if (b->alt_name) {
+			snprintf(alt_filename, sizeof(alt_filename), "%s.xbm", b->alt_name);
+		}
 		if (!*b->active.buffer) {
-			button_xbm_load(filename, b->active.buffer,
+			button_xbm_load(filename, alt_filename, b->active.buffer,
 				b->fallback_button, b->active.rgba);
 		}
 		if (!*b->inactive.buffer) {
-			button_xbm_load(filename, b->inactive.buffer,
+			button_xbm_load(filename, alt_filename, b->inactive.buffer,
 				b->fallback_button, b->inactive.rgba);
 		}
 	}

--- a/src/theme.c
+++ b/src/theme.c
@@ -97,7 +97,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"max_toggled",
-			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+			{ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
 			{
 				&theme->button_restore_active_unpressed,
 				theme->window_active_button_max_unpressed_image_color,
@@ -157,7 +157,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"max_hover_toggled",
-			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+			{ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
 			{
 				&theme->button_restore_active_hover,
 				theme->window_active_button_max_unpressed_image_color,


### PR DESCRIPTION
I don't know if this is of interest, but I have been working with labwc on a system which used to run Openbox, and I have noticed a couple of features which Openbox has which are not implemented in labwc.

1) The window header bar button icon for "maximize" is only used on non-maximized windows; on windows which are already maximized, a different "restore" icon is shown.

2) Mouse pointer hover over a window header bar button is shown by a subtle change in the icon which is displayed, usually a slight increase in size.

Neither of these appear to be implemented in labwc at present, and their absence is noticeable when moving from Openbox. This PR implements both, allowing a "hover" icon to be supplied in the theme for each button, and allowing a "restore" icon to be defined for the maximize button in addition to the standard "maximize" icon.

The fallback cases for each are the same as the originals, so unless the relevant icons are defined in the theme, then no change will be seen.

I have only limited experience of the labwc code - this implementation appears to work reliably to me, and should be reasonably efficient; the additional icons are defined as parts of the scene tree for the buttons, and are enabled or disabled as appropriate - but this may not be the best way to do this.

From my reading of the scope document, this appears to be category B functionality, regarded as nice to have, so hopefully this is a useful contribution.