### PR TITLE
meson.build: install badges for labwc and migrate to data/ 

### DIFF
--- a/data/labwc-symbolic.svg
+++ b/data/labwc-symbolic.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--labwc logo #2 (C) Johan Malm LICENSE: CC BY-SA 4.0-->
+<svg xmlns="http://www.w3.org/2000/svg" width="256px" height="256px"
+     viewbox="0 0 256 256"
+     stroke-linecap="round" stroke-linejoin="round" stroke-width="12">
+  <path fill="#ffffff" stroke="#ffffff" d="m 26 68 91 55 v 108 l -76 -61 z" />
+  <path fill="#000000" stroke="#000000" d="m 229 68 -91 55 v 108 l 76 -61 z" />
+</svg>

--- a/data/labwc.desktop
+++ b/data/labwc.desktop
@@ -2,5 +2,6 @@
 Name=labwc
 Comment=A wayland stacking compositor
 Exec=labwc
+Icon=labwc
 Type=Application
 DesktopNames=wlroots

--- a/data/labwc.svg
+++ b/data/labwc.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--labwc logo #2 (C) Johan Malm LICENSE: CC BY-SA 4.0-->
+<svg xmlns="http://www.w3.org/2000/svg" width="256px" height="256px"
+     viewbox="0 0 256 256"
+     stroke-linecap="round" stroke-linejoin="round" stroke-width="12">
+  <path fill="#f0d70f" stroke="#f0d70f" d="m 26 68 91 55 v 108 l -76 -61 z" />
+  <path fill="#d02f90" stroke="#d02f90" d="m 229 68 -91 55 v 108 l 76 -61 z" />
+</svg>

--- a/meson.build
+++ b/meson.build
@@ -134,4 +134,10 @@ executable(
   install: true,
 )
 
-install_data('docs/labwc.desktop', install_dir: get_option('datadir') / 'wayland-sessions')
+install_data('data/labwc.desktop', install_dir: get_option('datadir') / 'wayland-sessions')
+
+icons = ['labwc-symbolic.svg', 'labwc.svg']
+foreach icon : icons
+  icon_path = join_paths('data', icon)
+  install_data(icon_path, install_dir: get_option('datadir') / 'icons/hicolor/scalable/apps')
+endforeach


### PR DESCRIPTION
A .desktop file was previously added for the labwc session, this adds a
badge for it where it is supported. The .desktop files and the badges
are also moved to `data/`.

Ref: #36, 9fa783e, labwc/labwc-artwork#7

An example from lightdm:

Before:
![2024-01-22_15-27-37](https://github.com/labwc/labwc/assets/10281587/980947b5-1254-4bf1-97d4-b9d1969f1e03)

After:
![2024-01-22_15-48-12](https://github.com/labwc/labwc/assets/10281587/369e6bc9-a421-4101-bcad-b78ea9d85105)