### PR TITLE
resistance: add window-edge resistance for interactive moves/resizes

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -197,9 +197,14 @@ this is for compatibility with Openbox.
 ## RESISTANCE
 
 *<resistance><screenEdgeStrength>*
-	Screen Edge Strength is how far past the screen's edge your cursor must
-	move before the window will move with it. Resistance is counted in
-	pixels. Default is 20 pixels.
+	Screen-edge strength is the distance, in pixels, past the edge of a
+	screen the cursor must move before an interactive move or resize of a
+	window will continue past the edge. Default is 20 pixels.
+
+*<resistance><windowEdgeStrength>*
+	Window-edge strength is the distance, in pixels, past the edge of any
+	other window the cursor must move before an interactive move or resize
+	of a window will continue past the edge. Default is 20 pixels.
 
 ## FOCUS
 

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -196,15 +196,26 @@ this is for compatibility with Openbox.
 
 ## RESISTANCE
 
-*<resistance><screenEdgeStrength>*
-	Screen-edge strength is the distance, in pixels, past the edge of a
-	screen the cursor must move before an interactive move or resize of a
-	window will continue past the edge. Default is 20 pixels.
-
+*<resistance><screenEdgeStrength>*++
 *<resistance><windowEdgeStrength>*
-	Window-edge strength is the distance, in pixels, past the edge of any
-	other window the cursor must move before an interactive move or resize
-	of a window will continue past the edge. Default is 20 pixels.
+	Resist interactive moves and resizes of a window across screen edges or
+	the edges of any other window, respectively.
+
+	When an edge strength is positive, it indicates a distance, in pixels,
+	that the cursor must move past any relevant encountered edge before an
+	interactive move or resize operation will continue across that edge.
+
+	When the strength is negative, any interactive move or resize operation
+	that brings the cursor within the absolute value of the specified
+	distance, in pixels, from any relevant edge will snap the operation to
+	that edge. Thus, as a move or resize approaches an edge, it will
+	"attract" the cursor to that edge within the specified distance. As the
+	move or resize continues past the edge, it will provide resistance until
+	the cursor has moved beyond the distance.
+
+	A strength of zero disables the corresponding resistance effect.
+
+	The default value for both parameters is 20 pixels.
 
 ## FOCUS
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -66,6 +66,7 @@
   <!-- edge strength is in pixels -->
   <resistance>
     <screenEdgeStrength>20</screenEdgeStrength>
+    <windowEdgeStrength>20</windowEdgeStrength>
   </resistance>
 
   <!-- Show a simple resize and move indicator -->

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -110,6 +110,7 @@ struct rcxml {
 
 	/* resistance */
 	int screen_edge_strength;
+	int window_edge_strength;
 
 	/* window snapping */
 	int snap_edge_range;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -807,6 +807,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.kb_layout_per_window = !strcasecmp(content, "window");
 	} else if (!strcasecmp(nodename, "screenEdgeStrength.resistance")) {
 		rc.screen_edge_strength = atoi(content);
+	} else if (!strcasecmp(nodename, "windowEdgeStrength.resistance")) {
+		rc.window_edge_strength = atoi(content);
 	} else if (!strcasecmp(nodename, "range.snapping")) {
 		rc.snap_edge_range = atoi(content);
 	} else if (!strcasecmp(nodename, "topMaximize.snapping")) {
@@ -1061,6 +1063,7 @@ rcxml_init(void)
 	rc.kb_numlock_enable = true;
 	rc.kb_layout_per_window = false;
 	rc.screen_edge_strength = 20;
+	rc.window_edge_strength = 20;
 
 	rc.snap_edge_range = 1;
 	rc.snap_top_maximize = true;

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -245,12 +245,16 @@ process_cursor_resize(struct server *server, uint32_t time)
 	struct wlr_box new_view_geo = view->current;
 
 	if (server->resize_edges & WLR_EDGE_TOP) {
+		/* Shift y to anchor bottom edge when resizing top */
+		new_view_geo.y = server->grab_box.y + dy;
 		new_view_geo.height = server->grab_box.height - dy;
 	} else if (server->resize_edges & WLR_EDGE_BOTTOM) {
 		new_view_geo.height = server->grab_box.height + dy;
 	}
 
 	if (server->resize_edges & WLR_EDGE_LEFT) {
+		/* Shift x to anchor right edge when resizing left */
+		new_view_geo.x = server->grab_box.x + dx;
 		new_view_geo.width = server->grab_box.width - dx;
 	} else if (server->resize_edges & WLR_EDGE_RIGHT) {
 		new_view_geo.width = server->grab_box.width + dx;
@@ -260,13 +264,13 @@ process_cursor_resize(struct server *server, uint32_t time)
 	view_adjust_size(view, &new_view_geo.width, &new_view_geo.height);
 
 	if (server->resize_edges & WLR_EDGE_TOP) {
-		/* anchor bottom edge */
+		/* After size adjustments, make sure to anchor bottom edge */
 		new_view_geo.y = server->grab_box.y +
 			server->grab_box.height - new_view_geo.height;
 	}
 
 	if (server->resize_edges & WLR_EDGE_LEFT) {
-		/* anchor right edge */
+		/* After size adjustments, make sure to anchor bottom right */
 		new_view_geo.x = server->grab_box.x +
 			server->grab_box.width - new_view_geo.width;
 	}

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -12,20 +12,28 @@ static void
 is_within_resistance_range(struct border view, struct border target,
 		struct border other, struct border *flags, int strength)
 {
-	if (view.left >= other.left && target.left < other.left
-			&& target.left >= other.left - strength) {
-		flags->left = 1;
-	} else if (view.right <= other.right && target.right > other.right
-			&& target.right <= other.right + strength) {
-		flags->right = 1;
+	if (view.left >= other.left) {
+		const int lo = other.left - abs(strength);
+		const int hi = other.left - MIN(strength, 0);
+		flags->left = target.left >= lo && target.left < hi;
 	}
 
-	if (view.top >= other.top && target.top < other.top
-			&& target.top >= other.top - strength) {
-		flags->top = 1;
-	} else if (view.bottom <= other.bottom && target.bottom > other.bottom
-			&& target.bottom <= other.bottom + strength) {
-		flags->bottom = 1;
+	if (!flags->left && view.right <= other.right) {
+		const int lo = other.right + MIN(strength, 0);
+		const int hi = other.right + abs(strength);
+		flags->right = target.right > lo && target.right <= hi;
+	}
+
+	if (view.top >= other.top) {
+		const int lo = other.top - abs(strength);
+		const int hi = other.top - MIN(strength, 0);
+		flags->top = target.top >= lo && target.top < hi;
+	}
+
+	if (!flags->top && view.bottom <= other.bottom) {
+		const int lo = other.bottom + MIN(strength, 0);
+		const int hi = other.bottom + abs(strength);
+		flags->bottom = target.bottom > lo && target.bottom <= hi;
 	}
 }
 
@@ -75,7 +83,7 @@ static void
 find_neighbor_edges(struct view *view, struct wlr_box new_geom,
 		struct border *next_edges, bool move)
 {
-	if (rc.window_edge_strength <= 0) {
+	if (rc.window_edge_strength == 0) {
 		return;
 	}
 
@@ -118,7 +126,7 @@ static void
 find_screen_edges(struct view *view, struct wlr_box new_geom,
 		struct border *next_edges, bool move)
 {
-	if (rc.screen_edge_strength <= 0) {
+	if (rc.screen_edge_strength == 0) {
 		return;
 	}
 


### PR DESCRIPTION
This includes a general refactor of the resistance logic as well as re-use of the major components to allow resistance to apply to window edges in addition to screen edges. Moving behavior seems to be correct, but there are still a couple of bugs with resizing:
- [x] Resizing to the right snaps to another window as expected
- [x] Resizing to the left or to the top does not seem to encounter any resistance
- [x] Resizing to the bottom causes strange jumps in window size