### PR TITLE
keyboard: set keyboard layout on reconfigure

### DIFF
--- a/include/input/keyboard.h
+++ b/include/input/keyboard.h
@@ -9,8 +9,11 @@ struct seat;
 struct keyboard;
 struct wlr_keyboard;
 
-void keyboard_init(struct seat *seat);
-void keyboard_finish(struct seat *seat);
+void keyboard_configure(struct seat *seat, struct wlr_keyboard *kb,
+	bool is_virtual);
+
+void keyboard_group_init(struct seat *seat);
+void keyboard_group_finish(struct seat *seat);
 
 void keyboard_setup_handlers(struct keyboard *keyboard);
 void keyboard_set_numlock(struct wlr_keyboard *keyboard);

--- a/src/input/input.c
+++ b/src/input/input.c
@@ -7,12 +7,12 @@ void
 input_handlers_init(struct seat *seat)
 {
 	cursor_init(seat);
-	keyboard_init(seat);
+	keyboard_group_init(seat);
 }
 
 void
 input_handlers_finish(struct seat *seat)
 {
 	cursor_finish(seat);
-	keyboard_finish(seat);
+	keyboard_group_finish(seat);
 }

--- a/src/seat.c
+++ b/src/seat.c
@@ -506,13 +506,16 @@ seat_finish(struct server *server)
 }
 
 static void
-configure_keyboard(struct wlr_input_device *device)
+configure_keyboard(struct seat *seat, struct input *input)
 {
+	struct wlr_input_device *device = input->wlr_input_device;
 	assert(device->type == WLR_INPUT_DEVICE_KEYBOARD);
+	struct keyboard *keyboard = (struct keyboard *)input;
 	struct wlr_keyboard *kb = wlr_keyboard_from_input_device(device);
-	wlr_keyboard_set_repeat_info(kb, rc.repeat_rate, rc.repeat_delay);
+	keyboard_configure(seat, kb, keyboard->is_virtual);
 }
 
+/* This is called on SIGHUP (generally in response to labwc --reconfigure */
 void
 seat_reconfigure(struct server *server)
 {
@@ -521,7 +524,7 @@ seat_reconfigure(struct server *server)
 	wl_list_for_each(input, &seat->inputs, link) {
 		switch (input->wlr_input_device->type) {
 		case WLR_INPUT_DEVICE_KEYBOARD:
-			configure_keyboard(input->wlr_input_device);
+			configure_keyboard(seat, input);
 			break;
 		case WLR_INPUT_DEVICE_POINTER:
 			configure_libinput(input->wlr_input_device);

--- a/src/server.c
+++ b/src/server.c
@@ -61,7 +61,6 @@ reload_config_and_theme(void)
 	regions_reconfigure(g_server);
 	resize_indicator_reconfigure(g_server);
 	kde_server_decoration_update_default();
-	keybind_update_keycodes(g_server);
 }
 
 static int


### PR DESCRIPTION
If keyboard-layout-per-toplevel-window is used, reset the group (index) for each window on --reconfigure whenever XKB_DEFAULT_LAYOUT has changed.

Refactor to use a common configure function for reconfigure and keyboard-group creation.

Co-authored-by: @johanmalm

Fixes #1407