### PR TITLE
Initial graphics tablet support

### DIFF
--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -11,6 +11,7 @@ struct seat;
 struct server;
 struct wlr_surface;
 struct wlr_scene_node;
+enum wlr_button_state;
 
 /* Cursors used internally by labwc */
 enum lab_cursors {
@@ -118,6 +119,11 @@ void cursor_update_focus(struct server *server);
 void cursor_update_image(struct seat *seat);
 
 void cursor_init(struct seat *seat);
+void cursor_emulate_move_absolute(struct seat *seat,
+		struct wlr_input_device *device,
+		double x, double y, uint32_t time_msec);
+void cursor_emulate_button(struct seat *seat,
+		uint32_t button, enum wlr_button_state state, uint32_t time_msec);
 void cursor_finish(struct seat *seat);
 
 #endif /* LABWC_CURSOR_H */

--- a/include/input/drawing_tablet.h
+++ b/include/input/drawing_tablet.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_DRAWING_TABLET_H
+#define LABWC_DRAWING_TABLET_H
+
+#include <wayland-server-core.h>
+struct seat;
+struct wlr_device;
+struct wlr_input_device;
+
+struct drawing_tablet {
+	struct seat *seat;
+	struct wlr_tablet *tablet;
+	double x, y;
+	struct {
+		struct wl_listener axis;
+		struct wl_listener tip;
+		struct wl_listener button;
+		struct wl_listener destroy;
+		// no interest in proximity events
+	} handlers;
+};
+
+void drawing_tablet_setup_handlers(struct seat *seat, struct wlr_input_device *wlr_input_device);
+
+#endif /* LABWC_DRAWING_TABLET_H */

--- a/src/input/drawing_tablet.c
+++ b/src/input/drawing_tablet.c
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <assert.h>
+#include <stdlib.h>
+#include <linux/input-event-codes.h>
+#include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/util/log.h>
+#include "common/macros.h"
+#include "common/mem.h"
+#include "config/rcxml.h"
+#include "input/cursor.h"
+#include "input/drawing_tablet.h"
+
+#include "config/rcxml.h"
+
+static void
+handle_axis(struct wl_listener *listener, void *data)
+{
+	struct wlr_tablet_tool_axis_event *ev = data;
+	struct drawing_tablet *tablet = ev->tablet->data;
+	if (ev->updated_axes & (WLR_TABLET_TOOL_AXIS_X | WLR_TABLET_TOOL_AXIS_Y)) {
+		if (ev->updated_axes & WLR_TABLET_TOOL_AXIS_X) {
+			tablet->x = ev->x;
+		}
+		if (ev->updated_axes & WLR_TABLET_TOOL_AXIS_Y) {
+			tablet->y = ev->y;
+		}
+
+		double x = tablet->x;
+		double y = tablet->y;
+		cursor_emulate_move_absolute(tablet->seat, &ev->tablet->base, x, y, ev->time_msec);
+	}
+	// Ignore other events
+}
+
+static void
+handle_tip(struct wl_listener *listener, void *data)
+{
+	struct wlr_tablet_tool_tip_event *ev = data;
+	struct drawing_tablet *tablet = ev->tablet->data;
+
+	cursor_emulate_button(tablet->seat,
+		BTN_LEFT,
+		ev->state == WLR_TABLET_TOOL_TIP_DOWN
+			? WLR_BUTTON_PRESSED
+			: WLR_BUTTON_RELEASED,
+		ev->time_msec);
+}
+
+static void
+handle_button(struct wl_listener *listener, void *data)
+{
+	struct wlr_tablet_tool_button_event *ev = data;
+	struct drawing_tablet *tablet = ev->tablet->data;
+
+	uint32_t button;
+	switch (ev->button) {
+	case BTN_STYLUS:
+		button = BTN_RIGHT;
+		break;
+	case BTN_STYLUS2:
+		button = BTN_MIDDLE;
+		break;
+	default:
+		wlr_log(WLR_DEBUG, "no button map target");
+		return;
+	}
+
+	cursor_emulate_button(tablet->seat, button, ev->state, ev->time_msec);
+}
+
+static void
+handle_destroy(struct wl_listener *listener, void *data)
+{
+	struct drawing_tablet *tablet =
+		wl_container_of(listener, tablet, handlers.destroy);
+	free(tablet);
+}
+
+static void
+setup_pad(struct seat *seat, struct wlr_input_device *wlr_device)
+{
+	wlr_log(WLR_INFO, "not setting up pad");
+}
+
+static void
+setup_pen(struct seat *seat, struct wlr_input_device *wlr_device)
+{
+	wlr_log(WLR_DEBUG, "setting up tablet");
+	struct drawing_tablet *tablet = znew(*tablet);
+	tablet->seat = seat;
+	tablet->tablet = wlr_tablet_from_input_device(wlr_device);
+	tablet->tablet->data = tablet;
+	tablet->x = 0.0;
+	tablet->y = 0.0;
+	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, axis);
+	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, tip);
+	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, button);
+	CONNECT_SIGNAL(wlr_device, &tablet->handlers, destroy);
+}
+
+void
+drawing_tablet_setup_handlers(struct seat *seat, struct wlr_input_device *device)
+{
+	switch (device->type) {
+	case WLR_INPUT_DEVICE_TABLET_PAD:
+		setup_pad(seat, device);
+		break;
+	case WLR_INPUT_DEVICE_TABLET_TOOL:
+		setup_pen(seat, device);
+		break;
+	default:
+		assert(false && "tried to add non-tablet as tablet");
+	}
+}

--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -1,5 +1,6 @@
 labwc_sources += files(
   'cursor.c',
+  'drawing_tablet.c',
   'gestures.c',
   'input.c',
   'keyboard.c',

--- a/src/seat.c
+++ b/src/seat.c
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_touch.h>
 #include <wlr/util/log.h>
 #include "common/mem.h"
+#include "input/drawing_tablet.h"
 #include "input/input.h"
 #include "input/keyboard.h"
 #include "input/key-state.h"
@@ -254,6 +255,16 @@ new_touch(struct seat *seat, struct wlr_input_device *dev)
 	return input;
 }
 
+static struct input *
+new_tablet(struct seat *seat, struct wlr_input_device *dev)
+{
+	struct input *input = znew(*input);
+	input->wlr_input_device = dev;
+	drawing_tablet_setup_handlers(seat, dev);
+
+	return input;
+}
+
 static void
 seat_update_capabilities(struct seat *seat)
 {
@@ -305,6 +316,10 @@ new_input_notify(struct wl_listener *listener, void *data)
 		break;
 	case WLR_INPUT_DEVICE_TOUCH:
 		input = new_touch(seat, device);
+		break;
+	case WLR_INPUT_DEVICE_TABLET_PAD:
+	case WLR_INPUT_DEVICE_TABLET_TOOL:
+		input = new_tablet(seat, device);
 		break;
 	default:
 		wlr_log(WLR_INFO, "unsupported input device");


### PR DESCRIPTION
This PR adds initial support for cursor emulation with a graphics tablet (https://github.com/labwc/labwc/issues/1060). No configuration options (yet), just mapping all of the tablet surface to the output area with a fixed button mapping.

All commits are based on @Consolatis  work from https://github.com/labwc/labwc/issues/1060#issuecomment-1786384495 and all findings in https://github.com/labwc/labwc/issues/1060 The commits have a co-author assigned.

I'm using this code for a week now (with https://github.com/labwc/labwc/issues/1060#issuecomment-1826875020 op top of it) and haven't noticed any issues.
