### PR TITLE
Use cursor emulate events to handle touch on headerbar

### DIFF
--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <wayland-util.h>
 #include <wlr/types/wlr_touch.h>
+#include <linux/input-event-codes.h>
 #include "common/mem.h"
 #include "common/scene-helpers.h"
 #include "idle.h"
@@ -61,6 +62,8 @@ touch_motion(struct wl_listener *listener, void *data)
 
 			wlr_seat_touch_notify_motion(seat->seat, event->time_msec,
 				event->touch_id, sx, sy);
+			cursor_emulate_move_absolute(seat, &event->touch->base,
+				event->x, event->y, event->time_msec);
 			return;
 		}
 	}
@@ -104,6 +107,12 @@ touch_down(struct wl_listener *listener, void *data)
 		wlr_seat_touch_notify_down(seat->seat, surface,
 			event->time_msec, event->touch_id, sx, sy);
 	}
+	else {
+		cursor_emulate_move_absolute(seat, &event->touch->base,
+			event->x, event->y, event->time_msec);
+		cursor_emulate_button(seat, BTN_LEFT, WLR_BUTTON_PRESSED,
+			event->time_msec);
+	}
 }
 
 static void
@@ -123,6 +132,8 @@ touch_up(struct wl_listener *listener, void *data)
 	}
 
 	wlr_seat_touch_notify_up(seat->seat, event->time_msec, event->touch_id);
+	cursor_emulate_button(seat, BTN_LEFT, WLR_BUTTON_RELEASED,
+		event->time_msec);
 }
 
 void

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -106,8 +106,7 @@ touch_down(struct wl_listener *listener, void *data)
 	if (surface) {
 		wlr_seat_touch_notify_down(seat->seat, surface,
 			event->time_msec, event->touch_id, sx, sy);
-	}
-	else {
+	} else {
 		cursor_emulate_move_absolute(seat, &event->touch->base,
 			event->x, event->y, event->time_msec);
 		cursor_emulate_button(seat, BTN_LEFT, WLR_BUTTON_PRESSED,

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -13,6 +13,7 @@ struct touch_point {
 	int32_t touch_id;
 	uint32_t x_offset;
 	uint32_t y_offset;
+	struct wlr_surface *surface;
 	struct wl_list link; /* seat.touch_points */
 };
 
@@ -62,8 +63,10 @@ touch_motion(struct wl_listener *listener, void *data)
 
 			wlr_seat_touch_notify_motion(seat->seat, event->time_msec,
 				event->touch_id, sx, sy);
-			cursor_emulate_move_absolute(seat, &event->touch->base,
-				event->x, event->y, event->time_msec);
+			if (!touch_point->surface) {
+				cursor_emulate_move_absolute(seat, &event->touch->base,
+					event->x, event->y, event->time_msec);
+			}
 			return;
 		}
 	}
@@ -84,11 +87,10 @@ touch_down(struct wl_listener *listener, void *data)
 	struct wlr_touch_down_event *event = data;
 
 	/* Compute layout => surface offset and save for this touch point */
-	double x_offset, y_offset;
-	struct wlr_surface *surface = touch_get_coords(seat, event->touch,
-			event->x, event->y, &x_offset, &y_offset);
-
 	struct touch_point *touch_point = znew(*touch_point);
+	double x_offset, y_offset;
+	touch_point->surface = touch_get_coords(seat, event->touch,
+			event->x, event->y, &x_offset, &y_offset);
 	touch_point->touch_id = event->touch_id;
 	touch_point->x_offset = x_offset;
 	touch_point->y_offset = y_offset;
@@ -103,8 +105,8 @@ touch_down(struct wl_listener *listener, void *data)
 	double sx = lx - x_offset;
 	double sy = ly - y_offset;
 
-	if (surface) {
-		wlr_seat_touch_notify_down(seat->seat, surface,
+	if (touch_point->surface) {
+		wlr_seat_touch_notify_down(seat->seat, touch_point->surface,
 			event->time_msec, event->touch_id, sx, sy);
 	} else {
 		cursor_emulate_move_absolute(seat, &event->touch->base,
@@ -124,6 +126,10 @@ touch_up(struct wl_listener *listener, void *data)
 	struct touch_point *touch_point, *tmp;
 	wl_list_for_each_safe(touch_point, tmp, &seat->touch_points, link) {
 		if (touch_point->touch_id == event->touch_id) {
+			if (!touch_point->surface) {
+				cursor_emulate_button(seat, BTN_LEFT, WLR_BUTTON_RELEASED,
+					event->time_msec);
+			}
 			wl_list_remove(&touch_point->link);
 			zfree(touch_point);
 			break;
@@ -131,8 +137,6 @@ touch_up(struct wl_listener *listener, void *data)
 	}
 
 	wlr_seat_touch_notify_up(seat->seat, event->time_msec, event->touch_id);
-	cursor_emulate_button(seat, BTN_LEFT, WLR_BUTTON_RELEASED,
-		event->time_msec);
 }
 
 void

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -116,9 +116,9 @@ touch_down(struct wl_listener *listener, void *data)
 		struct mousebind *mousebind;
 		wl_list_for_each(mousebind, &rc.mousebinds, link) {
 			if (mousebind->mouse_event == MOUSE_ACTION_PRESS
-				&& mousebind->button == BTN_LEFT
-				&& mousebind->context == LAB_SSD_CLIENT) {
-					actions_run(view, seat->server, &mousebind->actions, 0);
+					&& mousebind->button == BTN_LEFT
+					&& mousebind->context == LAB_SSD_CLIENT) {
+				actions_run(view, seat->server, &mousebind->actions, 0);
 			}
 		}
 

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -100,10 +100,11 @@ touch_down(struct wl_listener *listener, void *data)
 	wl_list_insert(&seat->touch_points, &touch_point->link);
 
 	if (touch_point->surface) {
-		/* Convert coordinates: first [0, 1] => layout, then apply offsets */
+		/* Convert coordinates: first [0, 1] => layout,
+		 * then apply offsets */
 		double lx, ly;
-		wlr_cursor_absolute_to_layout_coords(seat->cursor, &event->touch->base,
-			event->x, event->y, &lx, &ly);
+		wlr_cursor_absolute_to_layout_coords(seat->cursor,
+			&event->touch->base, event->x, event->y, &lx, &ly);
 
 		/* Apply offsets to get surface coords before reporting event */
 		double sx = lx - x_offset;

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -49,16 +49,17 @@ touch_motion(struct wl_listener *listener, void *data)
 	struct wlr_touch_motion_event *event = data;
 	idle_manager_notify_activity(seat->seat);
 
-	/* Convert coordinates: first [0, 1] => layout, then apply offsets */
-	double lx, ly;
-	wlr_cursor_absolute_to_layout_coords(seat->cursor, &event->touch->base,
-		event->x, event->y, &lx, &ly);
-
 	/* Find existing touch point to determine initial offsets to subtract */
 	struct touch_point *touch_point;
 	wl_list_for_each(touch_point, &seat->touch_points, link) {
 		if (touch_point->touch_id == event->touch_id) {
 			if (touch_point->surface) {
+				/* Convert coordinates: first [0, 1] => layout, then apply offsets */
+				double lx, ly;
+				wlr_cursor_absolute_to_layout_coords(seat->cursor, &event->touch->base,
+					event->x, event->y, &lx, &ly);
+
+				/* Apply offsets to get surface coords before reporting event */
 				double sx = lx - touch_point->x_offset;
 				double sy = ly - touch_point->y_offset;
 
@@ -98,11 +99,12 @@ touch_down(struct wl_listener *listener, void *data)
 
 	wl_list_insert(&seat->touch_points, &touch_point->link);
 
-	double lx, ly;
-	wlr_cursor_absolute_to_layout_coords(seat->cursor, &event->touch->base,
-		event->x, event->y, &lx, &ly);
-
 	if (touch_point->surface) {
+		/* Convert coordinates: first [0, 1] => layout, then apply offsets */
+		double lx, ly;
+		wlr_cursor_absolute_to_layout_coords(seat->cursor, &event->touch->base,
+			event->x, event->y, &lx, &ly);
+
 		/* Apply offsets to get surface coords before reporting event */
 		double sx = lx - x_offset;
 		double sy = ly - y_offset;

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -54,10 +54,10 @@ touch_motion(struct wl_listener *listener, void *data)
 	wl_list_for_each(touch_point, &seat->touch_points, link) {
 		if (touch_point->touch_id == event->touch_id) {
 			if (touch_point->surface) {
-				/* Convert coordinates: first [0, 1] => layout, then apply offsets */
+				/* Convert coordinates: first [0, 1] => layout */
 				double lx, ly;
-				wlr_cursor_absolute_to_layout_coords(seat->cursor, &event->touch->base,
-					event->x, event->y, &lx, &ly);
+				wlr_cursor_absolute_to_layout_coords(seat->cursor,
+					&event->touch->base, event->x, event->y, &lx, &ly);
 
 				/* Apply offsets to get surface coords before reporting event */
 				double sx = lx - touch_point->x_offset;
@@ -100,8 +100,7 @@ touch_down(struct wl_listener *listener, void *data)
 	wl_list_insert(&seat->touch_points, &touch_point->link);
 
 	if (touch_point->surface) {
-		/* Convert coordinates: first [0, 1] => layout,
-		 * then apply offsets */
+		/* Convert coordinates: first [0, 1] => layout */
 		double lx, ly;
 		wlr_cursor_absolute_to_layout_coords(seat->cursor,
 			&event->touch->base, event->x, event->y, &lx, &ly);

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -7,6 +7,9 @@
 #include "idle.h"
 #include "input/touch.h"
 #include "labwc.h"
+#include "config/mousebind.h"
+#include "action.h"
+#include "view.h"
 
 /* Holds layout -> surface offsets to report motion events in relative coords */
 struct touch_point {
@@ -108,6 +111,16 @@ touch_down(struct wl_listener *listener, void *data)
 		/* Apply offsets to get surface coords before reporting event */
 		double sx = lx - x_offset;
 		double sy = ly - y_offset;
+
+		struct view *view = view_from_wlr_surface(touch_point->surface);
+		struct mousebind *mousebind;
+		wl_list_for_each(mousebind, &rc.mousebinds,link) {
+			if (mousebind->mouse_event == MOUSE_ACTION_PRESS
+				&& mousebind->button == BTN_LEFT
+				&& mousebind->context == LAB_SSD_CLIENT) {
+					actions_run(view, seat->server, &mousebind->actions, 0);
+			}
+		}
 
 		wlr_seat_touch_notify_down(seat->seat, touch_point->surface,
 			event->time_msec, event->touch_id, sx, sy);

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -61,9 +61,10 @@ touch_motion(struct wl_listener *listener, void *data)
 			double sx = lx - touch_point->x_offset;
 			double sy = ly - touch_point->y_offset;
 
-			wlr_seat_touch_notify_motion(seat->seat, event->time_msec,
-				event->touch_id, sx, sy);
-			if (!touch_point->surface) {
+			if (touch_point->surface) {
+				wlr_seat_touch_notify_motion(seat->seat, event->time_msec,
+					event->touch_id, sx, sy);
+			} else {
 				cursor_emulate_move_absolute(seat, &event->touch->base,
 					event->x, event->y, event->time_msec);
 			}
@@ -126,7 +127,10 @@ touch_up(struct wl_listener *listener, void *data)
 	struct touch_point *touch_point, *tmp;
 	wl_list_for_each_safe(touch_point, tmp, &seat->touch_points, link) {
 		if (touch_point->touch_id == event->touch_id) {
-			if (!touch_point->surface) {
+			if (touch_point->surface) {
+				wlr_seat_touch_notify_up(seat->seat, event->time_msec,
+					event->touch_id);
+			} else {
 				cursor_emulate_button(seat, BTN_LEFT, WLR_BUTTON_RELEASED,
 					event->time_msec);
 			}
@@ -135,8 +139,6 @@ touch_up(struct wl_listener *listener, void *data)
 			break;
 		}
 	}
-
-	wlr_seat_touch_notify_up(seat->seat, event->time_msec, event->touch_id);
 }
 
 void

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -114,7 +114,7 @@ touch_down(struct wl_listener *listener, void *data)
 
 		struct view *view = view_from_wlr_surface(touch_point->surface);
 		struct mousebind *mousebind;
-		wl_list_for_each(mousebind, &rc.mousebinds,link) {
+		wl_list_for_each(mousebind, &rc.mousebinds, link) {
 			if (mousebind->mouse_event == MOUSE_ACTION_PRESS
 				&& mousebind->button == BTN_LEFT
 				&& mousebind->context == LAB_SSD_CLIENT) {

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -58,10 +58,10 @@ touch_motion(struct wl_listener *listener, void *data)
 	struct touch_point *touch_point;
 	wl_list_for_each(touch_point, &seat->touch_points, link) {
 		if (touch_point->touch_id == event->touch_id) {
-			double sx = lx - touch_point->x_offset;
-			double sy = ly - touch_point->y_offset;
-
 			if (touch_point->surface) {
+				double sx = lx - touch_point->x_offset;
+				double sy = ly - touch_point->y_offset;
+
 				wlr_seat_touch_notify_motion(seat->seat, event->time_msec,
 					event->touch_id, sx, sy);
 			} else {
@@ -102,11 +102,11 @@ touch_down(struct wl_listener *listener, void *data)
 	wlr_cursor_absolute_to_layout_coords(seat->cursor, &event->touch->base,
 		event->x, event->y, &lx, &ly);
 
-	/* Apply offsets to get surface coords before reporting event */
-	double sx = lx - x_offset;
-	double sy = ly - y_offset;
-
 	if (touch_point->surface) {
+		/* Apply offsets to get surface coords before reporting event */
+		double sx = lx - x_offset;
+		double sy = ly - y_offset;
+
 		wlr_seat_touch_notify_down(seat->seat, touch_point->surface,
 			event->time_msec, event->touch_id, sx, sy);
 	} else {


### PR DESCRIPTION
https://github.com/labwc/labwc/issues/1545

This PR uses cursor emulate events to respond to touchscreen input on window headerbars and frames.

I have no idea if this is the correct way to do this, but it seems to work pretty well in my testing. Someone who understands more about how this area of the code works should probably review it, as there is probably a better way to do it!