### PR TITLE
src/action.c: fix MoveToOutput action by renaming 'name' argument

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -163,12 +163,12 @@ Actions are used in menus and keyboard/mouse bindings.
 	to the center of the window. If the given output does not contain
 	any windows, the cursor is centered on the given output.
 
-*<action name="MoveToOutput" name="HDMI-A-1" direction="value" wrap="no" />*
+*<action name="MoveToOutput" output="HDMI-A-1" direction="value" wrap="no" />*
 	Moves active window to other output, unless the window state is
 	fullscreen.
 
-	If *name* is specified, the window will be sent directly to the specified
-	output and *direction* is ignored. If *name* is omitted, *direction* may
+	If *output* is specified, the window will be sent directly to the specified
+	output and *direction* is ignored. If *output* is omitted, *direction* may
 	be one of "left", "right", "up" or "down" to indicate that the window
 	should be moved to the next output in that direction (if one exists). 
 

--- a/src/action.c
+++ b/src/action.c
@@ -383,7 +383,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 		}
 		break;
 	case ACTION_TYPE_MOVE_TO_OUTPUT:
-		if (!strcmp(argument, "name")) {
+		if (!strcmp(argument, "output")) {
 			action_arg_add_str(action, argument, content);
 			goto cleanup;
 		}
@@ -921,10 +921,10 @@ actions_run(struct view *activator, struct server *server,
 			if (!view) {
 				break;
 			}
-			const char *name = action_get_str(action, "name", NULL);
+			const char *output_name = action_get_str(action, "output", NULL);
 			struct output *target = NULL;
-			if (name) {
-				target = output_from_name(view->server, name);
+			if (output_name) {
+				target = output_from_name(view->server, output_name);
 			} else {
 				/* Config parsing makes sure that direction is a valid direction */
 				enum view_edge edge = action_get_int(action, "direction", 0);


### PR DESCRIPTION
We were using the argument name 'name' before
which is already used by the action itself:
`<action name="MoveToOutput" name="HDMI-A-1" />`

Change the argument name to "output" which also
matches the `FocusOutput` action.

Fixes:
- #1589
Reported-by: @bnason (thanks!)
---
Only lightly tested.