### PR TITLE
session.c: updated dbus activation environment with more env vars

### DIFF
--- a/src/config/session.c
+++ b/src/config/session.c
@@ -124,7 +124,8 @@ void
 session_autostart_init(void)
 {
 	/* Update dbus and systemd user environment, each may fail gracefully */
-	update_activation_env("DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP");
+	update_activation_env("DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP "
+		"XCURSOR_SIZE XCURSOR_THEME XDG_SESSION_TYPE LABWC_PID");
 
 	struct wl_list paths;
 	paths_config_create(&paths, "autostart");


### PR DESCRIPTION
This PR resolves issue #694.
(This is my very first open source contribution.) 