### PR TITLE
src/output.c: notify clients about config errors

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -518,9 +518,15 @@ verify_output_config_v1(const struct wlr_output_configuration_v1 *config)
 
 			if (wlr_output_is_wl(head->state.output) && refresh != 0) {
 				/* Wayland backend does not support refresh rates */
-				err_msg = "Wayland backend refresh rate unsupported";
+				err_msg = "Wayland backend refresh rates unsupported";
 				goto custom_mode_failed;
 			}
+		}
+
+		if (wlr_output_is_wl(head->state.output)
+				&& !head->state.adaptive_sync_enabled) {
+			err_msg = "Wayland backend requires adaptive sync";
+			goto custom_mode_failed;
 		}
 
 		/*


### PR DESCRIPTION
Preliminary fix for
- #1525

Based on the protocol we should also revert all previously correctly committed outputs.
#1528 is doing just that but may cause regressions so we need a short term solution and then deal with potential issues in #1528 after the release.

@Tamaranch
Testing would be greatly appreciated so we can include this preliminary fix for the next release.