### PR TITLE
Icon refactoring

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -212,7 +212,8 @@ One advantage of xbm buttons over other formats is that they change color based
 on the theme. Other formats use the suffices "-active" and "-inactive" to align
 with the respective titlebar colors. For example: "close-active.png"
 
-For compatibility reasons, the following alternative names are supported:
+For compatibility reasons, the following alternative names are supported
+for xbm files:
 
 - max_hover_toggled.xbm for max_toggled_hover.xbm
 

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -206,11 +206,15 @@ over the button in question:
 - iconify_hover.xbm
 - close_hover.xbm
 - menu_hover.xbm
-- max_hover_toggled.xbm
+- max_toggled_hover.xbm
 
 One advantage of xbm buttons over other formats is that they change color based
 on the theme. Other formats use the suffices "-active" and "-inactive" to align
 with the respective titlebar colors. For example: "close-active.png"
+
+For compatibility reasons, the following alternative names are supported:
+
+- max_hover_toggled.xbm for max_toggled_hover.xbm
 
 # DEFINITIONS
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -173,16 +173,8 @@ load_buttons(struct theme *theme)
 		/* Try png icon first */
 		snprintf(filename, sizeof(filename), "%s-active.png", b->name);
 		button_png_load(filename, b->active.buffer);
-		if (!*b->active.buffer && b->alt_name) {
-			snprintf(filename, sizeof(filename), "%s-active.png", b->alt_name);
-			button_png_load(filename, b->active.buffer);
-		}
 		snprintf(filename, sizeof(filename), "%s-inactive.png", b->name);
 		button_png_load(filename, b->inactive.buffer);
-		if (!*b->inactive.buffer && b->alt_name) {
-			snprintf(filename, sizeof(filename), "%s-inactive.png", b->alt_name);
-			button_png_load(filename, b->inactive.buffer);
-		}
 
 #if HAVE_RSVG
 		/* Then try svg icon */
@@ -191,16 +183,8 @@ load_buttons(struct theme *theme)
 			snprintf(filename, sizeof(filename), "%s-active.svg", b->name);
 			button_svg_load(filename, b->active.buffer, size);
 		}
-		if (!*b->active.buffer && b->alt_name) {
-			snprintf(filename, sizeof(filename), "%s-active.svg", b->alt_name);
-			button_svg_load(filename, b->active.buffer, size);
-		}
 		if (!*b->inactive.buffer) {
 			snprintf(filename, sizeof(filename), "%s-inactive.svg", b->name);
-			button_svg_load(filename, b->inactive.buffer, size);
-		}
-		if (!*b->active.buffer && b->alt_name) {
-			snprintf(filename, sizeof(filename), "%s-inactive.svg", b->alt_name);
 			button_svg_load(filename, b->inactive.buffer, size);
 		}
 #endif

--- a/src/theme.c
+++ b/src/theme.c
@@ -59,128 +59,78 @@ drop(struct lab_data_buffer **buffer)
 static void
 load_buttons(struct theme *theme)
 {
-	struct button buttons[] = {
-		{
-			"menu", NULL,
-			{ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
-			{
-				&theme->button_menu_active_unpressed,
-				theme->window_active_button_menu_unpressed_image_color,
-			},
-			{
-				&theme->button_menu_inactive_unpressed,
-				theme->window_inactive_button_menu_unpressed_image_color,
-			},
-		},
-		{
-			"iconify", NULL,
-			{ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
-			{
-				&theme->button_iconify_active_unpressed,
-				theme->window_active_button_iconify_unpressed_image_color,
-			},
-			{
-				&theme->button_iconify_inactive_unpressed,
-				theme->window_inactive_button_iconify_unpressed_image_color,
-			},
-		},
-		{
-			"max", NULL,
-			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
-			{
-				&theme->button_maximize_active_unpressed,
-				theme->window_active_button_max_unpressed_image_color,
-			},
-			{
-				&theme->button_maximize_inactive_unpressed,
-				theme->window_inactive_button_max_unpressed_image_color,
-			},
-		},
-		{
-			"max_toggled", NULL,
-			{ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
-			{
-				&theme->button_restore_active_unpressed,
-				theme->window_active_button_max_unpressed_image_color,
-			},
-			{
-				&theme->button_restore_inactive_unpressed,
-				theme->window_inactive_button_max_unpressed_image_color,
-			},
-		},
-		{
-			"close", NULL,
-			{ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
-			{
-				&theme->button_close_active_unpressed,
-				theme->window_active_button_close_unpressed_image_color,
-			},
-			{
-				&theme->button_close_inactive_unpressed,
-				theme->window_inactive_button_close_unpressed_image_color,
-			},
-		},
-		{
-			"menu_hover", NULL,
-			{ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
-			{
-				&theme->button_menu_active_hover,
-				theme->window_active_button_menu_unpressed_image_color,
-			},
-			{
-				&theme->button_menu_inactive_hover,
-				theme->window_inactive_button_menu_unpressed_image_color,
-			},
-		},
-		{
-			"iconify_hover", NULL,
-			{ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
-			{
-				&theme->button_iconify_active_hover,
-				theme->window_active_button_iconify_unpressed_image_color,
-			},
-			{
-				&theme->button_iconify_inactive_hover,
-				theme->window_inactive_button_iconify_unpressed_image_color,
-			},
-		},
-		{
-			"max_hover", NULL,
-			{ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
-			{
-				&theme->button_maximize_active_hover,
-				theme->window_active_button_max_unpressed_image_color,
-			},
-			{
-				&theme->button_maximize_inactive_hover,
-				theme->window_inactive_button_max_unpressed_image_color,
-			},
-		},
-		{
-			"max_hover_toggled", "max_toggled_hover",
-			{ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
-			{
-				&theme->button_restore_active_hover,
-				theme->window_active_button_max_unpressed_image_color,
-			},
-			{
-				&theme->button_restore_inactive_hover,
-				theme->window_inactive_button_max_unpressed_image_color,
-			},
-		},
-		{
-			"close_hover", NULL,
-			{ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
-			{
-				&theme->button_close_active_hover,
-				theme->window_active_button_close_unpressed_image_color,
-			},
-			{
-				&theme->button_close_inactive_hover,
-				theme->window_inactive_button_close_unpressed_image_color,
-			},
-		},
-	};
+	struct button buttons[] = { {
+		.name = "menu",
+		.fallback_button = { 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
+		.active.buffer = &theme->button_menu_active_unpressed,
+		.active.rgba = theme->window_active_button_menu_unpressed_image_color,
+		.inactive.buffer = &theme->button_menu_inactive_unpressed,
+		.inactive.rgba = theme->window_inactive_button_menu_unpressed_image_color,
+	}, {
+		.name = "iconify",
+		.fallback_button = { 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
+		.active.buffer = &theme->button_iconify_active_unpressed,
+		.active.rgba = theme->window_active_button_iconify_unpressed_image_color,
+		.inactive.buffer = &theme->button_iconify_inactive_unpressed,
+		.inactive.rgba = theme->window_inactive_button_iconify_unpressed_image_color,
+	}, {
+		.name = "max",
+		.fallback_button = { 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+		.active.buffer = &theme->button_maximize_active_unpressed,
+		.active.rgba = theme->window_active_button_max_unpressed_image_color,
+		.inactive.buffer = &theme->button_maximize_inactive_unpressed,
+		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
+	}, {
+		.name = "max_toggled",
+		.fallback_button = { 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
+		.active.buffer = &theme->button_restore_active_unpressed,
+		.active.rgba = theme->window_active_button_max_unpressed_image_color,
+		.inactive.buffer = &theme->button_restore_inactive_unpressed,
+		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
+	}, {
+		.name = "close",
+		.fallback_button = { 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
+		.active.buffer = &theme->button_close_active_unpressed,
+		.active.rgba = theme->window_active_button_close_unpressed_image_color,
+		.inactive.buffer = &theme->button_close_inactive_unpressed,
+		.inactive.rgba = theme->window_inactive_button_close_unpressed_image_color,
+	}, {
+		.name = "menu_hover",
+		.fallback_button = { 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
+		.active.buffer = &theme->button_menu_active_hover,
+		.active.rgba = theme->window_active_button_menu_unpressed_image_color,
+		.inactive.buffer = &theme->button_menu_inactive_hover,
+		.inactive.rgba = theme->window_inactive_button_menu_unpressed_image_color,
+	}, {
+		.name = "iconify_hover",
+		.fallback_button = { 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
+		.active.buffer = &theme->button_iconify_active_hover,
+		.active.rgba = theme->window_active_button_iconify_unpressed_image_color,
+		.inactive.buffer = &theme->button_iconify_inactive_hover,
+		.inactive.rgba = theme->window_inactive_button_iconify_unpressed_image_color,
+	}, {
+		.name = "max_hover",
+		.fallback_button = { 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+		.active.buffer = &theme->button_maximize_active_hover,
+		.active.rgba = theme->window_active_button_max_unpressed_image_color,
+		.inactive.buffer = &theme->button_maximize_inactive_hover,
+		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
+	}, {
+		.name = "max_hover_toggled",
+		.alt_name = "max_toggled_hover",
+		.fallback_button = { 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
+		.active.buffer = &theme->button_restore_active_hover,
+		.active.rgba = theme->window_active_button_max_unpressed_image_color,
+		.inactive.buffer = &theme->button_restore_inactive_hover,
+		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
+	}, {
+		.name = "close_hover",
+		.fallback_button = { 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
+		.active.buffer = &theme->button_close_active_hover,
+		.active.rgba = theme->window_active_button_close_unpressed_image_color,
+		.inactive.buffer = &theme->button_close_inactive_hover,
+		.inactive.rgba = theme->window_inactive_button_close_unpressed_image_color,
+	}, };
 
 	char filename[4096] = {0};
 	char alt_filename[4096] = {0};

--- a/src/theme.c
+++ b/src/theme.c
@@ -56,6 +56,36 @@ drop(struct lab_data_buffer **buffer)
 	}
 }
 
+/*
+ * We use the following button filename schema: "BUTTON [TOGGLED] [STATE]"
+ * with the words separted by underscore, and the following meaning:
+ *   - BUTTON can be one of 'max', 'iconify', 'close', 'menu'
+ *   - TOGGLED is either 'toggled' or nothing
+ *   - STATE is 'hover' or nothing. In future, 'pressed' may be supported too.
+ *
+ * We believe that this is how the vast majority of extant openbox themes out
+ * there are constructed and it is consistent with the openbox.org wiki. But
+ * please be aware that it is actually different to vanilla Openbox which uses:
+ * "BUTTON [STATE] [TOGGLED]" following an unfortunate commit in 2014 which
+ * broke themes and led to some distros patching Openbox:
+ * https://github.com/danakj/openbox/commit/35e92e4c2a45b28d5c2c9b44b64aeb4222098c94
+ *
+ * Arch Linux and Debian patch Openbox to keep the old syntax (the one we use).
+ * https://gitlab.archlinux.org/archlinux/packaging/packages/openbox/-/blob/main/debian-887908.patch?ref_type=heads
+ * This patch does the following:
+ *   - reads "%s_toggled_pressed.xbm" and "%s_toggled_hover.xbm" instead of the
+ *     'hover_toggled' equivalents.
+ *   - parses 'toggled.unpressed', toggled.pressed' and 'toggled.hover' instead
+ *     of the other way around ('*.toggled') when processing themerc.
+ *
+ * For compatibility with distros which do not apply similar patches, we support
+ * the hover-before-toggle too, for example:
+ *
+ *	.name = "max_toggled_hover",
+ *	.alt_name = "max_hover_toggled",
+ *
+ * ...in the button array definition below.
+ */
 static void
 load_buttons(struct theme *theme)
 {
@@ -116,8 +146,8 @@ load_buttons(struct theme *theme)
 		.inactive.buffer = &theme->button_maximize_inactive_hover,
 		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
 	}, {
-		.name = "max_hover_toggled",
-		.alt_name = "max_toggled_hover",
+		.name = "max_toggled_hover",
+		.alt_name = "max_hover_toggled",
 		.fallback_button = { 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
 		.active.buffer = &theme->button_restore_active_hover,
 		.active.rgba = theme->window_active_button_max_unpressed_image_color,


### PR DESCRIPTION
- make button array definition easier to read
- use `max_toggled_hover` with `max_hover_toggled` the alternative
- do not support svg+png icons in max_hover_toggled format

Will wait until this is reviewed/merged and then move onto refactoring `button_xbm_load()` and sort out the fallback regression.
Will try to weave #1296 into it at that point.


Cc @spl237 - for awareness