### PR TITLE
docs/environment: remove MOZ_ENABLE_WAYLAND variable

### DIFF
--- a/docs/environment
+++ b/docs/environment
@@ -23,12 +23,6 @@
 # XKB_DEFAULT_OPTIONS=grp:shift_caps_toggle
 
 ##
-## Force firefox to use wayland backend.
-##
-
-# MOZ_ENABLE_WAYLAND=1
-
-##
 ## Set cursor theme and size. Find system icons themes with:
 ## `find /usr/share/icons/ -type d -name "cursors"`
 ##


### PR DESCRIPTION
Starting with version 121, Firefox enables Wayland by default: https://bugzilla.mozilla.org/show_bug.cgi?id=1752398.