### PR TITLE
interactive: unify interactive_{cancel,finish} where possible

### DIFF
--- a/src/interactive.c
+++ b/src/interactive.c
@@ -196,24 +196,18 @@ snap_to_region(struct view *view)
 void
 interactive_finish(struct view *view)
 {
-	if (view->server->grabbed_view == view) {
-		regions_hide_overlay(&view->server->seat);
-		if (view->server->input_mode == LAB_INPUT_STATE_MOVE) {
-			if (!snap_to_region(view)) {
-				if (!snap_to_edge(view)) {
-					/* Reset tiled state if not snapped */
-					view_set_untiled(view);
-				}
-			}
-		}
-		resize_indicator_hide(view);
-
-		view->server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
-		view->server->grabbed_view = NULL;
-
-		/* Update focus/cursor image */
-		cursor_update_focus(view->server);
+	if (view->server->grabbed_view != view) {
+		return;
 	}
+
+	if (view->server->input_mode == LAB_INPUT_STATE_MOVE) {
+		/* Reset tiled state if not snapped */
+		if (!snap_to_region(view) && !snap_to_edge(view)) {
+			view_set_untiled(view);
+		}
+	}
+
+	interactive_cancel(view);
 }
 
 /*
@@ -224,11 +218,17 @@ interactive_finish(struct view *view)
 void
 interactive_cancel(struct view *view)
 {
-	if (view->server->grabbed_view == view) {
-		resize_indicator_hide(view);
-		view->server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
-		view->server->grabbed_view = NULL;
-		/* Update focus/cursor image */
-		cursor_update_focus(view->server);
+	if (view->server->grabbed_view != view) {
+		return;
 	}
+
+	regions_hide_overlay(&view->server->seat);
+
+	resize_indicator_hide(view);
+
+	view->server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
+	view->server->grabbed_view = NULL;
+
+	/* Update focus/cursor image */
+	cursor_update_focus(view->server);
 }


### PR DESCRIPTION
This also fixes a bug wherein dragging a window and pressing a hot-key to maximize or fullscreen a window could leave a snap-region highlight visible after the interactive move was canceled.

To reproduce the issue, define an arbitrary snap region and assign a keybind like `W-f`, that will fullscreen a window. The `Super` key also causes regions to be highlighted during interactive moves, so start dragging a window, press and hold `Super` to highlight the snap region, and press `f` to fullscreen the window. Release the mouse button and press the `W-f` keybind to bring the window out of fullscreen. The snap region will still be highlighted until another interactive move triggers it to disappear.