### PR TITLE
docs/rc.xml: remove gap from the example config

### DIFF
--- a/docs/rc.xml
+++ b/docs/rc.xml
@@ -7,10 +7,6 @@
 
 <labwc_config>
 
-  <core>
-    <gap>10</gap>
-  </core>
-
   <theme>
     <name></name>
     <cornerRadius>8</cornerRadius>


### PR DESCRIPTION
Some distro packages install the example config at `/etc/xdg/labwc/rc.xml` and thus users of those packages were having a gap 10 setting by default.

Lets remove the gap from the example config to match our intended default.