### PR TITLE
Reload keymap on reconfigure

### DIFF
--- a/include/input/keyboard.h
+++ b/include/input/keyboard.h
@@ -10,6 +10,7 @@ struct keyboard;
 struct wlr_keyboard;
 
 void keyboard_init(struct seat *seat);
+void keyboard_reload(struct seat *seat);
 void keyboard_finish(struct seat *seat);
 
 void keyboard_setup_handlers(struct keyboard *keyboard);

--- a/include/input/keyboard.h
+++ b/include/input/keyboard.h
@@ -9,8 +9,7 @@ struct seat;
 struct keyboard;
 struct wlr_keyboard;
 
-void keyboard_init(struct seat *seat);
-void keyboard_reload(struct seat *seat);
+void keyboard_init(struct seat *seat, bool reconfig);
 void keyboard_finish(struct seat *seat);
 
 void keyboard_setup_handlers(struct keyboard *keyboard);

--- a/src/input/input.c
+++ b/src/input/input.c
@@ -7,7 +7,7 @@ void
 input_handlers_init(struct seat *seat)
 {
 	cursor_init(seat);
-	keyboard_init(seat);
+	keyboard_init(seat, false);
 }
 
 void

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -614,6 +614,24 @@ keyboard_init(struct seat *seat)
 }
 
 void
+keyboard_reload(struct seat *seat)
+{
+	struct wlr_keyboard *kb = wlr_seat_get_keyboard(seat->seat);
+	struct xkb_rule_names rules = { 0 };
+	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+		XKB_KEYMAP_COMPILE_NO_FLAGS);
+	if (keymap) {
+		wlr_keyboard_set_keymap(kb, keymap);
+		xkb_keymap_unref(keymap);
+	} else {
+		wlr_log(WLR_ERROR, "Failed to create xkb keymap");
+	}
+	xkb_context_unref(context);
+	wlr_keyboard_set_repeat_info(kb, rc.repeat_rate, rc.repeat_delay);
+}
+
+void
 keyboard_setup_handlers(struct keyboard *keyboard)
 {
 	struct wlr_keyboard *wlr_kb = keyboard->wlr_keyboard;

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -593,10 +593,15 @@ keyboard_update_layout(struct seat *seat, xkb_layout_index_t layout)
 }
 
 void
-keyboard_init(struct seat *seat)
+keyboard_init(struct seat *seat, bool reconfig)
 {
-	seat->keyboard_group = wlr_keyboard_group_create();
-	struct wlr_keyboard *kb = &seat->keyboard_group->keyboard;
+	struct wlr_keyboard *kb;
+	if (reconfig) {
+		kb = wlr_seat_get_keyboard(seat->seat);
+	} else {
+		seat->keyboard_group = wlr_keyboard_group_create();
+		kb = &seat->keyboard_group->keyboard;
+	}
 	struct xkb_rule_names rules = { 0 };
 	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
@@ -611,24 +616,6 @@ keyboard_init(struct seat *seat)
 	wlr_keyboard_set_repeat_info(kb, rc.repeat_rate, rc.repeat_delay);
 
 	keybind_update_keycodes(seat->server);
-}
-
-void
-keyboard_reload(struct seat *seat)
-{
-	struct wlr_keyboard *kb = wlr_seat_get_keyboard(seat->seat);
-	struct xkb_rule_names rules = { 0 };
-	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-	struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
-		XKB_KEYMAP_COMPILE_NO_FLAGS);
-	if (keymap) {
-		wlr_keyboard_set_keymap(kb, keymap);
-		xkb_keymap_unref(keymap);
-	} else {
-		wlr_log(WLR_ERROR, "Failed to create xkb keymap");
-	}
-	xkb_context_unref(context);
-	wlr_keyboard_set_repeat_info(kb, rc.repeat_rate, rc.repeat_delay);
 }
 
 void

--- a/src/seat.c
+++ b/src/seat.c
@@ -537,6 +537,7 @@ seat_reconfigure(struct server *server)
 			break;
 		}
 	}
+	keyboard_reload(seat);
 }
 
 static void

--- a/src/seat.c
+++ b/src/seat.c
@@ -537,7 +537,7 @@ seat_reconfigure(struct server *server)
 			break;
 		}
 	}
-	keyboard_reload(seat);
+	keyboard_init(seat, true);
 }
 
 static void

--- a/src/server.c
+++ b/src/server.c
@@ -61,7 +61,6 @@ reload_config_and_theme(void)
 	regions_reconfigure(g_server);
 	resize_indicator_reconfigure(g_server);
 	kde_server_decoration_update_default();
-	keybind_update_keycodes(g_server);
 }
 
 static int


### PR DESCRIPTION
This reloads the keymap according to the current XKB_DEFAULT_ environment variables when labwc --reconfigure is called, as discussed here - https://github.com/labwc/labwc/issues/1407

I'm not sure if this is exactly the right approach, but it is what wayfire does, and it seems to work.