### PR TITLE
feat: move / fit to output action

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -163,6 +163,19 @@ Actions are used in menus and keyboard/mouse bindings.
 	to the center of the window. If the given output does not contain
 	any windows, the cursor is centered on the given output.
 
+*<action name="MoveToOutput" name="HDMI-A-1" direction="value" />*
+	Moves active window to other output, unless the window state is
+	fullscreen.
+
+	If *name* is specified, the window will be sent directly to the specified
+	output and *direction* is ignored. If *name* is omitted, *direction* may
+	be one of "left", "right", "up" or "down" to indicate that the window
+	should be moved to the next output in that direction (if one exists). 
+
+*<action name="FitToOutput" />*
+	Resizes active window size to width and height of the output when the
+	window size exceeds the output size.
+
 *<action name="GoToDesktop" to="value" wrap="yes" />*
 	Switch to workspace.
 

--- a/include/view.h
+++ b/include/view.h
@@ -481,6 +481,7 @@ void view_on_output_destroy(struct view *view);
 void view_connect_map(struct view *view, struct wlr_surface *surface);
 void view_destroy(struct view *view);
 
+struct output *view_get_adjacent_output(struct view *view, enum view_edge edge);
 enum view_axis view_axis_parse(const char *direction);
 enum view_edge view_edge_parse(const char *direction);
 

--- a/include/view.h
+++ b/include/view.h
@@ -414,7 +414,7 @@ void view_center(struct view *view, const struct wlr_box *ref);
  * view_place_initial - apply initial placement strategy to view
  * @view: view to be placed
  */
-void view_place_initial(struct view *view);
+void view_place_initial(struct view *view, bool allow_cursor);
 void view_constrain_size_to_that_of_usable_area(struct view *view);
 
 void view_restore_to(struct view *view, struct wlr_box geometry);

--- a/include/view.h
+++ b/include/view.h
@@ -445,6 +445,7 @@ void view_shrink_to_edge(struct view *view, enum view_edge direction);
 void view_snap_to_edge(struct view *view, enum view_edge direction,
 	bool across_outputs, bool store_natural_geometry);
 void view_snap_to_region(struct view *view, struct region *region, bool store_natural_geometry);
+void view_move_to_output(struct view *view, struct output *output);
 
 void view_move_to_front(struct view *view);
 void view_move_to_back(struct view *view);

--- a/src/action.c
+++ b/src/action.c
@@ -98,6 +98,7 @@ enum action_type {
 	ACTION_TYPE_TOGGLE_KEYBINDS,
 	ACTION_TYPE_FOCUS_OUTPUT,
 	ACTION_TYPE_MOVE_TO_OUTPUT,
+	ACTION_TYPE_FIT_TO_OUTPUT,
 	ACTION_TYPE_IF,
 	ACTION_TYPE_FOR_EACH,
 	ACTION_TYPE_VIRTUAL_OUTPUT_ADD,
@@ -150,6 +151,7 @@ const char *action_names[] = {
 	"ToggleKeybinds",
 	"FocusOutput",
 	"MoveToOutput",
+	"FitToOutput",
 	"If",
 	"ForEach",
 	"VirtualOutputAdd",
@@ -929,6 +931,12 @@ actions_run(struct view *activator, struct server *server,
 				break;
 			}
 			view_move_to_output(view, target);
+			break;
+		case ACTION_TYPE_FIT_TO_OUTPUT:
+			if (!view) {
+				break;
+			}
+			view_constrain_size_to_that_of_usable_area(view);
 			break;
 		case ACTION_TYPE_SNAP_TO_REGION:
 			if (!view) {

--- a/src/view.c
+++ b/src/view.c
@@ -1792,6 +1792,31 @@ view_snap_to_region(struct view *view, struct region *region,
 	view_apply_region_geometry(view);
 }
 
+void
+view_move_to_output(struct view *view, struct output *output)
+{
+	assert(view);
+	if (view->fullscreen) {
+		return;
+	}
+
+	view_invalidate_last_layout_geometry(view);
+	view_set_output(view, output);
+	if (view_is_floating(view)) {
+		struct wlr_box output_area = output_usable_area_in_layout_coords(output);
+		view->pending.x = output_area.x;
+		view->pending.y = output_area.y;
+		view_place_initial(view, /* allow_cursor */ false);
+	} else if (view->maximized != VIEW_AXIS_NONE) {
+		view_apply_maximized_geometry(view);
+	} else if (view->tiled) {
+		view_apply_tiled_geometry(view);
+	} else if (view->tiled_region) {
+		struct region *region = regions_from_name(view->tiled_region->name, output);
+		view_snap_to_region(view, region, /*store_natural_geometry*/ false);
+	}
+}
+
 static void
 for_each_subview(struct view *view, void (*action)(struct view *))
 {

--- a/src/view.c
+++ b/src/view.c
@@ -728,9 +728,9 @@ view_center(struct view *view, const struct wlr_box *ref)
 }
 
 void
-view_place_initial(struct view *view)
+view_place_initial(struct view *view, bool allow_cursor)
 {
-	if (rc.placement_policy == LAB_PLACE_CURSOR) {
+	if (allow_cursor && rc.placement_policy == LAB_PLACE_CURSOR) {
 		view_move_to_cursor(view);
 		return;
 	} else if (rc.placement_policy == LAB_PLACE_AUTOMATIC) {

--- a/src/view.c
+++ b/src/view.c
@@ -651,7 +651,7 @@ view_adjust_floating_geometry(struct view *view, struct wlr_box *geometry)
 		}
 	} else {
 		/*
-		 * Reposition offscreen views; if automatic placement was is
+		 * Reposition offscreen views; if automatic placement is
 		 * configured, try to automatically place the windows.
 		 */
 		if (rc.placement_policy == LAB_PLACE_AUTOMATIC) {

--- a/src/view.c
+++ b/src/view.c
@@ -1465,7 +1465,7 @@ view_on_output_destroy(struct view *view)
 	view->output = NULL;
 }
 
-static struct output *
+struct output *
 view_get_adjacent_output(struct view *view, enum view_edge edge)
 {
 	assert(view);

--- a/src/view.c
+++ b/src/view.c
@@ -763,7 +763,7 @@ view_constrain_size_to_that_of_usable_area(struct view *view)
 	}
 
 	if (available_height >= view->pending.height &&
-			available_width >= view->pending.height) {
+			available_width >= view->pending.width) {
 		return;
 	}
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -435,7 +435,7 @@ set_initial_position(struct view *view)
 	}
 
 	/* All other views are placed according to a configured strategy */
-	view_place_initial(view);
+	view_place_initial(view, /* allow_cursor */ true);
 }
 
 static const char *

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -519,7 +519,7 @@ set_initial_position(struct view *view,
 		view_constrain_size_to_that_of_usable_area(view);
 
 		if (view_is_floating(view)) {
-			view_place_initial(view);
+			view_place_initial(view, /* allow_cursor */ true);
 		} else {
 			/*
 			 * View is maximized/fullscreen. Center the


### PR DESCRIPTION
As a follow up to https://github.com/labwc/labwc/discussions/1374#discussioncomment-8070782 I wanted to give "~Send~MoveToOutput" another try.

~I guess I'm quite close but I need some hints how to  finish. Playing with it, my code seems to work for snapped and tiled windows,  but I fail at floating windows. What I had in mind was just moving a floating window to the other output and then position it like it was newly started, thus placed and resized according to placement policy (centered or natural). But somehow I haven't found the correct functions for that. Any hints?~