### PR TITLE
xwayland: prevent crash due to unexpected surface dissociate events

### DIFF
--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -135,6 +135,19 @@ handle_dissociate(struct wl_listener *listener, void *data)
 	struct xwayland_unmanaged *unmanaged =
 		wl_container_of(listener, unmanaged, dissociate);
 
+	if (!unmanaged->mappable.connected) {
+		/*
+		 * In some cases wlroots fails to emit the associate event
+		 * due to an early return in xwayland_surface_associate().
+		 * This is arguably a wlroots bug, but nevertheless it
+		 * should not bring down labwc.
+		 *
+		 * TODO: Potentially remove when starting to track
+		 *       wlroots 0.18 and it got fixed upstream.
+		 */
+		wlr_log(WLR_ERROR, "dissociate received before associate");
+		return;
+	}
 	mappable_disconnect(&unmanaged->mappable);
 }
 
@@ -225,6 +238,9 @@ xwayland_unmanaged_create(struct server *server,
 	CONNECT_SIGNAL(xsurface, unmanaged, request_configure);
 	CONNECT_SIGNAL(xsurface, unmanaged, set_override_redirect);
 
+	if (xsurface->surface) {
+		handle_associate(&unmanaged->associate, NULL);
+	}
 	if (mapped) {
 		handle_map(&unmanaged->mappable.map, NULL);
 	}

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -252,6 +252,19 @@ handle_dissociate(struct wl_listener *listener, void *data)
 	struct xwayland_view *xwayland_view =
 		wl_container_of(listener, xwayland_view, dissociate);
 
+	if (!xwayland_view->base.mappable.connected) {
+		/*
+		 * In some cases wlroots fails to emit the associate event
+		 * due to an early return in xwayland_surface_associate().
+		 * This is arguably a wlroots bug, but nevertheless it
+		 * should not bring down labwc.
+		 *
+		 * TODO: Potentially remove when starting to track
+		 *       wlroots 0.18 and it got fixed upstream.
+		 */
+		wlr_log(WLR_ERROR, "dissociate received before associate");
+		return;
+	}
 	mappable_disconnect(&xwayland_view->base.mappable);
 }
 
@@ -855,6 +868,9 @@ xwayland_view_create(struct server *server,
 
 	wl_list_insert(&view->server->views, &view->link);
 
+	if (xsurface->surface) {
+		handle_associate(&xwayland_view->associate, NULL);
+	}
 	if (mapped) {
 		xwayland_view_map(view);
 	}


### PR DESCRIPTION
Fixes
- #1360
- #1466

Follow-up from
- #1470

Not personally tested but code LGTM.
Originally written by @jlindgren90, I only added the `TODO` comment and modified the commit body to close the 2 issues.