### PR TITLE
CONTRIBUTING.md: update deprecated meson command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ If the compositor crashes, a good starting point is to produce a backtrace by
 building with ASAN/UBSAN:
 
 ```
-meson -Db_sanitize=address,undefined build/
-ninja -C build/
+meson setup -Db_sanitize=address,undefined build/
+meson compile -C build/
 ```
 
 ## Debug Logs


### PR DESCRIPTION
Fixes "WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.", plus use `meson compile -C build/` like in README.md instead of `ninja -C build/`