### PR TITLE
CONTRIBUTING.md: correct the instructions for adding a locale code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,10 +354,10 @@ Translators can add their `MY_LOCALE.po` files to the `po` directory
 based on `po/labwc.pot` and issue a pull request. To do this they can
 generate their `MY_LOCALE.po` file in a few steps:
 
-1. Edit the `po/LINGUAS` file to add their locale name by adding a space
-   to the end of the field and typing the locale code.
-2. Copy the po/labwc.pot to po/MY_LOCALE.po
-3. Edit the newly generated MY_LOCALE.po file with some of their
+1. Edit the `po/LINGUAS` file to add their locale code in English
+   alphabetical order to the field of locale codes.
+2. Copy the `po/labwc.pot` to `po/MY_LOCALE.po`
+3. Edit the newly generated `MY_LOCALE.po` file with some of their
 contact and locale details in the header of the file then add the
 translation strings under each English string.
 


### PR DESCRIPTION
The wording was wrong. Should be in alphabetical order.