### PR TITLE
view, xwayland: fixes for new size constraints

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -505,8 +505,6 @@ set_initial_position(struct view *view,
 			XCB_ICCCM_SIZE_HINT_US_POSITION |
 			XCB_ICCCM_SIZE_HINT_P_POSITION));
 
-	view_constrain_size_to_that_of_usable_area(view);
-
 	if (has_position) {
 		/*
 		 * Make sure a floating view is onscreen. For a
@@ -518,6 +516,8 @@ set_initial_position(struct view *view,
 			view_adjust_for_layout_change(view);
 		}
 	} else {
+		view_constrain_size_to_that_of_usable_area(view);
+
 		if (view_is_floating(view)) {
 			view_place_initial(view);
 		} else {


### PR DESCRIPTION
Calling the new `view_constrain_size_to_that_of_usable_area` has some unexpected side-effects for multi-output configurations. In particular, setting `box.x = view->pending.x` and `box.y = view->pending.y` before any placement is selected most likely sets them each to zero. Then, calling `view_move_resize` seems to (eventually) trigger `view_discover_output`, which will override any `view->output` set in, *e.g.*, `xdg_toplevel_view_map` to be the output nearest the cursor. The end result is that, in `center` or `automatic` placement modes, the call to `view_constrain_size_to_that_of_usable_area` will force new windows to always appear on the display at (0, 0), regardless of where the cursor is.

To fix this, I've made a couple of changes to `view_constrain_size_to_that_of_usable_area`:
1. If the window is already small enough, just make this function a no-op. We don't need to move a window that will fit where it needs to be, and the placement algorithm will take care of the rest.
2. If the window *is* resized by this function, ensure that the `x` and `y` coordinates are chosen to place the window inside its target display, so that `view_discover_output` doesn't relocate it before the placement algorithm takes over.

While I was at it, I decided to call this function for Xwayland windows only when they don't have a client-requested geometry, because I figure something like `urxvt -geometry [...]` probably ought to override all of the intelligence and do exactly what the user asked.

cc: @johanmalm 