### PR TITLE
config: refactor config/theme directories handling

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -18,6 +18,19 @@ searched for in the following order:
 - ${XDG_CONFIG_HOME:-$HOME/.config}/labwc
 - ${XDG_CONFIG_DIRS:-/etc/xdg}/labwc
 
+When $XDG_CONFIG_HOME is defined, it replaces (rather than augments)
+$HOME/.config. The same is the case for $XDG_CONFIG_DIRS and /etc/xdg.
+
+The XDG Base Directory Specification does not specify whether or not programs
+should (a) allow the first-identified configuration file to supersede any
+others, or (b) define rules for merging the information from more than one file.
+
+By default, labwc uses option (a), reading only the first file identified.  With
+the --merge-config option, the search order is reserved, but every configuration
+file encountered is processed in turn. Thus, user-specific files will augment
+system-wide configurations, with conflicts favoring the user-specific
+alternative.
+
 The configuration directory location can be override with the -C command line
 option.
 

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -15,6 +15,9 @@ searched for in the following order:
 - /usr/local/share/themes/<theme-name>/openbox-3/
 - /opt/share/themes/<theme-name>/openbox-3/
 
+When $XDG_DATA_HOME is defined, it replaces (rather than augments)
+$HOME/.local/share. The same is the case for $XDG_DATA_DIRS and /usr/share/.
+
 Choosing a theme is done by editing the <name> key in the <theme> section of
 the rc.xml configuration file (labwc-config(5)).
 

--- a/docs/labwc.1.scd
+++ b/docs/labwc.1.scd
@@ -45,6 +45,9 @@ the `--exit` and `--reconfigure` options use.
 *-h, --help*
 	Show help message and quit
 
+*-m, --merge-config*
+	Merge user config/theme files in all XDG Base Directories
+
 *-r, --reconfigure*
 	Reload the compositor configuration
 

--- a/include/common/dir.h
+++ b/include/common/dir.h
@@ -2,12 +2,19 @@
 #ifndef LABWC_DIR_H
 #define LABWC_DIR_H
 
-char *config_dir(void);
+#include <wayland-server-core.h>
 
-/**
- * theme_dir - find theme directory containing theme @theme_name
- * @theme_name: theme to search for
- */
-char *theme_dir(const char *theme_name);
+struct path {
+	char *string;
+	struct wl_list link;
+};
+
+struct wl_list *paths_get_prev(struct wl_list *elm);
+struct wl_list *paths_get_next(struct wl_list *elm);
+
+void paths_config_create(struct wl_list *paths, const char *filename);
+void paths_theme_create(struct wl_list *paths, const char *theme_name,
+	const char *filename);
+void paths_destroy(struct wl_list *paths);
 
 #endif /* LABWC_DIR_H */

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -48,6 +48,7 @@ struct window_switcher_field {
 
 struct rcxml {
 	char *config_dir;
+	bool merge_config;
 
 	/* core */
 	bool xdg_shell_server_side_deco;

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -47,7 +47,9 @@ struct window_switcher_field {
 };
 
 struct rcxml {
+	/* from command line */
 	char *config_dir;
+	char *config_file;
 	bool merge_config;
 
 	/* core */

--- a/include/config/session.h
+++ b/include/config/session.h
@@ -4,17 +4,15 @@
 
 /**
  * session_environment_init - set enrivonment variables based on <key>=<value>
- * @dir: path to config directory
  * pairs in `${XDG_CONFIG_DIRS:-/etc/xdg}/lawbc/environment` with user override
  * in `${XDG_CONFIG_HOME:-$HOME/.config}`
  */
-void session_environment_init(const char *dir);
+void session_environment_init(void);
 
 /**
  * session_autostart_init - run autostart file as shell script
- * @dir: path to config directory
  * Note: Same as `sh ~/.config/labwc/autostart` (or equivalent XDG config dir)
  */
-void session_autostart_init(const char *dir);
+void session_autostart_init(void);
 
 #endif /* LABWC_SESSION_H */

--- a/src/button/button-png.c
+++ b/src/button/button-png.c
@@ -49,6 +49,9 @@ button_png_load(const char *button_name, struct lab_data_buffer **buffer)
 		wlr_buffer_drop(&(*buffer)->base);
 		*buffer = NULL;
 	}
+	if (!button_name || !*button_name) {
+		return;
+	}
 
 	char path[4096] = { 0 };
 	button_filename(button_name, path, sizeof(path));

--- a/src/button/button-svg.c
+++ b/src/button/button-svg.c
@@ -22,6 +22,9 @@ button_svg_load(const char *button_name, struct lab_data_buffer **buffer,
 		wlr_buffer_drop(&(*buffer)->base);
 		*buffer = NULL;
 	}
+	if (!button_name || !*button_name) {
+		return;
+	}
 
 	char filename[4096] = { 0 };
 	button_filename(button_name, filename, sizeof(filename));

--- a/src/button/button-xbm.c
+++ b/src/button/button-xbm.c
@@ -279,6 +279,9 @@ button_xbm_load(const char *button_name, struct lab_data_buffer **buffer,
 		wlr_buffer_drop(&(*buffer)->base);
 		*buffer = NULL;
 	}
+	if (!button_name || !*button_name) {
+		return;
+	}
 	color = argb32(rgba);
 
 	/* Read file into memory as it's easier to tokenize that way */

--- a/src/button/common.c
+++ b/src/button/common.c
@@ -1,11 +1,27 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <stdio.h>
+#include <unistd.h>
 #include "button/common.h"
 #include "common/dir.h"
 #include "config/rcxml.h"
+#include "labwc.h"
 
 void
 button_filename(const char *name, char *buf, size_t len)
 {
-	snprintf(buf, len, "%s/%s", theme_dir(rc.theme_name), name);
+	struct wl_list paths;
+	paths_theme_create(&paths, rc.theme_name, name);
+
+	/*
+	 * You can't really merge buttons, so let's just iterate forwards
+	 * and stop on the first hit
+	 */
+	struct path *path;
+	wl_list_for_each(path, &paths, link) {
+		if (access(path->string, R_OK) == 0) {
+			snprintf(buf, len, "%s", path->string);
+			break;
+		}
+	}
+	paths_destroy(&paths);
 }

--- a/src/common/dir.c
+++ b/src/common/dir.c
@@ -4,143 +4,190 @@
  *
  * Copyright Johan Malm 2020
  */
-
+#include <assert.h>
 #include <glib.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include "common/dir.h"
+#include "common/buf.h"
+#include "common/list.h"
+#include "common/mem.h"
+#include "common/string-helpers.h"
+#include "labwc.h"
 
 struct dir {
 	const char *prefix;
+	const char *default_prefix;
 	const char *path;
 };
 
 static struct dir config_dirs[] = {
-	{ "XDG_CONFIG_HOME", "labwc" },
-	{ "HOME", ".config/labwc" },
-	{ "XDG_CONFIG_DIRS", "labwc" },
-	{ NULL, "/etc/xdg/labwc" },
-	{ NULL, NULL }
+	{
+		.prefix = "XDG_CONFIG_HOME",
+		.default_prefix = "$HOME/.config",
+		.path = "labwc"
+	}, {
+		.prefix = "XDG_CONFIG_DIRS",
+		.default_prefix = "/etc/xdg",
+		.path = "labwc",
+	}, {
+		.path = NULL,
+	}
 };
 
 static struct dir theme_dirs[] = {
-	{ "XDG_DATA_HOME", "themes" },
-	{ "HOME", ".local/share/themes" },
-	{ "HOME", ".themes" },
-	{ "XDG_DATA_DIRS", "themes" },
-	{ NULL, "/usr/share/themes" },
-	{ NULL, "/usr/local/share/themes" },
-	{ NULL, "/opt/share/themes" },
-	{ NULL, NULL }
+	{
+		.prefix = "XDG_DATA_HOME",
+		.default_prefix = "$HOME/.local/share",
+		.path = "themes",
+	}, {
+		.prefix = "HOME",
+		.path = ".themes",
+	}, {
+		.prefix = "XDG_DATA_DIRS",
+		.default_prefix = "/usr/share:/usr/local/share:/opt/share",
+		.path = "themes",
+	}, {
+		.path = NULL,
+	}
 };
-
-static bool
-isdir(const char *path)
-{
-	struct stat st;
-	return (!stat(path, &st) && S_ISDIR(st.st_mode));
-}
 
 struct ctx {
 	void (*build_path_fn)(struct ctx *ctx, char *prefix, const char *path);
+	const char *filename;
 	char *buf;
 	size_t len;
 	struct dir *dirs;
 	const char *theme_name;
+	struct wl_list *list;
 };
+
+struct wl_list *paths_get_prev(struct wl_list *elm) { return elm->prev; }
+struct wl_list *paths_get_next(struct wl_list *elm) { return elm->next; }
 
 static void
 build_config_path(struct ctx *ctx, char *prefix, const char *path)
 {
-	if (!prefix) {
-		snprintf(ctx->buf, ctx->len, "%s", path);
-	} else {
-		snprintf(ctx->buf, ctx->len, "%s/%s", prefix, path);
-	}
+	assert(prefix);
+	snprintf(ctx->buf, ctx->len, "%s/%s/%s", prefix, path, ctx->filename);
 }
 
 static void
 build_theme_path(struct ctx *ctx, char *prefix, const char *path)
 {
-	if (!prefix) {
-		snprintf(ctx->buf, ctx->len, "%s/%s/openbox-3", path,
-			ctx->theme_name);
-	} else {
-		snprintf(ctx->buf, ctx->len, "%s/%s/%s/openbox-3", prefix, path,
-			ctx->theme_name);
-	}
+	assert(prefix);
+	snprintf(ctx->buf, ctx->len, "%s/%s/%s/openbox-3/%s", prefix, path,
+		ctx->theme_name, ctx->filename);
 }
 
-static char *
+static void
 find_dir(struct ctx *ctx)
 {
 	char *debug = getenv("LABWC_DEBUG_DIR_CONFIG_AND_THEME");
 
 	for (int i = 0; ctx->dirs[i].path; i++) {
 		struct dir d = ctx->dirs[i];
-		if (!d.prefix) {
-			/* handle /etc/xdg... */
-			ctx->build_path_fn(ctx, NULL, d.path);
+		struct buf prefix;
+		buf_init(&prefix);
+
+		/*
+		 * Replace (rather than augment) $HOME/.config with
+		 * $XDG_CONFIG_HOME if defined, and so on for the other
+		 * XDG Base Directories.
+		 */
+		char *pfxenv = getenv(d.prefix);
+		buf_add(&prefix, pfxenv ? pfxenv : d.default_prefix);
+		if (!prefix.len) {
+			free(prefix.buf);
+			continue;
+		}
+
+		/* Handle .default_prefix shell variables such as $HOME */
+		buf_expand_shell_variables(&prefix);
+
+		/*
+		 * Respect that $XDG_DATA_DIRS can contain multiple colon
+		 * separated paths and that we have structured the
+		 * .default_prefix in the same way.
+		 */
+		gchar * *prefixes;
+		prefixes = g_strsplit(prefix.buf, ":", -1);
+		for (gchar * *p = prefixes; *p; p++) {
+			ctx->build_path_fn(ctx, *p, d.path);
 			if (debug) {
 				fprintf(stderr, "%s\n", ctx->buf);
 			}
-			if (isdir(ctx->buf)) {
-				return ctx->buf;
-			}
-		} else {
-			/* handle $HOME/.config/... and $XDG_* */
-			char *prefix = getenv(d.prefix);
-			if (!prefix) {
-				continue;
-			}
-			gchar * *prefixes;
-			prefixes = g_strsplit(prefix, ":", -1);
-			for (gchar * *p = prefixes; *p; p++) {
-				ctx->build_path_fn(ctx, *p, d.path);
-				if (debug) {
-					fprintf(stderr, "%s\n", ctx->buf);
-				}
-				if (isdir(ctx->buf)) {
-					g_strfreev(prefixes);
-					return ctx->buf;
-				}
-			}
-			g_strfreev(prefixes);
+
+			/*
+			 * TODO: We could stat() and continue here if we really
+			 * wanted to only respect only the first hit, but feels
+			 * like it is probably overkill.
+			 */
+			struct path *path = znew(*path);
+			path->string = xstrdup(ctx->buf);
+			wl_list_append(ctx->list, &path->link);
 		}
+		g_strfreev(prefixes);
+		free(prefix.buf);
 	}
-	/* no directory was found */
-	ctx->buf[0] = '\0';
-	return ctx->buf;
 }
 
-char *
-config_dir(void)
+void
+paths_config_create(struct wl_list *paths, const char *filename)
 {
-	static char buf[4096] = { 0 };
-	if (buf[0] != '\0') {
-		return buf;
+	char buf[4096] = { 0 };
+	wl_list_init(paths);
+
+	/*
+	 * If user provided a config directory with the -C command line option,
+	 * then that trumps everything else and we do not create the
+	 * XDG-Base-Dir list.
+	 */
+	if (rc.config_dir) {
+		struct path *path = znew(*path);
+		path->string = strdup_printf("%s/%s", rc.config_dir, filename);
+		wl_list_append(paths, &path->link);
+		return;
 	}
+
 	struct ctx ctx = {
 		.build_path_fn = build_config_path,
+		.filename = filename,
 		.buf = buf,
 		.len = sizeof(buf),
-		.dirs = config_dirs
+		.dirs = config_dirs,
+		.list = paths,
 	};
-	return find_dir(&ctx);
+	find_dir(&ctx);
 }
 
-char *
-theme_dir(const char *theme_name)
+void
+paths_theme_create(struct wl_list *paths, const char *theme_name,
+		const char *filename)
 {
 	static char buf[4096] = { 0 };
+	wl_list_init(paths);
 	struct ctx ctx = {
 		.build_path_fn = build_theme_path,
+		.filename = filename,
 		.buf = buf,
 		.len = sizeof(buf),
 		.dirs = theme_dirs,
-		.theme_name = theme_name
+		.theme_name = theme_name,
+		.list = paths,
 	};
-	return find_dir(&ctx);
+	find_dir(&ctx);
+}
+
+void
+paths_destroy(struct wl_list *paths)
+{
+	struct path *path, *next;
+	wl_list_for_each_safe(path, next, paths, link) {
+		free(path->string);
+		wl_list_remove(&path->link);
+		free(path);
+	}
 }

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -7,10 +7,12 @@
 #include <sys/stat.h>
 #include <wlr/util/log.h>
 #include "common/buf.h"
+#include "common/dir.h"
 #include "common/file-helpers.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"
 #include "config/session.h"
+#include "labwc.h"
 
 static bool
 string_empty(const char *s)
@@ -45,14 +47,15 @@ error:
 	free(value.buf);
 }
 
-static void
+/* return true on successful read */
+static bool
 read_environment_file(const char *filename)
 {
 	char *line = NULL;
 	size_t len = 0;
 	FILE *stream = fopen(filename, "r");
 	if (!stream) {
-		return;
+		return false;
 	}
 	wlr_log(WLR_INFO, "read environment file %s", filename);
 	while (getline(&line, &len, stream) != -1) {
@@ -64,15 +67,7 @@ read_environment_file(const char *filename)
 	}
 	free(line);
 	fclose(stream);
-}
-
-static char *
-build_path(const char *dir, const char *filename)
-{
-	if (string_empty(dir) || string_empty(filename)) {
-		return NULL;
-	}
-	return strdup_printf("%s/%s", dir, filename);
+	return true;
 }
 
 static void
@@ -96,7 +91,7 @@ update_activation_env(const char *env_keys)
 }
 
 void
-session_environment_init(const char *dir)
+session_environment_init(void)
 {
 	/*
 	 * Set default for XDG_CURRENT_DESKTOP so xdg-desktop-portal-wlr is happy.
@@ -114,32 +109,49 @@ session_environment_init(const char *dir)
 	 */
 	setenv("_JAVA_AWT_WM_NONREPARENTING", "1", 0);
 
-	char *environment = build_path(dir, "environment");
-	if (!environment) {
-		return;
+	struct wl_list paths;
+	paths_config_create(&paths, "environment");
+
+	bool should_merge_config = rc.merge_config;
+	struct wl_list *(*iter)(struct wl_list *list);
+	iter = should_merge_config ? paths_get_prev : paths_get_next;
+
+	for (struct wl_list *elm = iter(&paths); elm != &paths; elm = iter(elm)) {
+		struct path *path = wl_container_of(elm, path, link);
+		bool success = read_environment_file(path->string);
+		if (success && !should_merge_config) {
+			break;
+		}
 	}
-	read_environment_file(environment);
-	free(environment);
+	paths_destroy(&paths);
 }
 
 void
-session_autostart_init(const char *dir)
+session_autostart_init(void)
 {
 	/* Update dbus and systemd user environment, each may fail gracefully */
 	update_activation_env("DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP");
 
-	char *autostart = build_path(dir, "autostart");
-	if (!autostart) {
-		return;
+	struct wl_list paths;
+	paths_config_create(&paths, "autostart");
+
+	bool should_merge_config = rc.merge_config;
+	struct wl_list *(*iter)(struct wl_list *list);
+	iter = should_merge_config ? paths_get_prev : paths_get_next;
+
+	for (struct wl_list *elm = iter(&paths); elm != &paths; elm = iter(elm)) {
+		struct path *path = wl_container_of(elm, path, link);
+		if (!file_exists(path->string)) {
+			continue;
+		}
+		wlr_log(WLR_INFO, "run autostart file %s", path->string);
+		char *cmd = strdup_printf("sh %s", path->string);
+		spawn_async_no_shell(cmd);
+		free(cmd);
+
+		if (!should_merge_config) {
+			break;
+		}
 	}
-	if (!file_exists(autostart)) {
-		wlr_log(WLR_ERROR, "no autostart file");
-		goto out;
-	}
-	wlr_log(WLR_INFO, "run autostart file %s", autostart);
-	char *cmd = strdup_printf("sh %s", autostart);
-	spawn_async_no_shell(cmd);
-	free(cmd);
-out:
-	free(autostart);
+	paths_destroy(&paths);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -87,7 +87,6 @@ main(int argc, char *argv[])
 	textdomain(GETTEXT_PACKAGE);
 #endif
 	char *startup_cmd = NULL;
-	char *config_file = NULL;
 	enum wlr_log_importance verbosity = WLR_ERROR;
 
 	int c;
@@ -99,7 +98,7 @@ main(int argc, char *argv[])
 		}
 		switch (c) {
 		case 'c':
-			config_file = optarg;
+			rc.config_file = optarg;
 			break;
 		case 'C':
 			rc.config_dir = optarg;
@@ -139,7 +138,7 @@ main(int argc, char *argv[])
 	die_on_detecting_suid();
 
 	session_environment_init();
-	rcxml_read(config_file);
+	rcxml_read(rc.config_file);
 
 	/*
 	 * Set environment variable LABWC_PID to the pid of the compositor

--- a/src/server.c
+++ b/src/server.c
@@ -67,7 +67,7 @@ reload_config_and_theme(void)
 static int
 handle_sighup(int signal, void *data)
 {
-	session_environment_init(rc.config_dir);
+	session_environment_init();
 	reload_config_and_theme();
 	return 0;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -47,7 +47,7 @@ static void
 reload_config_and_theme(void)
 {
 	rcxml_finish();
-	rcxml_read(NULL);
+	rcxml_read(rc.config_file);
 	theme_finish(g_server->theme);
 	theme_init(g_server->theme, rc.theme_name);
 


### PR DESCRIPTION
Instead of caching global config/theme directories, create lists of paths (e.g. '/home/foo/.config/labwc/rc.xml', '/etc/xdg/labwc/rc.xml', etc). This gives the flexibility to iterate forwards or backwards depending on if a config merge is wanted.

It also enables better fallback, for example if a particular theme does not exist in $HOME/.local/share/themes, it can be searched for in ~/.themes/ and so on.

This has the added benefit of using `fopen()` only and avoid the additional `stat()` in most situations.

~~Note: This only half-finished, so just pushing to share the idea. The for-loops in rcxml.c and menu.c use the new approach.~~

Related-to: #1411


@spl237 @ahesford Appreciate thoughts on alternative approach to #1411 
It's a bit bit rushed and only half-finished, but gives an idea of another approach... for discussion.
Happy to carry on working on it, but might take me a few days to get back to it.