### PR TITLE
ci: include scripts/find-banned.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Code Style
         run: |
           ./scripts/check
+          make -C scripts/helper
+          ./scripts/find-banned.sh
   build:
     name: Build
     needs: codestyle

--- a/scripts/helper/.gitignore
+++ b/scripts/helper/.gitignore
@@ -1,0 +1,2 @@
+find-idents
+*.o


### PR DESCRIPTION
...to search for functions which have been banned from our code base, because they're too easy to misuse, and even if used correctly, complicate audits, cause inconsistencies and/or make static analysis harder.