### PR TITLE
xwayland: set initial geometry in map_request handler

### DIFF
--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -69,6 +69,7 @@ struct xwayland_view {
 	struct wl_listener set_override_redirect;
 	struct wl_listener set_strut_partial;
 	struct wl_listener set_window_type;
+	struct wl_listener map_request;
 
 	/* Not (yet) implemented */
 /*	struct wl_listener set_role; */


### PR DESCRIPTION
Set the initial geometry of maximized/fullscreen views before actually mapping them, so that they can do their initial layout and drawing with the correct geometry. This avoids visual glitches and also avoids undesired layout changes with some apps (e.g. HomeBank).
    
Depends on: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4546
    
Fixes:
- #1320