### PR TITLE
client menu: add option to allow opening of menu at cursor

### DIFF
--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -100,6 +100,8 @@ struct rcxml {
 	struct wl_list mousebinds; /* struct mousebind.link */
 	double scroll_factor;
 
+	bool menu_client_menu_at_pointer;
+
 	/* touch tablet */
 	struct wl_list touch_configs;
 

--- a/src/action.c
+++ b/src/action.c
@@ -594,6 +594,8 @@ show_menu(struct server *server, struct view *view, const char *menu_name)
 			force_menu_top_left = true;
 		} else if (ssd_part_contains(LAB_SSD_PART_TITLEBAR, type)) {
 			force_menu_top_left = false;
+		} else if (rc.menu_client_menu_at_pointer) {
+			force_menu_top_left = false;
 		} else {
 			force_menu_top_left = true;
 		}

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -887,6 +887,11 @@ entry(xmlNode *node, char *nodename, char *content)
 			wlr_log(WLR_ERROR, "ignoring invalid value for notifyClient");
 		}
 
+	} else if (!strcasecmp(nodename, "menu_clientMenuAtPointer")) {
+		if (parse_bool(content, -1) == true) {
+			rc.menu_client_menu_at_pointer = true;
+		};
+
 	/* <windowSwitcher show="" preview="" outlines="" /> */
 	} else if (!strcasecmp(nodename, "show.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.show);
@@ -1156,6 +1161,8 @@ rcxml_init(void)
 	rc.window_switcher.criteria = LAB_VIEW_CRITERIA_CURRENT_WORKSPACE
 		| LAB_VIEW_CRITERIA_ROOT_TOPLEVEL
 		| LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER;
+
+	rc.menu_client_menu_at_pointer = false;
 
 	rc.resize_indicator = LAB_RESIZE_INDICATOR_NEVER;
 


### PR DESCRIPTION
Until now, the client menu can be two ways by default:

- left click on client menu button at the top left of the window bar
- right click anywhere on the window bar that isn't otherwise bound

The first option opens the menu button, while the second opens it on the window bar, whereever the mouse cursor is.

If one adds a way to open the menu elsewhere, e.g. with this:

```xml
<mouse>
  <context name="Frame">
    <mousebind button="S-Right" action="Press">
      <action name="ShowMenu">
        <menu>client-menu</menu>
      </action>
    </mousebind>
  <context>
</mouse>
```

the menu will open on the client menu spot.

With OpenBox, a similar configuration will result in the menu opening where the mouse cursor is, which is usually more convenient.

This patch adds an option (`menu_clientMenuAtPointer`) that will enable the same behavior as with OpenBox, and default to off (existing behavior).

I am not tied to the naming of the option (or that it lives in the RC root atm), but I thought I'd get the general ide reviewed and then letting the bikeshedding begin. Naturally, docs and rc.xml.all will also be added once the basics have been decided.