### PR TITLE
feat: touch output mapping

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -447,6 +447,16 @@ windows using the mouse.
 	<mouse><mousebind> entries exist, the same default mousebinds will be
 	loaded even if the <default /> element is not provided.
 
+## TOUCH
+
+```
+<touch mapToOutput="" />
+```
+
+*<touch mapToOutput="" />*
+	Direct cursor movement to a specified output. If the compositor is
+	running in nested mode, this does not take effect.
+
 ## TABLET
 
 ```

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -414,6 +414,12 @@
   </mouse>
 
   <!--
+    Direct cursor movement to a specified output. If the compositor is
+    running in nested mode, this does not take effect.
+  -->
+  <touch mapToOutput="" />
+
+  <!--
     The tablet cursor movement can be restricted to a single output.
     If output is left empty or the output does not exists, the tablet
     will span all outputs.

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -88,6 +88,11 @@ struct rcxml {
 	struct wl_list mousebinds; /* struct mousebind.link */
 	double scroll_factor;
 
+	/* touch tablet */
+	struct touch_config {
+		char *output_name;
+	} touch;
+
 	/* graphics tablet */
 	struct tablet_config {
 		char *output_name;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -863,6 +863,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "Invalid value for <resize popupShow />");
 		}
+	} else if (!strcasecmp(nodename, "mapToOutput.touch")) {
+		rc.touch.output_name = xstrdup(content);
 	} else if (!strcasecmp(nodename, "mapToOutput.tablet")) {
 		rc.tablet.output_name = xstrdup(content);
 	} else if (!strcasecmp(nodename, "rotate.tablet")) {
@@ -1045,6 +1047,8 @@ rcxml_init(void)
 
 	rc.doubleclick_time = 500;
 	rc.scroll_factor = 1.0;
+
+	rc.touch.output_name = NULL;
 
 	rc.tablet.output_name = NULL;
 	rc.tablet.rotation = 0;
@@ -1562,6 +1566,8 @@ rcxml_finish(void)
 		action_list_free(&m->actions);
 		zfree(m);
 	}
+
+	zfree(rc.touch.output_name);
 
 	zfree(rc.tablet.output_name);
 

--- a/src/seat.c
+++ b/src/seat.c
@@ -521,6 +521,7 @@ seat_reconfigure(struct server *server)
 			configure_libinput(input->wlr_input_device);
 			break;
 		case WLR_INPUT_DEVICE_TOUCH:
+			configure_libinput(input->wlr_input_device);
 			map_touch_to_output(seat, input->wlr_input_device);
 			break;
 		case WLR_INPUT_DEVICE_TABLET_TOOL:

--- a/src/seat.c
+++ b/src/seat.c
@@ -215,6 +215,14 @@ map_input_to_output(struct seat *seat, struct wlr_input_device *dev, char *outpu
 	wlr_cursor_map_input_to_region(seat->cursor, dev, NULL);
 }
 
+static void
+map_pointer_to_output(struct seat *seat, struct wlr_input_device *dev)
+{
+	struct wlr_pointer *pointer = wlr_pointer_from_input_device(dev);
+	wlr_log(WLR_INFO, "map pointer to output %s\n", pointer->output_name);
+	map_input_to_output(seat, dev, pointer->output_name);
+}
+
 static struct input *
 new_pointer(struct seat *seat, struct wlr_input_device *dev)
 {
@@ -225,9 +233,7 @@ new_pointer(struct seat *seat, struct wlr_input_device *dev)
 
 	/* In support of running with WLR_WL_OUTPUTS set to >=2 */
 	if (dev->type == WLR_INPUT_DEVICE_POINTER) {
-		struct wlr_pointer *pointer = wlr_pointer_from_input_device(dev);
-		wlr_log(WLR_INFO, "map pointer to output %s\n", pointer->output_name);
-		map_input_to_output(seat, dev, pointer->output_name);
+		map_pointer_to_output(seat, dev);
 	}
 	return input;
 }
@@ -659,6 +665,9 @@ seat_output_layout_changed(struct seat *seat)
 	struct input *input = NULL;
 	wl_list_for_each(input, &seat->inputs, link) {
 		switch (input->wlr_input_device->type) {
+		case WLR_INPUT_DEVICE_POINTER:
+			map_pointer_to_output(seat, input->wlr_input_device);
+			break;
 		case WLR_INPUT_DEVICE_TOUCH:
 			map_touch_to_output(seat, input->wlr_input_device);
 			break;

--- a/src/seat.c
+++ b/src/seat.c
@@ -263,6 +263,15 @@ new_keyboard(struct seat *seat, struct wlr_input_device *device, bool virtual)
 	return (struct input *)keyboard;
 }
 
+static void
+map_touch_to_output(struct seat *seat, struct wlr_input_device *dev)
+{
+	struct wlr_touch *touch = wlr_touch_from_input_device(dev);
+	char *output_name = touch->output_name ? touch->output_name : rc.touch.output_name;
+	wlr_log(WLR_INFO, "map touch to output %s\n", output_name);
+	map_input_to_output(seat, dev, output_name);
+}
+
 static struct input *
 new_touch(struct seat *seat, struct wlr_input_device *dev)
 {
@@ -273,9 +282,7 @@ new_touch(struct seat *seat, struct wlr_input_device *dev)
 
 	/* In support of running with WLR_WL_OUTPUTS set to >=2 */
 	if (dev->type == WLR_INPUT_DEVICE_TOUCH) {
-		struct wlr_touch *touch = wlr_touch_from_input_device(dev);
-		wlr_log(WLR_INFO, "map touch to output %s\n", touch->output_name);
-		map_input_to_output(seat, dev, touch->output_name);
+		map_touch_to_output(seat, dev);
 	}
 	return input;
 }

--- a/src/seat.c
+++ b/src/seat.c
@@ -279,11 +279,9 @@ new_touch(struct seat *seat, struct wlr_input_device *dev)
 	input->wlr_input_device = dev;
 	configure_libinput(dev);
 	wlr_cursor_attach_input_device(seat->cursor, dev);
-
 	/* In support of running with WLR_WL_OUTPUTS set to >=2 */
-	if (dev->type == WLR_INPUT_DEVICE_TOUCH) {
-		map_touch_to_output(seat, dev);
-	}
+	map_touch_to_output(seat, dev);
+
 	return input;
 }
 

--- a/src/seat.c
+++ b/src/seat.c
@@ -660,6 +660,9 @@ seat_output_layout_changed(struct seat *seat)
 	struct input *input = NULL;
 	wl_list_for_each(input, &seat->inputs, link) {
 		switch (input->wlr_input_device->type) {
+		case WLR_INPUT_DEVICE_TOUCH:
+			map_touch_to_output(seat, input->wlr_input_device);
+			break;
 		case WLR_INPUT_DEVICE_TABLET_TOOL:
 			map_input_to_output(seat, input->wlr_input_device, rc.tablet.output_name);
 			break;

--- a/src/seat.c
+++ b/src/seat.c
@@ -522,6 +522,9 @@ seat_reconfigure(struct server *server)
 		case WLR_INPUT_DEVICE_POINTER:
 			configure_libinput(input->wlr_input_device);
 			break;
+		case WLR_INPUT_DEVICE_TOUCH:
+			map_touch_to_output(seat, input->wlr_input_device);
+			break;
 		case WLR_INPUT_DEVICE_TABLET_TOOL:
 			map_input_to_output(seat, input->wlr_input_device, rc.tablet.output_name);
 			break;


### PR DESCRIPTION
From https://github.com/labwc/labwc/issues/1422

This adds a `<touch mapToOutput="" />` switch to the configuration, similar like the switch for `tablet`. This switch allows to override the linked output name from a touch device.

I don't have suitable hardware, so this needs validation from somebody else...
~Also no docs yet.~