### PR TITLE
layer: change logic for giving keyboard-interactivity

### DIFF
--- a/include/layers.h
+++ b/include/layers.h
@@ -6,6 +6,7 @@
 
 struct server;
 struct output;
+struct seat;
 
 struct lab_layer_surface {
 	struct wlr_scene_layer_surface_v1 *scene_layer_surface;
@@ -36,5 +37,7 @@ struct lab_layer_popup {
 void layers_init(struct server *server);
 
 void layers_arrange(struct output *output);
+void layer_try_set_focus(struct seat *seat,
+	struct wlr_layer_surface_v1 *layer_surface);
 
 #endif /* LABWC_LAYERS_H */

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -18,6 +18,7 @@
 #include "input/gestures.h"
 #include "input/touch.h"
 #include "labwc.h"
+#include "layers.h"
 #include "menu/menu.h"
 #include "regions.h"
 #include "resistance.h"
@@ -970,14 +971,14 @@ cursor_button_press(struct seat *seat, uint32_t button,
 		struct wlr_layer_surface_v1 *layer =
 			wlr_layer_surface_v1_try_from_wlr_surface(ctx.surface);
 		if (layer && layer->current.keyboard_interactive) {
-			seat_set_focus_layer(seat, layer);
+			layer_try_set_focus(seat, layer);
 		}
 	} else if (ctx.type == LAB_SSD_LAYER_SUBSURFACE) {
 		wlr_log(WLR_DEBUG, "press on layer-subsurface");
 		struct wlr_layer_surface_v1 *layer =
 			subsurface_parent_layer(ctx.surface);
 		if (layer && layer->current.keyboard_interactive) {
-			seat_set_focus_layer(seat, layer);
+			layer_try_set_focus(seat, layer);
 		}
 #ifdef HAVE_XWAYLAND
 	} else if (ctx.type == LAB_SSD_UNMANAGED) {

--- a/src/layers.c
+++ b/src/layers.c
@@ -318,8 +318,10 @@ handle_map(struct wl_listener *listener, void *data)
 	 * the scene. See wlr_scene_surface_create() documentation.
 	 */
 
-	struct seat *seat = &layer->server->seat;
-	layer_try_set_focus(seat, layer->scene_layer_surface->layer_surface);
+	/*
+	 * Processing of keyboard-interactivity changes is done in the
+	 * commit-handler.
+	 */
 }
 
 static void

--- a/src/seat.c
+++ b/src/seat.c
@@ -665,9 +665,7 @@ seat_set_focus_layer(struct seat *seat, struct wlr_layer_surface_v1 *layer)
 		return;
 	}
 	seat_focus(seat, layer->surface, /*is_lock_surface*/ false);
-	if (layer->current.layer >= ZWLR_LAYER_SHELL_V1_LAYER_TOP) {
-		seat->focused_layer = layer;
-	}
+	seat->focused_layer = layer;
 }
 
 static void


### PR DESCRIPTION
Use the following logic:
 - Exclusive: Grant regardless of layer. Previously it was only given if in top or overlay layers. Grant if in the same or higher layer than (nearer overlay) any other client with exclusive interactivity.
 - On-demand: Grant only if no other layer-shell client has exclusive keyboard interactivity. Previously it was treated the same as exclusive.
 - None: Unset focus if the commit associated with the 'none' came from the currently focused layer. Previously it was just unset regardless.

Remove unecessary top/overlay check in seat_set_focus_layer(). Such checks should be made prior to calling the function.

- [x] NOTE 1: This is to follow https://github.com/labwc/labwc/pull/1594
- [x] NOTE 2: We should also call `layer_try_set_focus()` from `src/input/cursor.c`. Should be simple 2-line-change after #1594