### PR TITLE
xwayland: use _NET_WM_WINDOW_TYPE to fix focus issues

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -108,8 +108,6 @@ struct view_impl {
 	void (*move_to_back)(struct view *view);
 	struct view *(*get_root)(struct view *self);
 	void (*append_children)(struct view *self, struct wl_array *children);
-	/* determines if view and surface are owned by the same process */
-	bool (*is_related)(struct view *self, struct wlr_surface *surface);
 	struct view_size_hints (*get_size_hints)(struct view *self);
 	/* if not implemented, VIEW_WANTS_FOCUS_ALWAYS is assumed */
 	enum view_wants_focus (*wants_focus)(struct view *self);
@@ -461,13 +459,6 @@ void view_move_to_back(struct view *view);
 struct view *view_get_root(struct view *view);
 void view_append_children(struct view *view, struct wl_array *children);
 bool view_on_output(struct view *view, struct output *output);
-
-/**
- * view_is_related() - determine if view and surface are owned by the
- * same application/process. Currently only implemented for xwayland
- * views/surfaces.
- */
-bool view_is_related(struct view *view, struct wlr_surface *surface);
 
 /**
  * view_has_strut_partial() - returns true for views that reserve space

--- a/include/view.h
+++ b/include/view.h
@@ -352,14 +352,6 @@ void view_array_append(struct server *server, struct wl_array *views,
 enum view_wants_focus view_wants_focus(struct view *view);
 
 /**
- * view_is_focusable_from() - variant of view_is_focusable()
- * that takes into account the previously focused surface
- * @view: view to be checked
- * @prev_surface: previously focused surface
- */
-bool view_is_focusable_from(struct view *view, struct wlr_surface *prev);
-
-/**
  * view_edge_invert() - select the opposite of a provided edge
  *
  * VIEW_EDGE_CENTER and VIEW_EDGE_INVALID both map to VIEW_EDGE_INVALID.
@@ -380,10 +372,7 @@ enum view_edge view_edge_invert(enum view_edge edge);
  * The only views that are allowed to be focusd are those that have a surface
  * and have been mapped at some point since creation.
  */
-static inline bool
-view_is_focusable(struct view *view) {
-	return view_is_focusable_from(view, NULL);
-}
+bool view_is_focusable(struct view *view);
 
 void mappable_connect(struct mappable *mappable, struct wlr_surface *surface,
 	wl_notify_func_t notify_map, wl_notify_func_t notify_unmap);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -214,8 +214,6 @@ desktop_cycle_view(struct server *server, struct view *start_view,
 struct view *
 desktop_topmost_focusable_view(struct server *server)
 {
-	struct wlr_surface *prev =
-		server->seat.seat->keyboard_state.focused_surface;
 	struct view *view;
 	struct wl_list *node_list;
 	struct wlr_scene_node *node;
@@ -226,7 +224,7 @@ desktop_topmost_focusable_view(struct server *server)
 			continue;
 		}
 		view = node_view_from_node(node);
-		if (view->mapped && view_is_focusable_from(view, prev)) {
+		if (view->mapped && view_is_focusable(view)) {
 			return view;
 		}
 	}

--- a/src/seat.c
+++ b/src/seat.c
@@ -426,20 +426,11 @@ focus_change_notify(struct wl_listener *listener, void *data)
 	struct wlr_surface *surface = event->new_surface;
 	struct view *view = surface ? view_from_wlr_surface(surface) : NULL;
 
-	/* Prevent focus switch to layershell client from updating view state */
-	if (surface && wlr_layer_surface_v1_try_from_wlr_surface(surface)) {
-		return;
-	}
-
 	/*
-	 * If an xwayland-unmanaged surface was focused belonging to the
-	 * same application as the focused view, allow the view to remain
-	 * active. This fixes an issue with menus immediately closing in
-	 * some X11 apps (try LibreOffice with SAL_USE_VCLPLUGIN=gen).
+	 * Prevent focus switch to non-view surface (e.g. layer-shell
+	 * or xwayland-unmanaged) from updating view state
 	 */
-	if (!view && server->active_view && event->new_surface
-			&& view_is_related(server->active_view,
-				event->new_surface)) {
+	if (surface && !view) {
 		return;
 	}
 

--- a/src/view.c
+++ b/src/view.c
@@ -162,28 +162,16 @@ view_wants_focus(struct view *view)
 }
 
 bool
-view_is_focusable_from(struct view *view, struct wlr_surface *prev)
+view_is_focusable(struct view *view)
 {
 	assert(view);
 	if (!view->surface) {
 		return false;
 	}
-	if (!view->mapped && !view->minimized) {
+	if (view_wants_focus(view) != VIEW_WANTS_FOCUS_ALWAYS) {
 		return false;
 	}
-	enum view_wants_focus wants_focus = view_wants_focus(view);
-	/*
-	 * Consider "offer focus" (Globally Active) views as focusable
-	 * only if another surface from the same application already had
-	 * focus. The goal is to allow focusing a parent window when a
-	 * dialog/popup is closed, but still avoid focusing standalone
-	 * panels/toolbars/notifications. Note that we are basically
-	 * guessing whether Globally Active views want focus, and will
-	 * probably be wrong some of the time.
-	 */
-	return (wants_focus == VIEW_WANTS_FOCUS_ALWAYS
-		|| (wants_focus == VIEW_WANTS_FOCUS_OFFER
-			&& prev && view_is_related(view, prev)));
+	return (view->mapped || view->minimized);
 }
 
 /**

--- a/src/view.c
+++ b/src/view.c
@@ -1971,17 +1971,6 @@ view_append_children(struct view *view, struct wl_array *children)
 }
 
 bool
-view_is_related(struct view *view, struct wlr_surface *surface)
-{
-	assert(view);
-	assert(surface);
-	if (view->impl->is_related) {
-		return view->impl->is_related(view, surface);
-	}
-	return false;
-}
-
-bool
 view_has_strut_partial(struct view *view)
 {
 	assert(view);

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -62,16 +62,6 @@ handle_map(struct wl_listener *listener, void *data)
 static void
 focus_next_surface(struct server *server, struct wlr_xwayland_surface *xsurface)
 {
-	/*
-	 * Try to focus on parent surface
-	 * This seems to fix JetBrains/Intellij window focus issues
-	 */
-	if (xsurface->parent && xsurface->parent->surface
-			&& wlr_xwayland_or_surface_wants_focus(xsurface->parent)) {
-		seat_focus_surface(&server->seat, xsurface->parent->surface);
-		return;
-	}
-
 	/* Try to focus on last created unmanaged xwayland surface */
 	struct xwayland_unmanaged *u;
 	struct wl_list *list = &server->unmanaged_surfaces;

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -792,17 +792,6 @@ xwayland_view_append_children(struct view *self, struct wl_array *children)
 	}
 }
 
-static bool
-xwayland_view_is_related(struct view *view, struct wlr_surface *surface)
-{
-	struct wlr_xwayland_surface *xsurface =
-		xwayland_surface_from_view(view);
-	struct wlr_xwayland_surface *xsurface2 =
-		wlr_xwayland_surface_try_from_wlr_surface(surface);
-
-	return (xsurface2 && xsurface2->pid == xsurface->pid);
-}
-
 static void
 xwayland_view_set_activated(struct view *view, bool activated)
 {
@@ -837,7 +826,6 @@ static const struct view_impl xwayland_view_impl = {
 	.move_to_back = xwayland_view_move_to_back,
 	.get_root = xwayland_view_get_root,
 	.append_children = xwayland_view_append_children,
-	.is_related = xwayland_view_is_related,
 	.get_size_hints = xwayland_view_get_size_hints,
 	.wants_focus = xwayland_view_wants_focus,
 	.has_strut_partial = xwayland_view_has_strut_partial,

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -91,17 +91,15 @@ xwayland_view_wants_focus(struct view *view)
 	 */
 	case WLR_ICCCM_INPUT_MODEL_GLOBAL:
 		/*
-		 * Assume the window does want focus if it wants window
-		 * decorations (according to _MOTIF_WM_HINTS). This is
-		 * a stop-gap fix to ensure that various applications
-		 * (mainly Java-based ones such as IntelliJ IDEA) get
-		 * focus normally and appear in the window switcher. It
-		 * would be better to match based on _NET_WM_WINDOW_TYPE
-		 * instead, but that property isn't currently available
-		 * through wlroots API.
+		 * Assume that NORMAL and DIALOG windows always want
+		 * focus. These window types should show up in the
+		 * Alt-Tab switcher and be automatically focused when
+		 * they become topmost.
 		 */
-		return (xsurface->decorations ==
-			WLR_XWAYLAND_SURFACE_DECORATIONS_ALL) ?
+		return (xwayland_surface_contains_window_type(xsurface,
+				NET_WM_WINDOW_TYPE_NORMAL)
+			|| xwayland_surface_contains_window_type(xsurface,
+				NET_WM_WINDOW_TYPE_DIALOG)) ?
 			VIEW_WANTS_FOCUS_ALWAYS : VIEW_WANTS_FOCUS_OFFER;
 
 	/*


### PR DESCRIPTION
Now that we have _NET_WM_WINDOW_TYPE support, we can use it to fix focus issues with Globally Active windows more properly, as we've discussed before (https://github.com/labwc/labwc/issues/1139#issuecomment-1763191003), and remove various hacks/workarounds that are no longer needed.

The first commit is the important one. The others aren't urgent but are nice cleanups, and will be more relevant when the wlroots support is in place to merge #1142. Details in the commit messages.

Fixes:
- #1139
- #1341