### PR TITLE
feat: add more mouse button definitions

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -407,6 +407,11 @@ windows using the mouse.
 	- Left
 	- Middle
 	- Right
+	- Side
+	- Extra
+	- Forward
+	- Back
+	- Task
 
 	Supported scroll *directions* are:
 	- Up

--- a/include/config/tablet.h
+++ b/include/config/tablet.h
@@ -20,7 +20,6 @@ struct button_map_entry {
 double tablet_get_dbl_if_positive(const char *content, const char *name);
 enum rotation tablet_parse_rotation(int value);
 uint32_t tablet_button_from_str(const char *button);
-uint32_t mouse_button_from_str(const char *button);
 void tablet_button_mapping_add(uint32_t from, uint32_t to);
 void tablet_load_default_button_mappings(void);
 

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -34,6 +34,16 @@ mousebind_button_from_str(const char *str, uint32_t *modifiers)
 		return BTN_RIGHT;
 	} else if (!strcasecmp(str, "Middle")) {
 		return BTN_MIDDLE;
+	} else if (!strcasecmp(str, "Side")) {
+		return BTN_SIDE;
+	} else if (!strcasecmp(str, "Extra")) {
+		return BTN_EXTRA;
+	} else if (!strcasecmp(str, "Forward")) {
+		return BTN_FORWARD;
+	} else if (!strcasecmp(str, "Back")) {
+		return BTN_BACK;
+	} else if (!strcasecmp(str, "Task")) {
+		return BTN_TASK;
 	}
 invalid:
 	wlr_log(WLR_ERROR, "unknown button (%s)", str);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -868,7 +868,7 @@ entry(xmlNode *node, char *nodename, char *content)
 		button_map_from = tablet_button_from_str(content);
 	} else if (!strcasecmp(nodename, "to.map.tablet")) {
 		if (button_map_from != UINT32_MAX) {
-			uint32_t button_map_to = mouse_button_from_str(content);
+			uint32_t button_map_to = mousebind_button_from_str(content, NULL);
 			if (button_map_to != UINT32_MAX) {
 				tablet_button_mapping_add(button_map_from, button_map_to);
 			}

--- a/src/config/tablet.c
+++ b/src/config/tablet.c
@@ -72,20 +72,6 @@ tablet_button_from_str(const char *button)
 	return UINT32_MAX;
 }
 
-uint32_t
-mouse_button_from_str(const char *button)
-{
-	if (!strcasecmp(button, "Left")) {
-		return BTN_LEFT;
-	} else if (!strcasecmp(button, "Right")) {
-		return BTN_RIGHT;
-	} else if (!strcasecmp(button, "Middle")) {
-		return BTN_MIDDLE;
-	}
-	wlr_log(WLR_ERROR, "Invalid value for mouse button: %s", button);
-	return UINT32_MAX;
-}
-
 void
 tablet_button_mapping_add(uint32_t from, uint32_t to)
 {


### PR DESCRIPTION
This allows those other mouse buttons (from https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h#L355 ) to be bound and also makes more buttons available to map to from tablet pen/pad buttons.
(Since I have only 4 buttons on my pad, this absolutely sufficient for me)

Also drop one method in favor of reuse.

Closes https://github.com/labwc/labwc/issues/1404 if we want to restrict tablets to pure mouse emulations (which i think is just fine).