### PR TITLE
fix adaptive sync fullscreen

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -810,9 +810,6 @@ output_remove_virtual(struct server *server, const char *output_name)
 void
 output_enable_adaptive_sync(struct wlr_output *output, bool enabled)
 {
-	if (output->pending.adaptive_sync_enabled == enabled) {
-		return;
-	}
 	wlr_output_enable_adaptive_sync(output, enabled);
 	if (!wlr_output_test(output)) {
 		wlr_output_enable_adaptive_sync(output, false);

--- a/src/view.c
+++ b/src/view.c
@@ -1877,7 +1877,7 @@ view_destroy(struct view *view)
 		view->fullscreen = false;
 		desktop_update_top_layer_visiblity(server);
 		if (rc.adaptive_sync == LAB_ADAPTIVE_SYNC_FULLSCREEN) {
-			wlr_output_enable_adaptive_sync(view->output->wlr_output, false);
+			set_adaptive_sync_fullscreen(view);
 		}
 	}
 


### PR DESCRIPTION
Issue was found that in some situations adaptive sync does not get disabled when it should when exiting fullscreen. This fixes it.