### PR TITLE
Revert "xdg: Fix visual glitch when resizing xfce4-terminal from left…

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -317,16 +317,9 @@ xdg_toplevel_view_configure(struct view *view, struct wlr_box geo)
 	if (serial > 0) {
 		set_pending_configure_serial(view, serial);
 	} else if (view->pending_configure_serial == 0) {
-		/*
-		 * We can't assume here that view->current is equal to
-		 * view->pending because some clients (e.g. terminals)
-		 * refuse to accept the exact size we requested. To
-		 * account for the size difference and avoid visual
-		 * glitches during resize, we apply the same position
-		 * adjustments here as in handle_commit().
-		 */
-		view_impl_apply_geometry(view, view->current.width,
-			view->current.height);
+		view->current.x = geo.x;
+		view->current.y = geo.y;
+		view_moved(view);
 	}
 }
 


### PR DESCRIPTION
… edge"

This reverts commit 31ec8f050cf9f2aafed1dd30490dc0aaf8ef32e0.

Commit c59aeb5 solves this in a different (hopefully more elegant) way.

Related-to: #1370