### PR TITLE
Add optional headless fallback output

### DIFF
--- a/docs/environment
+++ b/docs/environment
@@ -68,3 +68,18 @@
 
 # XDG_CURRENT_DESKTOP=wlroots
 
+##
+## This causes a virtual output to be created automatically whenever there
+## are no outputs around. This helps for cases like wayvnc so there is always
+## an output available to connect to. The name can be chosen freely but there
+## must be no duplicate output names, for this reason using VIRTUAL-x or a
+## physical connector name like HDMI-A-1 is not recommended as wlroots may
+## want to create outputs with those names later on which would then fail.
+##
+## Using an output name that starts with NOOP- has the additional benefit
+## that wayvnc will detect it being a virtual output and allow clients to
+## resize the output to match the client resolution.
+##
+
+# LABWC_FALLBACK_OUTPUT=NOOP-fallback
+

--- a/include/output-virtual.h
+++ b/include/output-virtual.h
@@ -8,5 +8,6 @@ struct wlr_output;
 void output_virtual_add(struct server *server, const char *output_name,
 		struct wlr_output **store_wlr_output);
 void output_virtual_remove(struct server *server, const char *output_name);
+void output_virtual_update_fallback(struct server *server);
 
 #endif

--- a/src/output.c
+++ b/src/output.c
@@ -24,6 +24,7 @@
 #include "labwc.h"
 #include "layers.h"
 #include "node.h"
+#include "output-virtual.h"
 #include "regions.h"
 #include "view.h"
 #include "xwayland.h"
@@ -694,6 +695,12 @@ handle_output_layout_change(struct wl_listener *listener, void *data)
 {
 	struct server *server =
 		wl_container_of(listener, server, output_layout_change);
+
+	/* Prevents unnecessary layout recalculations */
+	server->pending_output_layout_change++;
+	output_virtual_update_fallback(server);
+	server->pending_output_layout_change--;
+
 	do_output_layout_change(server);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -27,6 +27,7 @@
 #include "labwc.h"
 #include "layers.h"
 #include "menu/menu.h"
+#include "output-virtual.h"
 #include "regions.h"
 #include "resize_indicator.h"
 #include "theme.h"
@@ -69,6 +70,7 @@ handle_sighup(int signal, void *data)
 {
 	session_environment_init();
 	reload_config_and_theme();
+	output_virtual_update_fallback(g_server);
 	return 0;
 }
 
@@ -489,6 +491,9 @@ server_start(struct server *server)
 		wlr_log(WLR_ERROR, "unable to start the wlroots backend");
 		exit(EXIT_FAILURE);
 	}
+
+	/* Potentially set up the initial fallback output */
+	output_virtual_update_fallback(server);
 
 	if (setenv("WAYLAND_DISPLAY", socket, true) < 0) {
 		wlr_log_errno(WLR_ERROR, "unable to set WAYLAND_DISPLAY");


### PR DESCRIPTION
Follow-up from
- #1523

Copy from `docs/environment`
```
##
## This causes a virtual output to be created automatically whenever there
## are no outputs around. This helps for cases like wayvnc so there is always
## an output available to connect to. The name can be chosen freely but there
## must be no duplicate output names, for this reason using VIRTUAL-x or a
## physical connector name like HDMI-A-1 is not recommended as wlroots may
## want to create outputs with those names later on which would then fail.
##

# LABWC_FALLBACK_OUTPUT=NOOP-fallback
```

Things to do:
- [x] split everything into two commits:
  - [x] `store_wlr_output` arg for `virtual_output_add()` and `wlr_output_set_name()` refactor
  - [x] the actual fallback implementation
- [x] remove debug logging when creating / destroying outputs
- [x] add commit body explaining the use-case (copy paste from `docs/environment`?)
- [x] reconfigure support