### PR TITLE
Fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -177,7 +177,7 @@ The format is based on [Keep a Changelog]
   user-defined region), the snapped state is now discarded as soon as the
   dragging begins. This means that dragging from a snapped position to a
   maximized state (with the `topMaximize` option enabled) and then
-  un-maxmimizing the window will restore the window to its size and position
+  un-maximizing the window will restore the window to its size and position
   *before* it was snapped. In previous releases, un-maximizing would restore
   the window to its snapped state. To preserve the snapped state of a window
   when maximized, use the Maximize window button or the `ToggleMaximize`
@@ -192,7 +192,7 @@ The format is based on [Keep a Changelog]
 </resistance>
 ```
 
-- Run menu actions on button release intead of press.
+- Run menu actions on button release instead of press.
 - Constrain window size to that of usable area when an application is started.
   Issue #1399
 - Support showing the full `app_id` in the window switcher. Users with a custom
@@ -231,7 +231,7 @@ Should bug fixes be required against `0.6.6` (built with wlroots `0.16`), a
   for it in the client-menu under the Workspaces submenu. Written-by: @bnason
 - Account for space taken up by XWayland clients with `_NET_WM_STRUT_PARTIAL`
   property in the `usable_area` calculation. This increases inter-operability
-  with X11 desktop componenets.
+  with X11 desktop components.
 - Set XWayland's `_NET_WORKAREA` property based on usable area. XWayland
   clients use the `_NET_WORKAREA` root window property to determine how much of
   the screen is not covered by panels/docks. The property is used for example
@@ -297,7 +297,7 @@ relating to surface focus and keyboard issues, amongst others.
 
 - Do not reset XWayland window SSD on unminimize
 - Keep XWayland stacking order in sync when switching workspaces
-- Update top-layer visiblity on workspace-switch in order to show
+- Update top-layer visibility on workspace-switch in order to show
   top-layer layer-shell clients correctly when there is a window in
   fullscreen mode on another workspace. Issues: #1040 #1158
 - Make interactive window snapping with mouse more intuitive in
@@ -433,7 +433,7 @@ relating to surface focus and keyboard issues, amongst others.
 - xwayland: fix client request-unmap bug relating to foreign-toplevel handle
 - xwayland: fix race condition resulting in map view without surface
 - Limit SSD corner radius to the height of the titlebar
-- Fix rounded-corner bug producing weird artefacts when very large border
+- Fix rounded-corner bug producing weird artifacts when very large border
   thickness is used. Fixes #988
 - Ensure `string_prop()` handlers deal with destroying views. Fixes #1082
 - Fix SSD thickness calculation bug relating to titlebar. Fixes #1083
@@ -463,7 +463,7 @@ relating to surface focus and keyboard issues, amongst others.
 
 - Add support for `ext_idle_notify` protocol.
 - Window-switcher: #879 #969
-  - Set item-height based on font-heigth
+  - Set item-height based on font-height
   - Add theme option:
     - osd.window-switcher.width
     - osd.window-switcher.padding
@@ -674,7 +674,7 @@ particular thanks going to @Consolatis, @jlindgren90, @bi4k8, @Flrian and
 - Prevent re-focus for always-on-top views when switching workspaces.
   Written-by: @Consolatis
 - Make sure a default libinput category always exists to avoid devices not
-  being configured is some insances. Written-by: @jlindgren90
+  being configured is some instances. Written-by: @jlindgren90
 - Update cursor if it is within the OSD area when OSD appears/disappears.
   Written-by: @bi4k8
 - Provide generic parsing of XML action arguments to enable the use of the
@@ -741,7 +741,7 @@ reported, tested and fixed issues. Particular mentions go to @bi4k8,
   of outlines. Written-by: @Flrian
 - Render submenu arrows
 - Allow highest level menu definitions - typically used for root-menu and
-  client-menu - to be defined without label attritube, for example like this:
+  client-menu - to be defined without label attribute, for example like this:
   `<openbox_menu><menu id="root-menu">...</menu></openbox>`. Issue #472
 - Allow xdg-desktop-portal-wlr to work out of the box by initializing dbus
   and systemd activation environment. This enables for example OBS Studio
@@ -784,7 +784,7 @@ reported, tested and fixed issues. Particular mentions go to @bi4k8,
 - Enable tap be default on non-touch devices (which some laptop trackpads
   apparently are)
 - Handle missing cursor theme (issue #246). Written-by: @Consolatis
-- Fix various surface syncronization, stacking, positioning and focus
+- Fix various surface synchronization, stacking, positioning and focus
   issues, including those related to both xwayland, scroll/drag events
   and also #526 #483
 - On first map, do not center xwayland views with explicitly specified
@@ -806,7 +806,7 @@ reported, tested and fixed issues. Particular mentions go to @bi4k8,
   focused view.
 - Gracefully handle dying client during interactive move.
   Written-by: @Consolatis
-- Dynamically adjust server-side-deccoration invisible resize areas based
+- Dynamically adjust server-side-decoration invisible resize areas based
   on `usable_area` to ensure that cursor events are sent to clients such as
   panels in preference to grabbing window edges. Fixes #265.
   Written-by: @Consolatis
@@ -828,7 +828,7 @@ reported, tested and fixed issues. Particular mentions go to @bi4k8,
   unmaximized geometry is known when started in maximized mode.
   Fixes issue #305. Reported-by: @01micko
 - Support `<menu><item><action name="Execute"><execute>`
-  `<exectue>` is a deprecated name for `<command>`, but is supported for
+  `<execute>` is a deprecated name for `<command>`, but is supported for
   backward compatibility with old menu-generators.
 - Keep xwayland-shell SSD state on unmap/map cycle.
   Written-by: @Consolatis
@@ -875,7 +875,7 @@ reported, tested and fixed issues. Particular mentions go to @bi4k8,
 - Call foreign-toplevel-destroy when unmapping xwayland surfaces because
   some xwayland clients leave unmapped child views around. Although
   `handle_destroy()` is not called for these, we have to call
-  foreign-toplevel-destroy to avoid clients such as panels incorrecly
+  foreign-toplevel-destroy to avoid clients such as panels incorrectly
   showing them.
 - Handle xwayland `set_override_redirect` events to fix weird behaviour
   with gitk menus and rofi.
@@ -883,7 +883,7 @@ reported, tested and fixed issues. Particular mentions go to @bi4k8,
   Fixes #352 relating to JetBrains and Intellij focus issues
   Written-by: Jelle De Loecker
 - Do not segfault on missing drag icon. Written-by: @Consolatis
-- Fix windows irratically sticking to edges during move/resize.
+- Fix windows erratically sticking to edges during move/resize.
   Fixes issues #331 and #309
 
 ## [0.5.2] - 2022-05-17

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ modification.
 
 Openbox spec is somewhat of a stable standard considering how long it has
 remained unchanged for and how wide-spread its adoption is by lightweight
-distributions such as LXDE, LXQt, BunsenLabs, ArchLabs, Mabox and Raspian. Some
+distributions such as LXDE, LXQt, BunsenLabs, ArchLabs, Mabox and Raspbian. Some
 widely used themes (for example Numix and Arc) have built-in support.
 
 We could have invented a whole new syntax, but that's not where we want to

--- a/docs/environment
+++ b/docs/environment
@@ -61,7 +61,7 @@
 ##
 ## This allows xdg-desktop-portal-wlr to function (e.g. for screen-recording).
 ## It is automatically set to "wlroots" by labwc though, so it is only
-## includeded here for completeness. Again, labwc will not over-write an
+## included here for completeness. Again, labwc will not over-write an
 ## already set environment variable, so if you need it set to something else,
 ## then uncomment and adjust.
 ##

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -355,7 +355,7 @@ extending outward from the snapped edge.
 
 *<margin top="" bottom="" left="" right="" output="" />*
 	Specify the number of pixels to reserve at the edges of an output
-	(typically a dislay/screen/monitor). New, maximized and tiled windows
+	(typically a display/screen/monitor). New, maximized and tiled windows
 	will not be placed in these areas. The use-case for *<margin>* is as a
 	workaround for clients such as panels that do NOT support the
 	wlr-layer-shell protocol.

--- a/docs/labwc.1.scd
+++ b/docs/labwc.1.scd
@@ -64,7 +64,7 @@ the `--exit` and `--reconfigure` options use.
 
 # SESSION MANAGEMENT
 
-To enable the use of graphical clients launched via D-Bus or systemd servie
+To enable the use of graphical clients launched via D-Bus or systemd service
 activation, labwc can update both activation environments on launch. Provided
 that labwc is aware of an active D-Bus user session (*i.e.*, the environment
 variable `DBUS_SESSION_BUS_ADDRESS` is defined), the compositor will invoke the

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -423,7 +423,7 @@
   </mouse>
 
   <!--
-    A touch configuration can be bound to a specifc device. If device
+    A touch configuration can be bound to a specific device. If device
     name is left empty, the touch configuration applies to all touch
     devices or functions as a fallback. Multiple touch configurations
     can exist.

--- a/include/button/common.h
+++ b/include/button/common.h
@@ -8,7 +8,7 @@
  * @buf: Buffer to fill with the full filename
  * @len: Length of buffer
  *
- * Example return value: /usr/share/themes/Numix/openbox-3/iconfify.xbm
+ * Example return value: /usr/share/themes/Numix/openbox-3/iconify.xbm
  */
 void button_filename(const char *name, char *buf, size_t len);
 

--- a/include/common/spawn.h
+++ b/include/common/spawn.h
@@ -3,7 +3,7 @@
 #define LABWC_SPAWN_H
 
 /**
- * spawn_async_no_shell - execute asyncronously
+ * spawn_async_no_shell - execute asynchronously
  * @command: command to be executed
  */
 void spawn_async_no_shell(char const *command);

--- a/include/config/session.h
+++ b/include/config/session.h
@@ -5,8 +5,8 @@
 struct server;
 
 /**
- * session_environment_init - set enrivonment variables based on <key>=<value>
- * pairs in `${XDG_CONFIG_DIRS:-/etc/xdg}/lawbc/environment` with user override
+ * session_environment_init - set environment variables based on <key>=<value>
+ * pairs in `${XDG_CONFIG_DIRS:-/etc/xdg}/labwc/environment` with user override
  * in `${XDG_CONFIG_HOME:-$HOME/.config}`
  */
 void session_environment_init(void);

--- a/include/input/ime.h
+++ b/include/input/ime.h
@@ -12,7 +12,7 @@ struct keyboard;
 /*
  * The relay structure manages the relationship between text-inputs and
  * input-method on a given seat. Multiple text-inputs may be bound to a relay,
- * but at most one will be "active" (commucating with input-method) at a time.
+ * but at most one will be "active" (communicating with input-method) at a time.
  * At most one input-method may be bound to the seat. When an input-method and
  * an active text-input is present, the relay passes messages between them.
  */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -78,7 +78,7 @@ struct input {
  * Virtual keyboards should not belong to seat->keyboard_group. As a result we
  * need to be able to ascertain which wlr_keyboard key/modifier events come from
  * and we achieve that by using `struct keyboard` which inherits `struct input`
- * and adds keybord specific listeners and a wlr_keyboard pointer.
+ * and adds keyboard specific listeners and a wlr_keyboard pointer.
  */
 struct keyboard {
 	struct input base;

--- a/include/view.h
+++ b/include/view.h
@@ -377,7 +377,7 @@ enum view_edge view_edge_invert(enum view_edge edge);
  *	a. that have been created but never mapped;
  *	b. set to NULL after client minimize-request.
  *
- * The only views that are allowed to be focusd are those that have a surface
+ * The only views that are allowed to be focused are those that have a surface
  * and have been mapped at some point since creation.
  */
 bool view_is_focusable(struct view *view);

--- a/src/edges.c
+++ b/src/edges.c
@@ -384,7 +384,7 @@ edges_find_neighbors(struct border *nearest_edges, struct view *view,
 	assert(nearest_edges);
 
 	if (!output_is_usable(view->output)) {
-		wlr_log(WLR_DEBUG, "ignoring edge search for view on unsable output");
+		wlr_log(WLR_DEBUG, "ignoring edge search for view on unusable output");
 		return;
 	}
 
@@ -446,7 +446,7 @@ edges_find_outputs(struct border *nearest_edges, struct view *view,
 
 	if (!output_is_usable(view->output)) {
 		wlr_log(WLR_DEBUG,
-			"ignoring edge search for view on unsable output");
+			"ignoring edge search for view on unusable output");
 		return;
 	}
 
@@ -599,7 +599,7 @@ linear_interp(int x, int x1, int y1, int x2, int y2)
 		return 0.5 * (y1 + y2);
 	}
 
-	/* Othewise, linearly interpolate */
+	/* Otherwise, linearly interpolate */
 	int dx = x - x1;
 	return y1 + dx * (rise / (double)run);
 }

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -215,7 +215,7 @@ interactive_finish(struct view *view)
 }
 
 /*
- * Cancels interative move/resize without changing the state of the of
+ * Cancels interactive move/resize without changing the state of the of
  * the view in any way. This may leave the tiled state inconsistent with
  * the actual geometry of the view.
  */

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -435,7 +435,7 @@ handle_menu_element(xmlNode *n, struct server *server)
 		 *
 		 * Openbox spec requires a label="" defined here, but it is
 		 * actually pointless so we handle it with or without the label
-		 * attritute to make it easier for users to define "root-menu"
+		 * attribute to make it easier for users to define "root-menu"
 		 * and "client-menu".
 		 */
 		struct menu **submenu = NULL;

--- a/src/output-virtual.c
+++ b/src/output-virtual.c
@@ -58,7 +58,7 @@ output_virtual_add(struct server *server, const char *output_name,
 		wlr_output_set_name(wlr_output, output_name);
 	}
 	if (store_wlr_output) {
-		/* Ensures that we can use the new wlr_output pointer within new_output_nofity() */
+		/* Ensures that we can use the new wlr_output pointer within new_output_notify() */
 		*store_wlr_output = wlr_output;
 	}
 

--- a/src/output.c
+++ b/src/output.c
@@ -220,7 +220,7 @@ static void
 new_output_notify(struct wl_listener *listener, void *data)
 {
 	/*
-	 * This event is rasied by the backend when a new output (aka display
+	 * This event is raised by the backend when a new output (aka display
 	 * or monitor) becomes available.
 	 */
 	struct server *server = wl_container_of(listener, server, new_output);

--- a/src/placement.c
+++ b/src/placement.c
@@ -68,7 +68,7 @@ count_views(struct view *view)
 	return nviews;
 }
 
-/* Sort and de-deplicate a list of points that define a 1-D grid */
+/* Sort and de-duplicate a list of points that define a 1-D grid */
 static int
 order_grid(int *edges, int nedges)
 {

--- a/src/seat.c
+++ b/src/seat.c
@@ -98,7 +98,7 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	 *       that some libinput setting could not be applied.
 	 *
 	 * TODO: We are currently using int32_t with -1 as default
-	 *       to desribe the not-configured state. This is not
+	 *       to describe the not-configured state. This is not
 	 *       really optimal as we can't properly deal with
 	 *       enum values that are 0. After some discussion via
 	 *       IRC the best way forward seem to be to use a

--- a/src/theme.c
+++ b/src/theme.c
@@ -167,7 +167,7 @@ create_hover_fallback(struct theme *theme, const char *icon_name,
 
 /*
  * We use the following button filename schema: "BUTTON [TOGGLED] [STATE]"
- * with the words separted by underscore, and the following meaning:
+ * with the words separated by underscore, and the following meaning:
  *   - BUTTON can be one of 'max', 'iconify', 'close', 'menu'
  *   - TOGGLED is either 'toggled' or nothing
  *   - STATE is 'hover' or nothing. In future, 'pressed' may be supported too.
@@ -884,8 +884,8 @@ rounded_rect(struct rounded_corner_ctx *ctx)
 	 * We handle the edge-case where line-thickness > radius by merely
 	 * setting line-thickness = radius and in effect drawing a quadrant of a
 	 * circle. In this case the X and Y borders butt up against the arc and
-	 * overlap each other (as their line-thickessnes are greater than the
-	 * linethickness of the arc). As a result, there is no inner rounded
+	 * overlap each other (as their line-thicknesses are greater than the
+	 * line-thickness of the arc). As a result, there is no inner rounded
 	 * corners.
 	 *
 	 * So, in order to have inner rounded corners cornerRadius should be

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -148,7 +148,7 @@ handle_commit(struct wl_listener *listener, void *data)
 			 * wlr_xdg_toplevel_set_size and will send the retained
 			 * values with every subsequent configure request. If a
 			 * client has resized itself in the meantime, a
-			 * configure request that sends the now-outated size
+			 * configure request that sends the now-outdated size
 			 * may prompt the client to resize itself unexpectedly.
 			 *
 			 * Calling wlr_xdg_toplevel_set_size to update the
@@ -236,7 +236,7 @@ handle_request_move(struct wl_listener *listener, void *data)
 	 * This event is raised when a client would like to begin an interactive
 	 * move, typically because the user clicked on their client-side
 	 * decorations. Note that a more sophisticated compositor should check
-	 * the provied serial against a list of button press serials sent to
+	 * the provided serial against a list of button press serials sent to
 	 * this client, to prevent the client from requesting this whenever they
 	 * want.
 	 */
@@ -253,7 +253,7 @@ handle_request_resize(struct wl_listener *listener, void *data)
 	 * This event is raised when a client would like to begin an interactive
 	 * resize, typically because the user clicked on their client-side
 	 * decorations. Note that a more sophisticated compositor should check
-	 * the provied serial against a list of button press serials sent to
+	 * the provided serial against a list of button press serials sent to
 	 * this client, to prevent the client from requesting this whenever they
 	 * want.
 	 */


### PR DESCRIPTION
Found with Code Spell Checker extension in VSCode.