### PR TITLE
feat: add "AutoPlace" action

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -219,6 +219,10 @@ Actions are used in menus and keyboard/mouse bindings.
 	*output_name* The name of virtual output. If not supplied, will remove the
 	last virtual output added.
 
+*<action name="AutoPlace" />*
+	Use the automatic placement policy to move the active window to a
+	position on its output that will minimize overlap with other windows.
+
 *<action name="None" />*
 	If used as the only action for a binding: clear an earlier defined binding.
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -453,9 +453,13 @@
       <windowRule title="pcmanfm-desktop*">
         <skipTaskbar>yes</skipTaskbar>
         <skipWindowSwitcher>yes</skipWindowSwitcher>
-	<fixedPosition>yes</fixedPosition>
+        <fixedPosition>yes</fixedPosition>
         <action name="MoveTo" x="0" y="0" />
         <action name="ToggleAlwaysOnBottom"/>
+      </windowRule>
+      <windowRule identifier="org.qutebrowser.qutebrowser">
+        <action name="ResizeTo" width="1024" y="800" />
+        <action name="AutoPlace"/>
       </windowRule>
     </windowRules>
   -->

--- a/src/action.c
+++ b/src/action.c
@@ -16,6 +16,7 @@
 #include "debug.h"
 #include "labwc.h"
 #include "menu/menu.h"
+#include "placement.h"
 #include "regions.h"
 #include "ssd.h"
 #include "view.h"
@@ -100,6 +101,7 @@ enum action_type {
 	ACTION_TYPE_FOR_EACH,
 	ACTION_TYPE_VIRTUAL_OUTPUT_ADD,
 	ACTION_TYPE_VIRTUAL_OUTPUT_REMOVE,
+	ACTION_TYPE_AUTO_PLACE,
 };
 
 const char *action_names[] = {
@@ -146,6 +148,7 @@ const char *action_names[] = {
 	"ForEach",
 	"VirtualOutputAdd",
 	"VirtualOutputRemove",
+	"AutoPlace",
 	NULL
 };
 
@@ -938,6 +941,14 @@ actions_run(struct view *activator, struct server *server,
 				const char *output_name = action_get_str(action, "output_name",
 						NULL);
 				output_remove_virtual(server, output_name);
+			}
+			break;
+		case ACTION_TYPE_AUTO_PLACE:
+			if (view) {
+				int x = 0, y = 0;
+				if (placement_find_best(view, &x, &y)) {
+					view_move(view, x, y);
+				}
 			}
 			break;
 		case ACTION_TYPE_INVALID:


### PR DESCRIPTION
The AutoPlace action will apply `placement_find_best()` to an active view, moving it to a position on its output that will minimize overlap with other views. This may be useful interactively to rearrange windows, but is particularly useful when chained with a `ResizeTo` action in a window rule: the initial placement, when "automatic" is selected, will optimize for a size that is then immediately changed; a follow-up `AutoPlace` action can ensure that the new window size will not push the window off the screen.