### PR TITLE
Add fallback output

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -337,6 +337,9 @@ struct server {
 
 	struct menu *menu_current;
 	struct wl_list menus;
+
+	struct wl_event_source *destroy_timeout;
+	bool fallback_output;
 };
 
 #define LAB_NR_LAYERS (4)

--- a/src/output.c
+++ b/src/output.c
@@ -143,7 +143,7 @@ output_destroy_notify(struct wl_listener *listener, void *data)
 	free(output);
 
 	if (server->fallback_output && wl_list_length(&server->outputs) == 0) {
-		output_add_virtual(server, "HEADLESS");
+		output_add_virtual(server, "NOOP-1");
 	}
 }
 
@@ -199,7 +199,7 @@ static int
 handle_virtual_output_destroy_timeout(void *data)
 {
 	struct server *server = data;
-	output_remove_virtual(server, "HEADLESS");
+	output_remove_virtual(server, "NOOP-1");
 	wl_event_source_remove(server->destroy_timeout);
 	server->destroy_timeout = NULL;
 	return 0;
@@ -417,7 +417,7 @@ output_init(struct server *server)
 	output_manager_init(server);
 
 	if (getenv("LABWC_FALLBACK_OUTPUT")) {
-		output_add_virtual(server, "HEADLESS");
+		output_add_virtual(server, "NOOP-1");
 		server->destroy_timeout = NULL;
 		server->fallback_output = true;
 	} else {


### PR DESCRIPTION
This PR adds the ability to automatically enable a fallback output when there are no physical displays connected, to address the issue at https://github.com/any1/wayvnc/issues/286

The environment variable LABWC_FALLBACK_OUTPUT needs to be set to enable the new behaviour - if that is not set, no fallback output is created.

If that variable is set, then a default output called HEADLESS is created whenever there are no physical displays connected, and is destroyed as soon as a physical display is connected. This means that it is always possible to create a VNC connection to the compositor.

I am not sure this is the correct way to enable this behaviour, but it seems to work reliably in my testing, and is similar to the approach taken on wayfire to achieve the same functionality.