### PR TITLE
src/ssd: allow invisible resize area across outputs

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -124,7 +124,7 @@ struct view {
 	struct wl_list link;
 
 	/*
-	 * The output that the view is displayed on. Specifically:
+	 * The primary output that the view is displayed on. Specifically:
 	 *
 	 *  - For floating views, this is the output nearest to the
 	 *    center of the view. It is computed automatically when the
@@ -139,6 +139,16 @@ struct view {
 	 * by calling view_set_output() beforehand.
 	 */
 	struct output *output;
+
+	/*
+	 * The outputs that the view is displayed on.
+	 * This is used to notify the foreign toplevel
+	 * implementation and to update the SSD invisible
+	 * resize area.
+	 * It is a bitset of output->scene_output->index.
+	 */
+	uint64_t outputs;
+
 	struct workspace *workspace;
 	struct wlr_surface *surface;
 	struct wlr_scene_tree *scene_tree;
@@ -460,6 +470,7 @@ void view_move_to_front(struct view *view);
 void view_move_to_back(struct view *view);
 struct view *view_get_root(struct view *view);
 void view_append_children(struct view *view, struct wl_array *children);
+bool view_on_output(struct view *view, struct output *output);
 
 /**
  * view_is_related() - determine if view and surface are owned by the

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -107,11 +107,10 @@ void
 foreign_toplevel_update_outputs(struct view *view)
 {
 	assert(view->toplevel.handle);
-	struct wlr_output_layout *layout = view->server->output_layout;
+
 	struct output *output;
 	wl_list_for_each(output, &view->server->outputs, link) {
-		if (output_is_usable(output) && wlr_output_layout_intersects(
-				layout, output->wlr_output, &view->current)) {
+		if (view_on_output(view, output)) {
 			wlr_foreign_toplevel_handle_v1_output_enter(
 				view->toplevel.handle, output->wlr_output);
 		} else {


### PR DESCRIPTION
 This PR
- adds a new `view->outputs` bitset to store the calculation result of the intersection with \*all\* outputs the view is currently visible on. It is replacing the intersection in `src/foreign.c` to notify panels about the outputs so the result can be used for other cases like the invisible resize area around windows.
- uses the new `view->outputs` bitset in `src/ssd/ssd_extents.c`

This ensures that the invisible resize handle works across outputs
while still making sure that it won't leak into neighboring ones just
because it is positioned closely to an output edge (either manually,
maximized or snapped via SnapToEdge or SnapToRegion).

Fixes: #1486
Reported-By: @lurch

TODO:
- [x] remove the last `[wip]` commit that visualizes the invisible resize area to ease testing