### PR TITLE
Load hierarchy of rc.xml files from directories

### DIFF
--- a/include/common/dir.h
+++ b/include/common/dir.h
@@ -3,6 +3,7 @@
 #define LABWC_DIR_H
 
 char *config_dir(void);
+char *config_dir_n(int n);
 
 /**
  * theme_dir - find theme directory containing theme @theme_name

--- a/include/common/dir.h
+++ b/include/common/dir.h
@@ -3,7 +3,8 @@
 #define LABWC_DIR_H
 
 char *config_dir(void);
-char *config_dir_n(int n);
+char *user_config_dir(void);
+char *sys_config_dir(void);
 
 /**
  * theme_dir - find theme directory containing theme @theme_name

--- a/include/config/session.h
+++ b/include/config/session.h
@@ -4,17 +4,15 @@
 
 /**
  * session_environment_init - set enrivonment variables based on <key>=<value>
- * @dir: path to config directory
  * pairs in `${XDG_CONFIG_DIRS:-/etc/xdg}/lawbc/environment` with user override
  * in `${XDG_CONFIG_HOME:-$HOME/.config}`
  */
-void session_environment_init(const char *dir);
+void session_environment_init(void);
 
 /**
  * session_autostart_init - run autostart file as shell script
- * @dir: path to config directory
  * Note: Same as `sh ~/.config/labwc/autostart` (or equivalent XDG config dir)
  */
-void session_autostart_init(const char *dir);
+void session_autostart_init(void);
 
 #endif /* LABWC_SESSION_H */

--- a/src/common/dir.c
+++ b/src/common/dir.c
@@ -74,12 +74,12 @@ build_theme_path(struct ctx *ctx, char *prefix, const char *path)
 }
 
 static char *
-find_dir(struct ctx *ctx)
+find_dir(struct ctx *ctx, int n)
 {
 	char *debug = getenv("LABWC_DEBUG_DIR_CONFIG_AND_THEME");
 
 	for (int i = 0; ctx->dirs[i].path; i++) {
-		struct dir d = ctx->dirs[i];
+		struct dir d = ctx->dirs[n != -1 ? n : i];
 		if (!d.prefix) {
 			/* handle /etc/xdg... */
 			ctx->build_path_fn(ctx, NULL, d.path);
@@ -109,6 +109,9 @@ find_dir(struct ctx *ctx)
 			}
 			g_strfreev(prefixes);
 		}
+		if (n != -1) {
+			break;
+		}
 	}
 	/* no directory was found */
 	ctx->buf[0] = '\0';
@@ -128,7 +131,20 @@ config_dir(void)
 		.len = sizeof(buf),
 		.dirs = config_dirs
 	};
-	return find_dir(&ctx);
+	return find_dir(&ctx, -1);
+}
+
+char *
+config_dir_n(int n)
+{
+	char buf[4096] = { 0 };
+	struct ctx ctx = {
+		.build_path_fn = build_config_path,
+		.buf = buf,
+		.len = sizeof(buf),
+		.dirs = config_dirs
+	};
+	return find_dir(&ctx, n);
 }
 
 char *
@@ -142,5 +158,5 @@ theme_dir(const char *theme_name)
 		.dirs = theme_dirs,
 		.theme_name = theme_name
 	};
-	return find_dir(&ctx);
+	return find_dir(&ctx, -1);
 }

--- a/src/common/dir.c
+++ b/src/common/dir.c
@@ -154,11 +154,11 @@ sys_config_dir(void)
 char *
 config_dir(void)
 {
-	char *res = user_config_dir ();
+	char *res = user_config_dir();
 	if (res[0] != '\0') {
 		return res;
 	}
-	return sys_config_dir ();
+	return sys_config_dir();
 }
 
 char *

--- a/src/common/dir.c
+++ b/src/common/dir.c
@@ -144,7 +144,11 @@ config_dir_n(int n)
 		.len = sizeof(buf),
 		.dirs = config_dirs
 	};
-	return find_dir(&ctx, n);
+	if (n == 0) {
+		return find_dir(&ctx, getenv("XDG_CONFIG_HOME") ? 0 : 1);
+	} else {
+		return find_dir(&ctx, getenv("XDG_CONFIG_DIRS") ? 2 : 3);
+	}
 }
 
 char *

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1492,10 +1492,10 @@ rcxml_read(const char *filename)
 		line = NULL;
 		len = 0;
 		if (filename) {
-			sprintf(rcxml, "%s", filename);
+			snprintf(rcxml, sizeof(rcxml), "%s", filename);
 			i = 0;
 		} else {
-			sprintf(rcxml, "%s/rc.xml", config_dir_n(i));
+			snprintf(rcxml, sizeof(rcxml), "%s/rc.xml", config_dir_n(i));
 		}
 		/* Reading file into buffer before parsing - better for unit tests */
 		stream = fopen(rcxml, "r");

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1498,12 +1498,12 @@ rcxml_read(const char *filename)
 	} else {
 		/* merge user config with system config */
 		rcxml = strdup_printf("%s/rc.xml", sys_config_dir());
-		rcxml_read_file (rcxml);
-		free (rcxml);
+		rcxml_read_file(rcxml);
+		free(rcxml);
 
 		rcxml = strdup_printf("%s/rc.xml", user_config_dir());
-		rcxml_read_file (rcxml);
-		free (rcxml);
+		rcxml_read_file(rcxml);
+		free(rcxml);
 	}
 
 	post_processing();

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1453,25 +1453,6 @@ validate(void)
 	validate_actions();
 }
 
-static void
-rcxml_path(char *buf, size_t len)
-{
-	if (!rc.config_dir) {
-		return;
-	}
-	snprintf(buf, len, "%s/rc.xml", rc.config_dir);
-}
-
-static void
-find_config_file(char *buffer, size_t len, const char *filename)
-{
-	if (filename) {
-		snprintf(buffer, len, "%s", filename);
-		return;
-	}
-	rcxml_path(buffer, len);
-}
-
 void
 rcxml_read(const char *filename)
 {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1460,7 +1460,12 @@ rcxml_read(const char *filename)
 	char *line = NULL;
 	size_t len = 0;
 	struct buf b;
-	static char rcxml[4096] = {0};
+	char rcxml[4096] = {0};
+	static char saved_filename[4096] = {0};
+
+	if (filename) {
+		snprintf(saved_filename, sizeof(rcxml), "%s", filename);
+	}
 
 	rcxml_init();
 
@@ -1474,6 +1479,9 @@ rcxml_read(const char *filename)
 		len = 0;
 		if (filename) {
 			snprintf(rcxml, sizeof(rcxml), "%s", filename);
+			i = 0;
+		} else if (saved_filename[0] != 0) {
+			snprintf(rcxml, sizeof(rcxml), "%s", saved_filename);
 			i = 0;
 		} else {
 			snprintf(rcxml, sizeof(rcxml), "%s/rc.xml", config_dir_n(i));

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1474,7 +1474,7 @@ rcxml_read(const char *filename)
 	 * the first time. The specified 'filename' is only respected the first
 	 * time.
 	 */
-	for (int i = 3; i >= 0; i--) {
+	for (int i = 1; i >= 0; i--) {
 		line = NULL;
 		len = 0;
 		if (filename) {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1501,22 +1501,20 @@ rcxml_read(const char *filename)
 		stream = fopen(rcxml, "r");
 		if (!stream) {
 			wlr_log(WLR_ERROR, "cannot read (%s)", rcxml);
-		}
-		else
-		{
-		wlr_log(WLR_INFO, "read config file %s", rcxml);
-		buf_init(&b);
-		while (getline(&line, &len, stream) != -1) {
-			char *p = strrchr(line, '\n');
-			if (p) {
-				*p = '\0';
+		} else {
+			wlr_log(WLR_INFO, "read config file %s", rcxml);
+			buf_init(&b);
+			while (getline(&line, &len, stream) != -1) {
+				char *p = strrchr(line, '\n');
+				if (p) {
+					*p = '\0';
+				}
+				buf_add(&b, line);
 			}
-			buf_add(&b, line);
-		}
-		free(line);
-		fclose(stream);
-		rcxml_parse_xml(&b);
-		free(b.buf);
+			free(line);
+			fclose(stream);
+			rcxml_parse_xml(&b);
+			free(b.buf);
 		}
 	}
 	post_processing();

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -119,8 +119,7 @@ session_environment_init(void)
 	int i;
 	bool read = false;
 	char *environment;
-	for (i = 0; i < 2; i++)
-	{
+	for (i = 0; i < 2; i++)	{
 		environment = build_path(i ? sys_config_dir() : user_config_dir(), "environment");
 		if (environment) {
 			read = read_environment_file(environment);
@@ -140,8 +139,7 @@ session_autostart_init(void)
 
 	int i;
 	char *autostart;
-	for (i = 0; i < 2; i++)
-	{
+	for (i = 0; i < 2; i++)	{
 		autostart = build_path(i ? sys_config_dir() : user_config_dir(), "autostart");
 
 		if (autostart) {

--- a/src/main.c
+++ b/src/main.c
@@ -3,12 +3,12 @@
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
-#include <glib.h>
 #include "common/dir.h"
 #include "common/fd_util.h"
 #include "common/font.h"
 #include "common/mem.h"
 #include "common/spawn.h"
+#include "common/string-helpers.h"
 #include "config/session.h"
 #include "labwc.h"
 #include "theme.h"
@@ -22,7 +22,7 @@ static const struct option long_options[] = {
 	{"debug", no_argument, NULL, 'd'},
 	{"exit", no_argument, NULL, 'e'},
 	{"help", no_argument, NULL, 'h'},
-	{"mergeconfig", no_argument, NULL, 'm'},
+	{"merge-config", no_argument, NULL, 'm'},
 	{"reconfigure", no_argument, NULL, 'r'},
 	{"startup", required_argument, NULL, 's'},
 	{"version", no_argument, NULL, 'v'},
@@ -37,7 +37,7 @@ static const char labwc_usage[] =
 "  -d, --debug              Enable full logging, including debug information\n"
 "  -e, --exit               Exit the compositor\n"
 "  -h, --help               Show help message and quit\n"
-"  -m, --mergeconfig        Merge user rc.xml with system rc.xml\n"
+"  -m, --merge-config       Merge user rc.xml with system rc.xml\n"
 "  -r, --reconfigure        Reload the compositor configuration\n"
 "  -s, --startup <command>  Run command on startup\n"
 "  -v, --version            Show version number and quit\n"
@@ -143,11 +143,12 @@ main(int argc, char *argv[])
 	if (!rc.config_dir) {
 		rc.config_dir = config_dir();
 		if (!merge_rc && !config_file) {
-			config_file = g_strdup_printf("%s/rc.xml", rc.config_dir);
+			config_file = strdup_printf("%s/rc.xml", rc.config_dir);
 		}
 	} else if (!config_file) {
-		config_file = g_strdup_printf("%s/rc.xml", rc.config_dir);
+		config_file = strdup_printf("%s/rc.xml", rc.config_dir);
 	}
+
 	wlr_log(WLR_INFO, "using config dir (%s)\n", rc.config_dir);
 	session_environment_init(rc.config_dir);
 	rcxml_read(config_file);

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@ static const struct option long_options[] = {
 	{"debug", no_argument, NULL, 'd'},
 	{"exit", no_argument, NULL, 'e'},
 	{"help", no_argument, NULL, 'h'},
+	{"mergeconfig", no_argument, NULL, 'm'},
 	{"reconfigure", no_argument, NULL, 'r'},
 	{"startup", required_argument, NULL, 's'},
 	{"version", no_argument, NULL, 'v'},
@@ -36,6 +37,7 @@ static const char labwc_usage[] =
 "  -d, --debug              Enable full logging, including debug information\n"
 "  -e, --exit               Exit the compositor\n"
 "  -h, --help               Show help message and quit\n"
+"  -m, --mergeconfig        Merge user rc.xml with system rc.xml\n"
 "  -r, --reconfigure        Reload the compositor configuration\n"
 "  -s, --startup <command>  Run command on startup\n"
 "  -v, --version            Show version number and quit\n"
@@ -88,11 +90,12 @@ main(int argc, char *argv[])
 	char *startup_cmd = NULL;
 	char *config_file = NULL;
 	enum wlr_log_importance verbosity = WLR_ERROR;
+	bool merge_rc = false;
 
 	int c;
 	while (1) {
 		int index = 0;
-		c = getopt_long(argc, argv, "c:C:dehrs:vV", long_options, &index);
+		c = getopt_long(argc, argv, "c:C:dehmrs:vV", long_options, &index);
 		if (c == -1) {
 			break;
 		}
@@ -121,6 +124,9 @@ main(int argc, char *argv[])
 		case 'V':
 			verbosity = WLR_INFO;
 			break;
+		case 'm':
+			merge_rc = true;
+			break;
 		case 'h':
 		default:
 			usage();
@@ -136,6 +142,9 @@ main(int argc, char *argv[])
 
 	if (!rc.config_dir) {
 		rc.config_dir = config_dir();
+		if (merge_rc == false && !config_file) {
+			config_file = g_strdup_printf("%s/rc.xml", rc.config_dir);
+		}
 	} else if (!config_file) {
 		config_file = g_strdup_printf("%s/rc.xml", rc.config_dir);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -137,7 +137,7 @@ main(int argc, char *argv[])
 	if (!rc.config_dir) {
 		rc.config_dir = config_dir();
 	} else if (!config_file) {
-		config_file = g_strdup_printf ("%s/rc.xml", rc.config_dir);
+		config_file = g_strdup_printf("%s/rc.xml", rc.config_dir);
 	}
 	wlr_log(WLR_INFO, "using config dir (%s)\n", rc.config_dir);
 	session_environment_init(rc.config_dir);

--- a/src/main.c
+++ b/src/main.c
@@ -150,7 +150,7 @@ main(int argc, char *argv[])
 	}
 
 	wlr_log(WLR_INFO, "using config dir (%s)\n", rc.config_dir);
-	session_environment_init(rc.config_dir);
+	session_environment_init();
 	rcxml_read(config_file);
 
 	/*
@@ -184,7 +184,7 @@ main(int argc, char *argv[])
 
 	menu_init(&server);
 
-	session_autostart_init(rc.config_dir);
+	session_autostart_init();
 	if (startup_cmd) {
 		spawn_async_no_shell(startup_cmd);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
+#include <glib.h>
 #include "common/dir.h"
 #include "common/fd_util.h"
 #include "common/font.h"
@@ -135,6 +136,8 @@ main(int argc, char *argv[])
 
 	if (!rc.config_dir) {
 		rc.config_dir = config_dir();
+	} else if (!config_file) {
+		config_file = g_strdup_printf ("%s/rc.xml", rc.config_dir);
 	}
 	wlr_log(WLR_INFO, "using config dir (%s)\n", rc.config_dir);
 	session_environment_init(rc.config_dir);

--- a/src/main.c
+++ b/src/main.c
@@ -142,7 +142,7 @@ main(int argc, char *argv[])
 
 	if (!rc.config_dir) {
 		rc.config_dir = config_dir();
-		if (merge_rc == false && !config_file) {
+		if (!merge_rc && !config_file) {
 			config_file = g_strdup_printf("%s/rc.xml", rc.config_dir);
 		}
 	} else if (!config_file) {

--- a/src/server.c
+++ b/src/server.c
@@ -67,7 +67,7 @@ reload_config_and_theme(void)
 static int
 handle_sighup(int signal, void *data)
 {
-	session_environment_init(rc.config_dir);
+	session_environment_init();
 	reload_config_and_theme();
 	return 0;
 }


### PR DESCRIPTION
https://github.com/labwc/labwc/issues/1406

Following this discussion yesterday, here is a quick-and-dirty approach to loading multiple rc.xml files which seems to work.

I scan through the list of config directories in reverse order, global system directories first followed by user directories. (If a configuration file is specifically provided on the command line, that file is the only one loaded.) The XML in each is parsed in turn, and values defined in successive files override those in earlier files, while values which are not defined in a newer file take the value from the older file.

This does not do anything about making this behaviour opt-in or opt-out, but it does exactly what I need - allow me to set a global set of defaults in /etc/xdg/labwc.xml and override specific values with ~/.config/labwc/rc.xml.

I'm not expecting this to be taken as-is, but it is, I hope, a useful first attempt at adding this functionality, which I need for my implementation. Some mechanism whereby this functionality is made optional is probably worthwhile, based on the discussion above.