### PR TITLE
edges: limit edge attraction and resistance...

### DIFF
--- a/include/edges.h
+++ b/include/edges.h
@@ -50,6 +50,15 @@ edge_get_best(int next, int edge, bool decreasing)
 	return decreasing ? MAX(next, edge) : MIN(next, edge);
 }
 
+struct edge {
+	/* Position of an edge along the axis perpendicular to it */
+	int offset;
+
+	/* Limits of edge along axis parallel to it */
+	int min;
+	int max;
+};
+
 /*
  * edge_validator_t - edge validator signature
  * @best: pointer to the current "best" edge
@@ -57,16 +66,13 @@ edge_get_best(int next, int edge, bool decreasing)
  * @target: position to which the moving edge will be moved
  * @oppose: opposing edge of encountered region
  * @align: aligned edge of encountered region
- * @lesser: true if moving edge is top or left edge; false otherwise
  *
  * This function will be used by edge_find_neighbors and edge_find_outputs to
  * validate and select the "best" output or neighbor edge against which a
  * moving edge should be snapped. The moving edge has current position
  * "current" and desired position "target". The validator should determine
  * whether motion of the crosses the given opposed and aligned edges of a trial
- * region and should be considered a snap point. An edge is "lesser" if it
- * occupies a smaller coordinate than the opposite edge of the view region
- * (i.e., it is a top or left edge).
+ * region and should be considered a snap point.
  *
  * Opposing edges are on the opposite side of the target region from the moving
  * edge (i.e., left <-> right, top <-> bottom). When the moving edge snaps to
@@ -85,8 +91,8 @@ edge_get_best(int next, int edge, bool decreasing)
  * region edge (oppose or align) should be a preferred snap point, it should
  * update the value of *best accordingly.
  */
-typedef void (*edge_validator_t)(int *best,
-	int current, int target, int oppose, int align, bool lesser);
+typedef void (*edge_validator_t)(int *best, struct edge current,
+	struct edge target, struct edge oppose, struct edge align);
 
 void edges_initialize(struct border *edges);
 
@@ -106,5 +112,7 @@ void edges_adjust_move_coords(struct view *view, struct border edges,
 
 void edges_adjust_resize_geom(struct view *view, struct border edges,
 	uint32_t resize_edges, struct wlr_box *geom, bool use_pending);
+
+bool edges_traverse_edge(struct edge current, struct edge target, struct edge edge);
 
 #endif /* LABWC_EDGES_H */

--- a/include/view.h
+++ b/include/view.h
@@ -349,6 +349,15 @@ enum view_wants_focus view_wants_focus(struct view *view);
 bool view_is_focusable_from(struct view *view, struct wlr_surface *prev);
 
 /**
+ * view_edge_invert() - select the opposite of a provided edge
+ *
+ * VIEW_EDGE_CENTER and VIEW_EDGE_INVALID both map to VIEW_EDGE_INVALID.
+ *
+ * @edge: edge to be inverted
+ */
+enum view_edge view_edge_invert(enum view_edge edge);
+
+/**
  * view_is_focusable() - Check whether or not a view can be focused
  * @view: view to be checked
  *

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -10,11 +10,16 @@
 #include "view.h"
 
 static void
-check_edge(int *next, int current, int target,
-		int oppose, int align, bool lesser, int tolerance)
+check_edge(int *next, struct edge current, struct edge target,
+		struct edge oppose, struct edge align, int tolerance)
 {
+	int cur = current.offset;
+	int tgt = target.offset;
+	int opp = oppose.offset;
+	int aln = align.offset;
+
 	/* Ignore non-moving edges */
-	if (current == target) {
+	if (cur == tgt) {
 		return;
 	}
 
@@ -32,56 +37,56 @@ check_edge(int *next, int current, int target,
 	 */
 
 	/* Direction of motion for the edge */
-	const bool decreasing = target < current;
+	const bool decreasing = tgt < cur;
 
 	/* Check the opposing edge */
 	bool valid = false;
 	if (decreasing) {
-		const int lo = clipped_sub(oppose, abs(tolerance));
-		const int hi = clipped_sub(oppose, MIN(tolerance, 0));
-		valid = target >= lo && target < hi;
+		const int lo = clipped_sub(opp, abs(tolerance));
+		const int hi = clipped_sub(opp, MIN(tolerance, 0));
+		valid = tgt >= lo && tgt < hi;
 	} else {
 		/* Check for increasing movement across opposing edge */
-		const int lo = clipped_add(oppose, MIN(tolerance, 0));
-		const int hi = clipped_add(oppose, abs(tolerance));
-		valid = target > lo && target <= hi;
+		const int lo = clipped_add(opp, MIN(tolerance, 0));
+		const int hi = clipped_add(opp, abs(tolerance));
+		valid = tgt > lo && tgt <= hi;
 	}
 
-	if (valid) {
-		*next = edge_get_best(*next, oppose, decreasing);
+	if (valid && edges_traverse_edge(current, target, oppose)) {
+		*next = edge_get_best(*next, opp, decreasing);
 	}
 
 	/* Check the aligned edge */
 	valid = false;
 	if (decreasing) {
-		const int lo = clipped_sub(align, abs(tolerance));
-		const int hi = clipped_sub(align, MIN(tolerance, 0));
-		valid = target >= lo && target < hi;
+		const int lo = clipped_sub(aln, abs(tolerance));
+		const int hi = clipped_sub(aln, MIN(tolerance, 0));
+		valid = tgt >= lo && tgt < hi;
 	} else {
-		const int lo = clipped_add(align, MIN(tolerance, 0));
-		const int hi = clipped_add(align, abs(tolerance));
-		valid = target > lo && target <= hi;
+		const int lo = clipped_add(aln, MIN(tolerance, 0));
+		const int hi = clipped_add(aln, abs(tolerance));
+		valid = tgt > lo && tgt <= hi;
 	}
 
-	if (valid) {
-		*next = edge_get_best(*next, align, decreasing);
+	if (valid && edges_traverse_edge(current, target, align)) {
+		*next = edge_get_best(*next, aln, decreasing);
 	}
 }
 
 static void
-check_edge_output(int *next, int current, int target,
-		int oppose, int align, bool lesser)
+check_edge_output(int *next, struct edge current, struct edge target,
+		struct edge oppose, struct edge align)
 {
 	check_edge(next, current, target,
-		oppose, align, lesser, rc.screen_edge_strength);
+		oppose, align, rc.screen_edge_strength);
 }
 
 static void
-check_edge_window(int *next, int current, int target,
-		int oppose, int align, bool lesser)
+check_edge_window(int *next, struct edge current, struct edge target,
+		struct edge oppose, struct edge align)
 {
 	check_edge(next, current, target,
-		oppose, align, lesser, rc.window_edge_strength);
+		oppose, align, rc.window_edge_strength);
 }
 
 void

--- a/src/snap.c
+++ b/src/snap.c
@@ -12,9 +12,15 @@
 #include "view.h"
 
 static void
-check_edge(int *next, int current, int target, int oppose, int align, bool lesser)
+check_edge(int *next, struct edge current, struct edge target,
+		struct edge oppose, struct edge align)
 {
-	if (current == target) {
+	int cur = current.offset;
+	int tgt = target.offset;
+	int opp = oppose.offset;
+	int aln = align.offset;
+
+	if (cur == tgt) {
 		return;
 	}
 
@@ -32,18 +38,16 @@ check_edge(int *next, int current, int target, int oppose, int align, bool lesse
 	 */
 
 	/* Direction of motion for the edge */
-	const bool decreasing = target < current;
+	const bool decreasing = tgt < cur;
 
 	/* Check the opposing edge */
-	if ((target <= oppose && oppose < current) ||
-			(current < oppose && oppose <= target)) {
-		*next = edge_get_best(*next, oppose, decreasing);
+	if ((tgt <= opp && opp < cur) || (cur < opp && opp <= tgt)) {
+		*next = edge_get_best(*next, opp, decreasing);
 	}
 
 	/* Check the aligned edge */
-	if ((target <= align && align < current) ||
-			(current < align && align <= target)) {
-		*next = edge_get_best(*next, align, decreasing);
+	if ((tgt <= aln && aln < cur) || (cur < aln && aln <= tgt)) {
+		*next = edge_get_best(*next, aln, decreasing);
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -193,7 +193,7 @@ view_is_focusable_from(struct view *view, struct wlr_surface *prev)
  * They may be called repeatably during output layout changes.
  */
 
-static enum view_edge
+enum view_edge
 view_edge_invert(enum view_edge edge)
 {
 	switch (edge) {


### PR DESCRIPTION
...to edges actually encountered by motion during interactive moves and resizes.

A new `edges_traverse_edge` function determines if the motion of an edge (a move as well as a resize) actually encounters the finite edge of another region. This is used in the `check_edges` routine of `resistance.c` to limit considered edges to those that are actually traversed during an interactive move. The `check_edges` of `snap.c` still considers edges to be infinitely long, so keyboard actions that move windows will snap to an imaginary grid defined by the extension of all window edges. (This could be extended with, *e.g.*, a configuration option that optionall invokes `edges_traverse_edge` in that case as well.)

In addition, edges for minimized windows are ignored in all cases.