### PR TITLE
feat: Add active tablet area specification

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -394,14 +394,22 @@
   </mouse>
 
   <!--
+    The active tablet area can be specified by setting the top/left
+    coordinate (in mm) and/or width/height (in mm). If width or height
+    are omitted or default (0.0), width/height will be set to the
+    remaining width/height seen from top/left.
+
     The tablet orientation can be changed in 90 degree steps, thus
-    rotation can be set to [0|90|180|270].
+    rotation can be set to [0|90|180|270]. Rotation will be applied
+    after applying tablet area transformation.
 
     Tablet buttons emulate regular mouse buttons. The tablet *button* can
     be set to any of [tip|stylus|stylus2|stylus3]. Valid *to* mouse buttons
     are [left|right|middle].
   -->
   <tablet rotate="0">
+    <!-- Active area dimensions are in mm -->
+    <area top="0.0" left="0.0" width="0.0" height="0.0">
     <map button="tip" to="left" />
     <map button="stylus" to="right" />
     <map button="stylus2" to="middle" />

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -83,6 +83,7 @@ struct rcxml {
 
 	/* graphics tablet */
 	struct tablet_config {
+		struct wlr_fbox box;
 		enum rotation rotation;
 		uint16_t button_map_count;
 		struct button_map_entry button_map[BUTTON_MAP_MAX];

--- a/include/config/tablet.h
+++ b/include/config/tablet.h
@@ -17,6 +17,7 @@ struct button_map_entry {
 	uint32_t to;
 };
 
+double tablet_get_dbl_if_positive(const char *content, const char *name);
 enum rotation tablet_parse_rotation(int value);
 uint32_t tablet_button_from_str(const char *button);
 uint32_t mouse_button_from_str(const char *button);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -826,6 +826,14 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "Invalid value for <resize popupShow />");
 		}
+	} else if (!strcasecmp(nodename, "left.area.tablet")) {
+		rc.tablet.box.x = tablet_get_dbl_if_positive(content, "left");
+	} else if (!strcasecmp(nodename, "top.area.tablet")) {
+		rc.tablet.box.y = tablet_get_dbl_if_positive(content, "top");
+	} else if (!strcasecmp(nodename, "width.area.tablet")) {
+		rc.tablet.box.width = tablet_get_dbl_if_positive(content, "width");
+	} else if (!strcasecmp(nodename, "height.area.tablet")) {
+		rc.tablet.box.height = tablet_get_dbl_if_positive(content, "height");
 	} else if (!strcasecmp(nodename, "rotate.tablet")) {
 		rc.tablet.rotation = tablet_parse_rotation(atoi(content));
 	} else if (!strcasecmp(nodename, "button.map.tablet")) {
@@ -999,7 +1007,7 @@ rcxml_init(void)
 	rc.doubleclick_time = 500;
 	rc.scroll_factor = 1.0;
 
-	rc.tablet.button_map_count = 0;
+	rc.tablet.box = (struct wlr_fbox){0};
 	tablet_load_default_button_mappings();
 
 	rc.repeat_rate = 25;

--- a/src/config/tablet.c
+++ b/src/config/tablet.c
@@ -7,6 +7,17 @@
 #include "config/tablet.h"
 #include "config/rcxml.h"
 
+double
+tablet_get_dbl_if_positive(const char *content, const char *name)
+{
+	double value = atof(content);
+	if (value < 0) {
+		wlr_log(WLR_ERROR, "Invalid value for tablet area %s", name);
+		return 0;
+	}
+	return value;
+}
+
 enum rotation
 tablet_parse_rotation(int value)
 {
@@ -84,6 +95,7 @@ tablet_button_mapping_add(uint32_t from, uint32_t to)
 void
 tablet_load_default_button_mappings(void)
 {
+	rc.tablet.button_map_count = 0;
 	tablet_button_mapping_add(BTN_TOOL_PEN, BTN_LEFT); /* Used for the pen tip */
 	tablet_button_mapping_add(BTN_STYLUS, BTN_RIGHT);
 	tablet_button_mapping_add(BTN_STYLUS2, BTN_MIDDLE);

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -127,6 +127,8 @@ setup_pen(struct seat *seat, struct wlr_input_device *wlr_device)
 	tablet->tablet->data = tablet;
 	tablet->x = 0.0;
 	tablet->y = 0.0;
+	wlr_log(WLR_INFO, "tablet dimensions: %.2fmm x %.2fmm",
+		tablet->tablet->width_mm, tablet->tablet->height_mm);
 	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, axis);
 	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, tip);
 	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, button);


### PR DESCRIPTION
This PR allow to specify the responsive/active area of the tablet. The Wacom driver on Windows allows something similar, see e.g. https://101.wacom.com/UserHelp/en/PenMode.htm
I'm using this to truncate the active area so that the resulting aspect ratio matches the one from my monitor. Initially i had something like this https://github.com/labwc/labwc/issues/1060#issuecomment-1826875020 in mind, but accessing the output turned out rather tricky on startup and actually this approach here is much more flexible.

This is the last PR from me for anything with tablet cursor movement (for now) ;)