### PR TITLE
view: try to honor original geometry with layout changes

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -180,6 +180,13 @@ struct view {
 	 * maximized/fullscreen/tiled.
 	 */
 	struct wlr_box natural_geometry;
+	/*
+	 * Whenever an output layout change triggers a view relocation, the
+	 * last pending position (or natural geometry) will be saved so the
+	 * view may be restored to its original location on a subsequent layout
+	 * change.
+	 */
+	struct wlr_box last_layout_geometry;
 
 	/* used by xdg-shell views */
 	uint32_t pending_configure_serial;
@@ -420,6 +427,7 @@ bool view_is_floating(struct view *view);
 void view_move_to_workspace(struct view *view, struct workspace *workspace);
 void view_set_decorations(struct view *view, bool decorations);
 void view_toggle_fullscreen(struct view *view);
+void view_invalidate_last_layout_geometry(struct view *view);
 void view_adjust_for_layout_change(struct view *view);
 void view_move_to_edge(struct view *view, enum view_edge direction, bool snap_to_windows);
 void view_grow_to_edge(struct view *view, enum view_edge direction);

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -70,6 +70,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 		} else {
 			/* Store natural geometry at start of move */
 			view_store_natural_geometry(view);
+			view_invalidate_last_layout_geometry(view);
 		}
 
 		/* Prevent region snapping when just moving via A-Left mousebind */
@@ -86,6 +87,13 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 			 */
 			return;
 		}
+
+		/*
+		 * Resizing overrides any attempt to restore window
+		 * geometries altered by layout changes.
+		 */
+		view_invalidate_last_layout_geometry(view);
+
 		/*
 		 * If tiled or maximized in only one direction, reset
 		 * tiled/maximized state but keep the same geometry as


### PR DESCRIPTION
If a view's output disappears during a layout change, its original geometry will be captured as last_layout_geometry, which will remain valid unless the view's natural geometry is modified. If a subsequent layout change adds an output closer to a valid last_layout_geometry, the view will be relocated to that output.

The intent of this change is to more gracefully handle cases like `wlopm --off` and a subsequent `wlopm --on` which, at least on some multihead `amdgpu` setups, will send disconnect events that will trigger labwc to coalesce all views onto the last display to be disconnected. However, it also allows one to connect an external display to a laptop, put some windows there, remove the display and have them coalesce on the internal display, and then reattach the display and have the windows pushed back to where they began.

There are a few points that should be addressed before this is ready to merge:
- [ ] I am currently using `view_store_natural_geometry` to invalidate the `last_layout_geometry`. This means that, after labwc relocates a view because an output was lost, an interactive move, tiling or maximization of the view on its current output will prevent restoration to an original output. This seems clearly desirable, but does not cover cases when the user resizes a floating window (an interactive resize does not update the natural geometry). Should interactive resizes also call `view_store_natural_geometry` to trigger the invalidation, should the interactive resize manually invalidate the `last_layout_geometry`, or is there some better method to invalidate the `last_layout_geometry` that I am not considering?
- [ ] `view_discover_output` has been overloaded to identify an output closest to the midpoint of the original `last_layout_geometry`, which should mean that, with each new layout change, each view not altered by the user will get as close as possible to its original output. This seems like reasonable behavior, but am open to suggestions for refining this behavior.
- [ ] The `view_adjust_floating_geometry` function has been modified to check not whether a view is currently visible *within the layout*, but instead whether it is currently visible *on its assigned output*. This seems like a more proper check anyway, but I am not sure if there are corner cases that I am overlooking.