### PR TITLE
view: fix regression whereby cursor is not updated

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2046,7 +2046,6 @@ view_destroy(struct view *view)
 {
 	assert(view);
 	struct server *server = view->server;
-	bool need_cursor_update = false;
 
 	if (view->mappable.connected) {
 		mappable_disconnect(&view->mappable);
@@ -2068,13 +2067,11 @@ view_destroy(struct view *view)
 		/* Application got killed while moving around */
 		server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
 		server->grabbed_view = NULL;
-		need_cursor_update = true;
 		regions_hide_overlay(&server->seat);
 	}
 
 	if (server->active_view == view) {
 		server->active_view = NULL;
-		need_cursor_update = true;
 	}
 
 	if (server->last_raised_view == view) {
@@ -2130,7 +2127,5 @@ view_destroy(struct view *view)
 	wl_list_remove(&view->link);
 	free(view);
 
-	if (need_cursor_update) {
-		cursor_update_focus(server);
-	}
+	cursor_update_focus(server);
 }


### PR DESCRIPTION
...on view destruction because focus_change_notify() in seat.c changes server->active_view so the logic introduced by 6c6e406 (which checks if view =! active_view) is no longer right.

The glitches described in the commit below have not come back. https://github.com/labwc/labwc/commit/6c6e406507bfb0e9a809b74029b5b05b5a095768

Fixes #1393

@jlindgren90 - This relates to a couple of separate commits from you, so if you've got time, your eyes on this would helpful. Don't worry if you can't, I think the change is fine.