### PR TITLE
view: cancel interactive resize when shading

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2126,6 +2126,11 @@ view_set_shade(struct view *view, bool shaded)
 		return;
 	}
 
+	/* If this window is being resized, cancel the resize when shading */
+	if (shaded && view->server->input_mode == LAB_INPUT_STATE_RESIZE) {
+		interactive_cancel(view);
+	}
+
 	view->shaded = shaded;
 	ssd_enable_shade(view->ssd, view->shaded);
 	wlr_scene_node_set_enabled(view->scene_node, !view->shaded);


### PR DESCRIPTION
Resizing is forbidden on shaded views, and `resistance_resize_apply` asserts that `view->shaded` is false. This can trigger a crash during interactive resizes if a `ToggleShade` action is triggered. We can either ignore shade requests in `view_set_shade` if the view is interactively resizing, or cancel the interactive resize. The latter feels more natural. `interactive_cancel` is a no-op if the passed view is not the grabbed interactive view, so it should be safe to (try to) cancel interactivity even if the grabbed view is not the one being shaded.