### PR TITLE
view: ensure midpoint is visible on layout change

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -392,7 +392,6 @@ void view_moved(struct view *view);
 void view_minimize(struct view *view, bool minimized);
 bool view_compute_centered_position(struct view *view,
 	const struct wlr_box *ref, int w, int h, int *x, int *y);
-bool view_adjust_floating_geometry(struct view *view, struct wlr_box *geometry);
 void view_store_natural_geometry(struct view *view);
 
 /**


### PR DESCRIPTION
When restoring a window's natural geometry during a layout change, require a stricter definition of "visible": either a window's midpoint must be visible, or it will be repositioned. We still respect a mostly-offscreen natural geometry when restoring in an unchanged layout.

Fixes: #1476.