### PR TITLE
theme: use non-hover button variants as fallback

### DIFF
--- a/include/button/button-xbm.h
+++ b/include/button/button-xbm.h
@@ -6,6 +6,7 @@ struct lab_data_buffer;
 
 /* button_xbm_load - Convert xbm file to buffer with cairo surface */
 void button_xbm_load(const char *button_name, const char *alt_name,
-	struct lab_data_buffer **buffer, char *fallback_button, float *rgba);
+	struct lab_data_buffer **buffer, const char *fallback_button,
+	float *rgba);
 
 #endif /* LABWC_BUTTON_XBM_H */

--- a/include/theme.h
+++ b/include/theme.h
@@ -92,6 +92,7 @@ struct theme {
 	struct lab_data_buffer *button_iconify_inactive_unpressed;
 	struct lab_data_buffer *button_menu_inactive_unpressed;
 
+	/* hover variants are optional and may be NULL */
 	struct lab_data_buffer *button_close_active_hover;
 	struct lab_data_buffer *button_maximize_active_hover;
 	struct lab_data_buffer *button_restore_active_hover;

--- a/src/button/button-xbm.c
+++ b/src/button/button-xbm.c
@@ -260,7 +260,8 @@ parse_xbm_builtin(const char *button, int size)
 
 void
 button_xbm_load(const char *button_name, const char *alt_name,
-	struct lab_data_buffer **buffer, char *fallback_button, float *rgba)
+	struct lab_data_buffer **buffer, const char *fallback_button,
+	float *rgba)
 {
 	struct pixmap pixmap = {0};
 	if (*buffer) {
@@ -270,7 +271,7 @@ button_xbm_load(const char *button_name, const char *alt_name,
 
 	color = u32(rgba);
 
-	/* Read file into memory as it's easier to tokenzie that way */
+	/* Read file into memory as it's easier to tokenize that way */
 	char filename[4096] = { 0 };
 	button_filename(button_name, filename, sizeof(filename));
 	char *token_buffer = grab_file(filename);
@@ -294,11 +295,13 @@ button_xbm_load(const char *button_name, const char *alt_name,
 			}
 		}
 	}
-	if (!pixmap.data) {
+	if (!pixmap.data && fallback_button) {
 		pixmap = parse_xbm_builtin(fallback_button, 6);
 	}
 
 	/* Create buffer with free_on_destroy being true */
-	*buffer = buffer_create_wrap(pixmap.data, pixmap.width, pixmap.height,
-		pixmap.width * 4, true);
+	if (pixmap.data) {
+		*buffer = buffer_create_wrap(pixmap.data, pixmap.width,
+			pixmap.height, pixmap.width * 4, true);
+	}
 }

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -60,11 +60,22 @@ ssd_titlebar_create(struct ssd *ssd)
 			close_button_unpressed = &theme->button_close_active_unpressed->base;
 			maximize_button_unpressed = &theme->button_maximize_active_unpressed->base;
 			restore_button_unpressed = &theme->button_restore_active_unpressed->base;
-			menu_button_hover = &theme->button_menu_active_hover->base;
-			iconify_button_hover = &theme->button_iconify_active_hover->base;
-			close_button_hover = &theme->button_close_active_hover->base;
-			maximize_button_hover = &theme->button_maximize_active_hover->base;
-			restore_button_hover = &theme->button_restore_active_hover->base;
+
+			menu_button_hover = theme->button_menu_active_hover ?
+				&theme->button_menu_active_hover->base :
+				&theme->button_menu_active_unpressed->base;
+			iconify_button_hover = theme->button_iconify_active_hover ?
+				&theme->button_iconify_active_hover->base :
+				&theme->button_iconify_active_unpressed->base;
+			close_button_hover = theme->button_close_active_hover ?
+				&theme->button_close_active_hover->base :
+				&theme->button_close_active_unpressed->base;
+			maximize_button_hover = theme->button_maximize_active_hover ?
+				&theme->button_maximize_active_hover->base :
+				&theme->button_maximize_active_unpressed->base;
+			restore_button_hover = theme->button_restore_active_hover ?
+				&theme->button_restore_active_hover->base :
+				&theme->button_restore_active_unpressed->base;
 		} else {
 			color = theme->window_inactive_title_bg_color;
 			corner_top_left = &theme->corner_top_left_inactive_normal->base;
@@ -75,11 +86,23 @@ ssd_titlebar_create(struct ssd *ssd)
 				&theme->button_maximize_inactive_unpressed->base;
 			restore_button_unpressed = &theme->button_restore_inactive_unpressed->base;
 			close_button_unpressed = &theme->button_close_inactive_unpressed->base;
-			menu_button_hover = &theme->button_menu_inactive_hover->base;
-			iconify_button_hover = &theme->button_iconify_inactive_hover->base;
-			close_button_hover = &theme->button_close_inactive_hover->base;
-			maximize_button_hover = &theme->button_maximize_inactive_hover->base;
-			restore_button_hover = &theme->button_restore_inactive_hover->base;
+
+			menu_button_hover = theme->button_menu_inactive_hover ?
+				&theme->button_menu_inactive_hover->base :
+				&theme->button_menu_inactive_unpressed->base;
+			iconify_button_hover = theme->button_iconify_inactive_hover ?
+				&theme->button_iconify_inactive_hover->base :
+				&theme->button_iconify_inactive_unpressed->base;
+			close_button_hover = theme->button_close_inactive_hover ?
+				&theme->button_close_inactive_hover->base :
+				&theme->button_close_inactive_unpressed->base;
+			maximize_button_hover = theme->button_maximize_inactive_hover ?
+				&theme->button_maximize_inactive_hover->base :
+				&theme->button_maximize_inactive_unpressed->base;
+			restore_button_hover = theme->button_restore_inactive_hover ?
+				&theme->button_restore_inactive_hover->base :
+				&theme->button_restore_inactive_unpressed->base;
+
 			wlr_scene_node_set_enabled(&parent->node, false);
 		}
 		wl_list_init(&subtree->parts);

--- a/src/theme.c
+++ b/src/theme.c
@@ -40,7 +40,7 @@
 struct button {
 	const char *name;
 	const char *alt_name;
-	char fallback_button[6];	/* built-in 6x6 button */
+	const char *fallback_button;  /* built-in 6x6 button */
 	struct {
 		struct lab_data_buffer **buffer;
 		float *rgba;
@@ -91,56 +91,56 @@ load_buttons(struct theme *theme)
 {
 	struct button buttons[] = { {
 		.name = "menu",
-		.fallback_button = { 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
+		.fallback_button = (const char[]){ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
 		.active.buffer = &theme->button_menu_active_unpressed,
 		.active.rgba = theme->window_active_button_menu_unpressed_image_color,
 		.inactive.buffer = &theme->button_menu_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_menu_unpressed_image_color,
 	}, {
 		.name = "iconify",
-		.fallback_button = { 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
+		.fallback_button = (const char[]){ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
 		.active.buffer = &theme->button_iconify_active_unpressed,
 		.active.rgba = theme->window_active_button_iconify_unpressed_image_color,
 		.inactive.buffer = &theme->button_iconify_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_iconify_unpressed_image_color,
 	}, {
 		.name = "max",
-		.fallback_button = { 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
 		.active.buffer = &theme->button_maximize_active_unpressed,
 		.active.rgba = theme->window_active_button_max_unpressed_image_color,
 		.inactive.buffer = &theme->button_maximize_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
 	}, {
 		.name = "max_toggled",
-		.fallback_button = { 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
+		.fallback_button = (const char[]){ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
 		.active.buffer = &theme->button_restore_active_unpressed,
 		.active.rgba = theme->window_active_button_max_unpressed_image_color,
 		.inactive.buffer = &theme->button_restore_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
 	}, {
 		.name = "close",
-		.fallback_button = { 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
+		.fallback_button = (const char[]){ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
 		.active.buffer = &theme->button_close_active_unpressed,
 		.active.rgba = theme->window_active_button_close_unpressed_image_color,
 		.inactive.buffer = &theme->button_close_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_close_unpressed_image_color,
 	}, {
 		.name = "menu_hover",
-		.fallback_button = { 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_menu_active_hover,
 		.active.rgba = theme->window_active_button_menu_unpressed_image_color,
 		.inactive.buffer = &theme->button_menu_inactive_hover,
 		.inactive.rgba = theme->window_inactive_button_menu_unpressed_image_color,
 	}, {
 		.name = "iconify_hover",
-		.fallback_button = { 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_iconify_active_hover,
 		.active.rgba = theme->window_active_button_iconify_unpressed_image_color,
 		.inactive.buffer = &theme->button_iconify_inactive_hover,
 		.inactive.rgba = theme->window_inactive_button_iconify_unpressed_image_color,
 	}, {
 		.name = "max_hover",
-		.fallback_button = { 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_maximize_active_hover,
 		.active.rgba = theme->window_active_button_max_unpressed_image_color,
 		.inactive.buffer = &theme->button_maximize_inactive_hover,
@@ -148,14 +148,14 @@ load_buttons(struct theme *theme)
 	}, {
 		.name = "max_toggled_hover",
 		.alt_name = "max_hover_toggled",
-		.fallback_button = { 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_restore_active_hover,
 		.active.rgba = theme->window_active_button_max_unpressed_image_color,
 		.inactive.buffer = &theme->button_restore_inactive_hover,
 		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
 	}, {
 		.name = "close_hover",
-		.fallback_button = { 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_close_active_hover,
 		.active.rgba = theme->window_active_button_close_unpressed_image_color,
 		.inactive.buffer = &theme->button_close_inactive_hover,


### PR DESCRIPTION
Some themes don't have hover variants for button pixmaps. It looks better visually to use the non-hover variants as fallbacks rather than the built-in 6x6 pixmaps.