### PR TITLE
xwayland: Prevents usage of invalid data pointer

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -543,7 +543,7 @@ init_foreign_toplevel(struct view *view)
 		return;
 	}
 	struct view *parent = (struct view *)surface->parent->data;
-	if (!parent->toplevel.handle) {
+	if (!parent || !parent->toplevel.handle) {
 		return;
 	}
 	wlr_foreign_toplevel_handle_v1_set_parent(view->toplevel.handle, parent->toplevel.handle);


### PR DESCRIPTION
There are situations where the data pointer of a parent is NULL. Checking for NULL first fixes e.g. a segmentation fault in CLion when opening the settings window from a popup menu.

See also https://github.com/labwc/labwc/issues/1351#issuecomment-1867475324

Closes https://github.com/labwc/labwc/issues/1351