### PR TITLE
session: process environment.d and allow empty variables

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -37,13 +37,23 @@ option.
 All configuration and theme files except autostart and shutdown are re-loaded on
 receiving signal SIGHUP.
 
-The *environment* file is parsed as *variable=value* and sets environment
-variables accordingly. It is recommended to specify keyboard layout settings and
-cursor size/theme here; see environment variable section below for details. Note
-that the environment file is treated differently by openbox where it is simply
-sourced prior to running openbox.
-Note: Tilde (~) and environment variables in the value are expanded, but
-subshell syntax and apostrophes are ignored.
+Environment variables may be set within *environment* files, wherein each line
+defines shell variables in the format *variable=value*. It is recommended to
+specify keyboard layout settings and cursor size/theme here; see environment
+variable section below for details. Within an XDG Base Directory, a file named
+"environment" will be parsed first, followed by any file matching the glob
+"environment.d/\*.env". Files within the environment.d directory are parsed in
+an arbitrary order; any variables that must be set in a particular sequence
+should be set within the same file. Unless the --merge-config option is
+specified, labwc will consider a particular XDG Base Directory to have provided
+an environment file if that directory contains either the "environment"
+directory or at least one "environment.d/\*.env" file.
+
+Note: environment files are treated differently by Openbox, which will simply
+source the file as a valid shell script before running the window manager. Files
+are instead parsed directly by labwc, although any environment variables
+referenced as $VARIABLE or ${VARIABLE} will be substituted and the tilde (~)
+will be expanded as the user's home directory.
 
 The *autostart* file is executed as a shell script after labwc has read its
 configuration and set variables defined in the environment file. Additionally,

--- a/include/common/string-helpers.h
+++ b/include/common/string-helpers.h
@@ -59,7 +59,18 @@ char *strdup_printf(const char *fmt, ...);
  * The separator is arbitrary. When the separator is NULL, a single space will
  * be used.
  */
-char *str_join(const char * const parts[],
+char *str_join(const char *const parts[],
 	const char *restrict fmt, const char *restrict sep);
+
+/**
+ * str_endswith - indicate whether a string ends with a given suffix
+ * @string: string to test
+ * @suffix: suffix to expect in string
+ *
+ * If suffix is "" or NULL, this method always returns true; otherwise, this
+ * method returns true if and only if the full suffix exists at the end of the
+ * string.
+ */
+bool str_endswith(const char *const string, const char *const suffix);
 
 #endif /* LABWC_STRING_HELPERS_H */

--- a/src/common/string-helpers.c
+++ b/src/common/string-helpers.c
@@ -86,7 +86,7 @@ strdup_printf(const char *fmt, ...)
 }
 
 char *
-str_join(const char * const parts[],
+str_join(const char *const parts[],
 		const char *restrict fmt, const char *restrict sep)
 {
 	assert(parts);
@@ -154,3 +154,19 @@ str_join(const char * const parts[],
 	return buf;
 }
 
+bool
+str_endswith(const char *const string, const char *const suffix)
+{
+	size_t len_str = string ? strlen(string) : 0;
+	size_t len_sfx = suffix ? strlen(suffix) : 0;
+
+	if (len_str < len_sfx) {
+		return false;
+	}
+
+	if (len_sfx == 0) {
+		return true;
+	}
+
+	return strcmp(string + len_str - len_sfx, suffix) == 0;
+}


### PR DESCRIPTION
1. All '*.env' files in an 'environment.d' directory alongside each potential 'environment' file will be parsed and added to the environment.
2. For the purposes of configuration merging, an environment definition exists at one level if either the 'environment' file is defined or its corresponding 'environment.d' contains any valid '*.env' file.
3. Variable declarations of the form "VARIABLE=", with no following value, will be written to the environment as empty strings.

Quick tests show this working, but it hasn't been rigorously tested, and the merge logic needs testing as well.