### PR TITLE
fix: fall-through to default cursor in cursor_get_from_edge()

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -91,6 +91,8 @@ cursor_get_from_edge(uint32_t resize_edges)
 			"Failed to resolve wlroots edge %u to cursor name", resize_edges);
 		assert(false);
 	}
+
+	return LAB_CURSOR_DEFAULT;
 }
 
 static enum lab_cursors


### PR DESCRIPTION
When assertions are disabled, providing an unexpected input to cursor_get_from_edge will cause the non-void function to terminate without a return value. This may be effectively unreachable in practice. However, returning a default cursor as a fall-through case will both silence a compiler warning and prevent catastrophy should the function ever be called with a permitted value.