### PR TITLE
feat: implement <font place="InactiveWindow"> (ref scope: 2.4.7)

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -238,6 +238,7 @@ windows using the mouse.
 	The font to use for a specific element of a window, menu or OSD.
 	Places can be any of:
 	- ActiveWindow - titlebar of active window
+	- InactiveWindow - titlebar of all windows that aren't focused by the cursor
 	- MenuItem - menu item (currently only root menu)
 	- OnScreenDisplay - items in the on screen display
 	If no place attribute is provided, the setting will be applied to all

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -28,7 +28,7 @@
     <font place="InactiveWindow">
       <name>sans</name>
       <size>10</size>
-      <slant>italic</slant>
+      <slant>normal</slant>
       <weight>normal</weight>
     </font>
     <font place="MenuItem">

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -25,6 +25,12 @@
       <slant>normal</slant>
       <weight>normal</weight>
     </font>
+    <font place="InactiveWindow">
+      <name>sans</name>
+      <size>10</size>
+      <slant>italic</slant>
+      <weight>normal</weight>
+    </font>
     <font place="MenuItem">
       <name>sans</name>
       <size>10</size>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -51,6 +51,7 @@ struct rcxml {
 	int corner_radius;
 	bool ssd_keep_border;
 	struct font font_activewindow;
+	struct font font_inactivewindow;
 	struct font font_menuitem;
 	struct font font_osd;
 	/* Pointer to current theme */

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -597,6 +597,8 @@ enum_font_place(const char *place)
 	}
 	if (!strcasecmp(place, "ActiveWindow")) {
 		return FONT_PLACE_ACTIVEWINDOW;
+	} else if (!strcasecmp(place, "InactiveWindow")) {
+		return FONT_PLACE_INACTIVEWINDOW;
 	} else if (!strcasecmp(place, "MenuItem")) {
 		return FONT_PLACE_MENUITEM;
 	} else if (!strcasecmp(place, "OnScreenDisplay")

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -61,6 +61,7 @@ enum font_place {
 	FONT_PLACE_NONE = 0,
 	FONT_PLACE_UNKNOWN,
 	FONT_PLACE_ACTIVEWINDOW,
+	FONT_PLACE_INACTIVEWINDOW,
 	FONT_PLACE_MENUITEM,
 	FONT_PLACE_OSD,
 	/* TODO: Add all places based on Openbox's rc.xml */
@@ -564,11 +565,15 @@ fill_font(char *nodename, char *content, enum font_place place)
 		 * attribute, we set all font variables
 		 */
 		set_font_attr(&rc.font_activewindow, nodename, content);
+		set_font_attr(&rc.font_inactivewindow, nodename, content);
 		set_font_attr(&rc.font_menuitem, nodename, content);
 		set_font_attr(&rc.font_osd, nodename, content);
 		break;
 	case FONT_PLACE_ACTIVEWINDOW:
 		set_font_attr(&rc.font_activewindow, nodename, content);
+		break;
+	case FONT_PLACE_INACTIVEWINDOW:
+		set_font_attr(&rc.font_inactivewindow, nodename, content);
 		break;
 	case FONT_PLACE_MENUITEM:
 		set_font_attr(&rc.font_menuitem, nodename, content);
@@ -949,6 +954,7 @@ rcxml_init(void)
 	rc.corner_radius = 8;
 
 	init_font_defaults(&rc.font_activewindow);
+	init_font_defaults(&rc.font_inactivewindow);
 	init_font_defaults(&rc.font_menuitem);
 	init_font_defaults(&rc.font_osd);
 
@@ -1256,6 +1262,9 @@ post_processing(void)
 	if (!rc.font_activewindow.name) {
 		rc.font_activewindow.name = xstrdup("sans");
 	}
+	if (!rc.font_inactivewindow.name) {
+		rc.font_inactivewindow.name = xstrdup("sans");
+	}
 	if (!rc.font_menuitem.name) {
 		rc.font_menuitem.name = xstrdup("sans");
 	}
@@ -1440,6 +1449,7 @@ void
 rcxml_finish(void)
 {
 	zfree(rc.font_activewindow.name);
+	zfree(rc.font_inactivewindow.name);
 	zfree(rc.font_menuitem.name);
 	zfree(rc.font_osd.name);
 	zfree(rc.theme_name);

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -317,6 +317,7 @@ ssd_update_title(struct ssd *ssd)
 	bool title_unchanged = state->text && !strcmp(title, state->text);
 
 	float *text_color;
+	struct font *font = NULL;
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
 	struct ssd_state_title_width *dstate;
@@ -327,9 +328,11 @@ ssd_update_title(struct ssd *ssd)
 		if (subtree == &ssd->titlebar.active) {
 			dstate = &state->active;
 			text_color = theme->window_active_label_text_color;
+			font = &rc.font_activewindow;
 		} else {
 			dstate = &state->inactive;
 			text_color = theme->window_inactive_label_text_color;
+			font = &rc.font_inactivewindow;
 		}
 
 		if (title_bg_width <= 0) {
@@ -356,9 +359,8 @@ ssd_update_title(struct ssd *ssd)
 		}
 
 		if (part->buffer) {
-			/* TODO: Do we only have active window fonts? */
 			scaled_font_buffer_update(part->buffer, title,
-				title_bg_width, &rc.font_activewindow,
+				title_bg_width, font,
 				text_color, NULL);
 		}
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -848,7 +848,7 @@ create_corners(struct theme *theme)
 static void
 post_processing(struct theme *theme)
 {
-	int h = font_height(&rc.font_activewindow);
+	int h = MAX(font_height(&rc.font_activewindow), font_height(&rc.font_inactivewindow));
 	if (theme->title_height < h) {
 		theme->title_height = h + 2 * theme->padding_height;
 	}


### PR DESCRIPTION
Thanks you @Consolatis for the help of how to implement it.

Is the scope repo automatically updated or should I do it?

It works:
![image](https://github.com/labwc/labwc/assets/77110723/18e3f962-c7df-489a-80f8-93d76b850879)