### PR TITLE
Implement key binds to control virtual outputs

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -216,8 +216,8 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="VirtualOutputRemove" output_name="value" />*
 	Remove virtual output (headless backend).
 
-	*output_name* The name of virtual output. If not supplied, will remove first
-	found virtual output.
+	*output_name* The name of virtual output. If not supplied, will remove the
+	last virtual output added.
 
 *<action name="None" />*
 	If used as the only action for a binding: clear an earlier defined binding.

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -183,11 +183,10 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="VirtualOutputAdd" output_name="value" />*
 	Add virtual output (headless backend).
 
-	Virtual outputs is a useful mechanism. For example, it can be used to overlay
-	virtual output on real output, but with a different resolution (this can be
-	done with `wlr-randr` or `wdisplays`). After that, virtual output can be
-	selected for screen sharing (casting), effectively sharing only the region of
-	the screen.
+	For example, it can be used to overlay virtual output on real output, but with
+	a different resolution (this can be done with `wlr-randr` or `wdisplays`).
+	After that, virtual output can be selected for screen sharing (casting),
+	effectively sharing only the region of the screen.
 
 	It must be noted that overlaying virtual output and real output is not
 	endorsed or explicitely supported by wlroots. For example, after configuring
@@ -207,9 +206,9 @@ Actions are used in menus and keyboard/mouse bindings.
 	Note that the vertical resolution of "ScreenCasting" output is just 50px
 	smaller than "eDP-1" output to cut off bottom panel from screen sharing.
 
-	This setup is also useful for extending the desktop to (maybe mobile) remote
-	systems like tablets. E.g. simply adding a virtual output, attaching wayvnc to
-	it and running a VNC client on the remote system.
+	Virtual output is also useful for extending the desktop to (maybe mobile)
+	remote systems like tablets. E.g. simply adding a virtual output, attaching
+	wayvnc to it and running a VNC client on the remote system.
 
 	*output_name* The name of virtual output. Providing virtual output name is
 	beneficial for further automation. Default is "HEADLESS-X".

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -180,6 +180,46 @@ Actions are used in menus and keyboard/mouse bindings.
 	*wrap* [yes|no] Wrap around from last desktop to first, and vice
 	versa. Default yes.
 
+*<action name="VirtualOutputAdd" output_name="value" />*
+	Add virtual output (headless backend).
+
+	Virtual outputs is a useful mechanism. For example, it can be used to overlay
+	virtual output on real output, but with a different resolution (this can be
+	done with `wlr-randr` or `wdisplays`). After that, virtual output can be
+	selected for screen sharing (casting), effectively sharing only the region of
+	the screen.
+
+	It must be noted that overlaying virtual output and real output is not
+	endorsed or explicitely supported by wlroots. For example, after configuring
+	virtual output, real output must be reconfigured as well (for the overlay
+	configuration to work correctly). This is the example configuration:
+
+```
+<keybind key="W-v">
+  <action name="VirtualOutputAdd" output_name="ScreenCasting"/>
+  <action name="Execute" command='sh -c "wlr-randr --output ScreenCasting --pos 0,0 --scale 2 --custom-mode 3840x2110; wlr-randr --output eDP-1 --pos 0,0 --scale 2 --mode 3840x2160"'/>
+</keybind>
+<keybind key="W-c">
+  <action name="VirtualOutputRemove"/>
+</keybind>
+```
+
+	Note that the vertical resolution of "ScreenCasting" output is just 50px
+	smaller than "eDP-1" output to cut off bottom panel from screen sharing.
+
+	This setup is also useful for extending the desktop to (maybe mobile) remote
+	systems like tablets. E.g. simply adding a virtual output, attaching wayvnc to
+	it and running a VNC client on the remote system.
+
+	*output_name* The name of virtual output. Providing virtual output name is
+	beneficial for further automation. Default is "HEADLESS-X".
+
+*<action name="VirtualOutputRemove" output_name="value" />*
+	Remove virtual output (headless backend).
+
+	*output_name* The name of virtual output. If not supplied, will remove first
+	found virtual output.
+
 *<action name="None" />*
 	If used as the only action for a binding: clear an earlier defined binding.
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -471,6 +471,8 @@ struct wlr_box output_usable_area_in_layout_coords(struct output *output);
 struct wlr_box output_usable_area_scaled(struct output *output);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
+void virtual_output_add(struct server *server, const char *output_name);
+void virtual_output_remove(struct server *server, const char *output_name);
 
 void server_init(struct server *server);
 void server_start(struct server *server);

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -203,6 +203,10 @@ struct server {
 	struct wlr_renderer *renderer;
 	struct wlr_allocator *allocator;
 	struct wlr_backend *backend;
+	struct headless {
+		struct wlr_backend *backend;
+		char pending_output_name[4096];
+	} headless;
 	struct wlr_session *session;
 
 	struct wlr_xdg_shell *xdg_shell;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -471,8 +471,8 @@ struct wlr_box output_usable_area_in_layout_coords(struct output *output);
 struct wlr_box output_usable_area_scaled(struct output *output);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
-void virtual_output_add(struct server *server, const char *output_name);
-void virtual_output_remove(struct server *server, const char *output_name);
+void output_add_virtual(struct server *server, const char *output_name);
+void output_remove_virtual(struct server *server, const char *output_name);
 
 void server_init(struct server *server);
 void server_start(struct server *server);

--- a/src/action.c
+++ b/src/action.c
@@ -640,7 +640,8 @@ virtual_output_add(struct server *server, const char *output_name)
 		wl_list_for_each(output, &server->outputs, link) {
 			if (wlr_output_is_headless(output->wlr_output)) {
 				if (!strcmp(output->wlr_output->name, output_name)) {
-					wlr_log(WLR_DEBUG, "refusing to create virtual output with duplicate name");
+					wlr_log(WLR_DEBUG,
+					"refusing to create virtual output with duplicate name");
 					return;
 				}
 			}
@@ -980,13 +981,15 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_VIRTUAL_OUTPUT_ADD:
 			{
-				const char *output_name = action_get_str(action, "output_name", NULL);
+				const char *output_name = action_get_str(action, "output_name",
+						NULL);
 				virtual_output_add(server, output_name);
 			}
 			break;
 		case ACTION_TYPE_VIRTUAL_OUTPUT_REMOVE:
 			{
-				const char *output_name = action_get_str(action, "output_name", NULL);
+				const char *output_name = action_get_str(action, "output_name",
+						NULL);
 				virtual_output_remove(server, output_name);
 			}
 			break;

--- a/src/action.c
+++ b/src/action.c
@@ -930,14 +930,14 @@ actions_run(struct view *activator, struct server *server,
 			{
 				const char *output_name = action_get_str(action, "output_name",
 						NULL);
-				virtual_output_add(server, output_name);
+				output_add_virtual(server, output_name);
 			}
 			break;
 		case ACTION_TYPE_VIRTUAL_OUTPUT_REMOVE:
 			{
 				const char *output_name = action_get_str(action, "output_name",
 						NULL);
-				virtual_output_remove(server, output_name);
+				output_remove_virtual(server, output_name);
 			}
 			break;
 		case ACTION_TYPE_INVALID:

--- a/src/action.c
+++ b/src/action.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
-#include <wlr/backend/headless.h>
 #include <wlr/util/log.h>
 #include "action.h"
 #include "common/macros.h"

--- a/src/action.c
+++ b/src/action.c
@@ -629,58 +629,6 @@ run_if_action(struct view *view, struct server *server, struct action *action)
 	}
 }
 
-static void
-virtual_output_add(struct server *server, const char *output_name)
-{
-	if (output_name) {
-		/*
-		 * Prevent creating outputs with the same name
-		 */
-		struct output *output;
-		wl_list_for_each(output, &server->outputs, link) {
-			if (wlr_output_is_headless(output->wlr_output)) {
-				if (!strcmp(output->wlr_output->name, output_name)) {
-					wlr_log(WLR_DEBUG,
-					"refusing to create virtual output with duplicate name");
-					return;
-				}
-			}
-		}
-		strncpy(server->headless.pending_output_name, output_name,
-				sizeof(server->headless.pending_output_name));
-	} else {
-		server->headless.pending_output_name[0] = '\0';
-	}
-	wlr_headless_add_output(server->headless.backend, 1920, 1080);
-}
-
-static void
-virtual_output_remove(struct server *server, const char *output_name)
-{
-	struct output *output;
-	wl_list_for_each(output, &server->outputs, link) {
-		if (wlr_output_is_headless(output->wlr_output)) {
-			if (output_name) {
-				/*
-				 * Given virtual output name, find and destroy virtual output by
-				 * that name.
-				 */
-				if (!strcmp(output->wlr_output->name, output_name)) {
-					wlr_output_destroy(output->wlr_output);
-					return;
-				}
-			} else {
-				/*
-				 * When virtual output name was no supplied by user, simply
-				 * destroy the first virtual output found.
-				 */
-				wlr_output_destroy(output->wlr_output);
-				return;
-			}
-		}
-	}
-}
-
 void
 actions_run(struct view *activator, struct server *server,
 	struct wl_list *actions, uint32_t resize_edges)

--- a/src/output.c
+++ b/src/output.c
@@ -9,6 +9,8 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <strings.h>
+#include <wlr/backend/drm.h>
+#include <wlr/backend/headless.h>
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_output.h>
@@ -195,13 +197,20 @@ new_output_notify(struct wl_listener *listener, void *data)
 	struct wlr_output *wlr_output = data;
 
 	/*
+	 * Name virtual outputs.
+	 */
+	if (wlr_output_is_headless(wlr_output) && server->headless.pending_output_name[0] != '\0') {
+		wlr_output_set_name(wlr_output, server->headless.pending_output_name);
+	}
+
+	/*
 	 * We offer any display as available for lease, some apps like
 	 * gamescope, want to take ownership of a display when they can
 	 * to use planes and present directly.
 	 * This is also useful for debugging the DRM parts of
 	 * another compositor.
 	 */
-	if (server->drm_lease_manager) {
+	if (server->drm_lease_manager && wlr_output_is_drm(wlr_output)) {
 		wlr_drm_lease_v1_manager_offer_output(
 			server->drm_lease_manager, wlr_output);
 	}

--- a/src/output.c
+++ b/src/output.c
@@ -196,9 +196,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 	struct server *server = wl_container_of(listener, server, new_output);
 	struct wlr_output *wlr_output = data;
 
-	/*
-	 * Name virtual outputs.
-	 */
+	/* Name virtual output */
 	if (wlr_output_is_headless(wlr_output) && server->headless.pending_output_name[0] != '\0') {
 		wlr_output_set_name(wlr_output, server->headless.pending_output_name);
 		server->headless.pending_output_name[0] = '\0';
@@ -783,9 +781,7 @@ void
 output_add_virtual(struct server *server, const char *output_name)
 {
 	if (output_name) {
-		/*
-		 * Prevent creating outputs with the same name
-		 */
+		/* Prevent creating outputs with the same name */
 		struct output *output;
 		wl_list_for_each(output, &server->outputs, link) {
 			if (wlr_output_is_headless(output->wlr_output)) {

--- a/src/output.c
+++ b/src/output.c
@@ -785,7 +785,7 @@ output_add_virtual(struct server *server, const char *output_name)
 		struct output *output;
 		wl_list_for_each(output, &server->outputs, link) {
 			if (wlr_output_is_headless(output->wlr_output) &&
-				!strcmp(output->wlr_output->name, output_name)) {
+					!strcmp(output->wlr_output->name, output_name)) {
 				wlr_log(WLR_DEBUG,
 					"refusing to create virtual output with duplicate name");
 				return;
@@ -796,6 +796,10 @@ output_add_virtual(struct server *server, const char *output_name)
 	} else {
 		server->headless.pending_output_name[0] = '\0';
 	}
+	/*
+	 * Setting it to (0, 0) here disallows changing resolution from tools like
+	 * wlr-randr (returns error)
+	 */
 	wlr_headless_add_output(server->headless.backend, 1920, 1080);
 }
 

--- a/src/output.c
+++ b/src/output.c
@@ -784,12 +784,11 @@ output_add_virtual(struct server *server, const char *output_name)
 		/* Prevent creating outputs with the same name */
 		struct output *output;
 		wl_list_for_each(output, &server->outputs, link) {
-			if (wlr_output_is_headless(output->wlr_output)) {
-				if (!strcmp(output->wlr_output->name, output_name)) {
-					wlr_log(WLR_DEBUG,
+			if (wlr_output_is_headless(output->wlr_output) &&
+				!strcmp(output->wlr_output->name, output_name)) {
+				wlr_log(WLR_DEBUG,
 					"refusing to create virtual output with duplicate name");
-					return;
-				}
+				return;
 			}
 		}
 		strncpy(server->headless.pending_output_name, output_name,

--- a/src/output.c
+++ b/src/output.c
@@ -780,7 +780,7 @@ handle_output_power_manager_set_mode(struct wl_listener *listener, void *data)
 }
 
 void
-virtual_output_add(struct server *server, const char *output_name)
+output_add_virtual(struct server *server, const char *output_name)
 {
 	if (output_name) {
 		/*
@@ -805,7 +805,7 @@ virtual_output_add(struct server *server, const char *output_name)
 }
 
 void
-virtual_output_remove(struct server *server, const char *output_name)
+output_remove_virtual(struct server *server, const char *output_name)
 {
 	struct output *output;
 	wl_list_for_each(output, &server->outputs, link) {

--- a/src/server.c
+++ b/src/server.c
@@ -3,6 +3,8 @@
 #include "config.h"
 #include <signal.h>
 #include <sys/wait.h>
+#include <wlr/backend/headless.h>
+#include <wlr/backend/multi.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
@@ -255,6 +257,24 @@ server_init(struct server *server)
 		fprintf(stderr, helpful_seat_error_message);
 		exit(EXIT_FAILURE);
 	}
+
+	/*
+	 * Create headless backend to enable adding virtual outputs later on.
+	 */
+	server->headless.backend = wlr_headless_backend_create(server->wl_display);
+	if (!server->headless.backend) {
+		wlr_log(WLR_ERROR, "failed to create virtual output");
+		exit(EXIT_FAILURE);
+	}
+	wlr_multi_backend_add(server->backend, server->headless.backend);
+
+	/*
+	 * If we don't populate headless backend with a virtual output (that we
+	 * create and immediately destroy), then virtual outputs being added
+	 * later do not work properly when overlayed on real output. Content is
+	 * drawn on the virtual output, but not drawn on the real output.
+	 */
+	wlr_output_destroy(wlr_headless_add_output(server->headless.backend, 0, 0));
 
 	/*
 	 * Autocreates a renderer, either Pixman, GLES2 or Vulkan for us. The

--- a/src/server.c
+++ b/src/server.c
@@ -258,9 +258,7 @@ server_init(struct server *server)
 		exit(EXIT_FAILURE);
 	}
 
-	/*
-	 * Create headless backend to enable adding virtual outputs later on.
-	 */
+	/* Create headless backend to enable adding virtual outputs later on */
 	server->headless.backend = wlr_headless_backend_create(server->wl_display);
 	if (!server->headless.backend) {
 		wlr_log(WLR_ERROR, "failed to create virtual output");

--- a/src/server.c
+++ b/src/server.c
@@ -261,7 +261,7 @@ server_init(struct server *server)
 	/* Create headless backend to enable adding virtual outputs later on */
 	server->headless.backend = wlr_headless_backend_create(server->wl_display);
 	if (!server->headless.backend) {
-		wlr_log(WLR_ERROR, "failed to create virtual output");
+		wlr_log(WLR_ERROR, "unable to create headless backend");
 		exit(EXIT_FAILURE);
 	}
 	wlr_multi_backend_add(server->backend, server->headless.backend);
@@ -269,7 +269,7 @@ server_init(struct server *server)
 	/*
 	 * If we don't populate headless backend with a virtual output (that we
 	 * create and immediately destroy), then virtual outputs being added
-	 * later do not work properly when overlayed on real output. Content is
+	 * later do not work properly when overlaid on real output. Content is
 	 * drawn on the virtual output, but not drawn on the real output.
 	 */
 	wlr_output_destroy(wlr_headless_add_output(server->headless.backend, 0, 0));


### PR DESCRIPTION
It is now possible to use keybinds to add and remove virtual outputs (also called headless backend in wlroots terminology).

Closes #1279 

Thanks to @Consolatis for original PoC patch and guidance!