### PR TITLE
Tearing support

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -154,6 +154,9 @@ Actions are used in menus and keyboard/mouse bindings.
 	the usual keybinds will function again until switching back to the
 	original window. There can be multiple windows with this mode set.
 
+*<action name="ToggleTearing" />*
+	Toggles tearing for the focused window.
+
 *<action name="FocusOutput" output="HDMI-A-1" />*
 	Give focus to topmost window on given output and warp the cursor
 	to the center of the window. If the given output does not contain

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -133,10 +133,10 @@ this is for compatibility with Openbox.
 	Allow tearing to reduce input lag. Default is no.
 	This open requires setting the environment variable WLR_DRM_NO_ATOMIC=1.
 
-	*yes* allow tearing if an open window requests it.
+	*yes* allow tearing if the active window requests it.
 
-	*fullscreen* allow tearing if an open window requests it, or if any
-	window is in fullscreen mode.
+	*fullscreen* allow tearing if the active window requests it or is in
+	fullscreen mode.
 
 	*always* allow tearing regardless of window status.
 

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -109,6 +109,7 @@ this is for compatibility with Openbox.
   <decoration>server</decoration>
   <gap>0</gap>
   <adaptiveSync>no</adaptiveSync>
+  <allowTearing>no</allowTearing>
   <reuseOutputMode>no</reuseOutputMode>
 </core>
 ```
@@ -127,6 +128,17 @@ this is for compatibility with Openbox.
 
 	*fullscreen* enables adaptive sync whenever a window is in fullscreen
 	mode.
+
+*<core><allowTearing>* [yes|no|fullscreen|always]
+	Allow tearing to reduce input lag. Default is no.
+	This open requires setting the environment variable WLR_DRM_NO_ATOMIC=1.
+
+	*yes* allow tearing if an open window requests it.
+
+	*fullscreen* allow tearing if an open window requests it, or if any
+	window is in fullscreen mode.
+
+	*always* allow tearing regardless of window status.
 
 *<core><reuseOutputMode>* [yes|no]
 	Try to re-use the existing output mode (resolution / refresh rate).

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -133,8 +133,7 @@ this is for compatibility with Openbox.
 	Allow tearing to reduce input lag. Default is no.
 	This option requires setting the environment variable WLR_DRM_NO_ATOMIC=1.
 
-	*yes* allow tearing if the active window requests it,
-	or its enabled with action ToggleTearing.
+	*yes* allow tearing if requested by the active window.
 
 *<core><reuseOutputMode>* [yes|no]
 	Try to re-use the existing output mode (resolution / refresh rate).

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -129,16 +129,12 @@ this is for compatibility with Openbox.
 	*fullscreen* enables adaptive sync whenever a window is in fullscreen
 	mode.
 
-*<core><allowTearing>* [yes|no|fullscreen|always]
+*<core><allowTearing>* [yes|no]
 	Allow tearing to reduce input lag. Default is no.
-	This open requires setting the environment variable WLR_DRM_NO_ATOMIC=1.
+	This option requires setting the environment variable WLR_DRM_NO_ATOMIC=1.
 
-	*yes* allow tearing if the active window requests it.
-
-	*fullscreen* allow tearing if the active window requests it or is in
-	fullscreen mode.
-
-	*always* allow tearing regardless of window status.
+	*yes* allow tearing if the active window requests it,
+	or its enabled with action ToggleTearing.
 
 *<core><reuseOutputMode>* [yes|no]
 	Try to re-use the existing output mode (resolution / refresh rate).

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -11,6 +11,7 @@
     <decoration>server</decoration>
     <gap>0</gap>
     <adaptiveSync>no</adaptiveSync>
+    <allowTearing>no</allowTearing>
     <reuseOutputMode>no</reuseOutputMode>
   </core>
 

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -38,6 +38,7 @@ enum tearing_mode {
 	LAB_TEARING_DISABLED,
 	LAB_TEARING_ENABLED,
 	LAB_TEARING_FULLSCREEN,
+	LAB_TEARING_ALWAYS,
 };
 
 struct usable_area_override {

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -35,7 +35,7 @@ enum adaptive_sync_mode {
 };
 
 enum tearing_mode {
-	LAB_TEARING_DISABLED,
+	LAB_TEARING_DISABLED = 0,
 	LAB_TEARING_ENABLED,
 	LAB_TEARING_FULLSCREEN,
 	LAB_TEARING_ALWAYS,

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -34,6 +34,12 @@ enum adaptive_sync_mode {
 	LAB_ADAPTIVE_SYNC_FULLSCREEN,
 };
 
+enum tearing_mode {
+	LAB_TEARING_DISABLED,
+	LAB_TEARING_ENABLED,
+	LAB_TEARING_FULLSCREEN,
+};
+
 struct usable_area_override {
 	struct border margin;
 	char *output;
@@ -53,6 +59,7 @@ struct rcxml {
 	bool xdg_shell_server_side_deco;
 	int gap;
 	enum adaptive_sync_mode adaptive_sync;
+	enum tearing_mode allow_tearing;
 	bool reuse_output_mode;
 	enum view_placement_policy placement_policy;
 

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -34,13 +34,6 @@ enum adaptive_sync_mode {
 	LAB_ADAPTIVE_SYNC_FULLSCREEN,
 };
 
-enum tearing_mode {
-	LAB_TEARING_DISABLED = 0,
-	LAB_TEARING_ENABLED,
-	LAB_TEARING_FULLSCREEN,
-	LAB_TEARING_ALWAYS,
-};
-
 struct usable_area_override {
 	struct border margin;
 	char *output;
@@ -60,7 +53,7 @@ struct rcxml {
 	bool xdg_shell_server_side_deco;
 	int gap;
 	enum adaptive_sync_mode adaptive_sync;
-	enum tearing_mode allow_tearing;
+	bool allow_tearing;
 	bool reuse_output_mode;
 	enum view_placement_policy placement_policy;
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -39,6 +39,7 @@
 #include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
+#include <wlr/types/wlr_tearing_control_v1.h>
 #include <wlr/util/log.h>
 #include "config/keybind.h"
 #include "config/rcxml.h"
@@ -318,6 +319,9 @@ struct server {
 	struct wlr_pointer_constraints_v1 *constraints;
 	struct wl_listener new_constraint;
 
+	struct wlr_tearing_control_manager_v1 *tearing_control;
+	struct wl_listener tearing_new_object;
+
 	/* Set when in cycle (alt-tab) mode */
 	struct osd_state {
 		struct view *cycle_view;
@@ -479,6 +483,8 @@ void handle_output_power_manager_set_mode(struct wl_listener *listener,
 void output_add_virtual(struct server *server, const char *output_name);
 void output_remove_virtual(struct server *server, const char *output_name);
 void output_enable_adaptive_sync(struct wlr_output *output, bool enabled);
+void new_tearing_hint(struct wl_listener *listener, void *data);
+void set_tearing(struct output *output);
 
 void server_init(struct server *server);
 void server_start(struct server *server);

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -357,6 +357,7 @@ struct output {
 
 	bool leased;
 	bool gamma_lut_changed;
+	bool tearing;
 };
 
 #undef LAB_NR_LAYERS

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -361,7 +361,6 @@ struct output {
 
 	bool leased;
 	bool gamma_lut_changed;
-	bool tearing;
 };
 
 #undef LAB_NR_LAYERS
@@ -484,7 +483,6 @@ void output_add_virtual(struct server *server, const char *output_name);
 void output_remove_virtual(struct server *server, const char *output_name);
 void output_enable_adaptive_sync(struct wlr_output *output, bool enabled);
 void new_tearing_hint(struct wl_listener *listener, void *data);
-void set_tearing(struct output *output);
 
 void server_init(struct server *server);
 void server_start(struct server *server);

--- a/include/view.h
+++ b/include/view.h
@@ -151,6 +151,7 @@ struct view {
 	bool minimized;
 	enum view_axis maximized;
 	bool fullscreen;
+	bool tearing_hint;
 	bool visible_on_all_workspaces;
 	enum view_edge tiled;
 	bool inhibits_keybinds;

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -18,6 +18,7 @@ server_protocols = [
 	wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
 	wl_protocol_dir / 'staging/cursor-shape/cursor-shape-v1.xml',
 	wl_protocol_dir / 'staging/drm-lease/drm-lease-v1.xml',
+	wl_protocol_dir / 'staging/tearing-control/tearing-control-v1.xml',
 	'wlr-layer-shell-unstable-v1.xml',
 	'wlr-input-inhibitor-unstable-v1.xml',
 	'wlr-output-power-management-unstable-v1.xml',

--- a/src/action.c
+++ b/src/action.c
@@ -956,8 +956,9 @@ actions_run(struct view *activator, struct server *server,
 		case ACTION_TYPE_TOGGLE_TEARING:
 			if (view) {
 				view->tearing_hint = !view->tearing_hint;
+				wlr_log(WLR_DEBUG, "tearing %sabled",
+					view->tearing_hint ? "en" : "dis");
 			}
-			wlr_log(WLR_DEBUG, "tearing: %d", view->tearing_hint);
 			break;
 		case ACTION_TYPE_INVALID:
 			wlr_log(WLR_ERROR, "Not executing unknown action");

--- a/src/action.c
+++ b/src/action.c
@@ -102,6 +102,7 @@ enum action_type {
 	ACTION_TYPE_VIRTUAL_OUTPUT_ADD,
 	ACTION_TYPE_VIRTUAL_OUTPUT_REMOVE,
 	ACTION_TYPE_AUTO_PLACE,
+	ACTION_TYPE_TOGGLE_TEARING,
 };
 
 const char *action_names[] = {
@@ -149,6 +150,7 @@ const char *action_names[] = {
 	"VirtualOutputAdd",
 	"VirtualOutputRemove",
 	"AutoPlace",
+	"ToggleTearing",
 	NULL
 };
 
@@ -950,6 +952,12 @@ actions_run(struct view *activator, struct server *server,
 					view_move(view, x, y);
 				}
 			}
+			break;
+		case ACTION_TYPE_TOGGLE_TEARING:
+			if (view) {
+				view->tearing_hint = !view->tearing_hint;
+			}
+			wlr_log(WLR_DEBUG, "tearing: %d", view->tearing_hint);
 			break;
 		case ACTION_TYPE_INVALID:
 			wlr_log(WLR_ERROR, "Not executing unknown action");

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -626,6 +626,26 @@ set_adaptive_sync_mode(const char *str, enum adaptive_sync_mode *variable)
 }
 
 static void
+set_tearing_mode(const char *str, enum tearing_mode *variable)
+{
+	if (!strcasecmp(str, "fullscreen")) {
+		*variable = LAB_TEARING_FULLSCREEN;
+	} else {
+		int ret = parse_bool(str, -1);
+		if (ret == 1) {
+			*variable = LAB_TEARING_ENABLED;
+		} else {
+			*variable = LAB_TEARING_DISABLED;
+		}
+	}
+	if (*variable != LAB_TEARING_DISABLED &&
+		strcmp(getenv("WLR_DRM_NO_ATOMIC"), "1")) {
+		*variable = LAB_TEARING_DISABLED;
+		wlr_log(WLR_INFO, "WLR_DRM_NO_ATOMIC is not 1, tearing disabled");
+	}
+}
+
+static void
 entry(xmlNode *node, char *nodename, char *content)
 {
 	/* current <theme><font place=""></font></theme> */
@@ -727,6 +747,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.gap = atoi(content);
 	} else if (!strcasecmp(nodename, "adaptiveSync.core")) {
 		set_adaptive_sync_mode(content, &rc.adaptive_sync);
+	} else if (!strcasecmp(nodename, "allowTearing.core")) {
+		set_tearing_mode(content, &rc.allow_tearing);
 	} else if (!strcasecmp(nodename, "reuseOutputMode.core")) {
 		set_bool(content, &rc.reuse_output_mode);
 	} else if (!strcmp(nodename, "policy.placement")) {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -630,6 +630,8 @@ set_tearing_mode(const char *str, enum tearing_mode *variable)
 {
 	if (!strcasecmp(str, "fullscreen")) {
 		*variable = LAB_TEARING_FULLSCREEN;
+	} else if (!strcasecmp(str, "always"))	{
+		*variable = LAB_TEARING_ALWAYS;
 	} else {
 		int ret = parse_bool(str, -1);
 		if (ret == 1) {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -626,28 +626,6 @@ set_adaptive_sync_mode(const char *str, enum adaptive_sync_mode *variable)
 }
 
 static void
-set_tearing_mode(const char *str, enum tearing_mode *variable)
-{
-	if (!strcasecmp(str, "fullscreen")) {
-		*variable = LAB_TEARING_FULLSCREEN;
-	} else if (!strcasecmp(str, "always"))	{
-		*variable = LAB_TEARING_ALWAYS;
-	} else {
-		int ret = parse_bool(str, -1);
-		if (ret == 1) {
-			*variable = LAB_TEARING_ENABLED;
-		} else {
-			*variable = LAB_TEARING_DISABLED;
-		}
-	}
-	if (*variable != LAB_TEARING_DISABLED &&
-		strcmp(getenv("WLR_DRM_NO_ATOMIC"), "1")) {
-		*variable = LAB_TEARING_DISABLED;
-		wlr_log(WLR_INFO, "WLR_DRM_NO_ATOMIC is not 1, tearing disabled");
-	}
-}
-
-static void
 entry(xmlNode *node, char *nodename, char *content)
 {
 	/* current <theme><font place=""></font></theme> */
@@ -750,7 +728,11 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "adaptiveSync.core")) {
 		set_adaptive_sync_mode(content, &rc.adaptive_sync);
 	} else if (!strcasecmp(nodename, "allowTearing.core")) {
-		set_tearing_mode(content, &rc.allow_tearing);
+		set_bool(content, &rc.allow_tearing);
+		if (rc.allow_tearing && strcmp(getenv("WLR_DRM_NO_ATOMIC"), "1")) {
+			rc.allow_tearing = false;
+			wlr_log(WLR_INFO, "WLR_DRM_NO_ATOMIC is not 1, tearing disabled");
+		}
 	} else if (!strcasecmp(nodename, "reuseOutputMode.core")) {
 		set_bool(content, &rc.reuse_output_mode);
 	} else if (!strcmp(nodename, "policy.placement")) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ labwc_sources = files(
   'server.c',
   'session-lock.c',
   'snap.c',
+  'tearing.c',
   'theme.c',
   'view.c',
   'view-impl-common.c',

--- a/src/output.c
+++ b/src/output.c
@@ -68,9 +68,7 @@ output_frame_notify(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	if (output->tearing) {
-		output->wlr_output->pending.tearing_page_flip = true;
-	}
+	output->wlr_output->pending.tearing_page_flip = output->tearing;
 
 	lab_wlr_scene_output_commit(output->scene_output);
 
@@ -277,7 +275,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 
 	wl_list_init(&output->regions);
 
-	if (rc.allow_tearing == LAB_TEARING_ENABLED) {
+	if (rc.allow_tearing == LAB_TEARING_ALWAYS) {
 		output->tearing = true;
 	} else {
 		output->tearing = false;

--- a/src/output.c
+++ b/src/output.c
@@ -33,13 +33,8 @@ get_tearing_preference(struct output *output)
 	struct server *server = output->server;
 
 	/* Never allow tearing when disabled */
-	if (rc.allow_tearing == LAB_TEARING_DISABLED) {
+	if (!rc.allow_tearing) {
 		return false;
-	}
-
-	/* Allows allow tearing when forced */
-	if (rc.allow_tearing == LAB_TEARING_ALWAYS) {
-		return true;
 	}
 
 	/* Tearing is only allowed for the output with the active view */
@@ -47,14 +42,9 @@ get_tearing_preference(struct output *output)
 		return false;
 	}
 
-	/* If the active view requests tearing, allow it */
+	/* If the active view requests tearing, or it
+		has been requested with action, allow it */
 	if (server->active_view->tearing_hint) {
-		return true;
-	}
-
-	/* If the active view is fullscreen, allow tearing if configured */
-	if (rc.allow_tearing == LAB_TEARING_FULLSCREEN &&
-			server->active_view->fullscreen) {
 		return true;
 	}
 

--- a/src/output.c
+++ b/src/output.c
@@ -43,11 +43,7 @@ get_tearing_preference(struct output *output)
 	}
 
 	/* If the active view requests tearing, or it is toggled on with action, allow it */
-	if (server->active_view->tearing_hint) {
-		return true;
-	}
-
-	return false;
+	return server->active_view->tearing_hint;
 }
 
 static void

--- a/src/output.c
+++ b/src/output.c
@@ -42,8 +42,7 @@ get_tearing_preference(struct output *output)
 		return false;
 	}
 
-	/* If the active view requests tearing, or it
-		has been requested with action, allow it */
+	/* If the active view requests tearing, or it is toggled on with action, allow it */
 	if (server->active_view->tearing_hint) {
 		return true;
 	}

--- a/src/output.c
+++ b/src/output.c
@@ -68,7 +68,11 @@ output_frame_notify(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	wlr_scene_output_commit(output->scene_output, NULL);
+	if (output->tearing) {
+		output->wlr_output->pending.tearing_page_flip = true;
+	}
+
+	lab_wlr_scene_output_commit(output->scene_output);
 
 	struct timespec now = { 0 };
 	clock_gettime(CLOCK_MONOTONIC, &now);
@@ -272,6 +276,12 @@ new_output_notify(struct wl_listener *listener, void *data)
 	wl_signal_add(&wlr_output->events.request_state, &output->request_state);
 
 	wl_list_init(&output->regions);
+
+	if (rc.allow_tearing == LAB_TEARING_ENABLED) {
+		output->tearing = true;
+	} else {
+		output->tearing = false;
+	}
 
 	/*
 	 * Create layer-trees (background, bottom, top and overlay) and

--- a/src/server.c
+++ b/src/server.c
@@ -449,6 +449,10 @@ server_init(struct server *server)
 	wl_signal_add(&server->output_power_manager_v1->events.set_mode,
 		&server->output_power_manager_set_mode);
 
+	server->tearing_control = wlr_tearing_control_manager_v1_create(server->wl_display, 1);
+	server->tearing_new_object.notify = new_tearing_hint;
+	wl_signal_add(&server->tearing_control->events.new_object, &server->tearing_new_object);
+
 	layers_init(server);
 
 #if HAVE_XWAYLAND

--- a/src/tearing.c
+++ b/src/tearing.c
@@ -48,33 +48,3 @@ new_tearing_hint(struct wl_listener *listener, void *data)
 	controller->destroy.notify = tearing_controller_destroy;
 	wl_signal_add(&tearing_control->events.destroy, &controller->destroy);
 }
-
-void
-set_tearing(struct output *output)
-{
-	if (rc.allow_tearing == LAB_TEARING_DISABLED) {
-		output->tearing = false;
-		return;
-	}
-
-	if (rc.allow_tearing == LAB_TEARING_ALWAYS) {
-		output->tearing = true;
-		return;
-	}
-
-	struct server *server = output->server;
-	struct view *view;
-	bool on_fullscreen = rc.allow_tearing == LAB_TEARING_FULLSCREEN;
-
-	wl_list_for_each(view, &server->views, link) {
-		if (view->output != output) {
-			continue;
-		}
-
-		if (view->tearing_hint || (on_fullscreen && view->fullscreen)) {
-			output->tearing = true;
-			return;
-		}
-	}
-	output->tearing = false;
-}

--- a/src/tearing.c
+++ b/src/tearing.c
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "labwc.h"
+#include "view.h"
+
+struct tearing_controller {
+		struct wlr_tearing_control_v1 *tearing_control;
+		struct wl_listener set_hint;
+		struct wl_listener destroy;
+};
+
+static void
+set_tearing_hint(struct wl_listener *listener, void *data)
+{
+	struct tearing_controller *controller = wl_container_of(listener, controller, set_hint);
+	struct view *view = view_from_wlr_surface(controller->tearing_control->surface);
+	if (view) {
+		view->tearing_hint = controller->tearing_control->hint;
+	}
+}
+
+static void
+tearing_controller_destroy(struct wl_listener *listener, void *data)
+{
+	struct tearing_controller *controller = wl_container_of(listener, controller, destroy);
+	free(controller);
+}
+
+void
+new_tearing_hint(struct wl_listener *listener, void *data)
+{
+	struct server *server = wl_container_of(listener, server, tearing_new_object);
+	struct wlr_tearing_control_v1 *tearing_control = data;
+
+	enum wp_tearing_control_v1_presentation_hint hint =
+		wlr_tearing_control_manager_v1_surface_hint_from_surface
+		(server->tearing_control, tearing_control->surface);
+	wlr_log(WLR_DEBUG, "New presentation hint %d received for surface %p",
+		hint, tearing_control->surface);
+
+	struct tearing_controller *controller = calloc(1, sizeof(struct tearing_controller));
+	if (!controller) {
+		return;
+	}
+	controller->tearing_control = tearing_control;
+	controller->set_hint.notify = set_tearing_hint;
+	wl_signal_add(&tearing_control->events.set_hint, &controller->set_hint);
+	controller->destroy.notify = tearing_controller_destroy;
+	wl_signal_add(&tearing_control->events.destroy, &controller->destroy);
+}
+
+void
+set_tearing(struct output *output)
+{
+	if (rc.allow_tearing == LAB_TEARING_DISABLED) {
+		output->tearing = false;
+		return;
+	}
+
+	if (rc.allow_tearing == LAB_TEARING_ALWAYS) {
+		output->tearing = true;
+		return;
+	}
+
+	struct server *server = output->server;
+	struct view *view;
+	bool on_fullscreen = rc.allow_tearing == LAB_TEARING_FULLSCREEN;
+
+	wl_list_for_each(view, &server->views, link) {
+		if (view->output != output) {
+			continue;
+		}
+
+		if (view->tearing_hint || (on_fullscreen && view->fullscreen)) {
+			output->tearing = true;
+			return;
+		}
+	}
+	output->tearing = false;
+}

--- a/src/tearing.c
+++ b/src/tearing.c
@@ -14,8 +14,8 @@ set_tearing_hint(struct wl_listener *listener, void *data)
 {
 	struct tearing_controller *controller = wl_container_of(listener, controller, set_hint);
 	struct view *view = view_from_wlr_surface(controller->tearing_control->surface);
-	if (view) {
-		view->tearing_hint = controller->tearing_control->hint;
+	if (view && controller->tearing_control->hint) {
+		view->tearing_hint = true;
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -273,6 +273,16 @@ set_adaptive_sync_fullscreen(struct view *view)
 	wlr_output_commit(view->output->wlr_output);
 }
 
+static void
+set_tearing_fullscreen(struct view *view)
+{
+	if (rc.allow_tearing != LAB_TEARING_FULLSCREEN) {
+		return;
+	}
+	/* Enable tearing if view is fullscreen */
+	view->output->tearing = view->fullscreen;
+}
+
 void
 view_set_activated(struct view *view, bool activated)
 {
@@ -297,6 +307,7 @@ view_set_activated(struct view *view, bool activated)
 		}
 	}
 	set_adaptive_sync_fullscreen(view);
+	set_tearing_fullscreen(view);
 }
 
 void
@@ -1199,6 +1210,7 @@ view_set_fullscreen(struct view *view, bool fullscreen)
 		view_apply_special_geometry(view);
 	}
 	set_adaptive_sync_fullscreen(view);
+	set_tearing_fullscreen(view);
 }
 
 void
@@ -1868,6 +1880,9 @@ view_destroy(struct view *view)
 		desktop_update_top_layer_visiblity(server);
 		if (rc.adaptive_sync == LAB_ADAPTIVE_SYNC_FULLSCREEN) {
 			wlr_output_enable_adaptive_sync(view->output->wlr_output, false);
+		}
+		if (rc.allow_tearing == LAB_TEARING_FULLSCREEN) {
+			view->output->tearing = false;
 		}
 	}
 

--- a/src/view.c
+++ b/src/view.c
@@ -273,16 +273,6 @@ set_adaptive_sync_fullscreen(struct view *view)
 	wlr_output_commit(view->output->wlr_output);
 }
 
-static void
-set_tearing_fullscreen(struct view *view)
-{
-	if (rc.allow_tearing != LAB_TEARING_FULLSCREEN) {
-		return;
-	}
-	/* Enable tearing if view is fullscreen */
-	view->output->tearing = view->fullscreen;
-}
-
 void
 view_set_activated(struct view *view, bool activated)
 {
@@ -307,7 +297,7 @@ view_set_activated(struct view *view, bool activated)
 		}
 	}
 	set_adaptive_sync_fullscreen(view);
-	set_tearing_fullscreen(view);
+	set_tearing(view->output);
 }
 
 void
@@ -1210,7 +1200,7 @@ view_set_fullscreen(struct view *view, bool fullscreen)
 		view_apply_special_geometry(view);
 	}
 	set_adaptive_sync_fullscreen(view);
-	set_tearing_fullscreen(view);
+	set_tearing(view->output);
 }
 
 void
@@ -1880,9 +1870,6 @@ view_destroy(struct view *view)
 		desktop_update_top_layer_visiblity(server);
 		if (rc.adaptive_sync == LAB_ADAPTIVE_SYNC_FULLSCREEN) {
 			wlr_output_enable_adaptive_sync(view->output->wlr_output, false);
-		}
-		if (rc.allow_tearing == LAB_TEARING_FULLSCREEN) {
-			view->output->tearing = false;
 		}
 	}
 

--- a/src/view.c
+++ b/src/view.c
@@ -297,7 +297,6 @@ view_set_activated(struct view *view, bool activated)
 		}
 	}
 	set_adaptive_sync_fullscreen(view);
-	set_tearing(view->output);
 }
 
 void
@@ -1200,7 +1199,6 @@ view_set_fullscreen(struct view *view, bool fullscreen)
 		view_apply_special_geometry(view);
 	}
 	set_adaptive_sync_fullscreen(view);
-	set_tearing(view->output);
 }
 
 void


### PR DESCRIPTION
This adds allowTearing option. `<allowTearing>yes</allowTearing>` will enable tearing support. Also adds action ToggleTearing that can be used to enable it for windows that don't request tearing.

I decided to make it check if WLR_DRM_NO_ATOMIC is set to 1, and disable tearing otherwise, as currently that is required for it to work. That check can be removed later when we get support for atomic tearing page flips.