### PR TITLE
feat: Add tablet button mapping configuration

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -394,6 +394,18 @@
   </mouse>
 
   <!--
+    Tablet buttons emulate regular mouse buttons.
+
+    The tablet *button* can be set to any of [tip|stylus|stylus2|stylus3].
+    Valid *to* mouse buttons are [left|right|middle].
+  -->
+  <tablet>
+    <map button="tip" to="left" />
+    <map button="stylus" to="right" />
+    <map button="stylus2" to="middle" />
+  </tablet>
+
+  <!--
     The *category* element can be set to touch, touchpad, non-touch, default or
     the name of a device. You can obtain device names by running *libinput
     list-devices* as root or member of the input group.

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -9,6 +9,7 @@
 #include "common/border.h"
 #include "common/buf.h"
 #include "common/font.h"
+#include "config/tablet.h"
 #include "config/libinput.h"
 #include "resize_indicator.h"
 #include "theme.h"
@@ -79,6 +80,12 @@ struct rcxml {
 	long doubleclick_time;     /* in ms */
 	struct wl_list mousebinds; /* struct mousebind.link */
 	double scroll_factor;
+
+	/* graphics tablet */
+	struct tablet_config {
+		uint16_t button_map_count;
+		struct button_map_entry button_map[BUTTON_MAP_MAX];
+	} tablet;
 
 	/* libinput */
 	struct wl_list libinput_categories;

--- a/include/config/tablet.h
+++ b/include/config/tablet.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_TABLET_CONFIG_H
+#define LABWC_TABLET_CONFIG_H
+
+#include <stdint.h>
+
+#define BUTTON_MAP_MAX 16
+struct button_map_entry {
+	uint32_t from;
+	uint32_t to;
+};
+
+uint32_t tablet_button_from_str(const char *button);
+uint32_t mouse_button_from_str(const char *button);
+void tablet_button_mapping_add(uint32_t from, uint32_t to);
+void tablet_load_default_button_mappings(void);
+
+#endif /* LABWC_TABLET_CONFIG_H */

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-#ifndef LABWC_DRAWING_TABLET_H
-#define LABWC_DRAWING_TABLET_H
+#ifndef LABWC_TABLET_H
+#define LABWC_TABLET_H
 
 #include <wayland-server-core.h>
 struct seat;
@@ -20,6 +20,6 @@ struct drawing_tablet {
 	} handlers;
 };
 
-void drawing_tablet_setup_handlers(struct seat *seat, struct wlr_input_device *wlr_input_device);
+void tablet_setup_handlers(struct seat *seat, struct wlr_input_device *wlr_input_device);
 
-#endif /* LABWC_DRAWING_TABLET_H */
+#endif /* LABWC_TABLET_H */

--- a/src/config/meson.build
+++ b/src/config/meson.build
@@ -3,5 +3,6 @@ labwc_sources += files(
   'keybind.c',
   'session.c',
   'mousebind.c',
+  'tablet.c',
   'libinput.c',
 )

--- a/src/config/tablet.c
+++ b/src/config/tablet.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include <linux/input-event-codes.h>
+#include <stdint.h>
+#include <strings.h>
+#include <wlr/util/log.h>
+#include "config/tablet.h"
+#include "config/rcxml.h"
+
+uint32_t tablet_button_from_str(const char *button)
+{
+	if (!strcasecmp(button, "Tip")) {
+		return BTN_TOOL_PEN;
+	} else if (!strcasecmp(button, "Stylus")) {
+		return BTN_STYLUS;
+	} else if (!strcasecmp(button, "Stylus2")) {
+		return BTN_STYLUS2;
+	} else if (!strcasecmp(button, "Stylus3")) {
+		return BTN_STYLUS3;
+	}
+	wlr_log(WLR_ERROR, "Invalid value for tablet button: %s", button);
+	return UINT32_MAX;
+}
+
+uint32_t mouse_button_from_str(const char *button)
+{
+	if (!strcasecmp(button, "Left")) {
+		return BTN_LEFT;
+	} else if (!strcasecmp(button, "Right")) {
+		return BTN_RIGHT;
+	} else if (!strcasecmp(button, "Middle")) {
+		return BTN_MIDDLE;
+	}
+	wlr_log(WLR_ERROR, "Invalid value for mouse button: %s", button);
+	return UINT32_MAX;
+}
+
+void tablet_button_mapping_add(uint32_t from, uint32_t to)
+{
+	struct button_map_entry *entry;
+	for (size_t i = 0; i < rc.tablet.button_map_count; i++) {
+		entry = &rc.tablet.button_map[i];
+		if (entry->from == from) {
+			entry->to = to;
+			wlr_log(WLR_INFO, "Overwriting button map for 0x%x with 0x%x", from, to);
+			return;
+		}
+	}
+	if (rc.tablet.button_map_count == BUTTON_MAP_MAX) {
+		wlr_log(WLR_ERROR,
+			"Failed to add button mapping: only supporting up to %u mappings",
+			BUTTON_MAP_MAX);
+		return;
+	}
+	wlr_log(WLR_INFO, "Adding button map for 0x%x with 0x%x", from, to);
+	entry = &rc.tablet.button_map[rc.tablet.button_map_count];
+	entry->from = from;
+	entry->to = to;
+	rc.tablet.button_map_count++;
+}
+
+void tablet_load_default_button_mappings(void)
+{
+	tablet_button_mapping_add(BTN_TOOL_PEN, BTN_LEFT); /* Used for the pen tip */
+	tablet_button_mapping_add(BTN_STYLUS, BTN_RIGHT);
+	tablet_button_mapping_add(BTN_STYLUS2, BTN_MIDDLE);
+}

--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -1,6 +1,6 @@
 labwc_sources += files(
   'cursor.c',
-  'drawing_tablet.c',
+  'tablet.c',
   'gestures.c',
   'input.c',
   'keyboard.c',

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -9,7 +9,7 @@
 #include "common/mem.h"
 #include "config/rcxml.h"
 #include "input/cursor.h"
-#include "input/drawing_tablet.h"
+#include "input/tablet.h"
 
 static void
 handle_axis(struct wl_listener *listener, void *data)
@@ -109,7 +109,7 @@ setup_pen(struct seat *seat, struct wlr_input_device *wlr_device)
 }
 
 void
-drawing_tablet_setup_handlers(struct seat *seat, struct wlr_input_device *device)
+tablet_setup_handlers(struct seat *seat, struct wlr_input_device *device)
 {
 	switch (device->type) {
 	case WLR_INPUT_DEVICE_TABLET_PAD:

--- a/src/seat.c
+++ b/src/seat.c
@@ -9,7 +9,7 @@
 #include <wlr/types/wlr_touch.h>
 #include <wlr/util/log.h>
 #include "common/mem.h"
-#include "input/drawing_tablet.h"
+#include "input/tablet.h"
 #include "input/input.h"
 #include "input/keyboard.h"
 #include "input/key-state.h"
@@ -270,7 +270,7 @@ new_tablet(struct seat *seat, struct wlr_input_device *dev)
 {
 	struct input *input = znew(*input);
 	input->wlr_input_device = dev;
-	drawing_tablet_setup_handlers(seat, dev);
+	tablet_setup_handlers(seat, dev);
 
 	return input;
 }


### PR DESCRIPTION
This PR allows to configure the tablet pen buttons, thus which pen button emulates which mouse button.
Same as the earlier tablet PR, this one is also based on @Consolatis work in https://github.com/labwc/labwc/issues/1060#issuecomment-1786384495

I also added a rename in the last commit for consistency.