### PR TITLE
view: honor automatic placement when adjusting floating geometry

### DIFF
--- a/include/placement.h
+++ b/include/placement.h
@@ -3,8 +3,9 @@
 #define LABWC_PLACEMENT_H
 
 #include <stdbool.h>
+#include <wlr/util/box.h>
 #include "view.h"
 
-bool placement_find_best(struct view *view, int *x, int *y);
+bool placement_find_best(struct view *view, struct wlr_box *geometry);
 
 #endif /* LABWC_PLACEMENT_H */

--- a/src/action.c
+++ b/src/action.c
@@ -945,9 +945,9 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_AUTO_PLACE:
 			if (view) {
-				int x = 0, y = 0;
-				if (placement_find_best(view, &x, &y)) {
-					view_move(view, x, y);
+				struct wlr_box geometry = view->pending;
+				if (placement_find_best(view, &geometry)) {
+					view_move(view, geometry.x, geometry.y);
 				}
 			}
 			break;

--- a/src/view.c
+++ b/src/view.c
@@ -636,7 +636,17 @@ view_adjust_floating_geometry(struct view *view, struct wlr_box *geometry)
 			adjusted = true;
 		}
 	} else {
-		/* If offscreen, then just center the view */
+		/*
+		 * Reposition offscreen views; if automatic placement was is
+		 * configured, try to automatically place the windows.
+		 */
+		if (rc.placement_policy == LAB_PLACE_AUTOMATIC) {
+			if (placement_find_best(view, geometry)) {
+				return true;
+			}
+		}
+
+		/* If automatic placement failed or was not enabled, just center */
 		adjusted = view_compute_centered_position(view, NULL,
 			geometry->width, geometry->height,
 			&geometry->x, &geometry->y);
@@ -698,9 +708,9 @@ view_place_initial(struct view *view)
 		view_move_to_cursor(view);
 		return;
 	} else if (rc.placement_policy == LAB_PLACE_AUTOMATIC) {
-		int x = 0, y = 0;
-		if (placement_find_best(view, &x, &y)) {
-			view_move(view, x, y);
+		struct wlr_box geometry = view->pending;
+		if (placement_find_best(view, &geometry)) {
+			view_move(view, geometry.x, geometry.y);
 			return;
 		}
 	}


### PR DESCRIPTION
The `view_adjust_floating_geometry` function is called when un-maximizing a window or changing the output layout to ensure that views are well placed. Rather than always centering these views should they fall offscren, use the automatic placement strategy if so configured.

This alters the interface of `placement_find_best` to support passing an arbitrary geometry, because we wish to pass either `view->natural_geometry` or `view->pending`, depending on the reason for the placement.