### PR TITLE
Fix crash when a minimized fullscreen window closes

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2030,11 +2030,6 @@ view_destroy(struct view *view)
 	osd_on_view_destroy(view);
 	undecorate(view);
 
-	if (view->scene_tree) {
-		wlr_scene_node_destroy(&view->scene_tree->node);
-		view->scene_tree = NULL;
-	}
-
 	/*
 	 * The layer-shell top-layer is disabled when an application is running
 	 * in fullscreen mode, so if that's the case, we may have to re-enable
@@ -2052,6 +2047,16 @@ view_destroy(struct view *view)
 	if (server->menu_current
 			&& server->menu_current->triggered_by_view == view) {
 		menu_close_root(server);
+	}
+
+	/*
+	 * Destroy the view's scene tree. View methods assume this is non-NULL,
+	 * so we should avoid any calls to those between this and freeing the
+	 * view.
+	 */
+	if (view->scene_tree) {
+		wlr_scene_node_destroy(&view->scene_tree->node);
+		view->scene_tree = NULL;
 	}
 
 	/* Remove view from server->views */


### PR DESCRIPTION
To reproduce:
Open mpv on a short video; full-screen mpv; minimize it with a hotkey. When the minimized full-screen window closes, labwc always crashes.

Backtrace:
```
Thread 1 "labwc" received signal SIGSEGV, Segmentation fault.
matches_criteria (view=0x555556524fb0, criteria=(LAB_VIEW_CRITERIA_CURRENT_WORKSPACE | LAB_VIEW_CRITERIA_FULLSCREEN)) at ../src/view.c:95
95			if (view->scene_tree->node.parent
#0  matches_criteria (view=0x555556524fb0, criteria=(LAB_VIEW_CRITERIA_CURRENT_WORKSPACE | LAB_VIEW_CRITERIA_FULLSCREEN)) at ../src/view.c:95
        server = 0x7fffffffc8b0
#1  0x00005555555741cb in view_next (head=0x7fffffffd9b0, view=0x555556524fb0, criteria=(LAB_VIEW_CRITERIA_CURRENT_WORKSPACE | LAB_VIEW_CRITERIA_FULLSCREEN)) at ../src/view.c:134
        __PRETTY_FUNCTION__ = "view_next"
        elm = 0x555556524fc8
#2  0x000055555556411d in desktop_update_top_layer_visiblity (server=0x7fffffffc8b0) at ../src/desktop.c:309
        view = 0x0
        output = 0x7fffffffde18
        top = 2
        criteria = (LAB_VIEW_CRITERIA_CURRENT_WORKSPACE | LAB_VIEW_CRITERIA_FULLSCREEN)
#3  0x0000555555578e26 in view_destroy (view=0x555556524fb0) at ../src/view.c:2047
        __PRETTY_FUNCTION__ = "view_destroy"
        server = 0x7fffffffc8b0
        need_cursor_update = false
#4  0x000055555557af8a in handle_destroy (listener=0x555556525180, data=0x0) at ../src/xdg.c:204
        view = 0x555556524fb0
        __PRETTY_FUNCTION__ = "handle_destroy"
        xdg_toplevel_view = 0x555556524fb0
#5  0x00007ffff7f8801e in wl_signal_emit_mutable () at /usr/lib/libwayland-server.so.0
#6  0x00007ffff7ee0b47 in  () at /usr/lib/libwlroots.so.12
#7  0x00007ffff7ee0b9b in  () at /usr/lib/libwlroots.so.12
#8  0x00007ffff7ee27ff in  () at /usr/lib/libwlroots.so.12
#9  0x00007ffff7f899ba in  () at /usr/lib/libwayland-server.so.0
#10 0x00007ffff7f8a0db in wl_client_destroy () at /usr/lib/libwayland-server.so.0
#11 0x00007ffff7f8a60e in  () at /usr/lib/libwayland-server.so.0
#12 0x00007ffff7f89ae2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#13 0x00007ffff7f8a2d7 in wl_display_run () at /usr/lib/libwayland-server.so.0
#14 0x0000555555566e31 in main (argc=1, argv=0x7fffffffe0d8) at ../src/main.c:179
        startup_cmd = 0x0
        config_file = 0x0
        verbosity = WLR_ERROR
        c = -1
        pid = "495498\000\000\000\000\000\000\000\000\000\000\f\000\000\000\000\000\000\000\255Ao\367\377\177\000"
        server = {wl_display = 0x55555561d040, wl_event_loop = 0x55555561d130, renderer = 0x5555556f2b80, allocator = 0x555555e9bcb0, backend = 0x55555561d1d0, headless = {backend = 0x55555560dd30, pending_output_name = '\000' <repeats 4095 times>}, session = 0x55555561d260, xdg_shell = 0x555555faa0b0, layer_shell = 0x555555fe06a0, new_xdg_surface = {link = {prev = 0x555555faa100, next = 0x555555faa100}, notify = 0x55555557bb77 <xdg_surface_new>}, new_layer_surface = {link = {prev = 0x555555fe06c0, next = 0x555555fe06c0}, notify = 0x5555555664e0 <handle_new_layer_surface>}, kde_server_decoration = {link = {prev = 0x555555f411a8, next = 0x555555f411a8}, notify = 0x555555586bf7 <handle_new_server_decoration>}, xdg_toplevel_decoration = {link = {prev = 0x555555fe1fa0, next = 0x555555fe1fa0}, notify = 0x555555587024 <xdg_toplevel_decoration>}, input_inhibit = 0x555555fe23e0, input_inhibit_activate = {link = {prev = 0x555555fe2410, next = 0x555555fe2410}, notify = 0x55555556e2f9 <handle_input_inhibit>}, input_inhibit_deactivate = {link = {prev = 0x555555fe2420, next = 0x555555fe2420}, notify = 0x55555556e367 <handle_input_disinhibit>}, xdg_activation = 0x555555ee0ec0, xdg_activation_request = {link = {prev = 0x555555ee0ee8, next = 0x555555ee0ee8}, notify = 0x55555557ba3c <xdg_activation_handle_request>}, views = {prev = 0x5555562ce1d8, next = 0x55555651c9a8}, unmanaged_surfaces = {prev = 0x7fffffffd9c0, next = 0x7fffffffd9c0}, seat = {seat = 0x555555ecb290, server = 0x7fffffffc8b0, keyboard_group = 0x555555f40960, touch_points = {prev = 0x7fffffffd9e8, next = 0x7fffffffd9e8}, server_cursor = LAB_CURSOR_CLIENT, cursor = 0x555555ecd8f0, xcursor_manager = 0x555555ec0470, smooth_scroll_offset = {x = 0, y = 0}, current_constraint = 0x0, nr_inhibited_keybind_views = 0, workspace_osd_timer = 0x0, workspace_osd_shown_by_modifier = false, focused_layer = 0x0, pressed = {view = 0x0, node = 0x0, surface = 0x0, toplevel = 0x0, resize_edges = 0}, drag = {active = false, events = {request = {link = {prev = 0x555555ecb5c8, next = 0x555555ecb5c8}, notify = 0x555555564771 <handle_drag_request>}, start = {link = {prev = 0x555555ecb5d8, next = 0x555555ecb5d8}, notify = 0x55555556481c <handle_drag_start>}, destroy = {link = {prev = 0x0, next = 0x0}, notify = 0x5555555648f9 <handle_drag_destroy>}}, icons = 0x555555ec0f30}, region_active = 0x0, region_overlay = {tree = 0x0, {overlay = 0x0, pixman_overlay = 0x0}}, region_prevent_snap = false, active_client_while_inhibited = 0x0, inputs = {prev = 0x5555560472e8, next = 0x555555ff7708}, new_input = {link = {prev = 0x55555561d1e8, next = 0x55555561d1e8}, notify = 0x55555556d4f3 <new_input_notify>}, focus_change = {link = {prev = 0x555555ecb478, next = 0x55555603f8d8}, notify = 0x55555556d720 <focus_change_notify>}, cursor_motion = {link = {prev = 0x555555ecd908, next = 0x555555ecd908}, notify = 0x55555558890a <cursor_motion>}, cursor_motion_absolute = {link = {prev = 0x555555ecd918, next = 0x555555ecd918}, notify = 0x5555555889e6 <cursor_motion_absolute>}, cursor_button = {link = {prev = 0x555555ecd928, next = 0x555555ecd928}, notify = 0x5555555892bc <cursor_button>}, cursor_axis = {link = {prev = 0x555555ecd938, next = 0x555555ecd938}, notify = 0x5555555897fb <cursor_axis>}, cursor_frame = {link = {prev = 0x555555ecd948, next = 0x555555ecd948}, notify = 0x555555589940 <cursor_frame>}, pointer_gestures = 0x555555fa9e40, pinch_begin = {link = {prev = 0x555555ecd988, next = 0x555555ecd988}, notify = 0x55555558a6c8 <handle_pointer_pinch_begin>}, pinch_update = {link = {prev = 0x555555ecd998, next = 0x555555ecd998}, notify = 0x55555558a719 <handle_pointer_pinch_update>}, pinch_end = {link = {prev = 0x555555ecd9a8, next = 0x555555ecd9a8}, notify = 0x55555558a79a <handle_pointer_pinch_end>}, swipe_begin = {link = {prev = 0x555555ecd958, next = 0x555555ecd958}, notify = 0x55555558a7ef <handle_pointer_swipe_begin>}, swipe_update = {link = {prev = 0x555555ecd968, next = 0x555555ecd968}, notify = 0x55555558a840 <handle_pointer_swipe_update>}, swipe_end = {link = {prev = 0x555555ecd978, next = 0x555555ecd978}, notify = 0x55555558a8a7 <handle_pointer_swipe_end>}, request_cursor = {link = {prev = 0x555555ecb578, next = 0x555555ecb578}, notify = 0x55555558736b <request_cursor_notify>}, request_set_shape = {link = {prev = 0x555555fa9f08, next = 0x555555fa9f08}, notify = 0x5555555873ed <request_set_shape_notify>}, request_set_selection = {link = {prev = 0x555555ecb588, next = 0x555555ecb588}, notify = 0x5555555874e8 <request_set_selection_notify>}, request_set_primary_selection = {link = {prev = 0x555555ecb5a8, next = 0x555555ecb5a8}, notify = 0x555555587531 <request_set_primary_selection_notify>}, touch_down = {link = {prev = 0x555555ecd9e8, next = 0x555555ecd9e8}, notify = 0x55555558c55a <touch_down>}, touch_up = {link = {prev = 0x555555ecd9d8, next = 0x555555ecd9d8}, notify = 0x55555558c6da <touch_up>}, touch_motion = {link = {prev = 0x555555ecd9f8, next = 0x555555ecd9f8}, notify = 0x55555558c38b <touch_motion>}, touch_frame = {link = {prev = 0x555555ecda18, next = 0x555555ecda18}, notify = 0x55555558c52a <touch_frame>}, constraint_commit = {link = {prev = 0x7fffffffdd00, next = 0x7fffffffdd00}, notify = 0x0}, pressed_surface_destroy = {link = {prev = 0x0, next = 0x0}, notify = 0x55555556de41 <pressed_surface_destroy>}, virtual_pointer = 0x555555ec3600, virtual_pointer_new = {link = {prev = 0x555555ec3630, next = 0x555555ec3630}, notify = 0x55555556d616 <new_virtual_pointer>}, virtual_keyboard = 0x555555ec6a80, virtual_keyboard_new = {link = {prev = 0x555555ec6ab0, next = 0x555555ec6ab0}, notify = 0x55555556d6b4 <new_virtual_keyboard>}}, scene = 0x555555eca730, scene_layout = 0x555555ecae20, input_mode = LAB_INPUT_STATE_PASSTHROUGH, grabbed_view = 0x0, grab_x = 0, grab_y = 0, grab_box = {x = 0, y = 0, width = 0, height = 0}, resize_edges = 0, active_view = 0x5555562cf8f0, last_raised_view = 0x55555651c990, ssd_hover_state = 0x555555ea0340, view_tree = 0x555555eca8a0, xdg_popup_tree = 0x555555eca9c0, view_tree_always_on_top = 0x555555eca930, view_tree_always_on_bottom = 0x555555eca810, menu_tree = 0x555555ecaa50, workspaces = {prev = 0x555555ecacc0, next = 0x555555ec1510}, workspace_current = 0x555555ec1510, workspace_last = 0x0, outputs = {prev = 0x555555ea04b0, next = 0x555555ea04b0}, new_output = {link = {prev = 0x55555561d1f8, next = 0x55555561d1f8}, notify = 0x555555568bc4 <new_output_notify>}, output_layout = 0x555555ecadd0, output_layout_change = {link = {prev = 0x555555ecaef0, next = 0x555555ecdac8}, notify = 0x55555556995c <handle_output_layout_change>}, output_manager = 0x555555ecaf80, output_manager_apply = {link = {prev = 0x555555ecafb8, next = 0x555555ecafb8}, notify = 0x55555556966d <handle_output_manager_apply>}, pending_output_layout_change = 0, gamma_control_manager_v1 = 0x555555ea03c0, gamma_control_set_gamma = {link = {prev = 0x555555ea0400, next = 0x555555ea0400}, notify = 0x555555569989 <handle_gamma_control_set_gamma>}, session_lock = 0x0, foreign_toplevel_manager = 0x555555ebe570, drm_lease_manager = 0x555555fe0ae0, drm_lease_request = {link = {prev = 0x555555fe0b10, next = 0x555555fe0b10}, notify = 0x55555556e3c2 <handle_drm_lease_request>}, output_power_manager_v1 = 0x555555fe1a20, output_power_manager_set_mode = {link = {prev = 0x555555fe1a50, next = 0x555555fe1a50}, notify = 0x55555556a009 <handle_output_power_manager_set_mode>}, relative_pointer_manager = 0x555555fe1b30, constraints = 0x555555fe1110, new_constraint = {link = {prev = 0x555555fe1128, next = 0x555555fe1128}, notify = 0x5555555884f5 <create_constraint>}, tearing_control = 0x555555fe1910, tearing_new_object = {link = {prev = 0x555555fe1940, next = 0x555555fe1940}, notify = 0x555555570fb9 <new_tearing_hint>}, osd_state = {cycle_view = 0x0, preview_was_enabled = false, preview_node = 0x0, preview_anchor = 0x0, preview_outline = 0x0}, theme = 0x7fffffffc620, menu_current = 0x0, menus = {prev = 0x55555603f210, next = 0x5555561f5b90}}
        theme = {border_width = 1, padding_height = 2, title_height = 17, menu_overlap_x = 0, menu_overlap_y = 0, window_active_border_color = {0.980392158, 0.980392158, 0.980392158, 1}, window_inactive_border_color = {0.980392158, 0.980392158, 0.980392158, 1}, window_toggled_keybinds_color = {1, 0, 0, 1}, window_active_title_bg_color = {0.0470588244, 0.0470588244, 0.0470588244, 1}, window_inactive_title_bg_color = {0.0470588244, 0.0470588244, 0.0470588244, 1}, window_active_label_text_color = {0.980392158, 0.980392158, 0.980392158, 1}, window_inactive_label_text_color = {0.13333334, 0.13333334, 0.13333334, 1}, window_label_text_justify = LAB_JUSTIFY_RIGHT, window_active_button_menu_unpressed_image_color = {0.423529416, 0.619607866, 0.670588255, 1}, window_active_button_iconify_unpressed_image_color = {0.423529416, 0.619607866, 0.670588255, 1}, window_active_button_max_unpressed_image_color = {0.423529416, 0.619607866, 0.670588255, 1}, window_active_button_close_unpressed_image_color = {0.423529416, 0.619607866, 0.670588255, 1}, window_inactive_button_menu_unpressed_image_color = {0.278431386, 0.286274523, 0.301960796, 1}, window_inactive_button_iconify_unpressed_image_color = {0.278431386, 0.286274523, 0.301960796, 1}, window_inactive_button_max_unpressed_image_color = {0.278431386, 0.286274523, 0.301960796, 1}, window_inactive_button_close_unpressed_image_color = {0.278431386, 0.286274523, 0.301960796, 1}, menu_item_padding_x = 7, menu_item_padding_y = 4, menu_items_bg_color = {0.13333334, 0.13333334, 0.13333334, 1}, menu_items_text_color = {0.980392158, 0.980392158, 0.980392158, 1}, menu_items_active_bg_color = {0.0470588244, 0.0470588244, 0.0470588244, 1}, menu_items_active_text_color = {0, 0.588235319, 0.819607854, 1}, menu_min_width = 20, menu_max_width = 200, menu_separator_line_thickness = 1, menu_separator_padding_width = 6, menu_separator_padding_height = 3, menu_separator_color = {0.533333361, 0.533333361, 0.533333361, 1}, osd_border_width = 1, osd_bg_color = {0.0470588244, 0.0470588244, 0.0470588244, 1}, osd_border_color = {0.980392158, 0.980392158, 0.980392158, 1}, osd_label_text_color = {0.980392158, 0.980392158, 0.980392158, 1}, osd_window_switcher_width = 600, osd_window_switcher_padding = 4, osd_window_switcher_item_padding_x = 10, osd_window_switcher_item_padding_y = 1, osd_window_switcher_item_active_border_width = 2, osd_workspace_switcher_boxes_width = 20, osd_workspace_switcher_boxes_height = 20, button_close_active_unpressed = 0x5555561de440, button_maximize_active_unpressed = 0x5555561de4d0, button_restore_active_unpressed = 0x5555561e19a0, button_iconify_active_unpressed = 0x5555561dc940, button_menu_active_unpressed = 0x5555561d5a80, button_close_inactive_unpressed = 0x5555561df010, button_maximize_inactive_unpressed = 0x5555561df280, button_restore_inactive_unpressed = 0x5555561df400, button_iconify_inactive_unpressed = 0x5555561dd840, button_menu_inactive_unpressed = 0x5555561ea0d0, button_close_active_hover = 0x5555561f1d30, button_maximize_active_hover = 0x5555561e3620, button_restore_active_hover = 0x5555561efb30, button_iconify_active_hover = 0x5555561304b0, button_menu_active_hover = 0x5555561dd8d0, button_close_inactive_hover = 0x5555561f2e30, button_maximize_inactive_hover = 0x5555561eea30, button_restore_inactive_hover = 0x5555561f0c30, button_iconify_inactive_hover = 0x5555561de6d0, button_menu_inactive_hover = 0x5555561df310, corner_top_left_active_normal = 0x5555561dfc80, corner_top_right_active_normal = 0x5555561d2960, corner_top_left_inactive_normal = 0x555555ff35a0, corner_top_right_inactive_normal = 0x5555560f5bf0, osd_window_switcher_item_height = 19}
```