### PR TITLE
Option to show full app_id in window switcher

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -134,7 +134,7 @@ this is for compatibility with Openbox.
 
 ## WINDOW SWITCHER
 
-*<windowSwitcher show="" preview="" outlines="">*
+*<windowSwitcher show="" preview="" outlines="" full_app_id="">*
 	*show* [yes|no] Draw the OnScreenDisplay when switching between
 	windows. Default is yes.
 
@@ -143,6 +143,10 @@ this is for compatibility with Openbox.
 
 	*outlines* [yes|no] Draw an outline around the selected window when
 	switching between windows. Default is yes.
+
+	*full_app_id* [yes|no] Display full application identifier instead of trimmed
+	variant. Trimming removes the first two nodes of 'org.' strings. Default is
+	no.
 
 *<windowSwitcher><fields><field content="" width="%">*
 	Define window switcher fields.

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -154,6 +154,9 @@ this is for compatibility with Openbox.
 		- *identifier* Show identifier (app_id for native Wayland
 		  windows and WM_CLASS for XWayland clients)
 
+		- *trimmed_identifier* Show trimmed identifier. Trimming removes the first
+		  two nodes of 'org.' strings.
+
 		- *title* Show window title if different to app_id
 
 	*width* defines the width of the field expressed as a percentage of

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -134,7 +134,7 @@ this is for compatibility with Openbox.
 
 ## WINDOW SWITCHER
 
-*<windowSwitcher show="" preview="" outlines="" full_app_id="">*
+*<windowSwitcher show="" preview="" outlines="">*
 	*show* [yes|no] Draw the OnScreenDisplay when switching between
 	windows. Default is yes.
 
@@ -143,10 +143,6 @@ this is for compatibility with Openbox.
 
 	*outlines* [yes|no] Draw an outline around the selected window when
 	switching between windows. Default is yes.
-
-	*full_app_id* [yes|no] Display full application identifier instead of trimmed
-	variant. Trimming removes the first two nodes of 'org.' strings. Default is
-	no.
 
 *<windowSwitcher><fields><field content="" width="%">*
 	Define window switcher fields.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -52,7 +52,8 @@
   <windowSwitcher show="yes" preview="yes" outlines="yes">
     <fields>
       <field content="type" width="25%" />
-      <field content="identifier" width="25%" />
+      <field content="trimmed_identifier" width="25%" />
+      <!-- <field content="identifier" width="25%" /> -->
       <field content="title" width="50%" />
     </fields>
   </windowSwitcher>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -49,7 +49,7 @@
     Just as for window-rules, 'identifier' relates to app_id for native Wayland
     windows and WM_CLASS for XWayland clients.
   -->
-  <windowSwitcher show="yes" preview="yes" outlines="yes">
+  <windowSwitcher show="yes" preview="yes" outlines="yes" full_app_id="no">
     <fields>
       <field content="type" width="25%" />
       <field content="identifier" width="25%" />

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -49,7 +49,7 @@
     Just as for window-rules, 'identifier' relates to app_id for native Wayland
     windows and WM_CLASS for XWayland clients.
   -->
-  <windowSwitcher show="yes" preview="yes" outlines="yes" full_app_id="no">
+  <windowSwitcher show="yes" preview="yes" outlines="yes">
     <fields>
       <field content="type" width="25%" />
       <field content="identifier" width="25%" />

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -97,6 +97,7 @@ struct rcxml {
 		bool show;
 		bool preview;
 		bool outlines;
+		bool full_app_id;
 		struct wl_list fields;  /* struct window_switcher_field.link */
 	} window_switcher;
 

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -97,7 +97,6 @@ struct rcxml {
 		bool show;
 		bool preview;
 		bool outlines;
-		bool full_app_id;
 		struct wl_list fields;  /* struct window_switcher_field.link */
 	} window_switcher;
 

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -17,6 +17,7 @@ enum window_switcher_field_content {
 	LAB_FIELD_NONE = 0,
 	LAB_FIELD_TYPE,
 	LAB_FIELD_IDENTIFIER,
+	LAB_FIELD_TRIMMED_IDENTIFIER,
 	LAB_FIELD_TITLE,
 };
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -755,15 +755,13 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "topMaximize.snapping")) {
 		set_bool(content, &rc.snap_top_maximize);
 
-	/* <windowSwitcher show="" preview="" outlines="" full_app_id="" /> */
+	/* <windowSwitcher show="" preview="" outlines="" /> */
 	} else if (!strcasecmp(nodename, "show.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.show);
 	} else if (!strcasecmp(nodename, "preview.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.preview);
 	} else if (!strcasecmp(nodename, "outlines.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.outlines);
-	} else if (!strcasecmp(nodename, "full_app_id.windowSwitcher")) {
-		set_bool(content, &rc.window_switcher.full_app_id);
 
 	/* Remove this long term - just a friendly warning for now */
 	} else if (strstr(nodename, "windowswitcher.core")) {
@@ -978,7 +976,6 @@ rcxml_init(void)
 	rc.window_switcher.show = true;
 	rc.window_switcher.preview = true;
 	rc.window_switcher.outlines = true;
-	rc.window_switcher.full_app_id = false;
 
 	rc.resize_indicator = LAB_RESIZE_INDICATOR_NEVER;
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -755,13 +755,15 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "topMaximize.snapping")) {
 		set_bool(content, &rc.snap_top_maximize);
 
-	/* <windowSwitcher show="" preview="" outlines="" /> */
+	/* <windowSwitcher show="" preview="" outlines="" full_app_id="" /> */
 	} else if (!strcasecmp(nodename, "show.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.show);
 	} else if (!strcasecmp(nodename, "preview.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.preview);
 	} else if (!strcasecmp(nodename, "outlines.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.outlines);
+	} else if (!strcasecmp(nodename, "full_app_id.windowSwitcher")) {
+		set_bool(content, &rc.window_switcher.full_app_id);
 
 	/* Remove this long term - just a friendly warning for now */
 	} else if (strstr(nodename, "windowswitcher.core")) {
@@ -976,6 +978,7 @@ rcxml_init(void)
 	rc.window_switcher.show = true;
 	rc.window_switcher.preview = true;
 	rc.window_switcher.outlines = true;
+	rc.window_switcher.full_app_id = false;
 
 	rc.resize_indicator = LAB_RESIZE_INDICATOR_NEVER;
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -198,6 +198,8 @@ fill_window_switcher_field(char *nodename, char *content)
 		} else if (!strcmp(content, "app_id")) {
 			wlr_log(WLR_ERROR, "window-switcher field 'app_id' is deprecated");
 			current_field->content = LAB_FIELD_IDENTIFIER;
+		} else if (!strcmp(content, "trimmed_identifier")) {
+			current_field->content = LAB_FIELD_TRIMMED_IDENTIFIER;
 		} else if (!strcmp(content, "title")) {
 			current_field->content = LAB_FIELD_TITLE;
 		} else {
@@ -1218,7 +1220,7 @@ static struct {
 	int width;
 } fields[] = {
 	{ LAB_FIELD_TYPE, 25 },
-	{ LAB_FIELD_IDENTIFIER, 25 },
+	{ LAB_FIELD_TRIMMED_IDENTIFIER, 25 },
 	{ LAB_FIELD_TITLE, 50 },
 	{ LAB_FIELD_NONE, 0 },
 };

--- a/src/osd.c
+++ b/src/osd.c
@@ -44,6 +44,15 @@ get_formatted_app_id(struct view *view)
 	if (!s) {
 		return NULL;
 	}
+	return s;
+}
+
+static const char *
+get_trimmed_app_id(char *s)
+{
+	if (!s) {
+		return NULL;
+	}
 	/* remove the first two nodes of 'org.' strings */
 	if (!strncmp(s, "org.", 4)) {
 		char *p = s + 4;
@@ -355,6 +364,12 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 			case LAB_FIELD_IDENTIFIER:
 				buf_add(&buf, get_app_id(*view));
 				break;
+			case LAB_FIELD_TRIMMED_IDENTIFIER:
+				{
+					char *s = (char *)get_app_id(*view);
+					buf_add(&buf, get_trimmed_app_id(s));
+					break;
+				}
 			case LAB_FIELD_TITLE:
 				buf_add(&buf, get_title(*view));
 				break;

--- a/src/osd.c
+++ b/src/osd.c
@@ -44,9 +44,6 @@ get_formatted_app_id(struct view *view)
 	if (!s) {
 		return NULL;
 	}
-	if (rc.window_switcher.full_app_id) {
-		return s;
-	}
 	/* remove the first two nodes of 'org.' strings */
 	if (!strncmp(s, "org.", 4)) {
 		char *p = s + 4;

--- a/src/osd.c
+++ b/src/osd.c
@@ -44,6 +44,9 @@ get_formatted_app_id(struct view *view)
 	if (!s) {
 		return NULL;
 	}
+	if (rc.window_switcher.full_app_id) {
+		return s;
+	}
 	/* remove the first two nodes of 'org.' strings */
 	if (!strncmp(s, "org.", 4)) {
 		char *p = s + 4;


### PR DESCRIPTION
It is now possible to specify whether to show full application identifier or the trimmed variant in window switcher OSD.

Closes #1073 