### PR TITLE
Gap-handling fixes for placement, resistance

### DIFF
--- a/src/placement.c
+++ b/src/placement.c
@@ -418,18 +418,26 @@ placement_find_best(struct view *view, struct wlr_box *geometry)
 		return false;
 	}
 
-	/* Default placement is just the upper-left corner of the output */
+	/* Default placement is upper-left corner, respecting gaps */
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
-	geometry->x = usable.x + margin.left;
-	geometry->y = usable.y + margin.top;
+	geometry->x = usable.x + margin.left + rc.gap;
+	geometry->y = usable.y + margin.top + rc.gap;
 
 	/* Build the placement grid and overlap bitmap */
 	struct overlap_bitmap bmp = { 0 };
 	build_grid(&bmp, view);
 	build_overlap(&bmp, view);
 
-	int height = geometry->height + margin.top + margin.bottom;
-	int width = geometry->width + margin.left + margin.right;
+	/* Dimensions include gap along all edges to ensure proper separation */
+	int height = geometry->height + margin.top + margin.bottom + 2 * rc.gap;
+	int width = geometry->width + margin.left + margin.right + 2 * rc.gap;
+
+	/*
+	 * Overlap search identifies corners of the target region; view
+	 * coordinates must by set in by the SSD margin and user gaps.
+	 */
+	int offset_x = margin.left + rc.gap;
+	int offset_y = margin.top + rc.gap;
 
 	int min_overlap = INT_MAX;
 
@@ -488,18 +496,20 @@ placement_find_best(struct view *view, struct wlr_box *geometry)
 
 				if (rt) {
 					/* Extend window right from left edge */
-					geometry->x = bmp.cols[j] + margin.left;
+					geometry->x = bmp.cols[j] + offset_x;
 				} else {
 					/* Extend window left from right edge */
-					geometry->x = bmp.cols[j + 1] - width + margin.left;
+					geometry->x =
+						bmp.cols[j + 1] - width + offset_x;
 				}
 
 				if (dn) {
 					/* Extend window down from top edge */
-					geometry->y = bmp.rows[i] + margin.top;
+					geometry->y = bmp.rows[i] + offset_y;
 				} else {
 					/* Extend window up from bottom edge */
-					geometry->y = bmp.rows[i + 1] - height + margin.top;
+					geometry->y =
+						bmp.rows[i + 1] - height + offset_y;
 				}
 
 				/* If there is no overlap, the search is done. */

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -46,16 +46,19 @@ build_view_edges(struct view *view, struct wlr_box new_geom,
 	/* Use the effective height to properly snap shaded views */
 	int eff_height = view_effective_height(view, /* use_pending */ false);
 
-	view_edges->left = view->current.x - border.left + (move ? 1 : 0);
-	view_edges->top = view->current.y - border.top + (move ? 1 : 0);
-	view_edges->right = view->current.x + view->current.width + border.right;
-	view_edges->bottom = view->current.y + eff_height + border.bottom;
+	view_edges->left = view->current.x - border.left - rc.gap + (move ? 1 : 0);
+	view_edges->top = view->current.y - border.top - rc.gap + (move ? 1 : 0);
+	view_edges->right =
+		view->current.x + view->current.width + border.right + rc.gap;
+	view_edges->bottom =
+		view->current.y + eff_height + border.bottom + rc.gap;
 
-	target_edges->left = new_geom.x - border.left;
-	target_edges->top = new_geom.y - border.top;
-	target_edges->right = new_geom.x + new_geom.width + border.right;
+	target_edges->left = new_geom.x - border.left - rc.gap;
+	target_edges->top = new_geom.y - border.top - rc.gap;
+	target_edges->right =
+		new_geom.x + new_geom.width + border.right + rc.gap;
 	target_edges->bottom = new_geom.y + border.bottom +
-		(view->shaded ? 0 : new_geom.height);
+		(view->shaded ? 0 : new_geom.height) + rc.gap;
 }
 
 static void
@@ -189,15 +192,15 @@ resistance_move_apply(struct view *view, double *x, double *y)
 	find_neighbor_edges(view, new_geom, &next_edges, /* move */ true);
 
 	if (next_edges.left > INT_MIN) {
-		*x = next_edges.left + border.left;
+		*x = next_edges.left + border.left + rc.gap;
 	} else if (next_edges.right < INT_MAX) {
-		*x = next_edges.right - view->current.width - border.right;
+		*x = next_edges.right - view->current.width - border.right - rc.gap;
 	}
 
 	if (next_edges.top > INT_MIN) {
-		*y = next_edges.top + border.top;
+		*y = next_edges.top + border.top + rc.gap;
 	} else if (next_edges.bottom < INT_MAX) {
-		*y = next_edges.bottom - border.bottom
+		*y = next_edges.bottom - border.bottom - rc.gap
 			- view_effective_height(view, /* use_pending */ false);
 	}
 }
@@ -222,27 +225,27 @@ resistance_resize_apply(struct view *view, struct wlr_box *new_geom)
 
 	if (view->server->resize_edges & WLR_EDGE_LEFT) {
 		if (next_edges.left > INT_MIN) {
-			new_geom->x = next_edges.left + border.left;
+			new_geom->x = next_edges.left + border.left + rc.gap;
 			new_geom->width = view->current.width
 				+ view->current.x - new_geom->x;
 		}
 	} else if (view->server->resize_edges & WLR_EDGE_RIGHT) {
 		if (next_edges.right < INT_MAX) {
 			new_geom->width = next_edges.right
-				- view->current.x - border.right;
+				- view->current.x - border.right - rc.gap;
 		}
 	}
 
 	if (view->server->resize_edges & WLR_EDGE_TOP) {
 		if (next_edges.top > INT_MIN) {
-			new_geom->y = next_edges.top + border.top;
+			new_geom->y = next_edges.top + border.top + rc.gap;
 			new_geom->height = view->current.height
 				+ view->current.y - new_geom->y;
 		}
 	} else if (view->server->resize_edges & WLR_EDGE_BOTTOM) {
 		if (next_edges.bottom < INT_MAX) {
 			new_geom->height = next_edges.bottom
-				- view->current.y - border.bottom;
+				- view->current.y - border.bottom - rc.gap;
 		}
 	}
 }


### PR DESCRIPTION
There were a couple of... gaps... in my thinking about placement and resistance with respect to `rc.gap`:
- When initially placing windows, gaps should be considered during overlap calculation, and respected when actually positioning the window.
- Although I initially dismissed the idea of considering gaps in resistance calculations, playing around with nonzero gaps and dragging around windows convinces me that it feels more "natural" to respect the gap, especially because the `MoveToEdge` and `GrowToEdge` actions consider gaps. Resistance and attraction during interactive moves just feels better when it is encountered at points consistent with the actions.

In both places, this is accomplished by effectively increasing the size of the window being moved (or to be placed) to account for the gap, and then remembering to consider that extra padding when the time comes to actually set the view geometry. This seems to be the simplest approach and, in my testing, seems to produce the right results.