### PR TITLE
config: Remove invalid click method

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -680,7 +680,6 @@ extending outward from the snapped edge.
 	- *clickfinger* - Clicking with one, two or three finger(s) will produce
 	  left, right or middle button event without regard to the location of a
 	  click.
-	- *none* - Physical clicks will not produce button events.
 
 	The default method depends on the touchpad hardware.
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -472,7 +472,7 @@
       - pointerSpeed [-1.0 to 1.0]
       - accelProfile [flat|adaptive]
       - tapButtonMap [lrm|lmr]
-      - clickMethod [none|buttonAreas|clickfinger]
+      - clickMethod [buttonAreas|clickfinger]
   -->
   <libinput>
     <device category="default">

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -564,10 +564,7 @@ fill_libinput_category(char *nodename, char *content)
 			? LIBINPUT_CONFIG_DWT_ENABLED
 			: LIBINPUT_CONFIG_DWT_DISABLED;
 	} else if (!strcasecmp(nodename, "clickMethod")) {
-		if (!strcasecmp(content, "none")) {
-			current_libinput_category->click_method =
-				LIBINPUT_CONFIG_CLICK_METHOD_NONE;
-		} else if (!strcasecmp(content, "clickfinger")) {
+		if (!strcasecmp(content, "clickfinger")) {
 			current_libinput_category->click_method =
 				LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER;
 		} else if (!strcasecmp(content, "buttonAreas")) {


### PR DESCRIPTION
As far as I understood, there is no "none" click method, it is either software button area or clickfinger. See https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html#clickpad-software-button-behavior

Also our bit logic at https://github.com/labwc/labwc/blob/master/src/seat.c#L193 doesn't support setting anything from e.g. 3 (`LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS`) to 0 (`LIBINPUT_CONFIG_CLICK_METHOD_NONE`), because `x & 0 == 0`.

I figured this while trying to disable my dual sense touch pad. 
(The actual solution was https://github.com/labwc/labwc/pull/961)
