### PR TITLE
feat: add tablet output mapping

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -441,13 +441,23 @@ windows using the mouse.
 ## TABLET
 
 ```
-<tablet rotate="0">
+<tablet mapToOutput="" rotate="0">
   <area top="0.0" left="0.0" width="0.0" height="0.0">
   <map button="Tip" to="Left" />
   <map button="Stylus" to="Right" />
   <map button="Stylus2" to="Middle" />
 </tablet>
 ```
+
+*<tablet mapToOutput="" />*
+	The tablet cursor movement can be restricted to a single output.
+	If the output name is left empty or the output does not exists, the
+	tablet will span all outputs.
+
+*<tablet rotate="" />* [0|90|180|270]
+	The tablet orientation can be changed in 90 degree steps. Default is
+	no rotation (0). Rotation will be applied after applying tablet area
+	transformation.
 
 *<tablet><area top="mm" left="mm" width="mm" height="mm" />*
 	By default the complete tablet area is mapped to the full output.
@@ -467,11 +477,6 @@ windows using the mouse.
 	truncated to match the 21:9 aspect ratio of the output. By
 	additionally setting top to "12.5", the active area is centered
 	vertically on the tablet surface.
-
-*<tablet rotate="" />* [0|90|180|270]
-	The tablet orientation can be changed in 90 degree steps. Default is
-	no rotation (0). Rotation will be applied after applying tablet area
-	transformation.
 
 *<tablet><map button="" to="" />*
 	Tablet buttons emulate regular mouse buttons. If not specified otherwise,

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -394,20 +394,24 @@
   </mouse>
 
   <!--
-    The active tablet area can be specified by setting the *top*/*left*
-    coordinate (in mm) and/or *width*/*height* (in mm). If width or
-    height are omitted or default (0.0), width/height will be set to
-    the remaining width/height seen from top/left.
+    The tablet cursor movement can be restricted to a single output.
+    If output is left empty or the output does not exists, the tablet
+    will span all outputs.
 
     The tablet orientation can be changed in 90 degree steps, thus
     *rotate* can be set to [0|90|180|270]. Rotation will be applied
     after applying tablet area transformation.
 
+    The active tablet area can be specified by setting the *top*/*left*
+    coordinate (in mm) and/or *width*/*height* (in mm). If width or
+    height are omitted or default (0.0), width/height will be set to
+    the remaining width/height seen from top/left.
+
     Tablet buttons emulate regular mouse buttons. The tablet *button* can
     be set to any of [Tip|Stylus|Stylus2|Stylus3|Pad|Pad2|Pad3|..|Pad9].
     Valid *to* mouse buttons are [Left|Right|Middle].
   -->
-  <tablet rotate="0">
+  <tablet mapToOutput="" rotate="0">
     <!-- Active area dimensions are in mm -->
     <area top="0.0" left="0.0" width="0.0" height="0.0">
     <map button="Tip" to="Left" />

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -89,6 +89,7 @@ struct rcxml {
 
 	/* graphics tablet */
 	struct tablet_config {
+		char *output_name;
 		struct wlr_fbox box;
 		enum rotation rotation;
 		uint16_t button_map_count;

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -3,6 +3,7 @@
 #define LABWC_TABLET_H
 
 #include <wayland-server-core.h>
+
 struct seat;
 struct wlr_device;
 struct wlr_input_device;

--- a/include/input/tablet_pad.h
+++ b/include/input/tablet_pad.h
@@ -3,6 +3,7 @@
 #define LABWC_TABLET_PAD_H
 
 #include <wayland-server-core.h>
+
 struct seat;
 struct wlr_device;
 struct wlr_input_device;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -456,6 +456,7 @@ void seat_set_pressed(struct seat *seat, struct view *view,
 	struct wlr_scene_node *node, struct wlr_surface *surface,
 	struct wlr_surface *toplevel, uint32_t resize_edges);
 void seat_reset_pressed(struct seat *seat);
+void seat_output_layout_changed(struct seat *seat);
 
 void interactive_begin(struct view *view, enum input_mode mode, uint32_t edges);
 void interactive_finish(struct view *view);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -854,6 +854,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "Invalid value for <resize popupShow />");
 		}
+	} else if (!strcasecmp(nodename, "mapToOutput.tablet")) {
+		rc.tablet.output_name = xstrdup(content);
 	} else if (!strcasecmp(nodename, "rotate.tablet")) {
 		rc.tablet.rotation = tablet_parse_rotation(atoi(content));
 	} else if (!strcasecmp(nodename, "left.area.tablet")) {
@@ -1035,6 +1037,8 @@ rcxml_init(void)
 	rc.doubleclick_time = 500;
 	rc.scroll_factor = 1.0;
 
+	rc.tablet.output_name = NULL;
+	rc.tablet.rotation = 0;
 	rc.tablet.box = (struct wlr_fbox){0};
 	tablet_load_default_button_mappings();
 
@@ -1549,6 +1553,8 @@ rcxml_finish(void)
 		action_list_free(&m->actions);
 		zfree(m);
 	}
+
+	zfree(rc.tablet.output_name);
 
 	struct libinput_category *l, *l_tmp;
 	wl_list_for_each_safe(l, l_tmp, &rc.libinput_categories, link) {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -854,6 +854,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "Invalid value for <resize popupShow />");
 		}
+	} else if (!strcasecmp(nodename, "rotate.tablet")) {
+		rc.tablet.rotation = tablet_parse_rotation(atoi(content));
 	} else if (!strcasecmp(nodename, "left.area.tablet")) {
 		rc.tablet.box.x = tablet_get_dbl_if_positive(content, "left");
 	} else if (!strcasecmp(nodename, "top.area.tablet")) {
@@ -862,8 +864,6 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.tablet.box.width = tablet_get_dbl_if_positive(content, "width");
 	} else if (!strcasecmp(nodename, "height.area.tablet")) {
 		rc.tablet.box.height = tablet_get_dbl_if_positive(content, "height");
-	} else if (!strcasecmp(nodename, "rotate.tablet")) {
-		rc.tablet.rotation = tablet_parse_rotation(atoi(content));
 	} else if (!strcasecmp(nodename, "button.map.tablet")) {
 		button_map_from = tablet_button_from_str(content);
 	} else if (!strcasecmp(nodename, "to.map.tablet")) {

--- a/src/output.c
+++ b/src/output.c
@@ -85,6 +85,7 @@ output_destroy_notify(struct wl_listener *listener, void *data)
 	wl_list_remove(&output->frame.link);
 	wl_list_remove(&output->destroy.link);
 	wl_list_remove(&output->request_state.link);
+	seat_output_layout_changed(&output->server->seat);
 
 	for (size_t i = 0; i < ARRAY_SIZE(output->layer_tree); i++) {
 		wlr_scene_node_destroy(&output->layer_tree[i]->node);
@@ -329,6 +330,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 
 	server->pending_output_layout_change--;
 	do_output_layout_change(server);
+	seat_output_layout_changed(&output->server->seat);
 }
 
 void

--- a/src/seat.c
+++ b/src/seat.c
@@ -643,3 +643,18 @@ seat_reset_pressed(struct seat *seat)
 	seat->pressed.toplevel = NULL;
 	seat->pressed.resize_edges = 0;
 }
+
+void
+seat_output_layout_changed(struct seat *seat)
+{
+	struct input *input = NULL;
+	wl_list_for_each(input, &seat->inputs, link) {
+		switch (input->wlr_input_device->type) {
+		case WLR_INPUT_DEVICE_TABLET_TOOL:
+			map_input_to_output(seat, input->wlr_input_device, rc.tablet.output_name);
+			break;
+		default:
+			break;
+		}
+	}
+}

--- a/src/seat.c
+++ b/src/seat.c
@@ -351,11 +351,11 @@ new_input_notify(struct wl_listener *listener, void *data)
 	case WLR_INPUT_DEVICE_TOUCH:
 		input = new_touch(seat, device);
 		break;
-	case WLR_INPUT_DEVICE_TABLET_PAD:
-		input = new_tablet_pad(seat, device);
-		break;
 	case WLR_INPUT_DEVICE_TABLET_TOOL:
 		input = new_tablet(seat, device);
+		break;
+	case WLR_INPUT_DEVICE_TABLET_PAD:
+		input = new_tablet_pad(seat, device);
 		break;
 	default:
 		wlr_log(WLR_INFO, "unsupported input device");

--- a/src/seat.c
+++ b/src/seat.c
@@ -286,6 +286,9 @@ new_tablet(struct seat *seat, struct wlr_input_device *dev)
 	struct input *input = znew(*input);
 	input->wlr_input_device = dev;
 	tablet_init(seat, dev);
+	wlr_cursor_attach_input_device(seat->cursor, dev);
+	wlr_log(WLR_INFO, "map tablet to output %s\n", rc.tablet.output_name);
+	map_input_to_output(seat, dev, rc.tablet.output_name);
 
 	return input;
 }

--- a/src/seat.c
+++ b/src/seat.c
@@ -204,6 +204,17 @@ output_by_name(struct server *server, const char *name)
 	return NULL;
 }
 
+static void
+map_input_to_output(struct seat *seat, struct wlr_input_device *dev, char *output_name)
+{
+	struct wlr_output *output = NULL;
+	if (output_name) {
+		output = output_by_name(seat->server, output_name);
+	}
+	wlr_cursor_map_input_to_output(seat->cursor, dev, output);
+	wlr_cursor_map_input_to_region(seat->cursor, dev, NULL);
+}
+
 static struct input *
 new_pointer(struct seat *seat, struct wlr_input_device *dev)
 {
@@ -214,14 +225,9 @@ new_pointer(struct seat *seat, struct wlr_input_device *dev)
 
 	/* In support of running with WLR_WL_OUTPUTS set to >=2 */
 	if (dev->type == WLR_INPUT_DEVICE_POINTER) {
-		struct wlr_output *output = NULL;
 		struct wlr_pointer *pointer = wlr_pointer_from_input_device(dev);
 		wlr_log(WLR_INFO, "map pointer to output %s\n", pointer->output_name);
-		if (pointer->output_name) {
-			output = output_by_name(seat->server, pointer->output_name);
-		}
-		wlr_cursor_map_input_to_output(seat->cursor, dev, output);
-		wlr_cursor_map_input_to_region(seat->cursor, dev, NULL);
+		map_input_to_output(seat, dev, pointer->output_name);
 	}
 	return input;
 }
@@ -267,14 +273,9 @@ new_touch(struct seat *seat, struct wlr_input_device *dev)
 
 	/* In support of running with WLR_WL_OUTPUTS set to >=2 */
 	if (dev->type == WLR_INPUT_DEVICE_TOUCH) {
-		struct wlr_output *output = NULL;
 		struct wlr_touch *touch = wlr_touch_from_input_device(dev);
 		wlr_log(WLR_INFO, "map touch to output %s\n", touch->output_name);
-		if (touch->output_name) {
-			output = output_by_name(seat->server, touch->output_name);
-		}
-		wlr_cursor_map_input_to_output(seat->cursor, dev, output);
-		wlr_cursor_map_input_to_region(seat->cursor, dev, NULL);
+		map_input_to_output(seat, dev, touch->output_name);
 	}
 	return input;
 }

--- a/src/seat.c
+++ b/src/seat.c
@@ -515,6 +515,9 @@ seat_reconfigure(struct server *server)
 		case WLR_INPUT_DEVICE_POINTER:
 			configure_libinput(input->wlr_input_device);
 			break;
+		case WLR_INPUT_DEVICE_TABLET_TOOL:
+			map_input_to_output(seat, input->wlr_input_device, rc.tablet.output_name);
+			break;
 		default:
 			break;
 		}


### PR DESCRIPTION
This PR adds a configuration option to map a tablet surface to a single output in a multi-monitor setup. I've tested a lot of tablet/monitor hot-plug/reconfigure scenarios, so functionality-wise, this seems fine to me.

Please let me know what you think. I've also added a few formatting improvements from my earlier PRs.
PS: Last tablet feature PR from me, no more features missing in my opinion after this one ;) 

Closes https://github.com/labwc/labwc/issues/1405