### PR TITLE
Fixed some typos, whitespace, periods, 80-column lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@
 There is no one-way-fits-all method for debugging, so you have to use your
 antennae and do some detective work.
 
-This section contains some approachies which may prove useful.
+This section contains some approaches which may prove useful.
 
 ## Backtraces
 
@@ -108,7 +108,7 @@ to open an issue so we can add you to this list.
 # Coding Style
 
 labwc is written in the [Linux kernel coding style] with a small number of
-deviations to align with [Drew Devault's preferred coding style] nameley:
+deviations to align with [Drew Devault's preferred coding style] namely:
 
 1. [Function Declaration](https://git.sr.ht/~sircmpwn/cstyle#function-declarations)
 2. [Braces for one-line statement](https://git.sr.ht/~sircmpwn/cstyle#brace-placement)
@@ -353,7 +353,7 @@ Translators can add their `MY_LOCALE.po` files to the `po` directory
 based on `po/labwc.pot` and issue a pull request. To do this they can
 generate their `MY_LOCALE.po` file in a few steps:
 
-1. Edit the `po/LINGAUS` file to add their locale name by adding a space
+1. Edit the `po/LINGUAS` file to add their locale name by adding a space
    to the end of the field and typing the locale code.
 2. Copy the po/labwc.pot to po/MY_LOCALE.po
 3. Edit the newly generated MY_LOCALE.po file with some of their
@@ -411,11 +411,11 @@ follow the steps to be taken:
 [Drew Devault's preferred coding style]: https://git.sr.ht/~sircmpwn/cstyle
 [Linux kernel coding style]: https://www.kernel.org/doc/html/v4.10/process/coding-style.html
 [kernel-doc format]: https://docs.kernel.org/doc-guide/kernel-doc.html
-[commit messages]: https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/CONTRIBUTING.md#commit-messages 
+[commit messages]: https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/CONTRIBUTING.md#commit-messages
 [GNU C extensions]: https://gcc.gnu.org/onlinedocs/gcc/C-Extensions.html
 [`wl_container_of()`]: https://github.com/wayland-project/wayland/blob/985ab55d59db45ea62795c76dff5949343e86b2f/src/wayland-util.h#L409
 
-[^1]: The reference docuementation for glib notes that:
+[^1]: The reference documentation for glib notes that:
       "It's important to match g_malloc() with g_free(), plain malloc() with
       free(), and (if you're using C++) new with delete and new[] with
       delete[]. Otherwise bad things can happen, since these allocators may use

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -19,7 +19,7 @@ Actions are used in menus and keyboard/mouse bindings.
 	Execute command.  Note that in the interest of backward compatibility,
 	labwc supports <execute> as an alternative to <command> even though
 	openbox documentation states that it is deprecated.
-	Note: Tilde (~) is expanded in the command before passing to execvp()
+	Note: Tilde (~) is expanded in the command before passing to execvp().
 
 *<action name="Exit" />*
 	Exit labwc.
@@ -40,7 +40,7 @@ Actions are used in menus and keyboard/mouse bindings.
 	Iconify (minimize) focused window.
 
 *<action name="Move" />*
-	Begin interactive move of window under cursor
+	Begin interactive move of window under cursor.
 
 *<action name="MoveToEdge" direction="value" snapWindows="value" />*
 	Move window until it hits the next edge.
@@ -52,7 +52,7 @@ Actions are used in menus and keyboard/mouse bindings.
 	the next screen edge. Default is yes.
 
 *<action name="Resize" />*
-	Begin interactive resize of window under cursor
+	Begin interactive resize of window under cursor.
 
 *<action name="ResizeRelative" left="" right="" top="" bottom="" />*
 	Resize window relative to its current size. Values of left, right,
@@ -71,10 +71,10 @@ Actions are used in menus and keyboard/mouse bindings.
 	*direction* [left|up|right|down] Direction in which to shrink.
 
 *<action name="MoveTo" x="" y="" />*
-	Move to position (x, y)
+	Move to position (x, y).
 
 *<action name="ResizeTo" width="" height="" />*
-	Resize window
+	Resize window.
 
 	*width* The width to resize the window to in pixels.
 
@@ -141,7 +141,8 @@ Actions are used in menus and keyboard/mouse bindings.
 	support the wlr-layer-shell protocol.
 
 *<action name="ToggleOmnipresent" />*
-	Toggle omnipresent (visible on all workspaces / sticky) for the focused window.
+	Toggle omnipresent (visible on all workspaces / sticky) for the focused
+	window.
 
 *<action name="ToggleKeybinds" />*
 	Stop handling keybinds other than ToggleKeybinds itself.
@@ -186,15 +187,16 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="VirtualOutputAdd" output_name="value" />*
 	Add virtual output (headless backend).
 
-	For example, it can be used to overlay virtual output on real output, but with
-	a different resolution (this can be done with `wlr-randr` or `wdisplays`).
-	After that, virtual output can be selected for screen sharing (casting),
-	effectively sharing only the region of the screen.
+	For example, it can be used to overlay virtual output on real output,
+	but with a different resolution (this can be done with `wlr-randr`
+	or `wdisplays`). After that, virtual output can be selected for screen
+	sharing (casting), effectively sharing only the region of the screen.
 
 	It must be noted that overlaying virtual output and real output is not
-	endorsed or explicitly supported by wlroots. For example, after configuring
-	virtual output, real output must be reconfigured as well (for the overlay
-	configuration to work correctly). This is the example configuration:
+	endorsed or explicitly supported by wlroots. For example, after
+	configuring virtual output, real output must be reconfigured as well
+	(for the overlay configuration to work correctly). This is the example
+	configuration:
 
 ```
 <keybind key="W-v">
@@ -209,25 +211,27 @@ Actions are used in menus and keyboard/mouse bindings.
 	Note that the vertical resolution of "ScreenCasting" output is just 50px
 	smaller than "eDP-1" output to cut off bottom panel from screen sharing.
 
-	Virtual output is also useful for extending the desktop to (maybe mobile)
-	remote systems like tablets. E.g. simply adding a virtual output, attaching
-	wayvnc to it and running a VNC client on the remote system.
+	Virtual output is also useful for extending the desktop to (maybe
+	mobile)	remote systems like tablets. E.g. simply adding a virtual
+	output, attaching wayvnc to it and running a VNC client on the remote
+	system.
 
-	*output_name* The name of virtual output. Providing virtual output name is
-	beneficial for further automation. Default is "HEADLESS-X".
+	*output_name* The name of virtual output. Providing virtual output name
+	is beneficial for further automation. Default is "HEADLESS-X".
 
 *<action name="VirtualOutputRemove" output_name="value" />*
 	Remove virtual output (headless backend).
 
-	*output_name* The name of virtual output. If not supplied, will remove the
-	last virtual output added.
+	*output_name* The name of virtual output. If not supplied, will remove
+	the last virtual output added.
 
 *<action name="AutoPlace" />*
 	Use the automatic placement policy to move the active window to a
 	position on its output that will minimize overlap with other windows.
 
 *<action name="None" />*
-	If used as the only action for a binding: clear an earlier defined binding.
+	If used as the only action for a binding: clear an earlier defined
+	binding.
 
 # CONDITIONAL ACTIONS
 
@@ -266,7 +270,7 @@ Actions that execute other actions. Used in keyboard/mouse bindings.
 			XWayland clients.
 
 		This argument is optional.
-	
+
 	*then*
 		A list of actions to be executed if the window matches any
 		query. This argument is optional.

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -131,8 +131,8 @@ this is for compatibility with Openbox.
 
 *<core><allowTearing>* [yes|no]
 	Allow tearing to reduce input lag. Default is no.
-	This option requires setting the environment variable WLR_DRM_NO_ATOMIC=1.
-
+	This option requires setting the environment variable
+	WLR_DRM_NO_ATOMIC=1.
 	*yes* allow tearing if requested by the active window.
 
 *<core><reuseOutputMode>* [yes|no]
@@ -173,8 +173,8 @@ this is for compatibility with Openbox.
 		- *identifier* Show identifier (app_id for native Wayland
 		  windows and WM_CLASS for XWayland clients)
 
-		- *trimmed_identifier* Show trimmed identifier. Trimming removes the first
-		  two nodes of 'org.' strings.
+		- *trimmed_identifier* Show trimmed identifier. Trimming removes
+		  the first two nodes of 'org.' strings.
 
 		- *title* Show window title if different to app_id
 
@@ -208,7 +208,7 @@ this is for compatibility with Openbox.
 ## WINDOW SNAPPING
 
 The following two options relate to triggering window actions when moving
-windows using the mouse. 
+windows using the mouse.
 
 *<snapping><range>*
 	The distance in pixels from the edge of an output for window Move
@@ -236,9 +236,9 @@ windows using the mouse.
 	GoToDesktop and windows can be moved with SendToDesktop. See
 	labwc-actions(5) for more information about their arguments.
 
-	The number attribute defines the minimum number of workspaces. Default is 1. 
-	The number attribute is optional. If the number attribute is specified, names.name
-	is not required.
+	The number attribute defines the minimum number of workspaces. Default
+	is 1. The number attribute is optional. If the number attribute is
+	specified, names.name is not required.
 
 *<desktops><popupTime>*
 	Define the timeout after which to hide the workspace OSD.
@@ -260,7 +260,8 @@ windows using the mouse.
 	The font to use for a specific element of a window, menu or OSD.
 	Places can be any of:
 	- ActiveWindow - titlebar of active window
-	- InactiveWindow - titlebar of all windows that aren't focused by the cursor
+	- InactiveWindow - titlebar of all windows that aren't focused by the
+	  cursor
 	- MenuItem - menu item (currently only root menu)
 	- OnScreenDisplay - items in the on screen display
 	If no place attribute is provided, the setting will be applied to all
@@ -343,7 +344,7 @@ windows using the mouse.
 	Default is no.
 
 *<keyboard><keybind key=""><action name="">*
-	Keybind action. See labwc-action(5)
+	Keybind action. See labwc-action(5).
 
 *<keyboard><default />*
 	Load the default keybinds listed below. This is an addition to the
@@ -364,7 +365,7 @@ windows using the mouse.
 ```
 
 	Audio and MonBrightness keys are also bound to amixer and
-	brightnessctl respectively
+	brightnessctl, respectively.
 
 *<keyboard><repeatRate>*
 	Set the rate at which keypresses are repeated per second.
@@ -384,7 +385,7 @@ windows using the mouse.
 
 *<mouse><context name=""><mousebind button="" direction="" action=""><action>*
 	Multiple *<mousebind>* can exist within one *<context>*; and multiple
-	*<action>* can exist within one *<mousebind>*
+	*<action>* can exist within one *<mousebind>*.
 
 	Define a mouse binding. Supported context-names include:
 	- TitleBar: The decoration on top of the window, where the window
@@ -426,8 +427,9 @@ windows using the mouse.
 	- Left
 	- Right
 
-	Mouse buttons and directions can be combined with modifier-keys (shift (S),
-	super/logo (W), control (C), alt (A), meta (M) and hyper (H)), for example:
+	Mouse buttons and directions can be combined with modifier-keys
+	(shift (S), super/logo (W), control (C), alt (A), meta (M) and
+	hyper (H)), for example:
 	<mousebind button="A-Right" action="Press">
 
 	Supported mouse *actions* include:
@@ -479,17 +481,17 @@ windows using the mouse.
 
 	Aspect ratio example:
 	The dimensions of the tablet are 215mm x 115mm and the output has
-	a resolution of 3440x1440. When setting height to "90", because 
+	a resolution of 3440x1440. When setting height to "90", because
 	215 x 1440 / 3440 = 90, the responsive tablet area height will be
 	truncated to match the 21:9 aspect ratio of the output. By
 	additionally setting top to "12.5", the active area is centered
 	vertically on the tablet surface.
 
 *<tablet><map button="" to="" />*
-	Tablet buttons emulate regular mouse buttons. If not specified otherwise,
-	the tip (Tip) is mapped to left mouse click, the first pen button (Stylus)
-	is mapped to right mouse button click and the second pen button (Stylus2)
-	emulates a middle mouse button click.
+	Tablet buttons emulate regular mouse buttons. If not specified
+	otherwise, the tip (Tip) is mapped to left mouse click, the first pen
+	button (Stylus)	is mapped to right mouse button click and the second pen
+	button (Stylus2) emulates a middle mouse button click.
 
 	Supported map *buttons* are:
 	- Tip
@@ -545,7 +547,7 @@ windows using the mouse.
 
 	A list of device names can be obtained by running
 	*libinput list-devices* (you may need to be root or a part of the input
-	group to perform this.)
+	group to perform this).
 
 *<libinput><device><naturalScroll>* [yes|no]
 	Use natural scrolling for this category if available.
@@ -646,7 +648,7 @@ situation.
 
 *<windowRules><windowRule skipWindowSwitcher="">* [yes|no|default]
 	*skipWindowSwitcher* removes window from the Window Switcher (alt-tab
-	on-screen-display)
+	on-screen-display).
 
 *<windowRules><windowRule ignoreFocusRequest="">* [yes|no|default]
 	*ignoreFocusRequest* prevent window to activate itself.

--- a/docs/labwc-menu.5.scd
+++ b/docs/labwc-menu.5.scd
@@ -38,9 +38,9 @@ The menu file must be entirely enclosed within <openbox_menu> and
 
 *menu.id*
 	Each menu must be given an id, which is a unique identifier of the menu.
-	This id is used to refer to the menu in a ShowMenu action. 
-	Default identifiers are "client-menu" for the titlebar context menu and "root-menu" 
-	for the root window context menu. 
+	This id is used to refer to the menu in a ShowMenu action.
+	Default identifiers are "client-menu" for the titlebar context menu and
+	"root-menu" for the root window context menu.
 	Available localisation for the default "client-menu" is
 	only shown if no "client-menu" is present in menu.xml.
 

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -81,10 +81,10 @@ labwc-config(5).
 	value.
 
 *window.active.border.color*
-	Border color of active window
+	Border color of active window.
 
 *window.inactive.border.color*
-	Border color of inactive window
+	Border color of inactive window.
 
 *window.active.indicator.toggled-keybind.color*
 	Status indicator for the ToggleKeybinds action. Can be set to the same
@@ -92,16 +92,16 @@ labwc-config(5).
 	indicator.
 
 *window.active.title.bg.color*
-	Background color for the focused window's titlebar
+	Background color for the focused window's titlebar.
 
 *window.inactive.title.bg.color*
-	Background color for non-focused windows' titlebars
+	Background color for non-focused windows' titlebars.
 
 *window.active.label.text.color*
-	Text color for the focused window's titlebar
+	Text color for the focused window's titlebar.
 
 *window.inactive.label.text.color*
-	Text color non-focused windows' titlebars
+	Text color non-focused windows' titlebars.
 
 *window.label.text.justify*
 	Specifies how window titles are aligned in the titlebar for both
@@ -124,16 +124,16 @@ openbox and is used by many popular themes. For the sake of brevity, these
 elements are not listed here, but are supported.
 
 *menu.items.bg.color*
-	Background color of inactive menu items
+	Background color of inactive menu items.
 
 *menu.items.text.color*
-	Text color of inactive menu item
+	Text color of inactive menu item.
 
 *menu.items.active.bg.color*
-	Background color of active menu items
+	Background color of active menu items.
 
 *menu.items.active.text.color*
-	Text color of active menu item
+	Text color of active menu item.
 
 *menu.separator.width*
 	Line thickness of menu separators. Default 1.
@@ -148,16 +148,16 @@ elements are not listed here, but are supported.
 	Menu separator color. Default #888888.
 
 *osd.bg.color*
-	Background color of on-screen-display
+	Background color of on-screen-display.
 
 *osd.border.color*
-	Border color of on-screen-display
+	Border color of on-screen-display.
 
 *osd.border.width*
 	Border width of on-screen-display. Inherits *border.width* if not set.
 
 *osd.label.text.color*
-	Text color of on-screen-display
+	Text color of on-screen-display.
 
 *osd.window-switcher.width*
 	Width of window switcher in pixels. Default is 600.

--- a/docs/labwc.1.scd
+++ b/docs/labwc.1.scd
@@ -6,7 +6,7 @@ labwc - a wayland stacking compositor
 
 # SYNOPSIS
 
-*labwc*  [options...]
+*labwc* [options...]
 
 # DESCRIPTION
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -215,16 +215,34 @@
       <action name="Execute" command="brightnessctl set 10%-" />
     </keybind>
   <!-- SnapToRegion via W-Numpad -->
-    <!--
-    <keybind key="W-KP_7"><action name="SnapToRegion" region="top-left" /></keybind>
-    <keybind key="W-KP_8"><action name="SnapToRegion" region="top" /></keybind>
-    <keybind key="W-KP_9"><action name="SnapToRegion" region="top-right" /></keybind>
-    <keybind key="W-KP_4"><action name="SnapToRegion" region="left" /></keybind>
-    <keybind key="W-KP_5"><action name="SnapToRegion" region="center" /></keybind>
-    <keybind key="W-KP_6"><action name="SnapToRegion" region="right" /></keybind>
-    <keybind key="W-KP_1"><action name="SnapToRegion" region="bottom-left" /></keybind>
-    <keybind key="W-KP_2"><action name="SnapToRegion" region="bottom" /></keybind>
-    <keybind key="W-KP_3"><action name="SnapToRegion" region="bottom-right" /></keybind>
+  <!--
+    <keybind key="W-KP_7">
+      <action name="SnapToRegion" region="top-left" />
+    </keybind>
+    <keybind key="W-KP_8">
+      <action name="SnapToRegion" region="top" />
+    </keybind>
+    <keybind key="W-KP_9">
+      <action name="SnapToRegion" region="top-right" />
+    </keybind>
+    <keybind key="W-KP_4">
+      <action name="SnapToRegion" region="left" />
+    </keybind>
+    <keybind key="W-KP_5">
+      <action name="SnapToRegion" region="center" />
+    </keybind>
+    <keybind key="W-KP_6">
+      <action name="SnapToRegion" region="right" />
+    </keybind>
+    <keybind key="W-KP_1">
+      <action name="SnapToRegion" region="bottom-left" />
+    </keybind>
+    <keybind key="W-KP_2">
+      <action name="SnapToRegion" region="bottom" />
+    </keybind>
+    <keybind key="W-KP_3">
+      <action name="SnapToRegion" region="bottom-right" />
+    </keybind>
   -->
   </keyboard>
 
@@ -237,7 +255,8 @@
     below). If the default mousebinds are largely what you want, a sensible
     approach could be to start the <mouse> section with a <default />
     element, and then (re-)define any special binds you need such as launching
-    a custom menu when right-clicking on your desktop. See rc.xml for an example.
+    a custom menu when right-clicking on your desktop. See rc.xml for an
+    example.
   -->
   <mouse>
 
@@ -450,10 +469,10 @@
 
   <!--
     # Window Rules
-    #   - Criteria can consist of 'identifier' or 'title' or both (in which case
-    #     AND logic is used).
-    #   - 'identifier' relates to app_id for native Wayland windows and WM_CLASS
-    #     for XWayland clients.
+    #   - Criteria can consist of 'identifier' or 'title' or both (in which
+    #     case AND logic is used).
+    #   - 'identifier' relates to app_id for native Wayland windows and
+    #     WM_CLASS for XWayland clients.
     #   - Criteria can also contain `matchOnce="true"` meaning that the rule
     #     must only apply to the first instance of the window with that
     #     particular 'identifier' or 'title'.
@@ -468,8 +487,8 @@
     </windowRules>
 
     # Example below for `lxqt-panel` and `pcmanfm-qt \-\-desktop`
-    # where 'matchOnce' is used to avoid applying rule to the panel configuration
-    # window with the same 'app_id'
+    # where 'matchOnce' is used to avoid applying rule to the panel
+    # configuration window with the same 'app_id'.
 
     <windowRules>
       <windowRule identifier="lxqt-panel" matchOnce="true">


### PR DESCRIPTION
- typos: LINGUAS manually, rest with help of aspell(1)
- whitespace: some trailing spaces/tabs, one utf-8 NBSP (#xC2 #xA0)
- made most text in docs/ fit in max 80-column wide lines
- consistent trailing periods in sentences in labwc-actions.5.scd and labwc-config.5.scd; labwc-theme.5.scd had different consistency, changed it follow these other files with sentence-ending periods
- and ", respectively" (comma often used to separate)