### PR TITLE
Icon refactoring4

### DIFF
--- a/include/button/button-xbm.h
+++ b/include/button/button-xbm.h
@@ -6,6 +6,7 @@ struct lab_data_buffer;
 
 /* button_xbm_load - Convert xbm file to buffer with cairo surface */
 void button_xbm_load(const char *button_name, const char *alt_name,
-	struct lab_data_buffer **buffer, char *fallback_button, float *rgba);
+	struct lab_data_buffer **buffer, const char *fallback_button,
+	float *rgba);
 
 #endif /* LABWC_BUTTON_XBM_H */

--- a/include/button/button-xbm.h
+++ b/include/button/button-xbm.h
@@ -4,9 +4,19 @@
 
 struct lab_data_buffer;
 
+/**
+ * button_xbm_from_bitmap() - create button from monochrome bitmap
+ * @bitmap: bitmap data array in hexadecimal xbm format
+ * @buffer: cairo-surface-buffer to create
+ * @rgba: color
+ *
+ * Example bitmap: char button[6] = { 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f };
+ */
+void button_xbm_from_bitmap(const char *bitmap, struct lab_data_buffer **buffer,
+	float *rgba);
+
 /* button_xbm_load - Convert xbm file to buffer with cairo surface */
-void button_xbm_load(const char *button_name, const char *alt_name,
-	struct lab_data_buffer **buffer, const char *fallback_button,
+void button_xbm_load(const char *button_name, struct lab_data_buffer **buffer,
 	float *rgba);
 
 #endif /* LABWC_BUTTON_XBM_H */

--- a/include/common/graphic-helpers.h
+++ b/include/common/graphic-helpers.h
@@ -47,4 +47,14 @@ void set_cairo_color(cairo_t *cairo, float *color);
 /* Draws a border with a specified line width */
 void draw_cairo_border(cairo_t *cairo, struct wlr_fbox fbox, double line_width);
 
+struct lab_data_buffer;
+
+struct surface_context {
+	bool is_duplicate;
+	cairo_surface_t *surface;
+};
+
+struct surface_context get_cairo_surface_from_lab_data_buffer(
+	struct lab_data_buffer *buffer);
+
 #endif /* LABWC_GRAPHIC_HELPERS_H */

--- a/include/common/string-helpers.h
+++ b/include/common/string-helpers.h
@@ -3,6 +3,15 @@
 #define LABWC_STRING_HELPERS_H
 
 /**
+ * trim_last_field() - Trim last field of string splitting on provided delim
+ * @buf: string to trim
+ * @delim: delimitator
+ *
+ * Example: With delim='_' and buf="foo_bar_baz" the return value is "foo_bar"
+ */
+void trim_last_field(char *buf, char delim);
+
+/**
  * string_strip - strip white space left and right
  * Note: this function does a left skip, so the returning pointer cannot be
  * used to free any allocated memory

--- a/include/theme.h
+++ b/include/theme.h
@@ -92,6 +92,7 @@ struct theme {
 	struct lab_data_buffer *button_iconify_inactive_unpressed;
 	struct lab_data_buffer *button_menu_inactive_unpressed;
 
+	/* hover variants are optional and may be NULL */
 	struct lab_data_buffer *button_close_active_hover;
 	struct lab_data_buffer *button_maximize_active_hover;
 	struct lab_data_buffer *button_restore_active_hover;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -129,6 +129,8 @@ buffer_create_wrap(void *pixel_data, uint32_t width, uint32_t height,
 {
 	struct lab_data_buffer *buffer = znew(*buffer);
 	wlr_buffer_init(&buffer->base, &data_buffer_impl, width, height);
+	buffer->unscaled_width = width;
+	buffer->unscaled_height = height;
 	buffer->data = pixel_data;
 	buffer->format = DRM_FORMAT_ARGB8888;
 	buffer->stride = stride;

--- a/src/button/button-xbm.c
+++ b/src/button/button-xbm.c
@@ -260,7 +260,8 @@ parse_xbm_builtin(const char *button, int size)
 
 void
 button_xbm_load(const char *button_name, const char *alt_name,
-	struct lab_data_buffer **buffer, char *fallback_button, float *rgba)
+	struct lab_data_buffer **buffer, const char *fallback_button,
+	float *rgba)
 {
 	struct pixmap pixmap = {0};
 	if (*buffer) {
@@ -270,7 +271,7 @@ button_xbm_load(const char *button_name, const char *alt_name,
 
 	color = u32(rgba);
 
-	/* Read file into memory as it's easier to tokenzie that way */
+	/* Read file into memory as it's easier to tokenize that way */
 	char filename[4096] = { 0 };
 	button_filename(button_name, filename, sizeof(filename));
 	char *token_buffer = grab_file(filename);
@@ -294,11 +295,13 @@ button_xbm_load(const char *button_name, const char *alt_name,
 			}
 		}
 	}
-	if (!pixmap.data) {
+	if (!pixmap.data && fallback_button) {
 		pixmap = parse_xbm_builtin(fallback_button, 6);
 	}
 
 	/* Create buffer with free_on_destroy being true */
-	*buffer = buffer_create_wrap(pixmap.data, pixmap.width, pixmap.height,
-		pixmap.width * 4, true);
+	if (pixmap.data) {
+		*buffer = buffer_create_wrap(pixmap.data, pixmap.width,
+			pixmap.height, pixmap.width * 4, true);
+	}
 }

--- a/src/common/string-helpers.c
+++ b/src/common/string-helpers.c
@@ -6,6 +6,15 @@
 #include "common/mem.h"
 #include "common/string-helpers.h"
 
+void
+trim_last_field(char *buf, char delim)
+{
+	char *p = strrchr(buf, delim);
+	if (p) {
+		*p = '\0';
+	}
+}
+
 static void
 rtrim(char **s)
 {

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -60,6 +60,7 @@ ssd_titlebar_create(struct ssd *ssd)
 			close_button_unpressed = &theme->button_close_active_unpressed->base;
 			maximize_button_unpressed = &theme->button_maximize_active_unpressed->base;
 			restore_button_unpressed = &theme->button_restore_active_unpressed->base;
+
 			menu_button_hover = &theme->button_menu_active_hover->base;
 			iconify_button_hover = &theme->button_iconify_active_hover->base;
 			close_button_hover = &theme->button_close_active_hover->base;
@@ -75,11 +76,13 @@ ssd_titlebar_create(struct ssd *ssd)
 				&theme->button_maximize_inactive_unpressed->base;
 			restore_button_unpressed = &theme->button_restore_inactive_unpressed->base;
 			close_button_unpressed = &theme->button_close_inactive_unpressed->base;
+
 			menu_button_hover = &theme->button_menu_inactive_hover->base;
 			iconify_button_hover = &theme->button_iconify_inactive_hover->base;
 			close_button_hover = &theme->button_close_inactive_hover->base;
 			maximize_button_hover = &theme->button_maximize_inactive_hover->base;
 			restore_button_hover = &theme->button_restore_inactive_hover->base;
+
 			wlr_scene_node_set_enabled(&parent->node, false);
 		}
 		wl_list_init(&subtree->parts);

--- a/src/theme.c
+++ b/src/theme.c
@@ -40,7 +40,7 @@
 struct button {
 	const char *name;
 	const char *alt_name;
-	char fallback_button[6];	/* built-in 6x6 button */
+	const char *fallback_button;  /* built-in 6x6 button */
 	struct {
 		struct lab_data_buffer **buffer;
 		float *rgba;
@@ -91,56 +91,56 @@ load_buttons(struct theme *theme)
 {
 	struct button buttons[] = { {
 		.name = "menu",
-		.fallback_button = { 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
+		.fallback_button = (const char[]){ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
 		.active.buffer = &theme->button_menu_active_unpressed,
 		.active.rgba = theme->window_active_button_menu_unpressed_image_color,
 		.inactive.buffer = &theme->button_menu_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_menu_unpressed_image_color,
 	}, {
 		.name = "iconify",
-		.fallback_button = { 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
+		.fallback_button = (const char[]){ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
 		.active.buffer = &theme->button_iconify_active_unpressed,
 		.active.rgba = theme->window_active_button_iconify_unpressed_image_color,
 		.inactive.buffer = &theme->button_iconify_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_iconify_unpressed_image_color,
 	}, {
 		.name = "max",
-		.fallback_button = { 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
 		.active.buffer = &theme->button_maximize_active_unpressed,
 		.active.rgba = theme->window_active_button_max_unpressed_image_color,
 		.inactive.buffer = &theme->button_maximize_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
 	}, {
 		.name = "max_toggled",
-		.fallback_button = { 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
+		.fallback_button = (const char[]){ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
 		.active.buffer = &theme->button_restore_active_unpressed,
 		.active.rgba = theme->window_active_button_max_unpressed_image_color,
 		.inactive.buffer = &theme->button_restore_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
 	}, {
 		.name = "close",
-		.fallback_button = { 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
+		.fallback_button = (const char[]){ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
 		.active.buffer = &theme->button_close_active_unpressed,
 		.active.rgba = theme->window_active_button_close_unpressed_image_color,
 		.inactive.buffer = &theme->button_close_inactive_unpressed,
 		.inactive.rgba = theme->window_inactive_button_close_unpressed_image_color,
 	}, {
 		.name = "menu_hover",
-		.fallback_button = { 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_menu_active_hover,
 		.active.rgba = theme->window_active_button_menu_unpressed_image_color,
 		.inactive.buffer = &theme->button_menu_inactive_hover,
 		.inactive.rgba = theme->window_inactive_button_menu_unpressed_image_color,
 	}, {
 		.name = "iconify_hover",
-		.fallback_button = { 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_iconify_active_hover,
 		.active.rgba = theme->window_active_button_iconify_unpressed_image_color,
 		.inactive.buffer = &theme->button_iconify_inactive_hover,
 		.inactive.rgba = theme->window_inactive_button_iconify_unpressed_image_color,
 	}, {
 		.name = "max_hover",
-		.fallback_button = { 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_maximize_active_hover,
 		.active.rgba = theme->window_active_button_max_unpressed_image_color,
 		.inactive.buffer = &theme->button_maximize_inactive_hover,
@@ -148,14 +148,14 @@ load_buttons(struct theme *theme)
 	}, {
 		.name = "max_toggled_hover",
 		.alt_name = "max_hover_toggled",
-		.fallback_button = { 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_restore_active_hover,
 		.active.rgba = theme->window_active_button_max_unpressed_image_color,
 		.inactive.buffer = &theme->button_restore_inactive_hover,
 		.inactive.rgba = theme->window_inactive_button_max_unpressed_image_color,
 	}, {
 		.name = "close_hover",
-		.fallback_button = { 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
+		/* no fallback (non-hover variant is used instead) */
 		.active.buffer = &theme->button_close_active_hover,
 		.active.rgba = theme->window_active_button_close_unpressed_image_color,
 		.inactive.buffer = &theme->button_close_inactive_hover,


### PR DESCRIPTION
- Remove builtin bitmap fallbacks for `_hover` icons
- For `_hover` buttons with an xbm/svg/png, just copy the non-hover variant and add an overlay
- Simplify `button_xbm_load()` by moving some of the fallback logic to `theme.c`

