### PR TITLE
Use overlay colour rather than fallback icon if hover icons not defined

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -23,6 +23,7 @@ struct ssd_button {
 	struct wlr_scene_node *toggled;
 	struct wlr_scene_node *toggled_hover;
 	struct wlr_scene_node *background;
+	bool shade_hover;
 
 	struct wl_listener destroy;
 };

--- a/src/button/button-xbm.c
+++ b/src/button/button-xbm.c
@@ -294,7 +294,12 @@ button_xbm_load(const char *button_name, const char *alt_name,
 			}
 		}
 	}
+
 	if (!pixmap.data) {
+		if (fallback_button[0] == 0xFF) {
+			*buffer = NULL;
+			return;
+		}
 		pixmap = parse_xbm_builtin(fallback_button, 6);
 	}
 

--- a/src/button/button-xbm.c
+++ b/src/button/button-xbm.c
@@ -296,7 +296,7 @@ button_xbm_load(const char *button_name, const char *alt_name,
 	}
 
 	if (!pixmap.data) {
-		if (fallback_button[0] == 0xFF) {
+		if (fallback_button[0] == 0x40) {
 			*buffer = NULL;
 			return;
 		}

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -165,16 +165,23 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 		icon_geo.width, icon_geo.height);
 
 	/* Hover icon */
-	struct wlr_box hover_geo = get_scale_box(hover_buffer,
-		SSD_BUTTON_WIDTH, rc.theme->title_height);
-	struct ssd_part *hover_part = add_scene_buffer(part_list, type,
-		parent, hover_buffer, hover_geo.x, hover_geo.y);
+	struct ssd_part *hover_part;
+	if (hover_buffer) {
+		struct wlr_box hover_geo = get_scale_box(hover_buffer,
+			SSD_BUTTON_WIDTH, rc.theme->title_height);
+		hover_part = add_scene_buffer(part_list, type, parent,
+			hover_buffer, hover_geo.x, hover_geo.y);
 
-	/* Make sure big icons are scaled down if necessary */
-	wlr_scene_buffer_set_dest_size(
-		wlr_scene_buffer_from_node(hover_part->node),
-		hover_geo.width, hover_geo.height);
-
+		/* Make sure big icons are scaled down if necessary */
+		wlr_scene_buffer_set_dest_size(
+			wlr_scene_buffer_from_node(hover_part->node),
+			hover_geo.width, hover_geo.height);
+	}
+	else {
+		float hover_bg[4] = {0.15f, 0.15f, 0.15f, 0.3f};
+		hover_part = add_scene_rect(part_list, type, parent,
+			SSD_BUTTON_WIDTH, rc.theme->title_height, 0, 0, hover_bg);
+	}
 	wlr_scene_node_set_enabled(hover_part->node, false);
 
 	struct ssd_button *button = ssd_button_descriptor_create(button_root->node);
@@ -185,6 +192,7 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 	button->background = bg_rect->node;
 	button->toggled = NULL;
 	button->toggled_hover = NULL;
+	button->shade_hover = hover_buffer ? false : true;
 	return button_root;
 }
 
@@ -209,16 +217,24 @@ add_toggled_icon(struct wl_list *part_list, enum ssd_part_type type,
 
 	wlr_scene_node_set_enabled(alticon_part->node, false);
 
-	struct wlr_box hover_geo = get_scale_box(hover_buffer,
-		SSD_BUTTON_WIDTH, rc.theme->title_height);
-	struct ssd_part *althover_part = add_scene_buffer(part_list, type,
-		parent, hover_buffer, hover_geo.x, hover_geo.y);
+	struct ssd_part *althover_part;
+	if (hover_buffer) {
+		struct wlr_box hover_geo = get_scale_box(hover_buffer,
+			SSD_BUTTON_WIDTH, rc.theme->title_height);
+		althover_part = add_scene_buffer(part_list, type,
+			parent, hover_buffer, hover_geo.x, hover_geo.y);
 
-	wlr_scene_buffer_set_dest_size(
-		wlr_scene_buffer_from_node(althover_part->node),
-		hover_geo.width, hover_geo.height);
-
-	wlr_scene_node_set_enabled(althover_part->node, false);
+		wlr_scene_buffer_set_dest_size(
+			wlr_scene_buffer_from_node(althover_part->node),
+			hover_geo.width, hover_geo.height);
+	}
+	else
+	{
+		float hover_bg[4] = {0.15f, 0.15f, 0.15f, 0.3f};
+		althover_part = add_scene_rect(part_list, type, parent,
+			SSD_BUTTON_WIDTH, rc.theme->title_height, 0, 0, hover_bg);
+	}
+	wlr_scene_node_set_enabled (althover_part->node, false);
 
 	button->toggled = alticon_part->node;
 	button->toggled_hover = althover_part->node;

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -176,8 +176,7 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 		wlr_scene_buffer_set_dest_size(
 			wlr_scene_buffer_from_node(hover_part->node),
 			hover_geo.width, hover_geo.height);
-	}
-	else {
+	} else {
 		float hover_bg[4] = {0.15f, 0.15f, 0.15f, 0.3f};
 		hover_part = add_scene_rect(part_list, type, parent,
 			SSD_BUTTON_WIDTH, rc.theme->title_height, 0, 0, hover_bg);
@@ -227,14 +226,12 @@ add_toggled_icon(struct wl_list *part_list, enum ssd_part_type type,
 		wlr_scene_buffer_set_dest_size(
 			wlr_scene_buffer_from_node(althover_part->node),
 			hover_geo.width, hover_geo.height);
-	}
-	else
-	{
+	} else {
 		float hover_bg[4] = {0.15f, 0.15f, 0.15f, 0.3f};
 		althover_part = add_scene_rect(part_list, type, parent,
 			SSD_BUTTON_WIDTH, rc.theme->title_height, 0, 0, hover_bg);
 	}
-	wlr_scene_node_set_enabled (althover_part->node, false);
+	wlr_scene_node_set_enabled(althover_part->node, false);
 
 	button->toggled = alticon_part->node;
 	button->toggled_hover = althover_part->node;

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -418,7 +418,8 @@ disable_old_hover:
 		hover_state->old_node = maximized ? button->toggled : button->normal;
 		hover_state->maximized = button->toggled ? (int)button->view->maximized : -1;
 		if (!button->shade_hover) {
-			wlr_scene_node_set_enabled(maximized ? button->toggled : button->normal, false);
+			wlr_scene_node_set_enabled(maximized ? button->toggled : button->normal,
+				false);
 		}
 	}
 }

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -417,7 +417,9 @@ disable_old_hover:
 		hover_state->node = maximized ? button->toggled_hover : button->hover;
 		hover_state->old_node = maximized ? button->toggled : button->normal;
 		hover_state->maximized = button->toggled ? (int)button->view->maximized : -1;
-		wlr_scene_node_set_enabled(maximized ? button->toggled : button->normal, false);
+		if (!button->shade_hover) {
+			wlr_scene_node_set_enabled(maximized ? button->toggled : button->normal, false);
+		}
 	}
 }
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -122,7 +122,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"menu_hover", NULL,
-			{ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
+			{ 0xFF, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_menu_active_hover,
 				theme->window_active_button_menu_unpressed_image_color,
@@ -134,7 +134,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"iconify_hover", NULL,
-			{ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
+			{ 0xFF, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_iconify_active_hover,
 				theme->window_active_button_iconify_unpressed_image_color,
@@ -146,7 +146,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"max_hover", NULL,
-			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+			{ 0xFF, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_maximize_active_hover,
 				theme->window_active_button_max_unpressed_image_color,
@@ -158,7 +158,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"max_hover_toggled", "max_toggled_hover",
-			{ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
+			{ 0xFF, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_restore_active_hover,
 				theme->window_active_button_max_unpressed_image_color,
@@ -170,7 +170,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"close_hover", NULL,
-			{ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
+			{ 0xFF, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_close_active_hover,
 				theme->window_active_button_close_unpressed_image_color,

--- a/src/theme.c
+++ b/src/theme.c
@@ -122,7 +122,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"menu_hover", NULL,
-			{ 0xFF, 0, 0, 0, 0, 0 },
+			{ 0x40, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_menu_active_hover,
 				theme->window_active_button_menu_unpressed_image_color,
@@ -134,7 +134,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"iconify_hover", NULL,
-			{ 0xFF, 0, 0, 0, 0, 0 },
+			{ 0x40, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_iconify_active_hover,
 				theme->window_active_button_iconify_unpressed_image_color,
@@ -146,7 +146,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"max_hover", NULL,
-			{ 0xFF, 0, 0, 0, 0, 0 },
+			{ 0x40, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_maximize_active_hover,
 				theme->window_active_button_max_unpressed_image_color,
@@ -158,7 +158,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"max_hover_toggled", "max_toggled_hover",
-			{ 0xFF, 0, 0, 0, 0, 0 },
+			{ 0x40, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_restore_active_hover,
 				theme->window_active_button_max_unpressed_image_color,
@@ -170,7 +170,7 @@ load_buttons(struct theme *theme)
 		},
 		{
 			"close_hover", NULL,
-			{ 0xFF, 0, 0, 0, 0, 0 },
+			{ 0x40, 0, 0, 0, 0, 0 },
 			{
 				&theme->button_close_active_hover,
 				theme->window_active_button_close_unpressed_image_color,


### PR DESCRIPTION
I think this should use the original hover overlay instead of the fallback XBM hover icons if hover icon files are not present in the theme. Seems to work ok for me.

If a fallback XBM has 0x40 as the first byte - which will never be the case for a real icon, as they only use the bottom 6 bits, that triggers the XBM icon loader to just set the icon buffer to NULL. If the SSD code finds a null icon buffer, it loads the overlay instead of the icon as the hover part of the scene.

The only untidy bit is because if the hover icon is used, we need to turn off the normal icon while the hover icon is displayed to prevent one showing through the other, and if the hover overlay is used, we need to leave the normal icon on. I've added a flag to the button structure to indicate which needs to happen - this is a bit clunky, so feel free to improve on it!