### PR TITLE
Add `touchpad` device type

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -435,11 +435,11 @@ windows using the mouse.
 *<libinput><device category="">*
 	Define a category of devices to use the configuration values that
 	follow. The category can be set to touch (devices that define a width
-	and height), non-touch, default, or the name of a device. You can obtain
-	your devices name by running *libinput list-devices* (you may need to
-	be root or a part of the input group to perform this.) Any members of
-	this category that are not set use the default for the device. With the
-	exception of tap-to-click, which is enabled by default.
+	and height), touchpad, non-touch, default, or the name of a device. You
+	can obtain your devices name by running *libinput list-devices* (you may
+	need to be root or a part of the input group to perform this.) Any
+	members of this category that are not set use the default for the
+	device. With the exception of tap-to-click, which is enabled by default.
 
 *<libinput><device category=""><naturalScroll>* [yes|no]
 	Use natural scrolling for this category if available.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -394,9 +394,9 @@
   </mouse>
 
   <!--
-    The *category* element can be set to touch, non-touch, default or the name
-    of a device. You can obtain device names by running *libinput list-devices*
-    as root or member of the input group.
+    The *category* element can be set to touch, touchpad, non-touch, default or
+    the name of a device. You can obtain device names by running *libinput
+    list-devices* as root or member of the input group.
 
     Tap is set to *yes* be default. All others are left blank in order to use
     device defaults.

--- a/include/config/libinput.h
+++ b/include/config/libinput.h
@@ -9,6 +9,7 @@
 enum device_type {
 	DEFAULT_DEVICE,
 	TOUCH_DEVICE,
+	TOUCHPAD_DEVICE,
 	NON_TOUCH_DEVICE,
 };
 

--- a/src/config/libinput.c
+++ b/src/config/libinput.c
@@ -32,6 +32,9 @@ get_device_type(const char *s)
 	if (!strcasecmp(s, "touch")) {
 		return TOUCH_DEVICE;
 	}
+	if (!strcasecmp(s, "touchpad")) {
+		return TOUCHPAD_DEVICE;
+	}
 	if (!strcasecmp(s, "non-touch")) {
 		return NON_TOUCH_DEVICE;
 	}

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -460,6 +460,7 @@ fill_libinput_category(char *nodename, char *content)
 
 	if (!strcmp(nodename, "category")) {
 		if (!strcmp(content, "touch")
+				|| !strcmp(content, "touchpad")
 				|| !strcmp(content, "non-touch")
 				|| !strcmp(content, "default")) {
 			current_libinput_category->type = get_device_type(content);


### PR DESCRIPTION
It is nice to have finer granularity for device types to allow for configurations such as using `naturalScroll` on touchpads, but not on regular pointer devices such as mice.