### PR TITLE
feat: Add initial tablet pad button mappings

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -404,8 +404,8 @@
     after applying tablet area transformation.
 
     Tablet buttons emulate regular mouse buttons. The tablet *button* can
-    be set to any of [tip|stylus|stylus2|stylus3]. Valid *to* mouse buttons
-    are [left|right|middle].
+    be set to any of [tip|stylus|stylus2|stylus3|pad|pad2|pad3|..|pad9].
+    Valid *to* mouse buttons are [left|right|middle].
   -->
   <tablet rotate="0">
     <!-- Active area dimensions are in mm -->

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -20,6 +20,7 @@ struct drawing_tablet {
 	} handlers;
 };
 
-void tablet_setup_handlers(struct seat *seat, struct wlr_input_device *wlr_input_device);
+uint32_t tablet_get_mapped_button(uint32_t src_button);
+void tablet_init(struct seat *seat, struct wlr_input_device *wlr_input_device);
 
 #endif /* LABWC_TABLET_H */

--- a/include/input/tablet_pad.h
+++ b/include/input/tablet_pad.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_TABLET_PAD_H
+#define LABWC_TABLET_PAD_H
+
+#include <wayland-server-core.h>
+struct seat;
+struct wlr_device;
+struct wlr_input_device;
+
+struct drawing_tablet_pad {
+	struct seat *seat;
+	struct wlr_tablet_pad *tablet;
+	struct {
+		struct wl_listener button;
+		struct wl_listener destroy;
+	} handlers;
+};
+
+void tablet_pad_init(struct seat *seat, struct wlr_input_device *wlr_input_device);
+
+#endif /* LABWC_TABLET_PAD_H */

--- a/include/input/tablet_pad.h
+++ b/include/input/tablet_pad.h
@@ -7,6 +7,16 @@ struct seat;
 struct wlr_device;
 struct wlr_input_device;
 
+#define LAB_BTN_PAD 0x0
+#define LAB_BTN_PAD2 0x1
+#define LAB_BTN_PAD3 0x2
+#define LAB_BTN_PAD4 0x3
+#define LAB_BTN_PAD5 0x4
+#define LAB_BTN_PAD6 0x5
+#define LAB_BTN_PAD7 0x6
+#define LAB_BTN_PAD8 0x7
+#define LAB_BTN_PAD9 0x8
+
 struct drawing_tablet_pad {
 	struct seat *seat;
 	struct wlr_tablet_pad *tablet;

--- a/src/config/tablet.c
+++ b/src/config/tablet.c
@@ -6,6 +6,7 @@
 #include <wlr/util/log.h>
 #include "config/tablet.h"
 #include "config/rcxml.h"
+#include "input/tablet_pad.h"
 
 double
 tablet_get_dbl_if_positive(const char *content, const char *name)
@@ -48,6 +49,24 @@ tablet_button_from_str(const char *button)
 		return BTN_STYLUS2;
 	} else if (!strcasecmp(button, "Stylus3")) {
 		return BTN_STYLUS3;
+	} else if (!strcasecmp(button, "Pad")) {
+		return LAB_BTN_PAD;
+	} else if (!strcasecmp(button, "Pad2")) {
+		return LAB_BTN_PAD2;
+	} else if (!strcasecmp(button, "Pad3")) {
+		return LAB_BTN_PAD3;
+	} else if (!strcasecmp(button, "Pad4")) {
+		return LAB_BTN_PAD4;
+	} else if (!strcasecmp(button, "Pad5")) {
+		return LAB_BTN_PAD5;
+	} else if (!strcasecmp(button, "Pad6")) {
+		return LAB_BTN_PAD6;
+	} else if (!strcasecmp(button, "Pad7")) {
+		return LAB_BTN_PAD7;
+	} else if (!strcasecmp(button, "Pad8")) {
+		return LAB_BTN_PAD8;
+	} else if (!strcasecmp(button, "Pad9")) {
+		return LAB_BTN_PAD9;
 	}
 	wlr_log(WLR_ERROR, "Invalid value for tablet button: %s", button);
 	return UINT32_MAX;

--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -1,6 +1,7 @@
 labwc_sources += files(
   'cursor.c',
   'tablet.c',
+  'tablet_pad.c',
   'gestures.c',
   'input.c',
   'keyboard.c',

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -86,8 +86,8 @@ handle_axis(struct wl_listener *listener, void *data)
 	// Ignore other events
 }
 
-static uint32_t
-get_mapped_button(uint32_t src_button)
+uint32_t
+tablet_get_mapped_button(uint32_t src_button)
 {
 	struct button_map_entry *map_entry;
 	for (size_t i = 0; i < rc.tablet.button_map_count; i++) {
@@ -106,7 +106,7 @@ handle_tip(struct wl_listener *listener, void *data)
 	struct wlr_tablet_tool_tip_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
 
-	uint32_t button = get_mapped_button(BTN_TOOL_PEN);
+	uint32_t button = tablet_get_mapped_button(BTN_TOOL_PEN);
 	if (!button) {
 		return;
 	}
@@ -125,7 +125,7 @@ handle_button(struct wl_listener *listener, void *data)
 	struct wlr_tablet_tool_button_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
 
-	uint32_t button = get_mapped_button(ev->button);
+	uint32_t button = tablet_get_mapped_button(ev->button);
 	if (!button) {
 		return;
 	}
@@ -141,14 +141,8 @@ handle_destroy(struct wl_listener *listener, void *data)
 	free(tablet);
 }
 
-static void
-setup_pad(struct seat *seat, struct wlr_input_device *wlr_device)
-{
-	wlr_log(WLR_INFO, "not setting up pad");
-}
-
-static void
-setup_pen(struct seat *seat, struct wlr_input_device *wlr_device)
+void
+tablet_init(struct seat *seat, struct wlr_input_device *wlr_device)
 {
 	wlr_log(WLR_DEBUG, "setting up tablet");
 	struct drawing_tablet *tablet = znew(*tablet);
@@ -163,19 +157,4 @@ setup_pen(struct seat *seat, struct wlr_input_device *wlr_device)
 	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, tip);
 	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, button);
 	CONNECT_SIGNAL(wlr_device, &tablet->handlers, destroy);
-}
-
-void
-tablet_setup_handlers(struct seat *seat, struct wlr_input_device *device)
-{
-	switch (device->type) {
-	case WLR_INPUT_DEVICE_TABLET_PAD:
-		setup_pad(seat, device);
-		break;
-	case WLR_INPUT_DEVICE_TABLET_TOOL:
-		setup_pen(seat, device);
-		break;
-	default:
-		assert(false && "tried to add non-tablet as tablet");
-	}
 }

--- a/src/input/tablet_pad.c
+++ b/src/input/tablet_pad.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/util/log.h>
+#include "common/macros.h"
+#include "common/mem.h"
+#include "config/rcxml.h"
+#include "input/cursor.h"
+#include "input/tablet.h"
+#include "input/tablet_pad.h"
+
+static void
+handle_button(struct wl_listener *listener, void *data)
+{
+	struct drawing_tablet_pad *tablet_pad =
+		wl_container_of(listener, tablet_pad, handlers.button);
+	struct wlr_tablet_pad_button_event *ev = data;
+
+	uint32_t button = tablet_get_mapped_button(ev->button);
+	if (!button) {
+		return;
+	}
+
+	cursor_emulate_button(tablet_pad->seat, button, ev->state, ev->time_msec);
+}
+
+static void
+handle_destroy(struct wl_listener *listener, void *data)
+{
+	struct drawing_tablet_pad *tablet =
+		wl_container_of(listener, tablet, handlers.destroy);
+	free(tablet);
+}
+
+void
+tablet_pad_init(struct seat *seat, struct wlr_input_device *wlr_device)
+{
+	wlr_log(WLR_DEBUG, "setting up tablet pad");
+	struct drawing_tablet_pad *tablet = znew(*tablet);
+	tablet->seat = seat;
+	tablet->tablet = wlr_tablet_pad_from_input_device(wlr_device);
+	tablet->tablet->data = tablet;
+	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, button);
+	CONNECT_SIGNAL(wlr_device, &tablet->handlers, destroy);
+}

--- a/src/seat.c
+++ b/src/seat.c
@@ -10,6 +10,7 @@
 #include <wlr/util/log.h>
 #include "common/mem.h"
 #include "input/tablet.h"
+#include "input/tablet_pad.h"
 #include "input/input.h"
 #include "input/keyboard.h"
 #include "input/key-state.h"
@@ -283,7 +284,17 @@ new_tablet(struct seat *seat, struct wlr_input_device *dev)
 {
 	struct input *input = znew(*input);
 	input->wlr_input_device = dev;
-	tablet_setup_handlers(seat, dev);
+	tablet_init(seat, dev);
+
+	return input;
+}
+
+static struct input *
+new_tablet_pad(struct seat *seat, struct wlr_input_device *dev)
+{
+	struct input *input = znew(*input);
+	input->wlr_input_device = dev;
+	tablet_pad_init(seat, dev);
 
 	return input;
 }
@@ -341,6 +352,8 @@ new_input_notify(struct wl_listener *listener, void *data)
 		input = new_touch(seat, device);
 		break;
 	case WLR_INPUT_DEVICE_TABLET_PAD:
+		input = new_tablet_pad(seat, device);
+		break;
 	case WLR_INPUT_DEVICE_TABLET_TOOL:
 		input = new_tablet(seat, device);
 		break;


### PR DESCRIPTION
This PR wires the tablet pad and lets you map tablet pad buttons to mouse buttons. This is probably not the most important feature but a good stepping stone to bind actions to pad and stylus buttons, like the  mouse-bindings.
 @Consolatis did also some work in his branch here https://github.com/labwc/labwc/issues/1060#issuecomment-1786384495 for that. That said, i guess adding mouse-like bindings needs some thinking up front, so I prefer to just open an issue for that after this PR to have a place to collect all thoughts.

I haven't found any `const`'s for the  pad buttons in wlroots. Please let know if you prefer to define our own `const`'s instead of using directly `0x0` etc.