### PR TITLE
keyboard: use 'us' as fallback for XKB_DEFAULT_LAYOUT

### DIFF
--- a/src/seat.c
+++ b/src/seat.c
@@ -296,6 +296,11 @@ new_keyboard(struct seat *seat, struct wlr_input_device *device, bool virtual)
 	keyboard->wlr_keyboard = kb;
 	keyboard->is_virtual = virtual;
 
+	if (!seat->keyboard_group->keyboard.keymap) {
+		wlr_log(WLR_ERROR, "cannot set keymap");
+		exit(EXIT_FAILURE);
+	}
+
 	wlr_keyboard_set_keymap(kb, seat->keyboard_group->keyboard.keymap);
 
 	/*


### PR DESCRIPTION
...if keymap cannot be created for the provided XKB_DEFAULT_LAYOUT.

If keymap still cannot be created, exit with a helpful message to avoid crash that is hard to understand.

Fixes: https://github.com/stefonarch/lxqt-labwc-session/issues/7