### PR TITLE
cursor: clear pointer focus on window moving/resizing interaction

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1109,10 +1109,6 @@ cursor_process_button_release(struct seat *seat, uint32_t button,
 	}
 
 	if (server->input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
-		if (pressed_surface) {
-			/* Ensure CSD clients see the release event */
-			return true;
-		}
 		return false;
 	}
 

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -153,6 +153,8 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 		view_restore_to(view, natural_geo);
 	}
 
+	wlr_seat_pointer_notify_clear_focus(seat->seat);
+
 	if (rc.resize_indicator) {
 		resize_indicator_show(view);
 	}


### PR DESCRIPTION
With this change, the pointer focus is cleared from the surface at the start of window moving/resizing interaction.
This prevents sending prevents sending unnecessary `wl_pointer.frame` events while interactions.
I guess this behavior follows the protocol, as it says about `xdg_toplevel.move`:
> If triggered, the surface will lose the focus of the device (wl_pointer, wl_touch, etc) used for the move. It is up to the compositor to visually indicate that the move is taking place, such as updating a pointer cursor, during the move. There is no guarantee that the device focus will return when the move is completed.

Likewise, I removed the lines sending button release event at the end of interaction.

I believe this change doesn't make any functional changes in most applications.