### PR TITLE
edges: do not apply resistance to invisible edges

### DIFF
--- a/include/edges.h
+++ b/include/edges.h
@@ -3,11 +3,15 @@
 #define LABWC_EDGES_H
 
 #include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include "common/macros.h"
 
 struct border;
 struct output;
+struct server;
 struct view;
+struct wlr_box;
 
 static inline int
 clipped_add(int a, int b)
@@ -102,7 +106,7 @@ void edges_adjust_geom(struct view *view, struct border edges,
 
 void edges_find_neighbors(struct border *nearest_edges, struct view *view,
 	struct wlr_box target, struct output *output,
-	edge_validator_t validator, bool use_pending);
+	edge_validator_t validator, bool use_pending, bool ignore_hidden);
 
 void edges_find_outputs(struct border *nearest_edges, struct view *view,
 	struct wlr_box target, struct output *output,
@@ -116,4 +120,5 @@ void edges_adjust_resize_geom(struct view *view, struct border edges,
 
 bool edges_traverse_edge(struct edge current, struct edge target, struct edge edge);
 
+void edges_calculate_visibility(struct server *server, struct view *ignored_view);
 #endif /* LABWC_EDGES_H */

--- a/include/view.h
+++ b/include/view.h
@@ -166,6 +166,7 @@ struct view {
 	bool tearing_hint;
 	bool visible_on_all_workspaces;
 	enum view_edge tiled;
+	uint32_t edges_visible;  /* enum wlr_edges bitset */
 	bool inhibits_keybinds;
 	xkb_layout_index_t keyboard_layout;
 

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "edges.h"
 #include "input/keyboard.h"
 #include "labwc.h"
 #include "regions.h"
@@ -122,6 +123,9 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 	server->resize_edges = edges;
 	if (rc.resize_indicator) {
 		resize_indicator_show(view);
+	}
+	if (rc.window_edge_strength) {
+		edges_calculate_visibility(server, view);
 	}
 }
 

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -114,8 +114,9 @@ resistance_move_apply(struct view *view, double *x, double *y)
 
 	if (rc.window_edge_strength != 0) {
 		/* Find any relevant window edges encountered by this move */
-		edges_find_neighbors(&next_edges, view, target, NULL,
-			check_edge_window, /* use_pending */ false);
+		edges_find_neighbors(&next_edges,
+			view, target, NULL, check_edge_window,
+			/* use_pending */ false, /* ignore_hidden */ true);
 	}
 
 	/* If any "best" edges were encountered during this move, snap motion */
@@ -143,8 +144,9 @@ resistance_resize_apply(struct view *view, struct wlr_box *new_geom)
 
 	if (rc.window_edge_strength != 0) {
 		/* Find any relevant window edges encountered by this move */
-		edges_find_neighbors(&next_edges, view, *new_geom, NULL,
-			check_edge_window, /* use_pending */ false);
+		edges_find_neighbors(&next_edges,
+			view, *new_geom, NULL, check_edge_window,
+			/* use_pending */ false, /* ignore_hidden */ true);
 	}
 
 	/* If any "best" edges were encountered during this move, snap motion */

--- a/src/snap.c
+++ b/src/snap.c
@@ -121,8 +121,9 @@ snap_move_to_edge(struct view *view, enum view_edge direction,
 		struct border next_edges;
 		edges_initialize(&next_edges);
 
-		edges_find_neighbors(&next_edges, view, target,
-			output, check_edge, /* use_pending */ true);
+		edges_find_neighbors(&next_edges,
+			view, target, output, check_edge,
+			/* use_pending */ true, /* ignore_hidden */ false);
 
 		/* If any "best" edges were encountered, limit motion */
 		edges_adjust_move_coords(view, next_edges,
@@ -196,8 +197,9 @@ snap_grow_to_next_edge(struct view *view, enum view_edge direction,
 	edges_initialize(&next_edges);
 
 	/* Limit motion to any intervening edge of other views on this output */
-	edges_find_neighbors(&next_edges, view, *geo,
-		output, check_edge, /* use_pending */ true);
+	edges_find_neighbors(&next_edges,
+		view, *geo, output, check_edge,
+		/* use_pending */ true, /* ignore_hidden */ false);
 	edges_adjust_resize_geom(view, next_edges,
 		resize_edges, geo, /* use_pending */ true);
 }
@@ -255,8 +257,9 @@ snap_shrink_to_next_edge(struct view *view, enum view_edge direction,
 		view->output, check_edge, /* use_pending */ true);
 
 	/* Limit motion to any intervening edge of ther views on this output */
-	edges_find_neighbors(&next_edges, view, *geo,
-		view->output, check_edge, /* use_pending */ true);
+	edges_find_neighbors(&next_edges,
+		view, *geo, view->output, check_edge,
+		/* use_pending */ true, /* ignore_hidden */ false);
 
 	edges_adjust_resize_geom(view, next_edges,
 		resize_edges, geo, /* use_pending */ true);


### PR DESCRIPTION
This is mostly the work of @Consolatis, in the [`feature/invisible_edge_snapping`](https://github.com/Consolatis/labwc/tree/feature/invisibile_edge_snapping) branch, to ignore invisible edges when applying resistance:
1. At the start of interactive operations on a particular view, the scene graph is walked to build, for each view, a bitfield of currently visible edges *without regard for the view receiving interaction*.
2. In `edges_find_neighbors`, all views which have no visible edges are skipped completely, unless the `ignore_hidden` flag is set to false (this is done for action-based snapping).
3. The standard validation done by the edge engine is modified so that any invisible edge is effectively moved out to infinity, which should remove it from consideration for snapping.

While I was cleaning up the changes and fixing my broken first attempt at making the edge engine ignore the invisibles, I also dropped the `enum view_edge` in favor of `enum wlr_edges`, which is both more relevant and used for new visibility calculations.

I've run through some tests and this seems to work as intended, although more thorough testing is appropriate.