### PR TITLE
Ignore move/resize request from clients when the view is not pressed

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -135,6 +135,10 @@ struct seat {
 	 * This allows to keep dragging a scrollbar or selecting text even
 	 * when moving outside of the window.
 	 *
+	 * It is also used to:
+	 * - determine the target view for action in "Drag" mousebind
+	 * - validate view move/resize requests from CSD clients
+	 *
 	 * Both (view && !surface) and (surface && !view) are possible.
 	 */
 	struct {

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -237,8 +237,7 @@ handle_request_move(struct wl_listener *listener, void *data)
 	 * move, typically because the user clicked on their client-side
 	 * decorations. Note that a more sophisticated compositor should check
 	 * the provied serial against a list of button press serials sent to
-	 * this
-	 * client, to prevent the client from requesting this whenever they
+	 * this client, to prevent the client from requesting this whenever they
 	 * want.
 	 */
 	struct view *view = wl_container_of(listener, view, request_move);
@@ -253,8 +252,7 @@ handle_request_resize(struct wl_listener *listener, void *data)
 	 * resize, typically because the user clicked on their client-side
 	 * decorations. Note that a more sophisticated compositor should check
 	 * the provied serial against a list of button press serials sent to
-	 * this
-	 * client, to prevent the client from requesting this whenever they
+	 * this client, to prevent the client from requesting this whenever they
 	 * want.
 	 */
 	struct wlr_xdg_toplevel_resize_event *event = data;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -241,7 +241,9 @@ handle_request_move(struct wl_listener *listener, void *data)
 	 * want.
 	 */
 	struct view *view = wl_container_of(listener, view, request_move);
-	interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
+	if (view == view->server->seat.pressed.view) {
+		interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
+	}
 }
 
 static void
@@ -257,7 +259,9 @@ handle_request_resize(struct wl_listener *listener, void *data)
 	 */
 	struct wlr_xdg_toplevel_resize_event *event = data;
 	struct view *view = wl_container_of(listener, view, request_resize);
-	interactive_begin(view, LAB_INPUT_STATE_RESIZE, event->edges);
+	if (view == view->server->seat.pressed.view) {
+		interactive_begin(view, LAB_INPUT_STATE_RESIZE, event->edges);
+	}
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -228,7 +228,9 @@ handle_request_move(struct wl_listener *listener, void *data)
 	 * want.
 	 */
 	struct view *view = wl_container_of(listener, view, request_move);
-	interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
+	if (view == view->server->seat.pressed.view) {
+		interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
+	}
 }
 
 static void
@@ -244,7 +246,9 @@ handle_request_resize(struct wl_listener *listener, void *data)
 	 */
 	struct wlr_xwayland_resize_event *event = data;
 	struct view *view = wl_container_of(listener, view, request_resize);
-	interactive_begin(view, LAB_INPUT_STATE_RESIZE, event->edges);
+	if (view == view->server->seat.pressed.view) {
+		interactive_begin(view, LAB_INPUT_STATE_RESIZE, event->edges);
+	}
 }
 
 static void


### PR DESCRIPTION
This is relevant for touchpad taps with `tapAndDrag` disabled.

When the user taps the client surface (e.g. mpv and un-decorated titlebar of chromium) with the setting above, libinput sends button press & release signals so quickly that the compositor receives move/resize request from the client after the button release signal is processed, so `interactive_finish()` is never called.

Since the checks I added are duplicated in `xdg.c` and `xwayland.c`, maybe it's better to move them into `view-impl-common.c` and share it.

This includes minor style fixes and additional comments on `seat.pressed`.