### PR TITLE
Window switch, add workspace info and window state (M/m/F)

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -206,7 +206,7 @@ this is for compatibility with Openbox.
 
 	*content* defines what the field shows and can be any of:
 
-		- *type* Show view type ("xdg-shell" or "xwayland")
+		- *type* Show view type ("W" for xdg-shell or "X" for xwayland)
 
 		- *identifier* Show identifier (app_id for native Wayland
 		  windows and WM_CLASS for XWayland clients)

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -207,7 +207,9 @@ this is for compatibility with Openbox.
 	*content* defines what the field shows and can be any of:
 
 		- *type* Show view type ("xdg-shell" or "xwayland")
-		- *type* Show view type all workspaces ("W" or "X")
+
+		- *winfo* Show window info *type* "X" or "W"
+		  along with *state* M/m/F (max, min, full)
 
 		- *identifier* Show identifier (app_id for native Wayland
 		  windows and WM_CLASS for XWayland clients)

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -208,9 +208,6 @@ this is for compatibility with Openbox.
 
 		- *type* Show view type ("xdg-shell" or "xwayland")
 
-		- *winfo* Show workspace name, *type* "X" or "W"
-		  along with *state* M/m/F (max, min, full)
-
 		- *identifier* Show identifier (app_id for native Wayland
 		  windows and WM_CLASS for XWayland clients)
 
@@ -218,6 +215,14 @@ this is for compatibility with Openbox.
 		  the first two nodes of 'org.' strings.
 
 		- *title* Show window title if different to app_id
+
+		- *workspace* Show workspace name
+
+		- *state* Show window state, M/m/F (max/min/full)
+
+		- *type_short* Show view type ("W" or "X")
+
+		- *output* Show output id, if more than one output detected
 
 	*width* defines the width of the field expressed as a percentage of
 	the overall window switcher width. The "%" character is required.

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -208,7 +208,7 @@ this is for compatibility with Openbox.
 
 		- *type* Show view type ("xdg-shell" or "xwayland")
 
-		- *winfo* Show window info *type* "X" or "W"
+		- *winfo* Show workspace name, *type* "X" or "W"
 		  along with *state* M/m/F (max, min, full)
 
 		- *identifier* Show identifier (app_id for native Wayland

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -206,7 +206,8 @@ this is for compatibility with Openbox.
 
 	*content* defines what the field shows and can be any of:
 
-		- *type* Show view type ("W" for xdg-shell or "X" for xwayland)
+		- *type* Show view type ("xdg-shell" or "xwayland")
+		- *type* Show view type all workspaces ("W" or "X")
 
 		- *identifier* Show identifier (app_id for native Wayland
 		  windows and WM_CLASS for XWayland clients)

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -64,12 +64,21 @@
   </windowSwitcher>
 
   <!--
-    When using all workspaces option of window switcher, there is a replacement
-    for "type" above called "winfo" that will give more info about the window,
-    workspace name, state of window (min, max, full) and output that it's on 
-    if more than one monitor is being used. 
+    When using all workspaces option of window switcher, there are extra fields
+    that can be used, workspace (variable length), state (single space), 
+    type_short (3 spaces), output (variable length), and can be set up 
+    like this. Note: output only shows if more than one output available.
 
-      <field content="winfo" width="25%" />
+    <windowSwitcher show="yes" preview="no" outlines="no" allWorkspaces="yes">
+      <fields>
+        <field content="workspace" width="5%" />
+        <field content="state" width="3%" />
+        <field content="type_short" width="3%" />
+        <field content="output" width="9%" />
+        <field content="identifier" width="30%" />
+        <field content="title" width="50%" />
+       </fields>  
+    </windowSwitcher>
   -->
 
   <!-- edge strength is in pixels -->

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -63,6 +63,15 @@
     </fields>
   </windowSwitcher>
 
+  <!--
+    When using all workspaces optiion of window switcher, there is a replacement
+    for "type" above called "winfo" that will give more info about the window,
+    workspace name, state of window (min, max, full) and output that it's on 
+    if more than one monitor is being used. 
+
+      <field content="winfo" width="25%" />
+  -->
+
   <!-- edge strength is in pixels -->
   <resistance>
     <screenEdgeStrength>20</screenEdgeStrength>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -64,7 +64,7 @@
   </windowSwitcher>
 
   <!--
-    When using all workspaces optiion of window switcher, there is a replacement
+    When using all workspaces option of window switcher, there is a replacement
     for "type" above called "winfo" that will give more info about the window,
     workspace name, state of window (min, max, full) and output that it's on 
     if more than one monitor is being used. 

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -141,6 +141,7 @@ struct rcxml {
 		bool show;
 		bool preview;
 		bool outlines;
+		bool allworkspaces;
 		uint32_t criteria;
 		struct wl_list fields;  /* struct window_switcher_field.link */
 	} window_switcher;

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -21,7 +21,10 @@ enum window_switcher_field_content {
 	LAB_FIELD_IDENTIFIER,
 	LAB_FIELD_TRIMMED_IDENTIFIER,
 	LAB_FIELD_TITLE,
-	LAB_FIELD_WINFO,
+	LAB_FIELD_WORKSPACE,
+	LAB_FIELD_WIN_STATE,
+	LAB_FIELD_TYPE_SHORT,
+	LAB_FIELD_OUTPUT,
 };
 
 enum view_placement_policy {
@@ -142,7 +145,6 @@ struct rcxml {
 		bool show;
 		bool preview;
 		bool outlines;
-		bool all_workspaces;
 		uint32_t criteria;
 		struct wl_list fields;  /* struct window_switcher_field.link */
 	} window_switcher;

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -21,6 +21,7 @@ enum window_switcher_field_content {
 	LAB_FIELD_IDENTIFIER,
 	LAB_FIELD_TRIMMED_IDENTIFIER,
 	LAB_FIELD_TITLE,
+	LAB_FIELD_WINFO,
 };
 
 enum view_placement_policy {
@@ -141,7 +142,7 @@ struct rcxml {
 		bool show;
 		bool preview;
 		bool outlines;
-		bool allworkspaces;
+		bool all_workspaces;
 		uint32_t criteria;
 		struct wl_list fields;  /* struct window_switcher_field.link */
 	} window_switcher;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1163,7 +1163,6 @@ rcxml_init(void)
 	rc.window_switcher.show = true;
 	rc.window_switcher.preview = true;
 	rc.window_switcher.outlines = true;
-	rc.window_switcher.all_workspaces = false;
 	rc.window_switcher.criteria = LAB_VIEW_CRITERIA_CURRENT_WORKSPACE
 		| LAB_VIEW_CRITERIA_ROOT_TOPLEVEL
 		| LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -206,6 +206,8 @@ fill_window_switcher_field(char *nodename, char *content)
 			current_field->content = LAB_FIELD_TRIMMED_IDENTIFIER;
 		} else if (!strcmp(content, "title")) {
 			current_field->content = LAB_FIELD_TITLE;
+		} else if (!strcmp(content, "winfo")) {
+			current_field->content = LAB_FIELD_WINFO;
 		} else {
 			wlr_log(WLR_ERROR, "bad windowSwitcher field '%s'", content);
 		}
@@ -895,8 +897,8 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "outlines.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.outlines);
 	} else if (!strcasecmp(nodename, "allWorkspaces.windowSwitcher")) {
-		set_bool(content, &rc.window_switcher.allworkspaces);
-		if (rc.window_switcher.allworkspaces) {
+		set_bool(content, &rc.window_switcher.all_workspaces);
+		if (rc.window_switcher.all_workspaces) {
 			rc.window_switcher.criteria &=
 				~LAB_VIEW_CRITERIA_CURRENT_WORKSPACE;
 		}
@@ -1156,7 +1158,7 @@ rcxml_init(void)
 	rc.window_switcher.show = true;
 	rc.window_switcher.preview = true;
 	rc.window_switcher.outlines = true;
-	rc.window_switcher.allworkspaces = false;
+	rc.window_switcher.all_workspaces = false;
 	rc.window_switcher.criteria = LAB_VIEW_CRITERIA_CURRENT_WORKSPACE
 		| LAB_VIEW_CRITERIA_ROOT_TOPLEVEL
 		| LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -206,8 +206,14 @@ fill_window_switcher_field(char *nodename, char *content)
 			current_field->content = LAB_FIELD_TRIMMED_IDENTIFIER;
 		} else if (!strcmp(content, "title")) {
 			current_field->content = LAB_FIELD_TITLE;
-		} else if (!strcmp(content, "winfo")) {
-			current_field->content = LAB_FIELD_WINFO;
+		} else if (!strcmp(content, "workspace")) {
+			current_field->content = LAB_FIELD_WORKSPACE;
+		} else if (!strcmp(content, "state")) {
+			current_field->content = LAB_FIELD_WIN_STATE;
+		} else if (!strcmp(content, "type_short")) {
+			current_field->content = LAB_FIELD_TYPE_SHORT;
+		} else if (!strcmp(content, "output")) {
+			current_field->content = LAB_FIELD_OUTPUT;
 		} else {
 			wlr_log(WLR_ERROR, "bad windowSwitcher field '%s'", content);
 		}
@@ -897,8 +903,7 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "outlines.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.outlines);
 	} else if (!strcasecmp(nodename, "allWorkspaces.windowSwitcher")) {
-		set_bool(content, &rc.window_switcher.all_workspaces);
-		if (rc.window_switcher.all_workspaces) {
+		if (parse_bool(content, -1) == true) {
 			rc.window_switcher.criteria &=
 				~LAB_VIEW_CRITERIA_CURRENT_WORKSPACE;
 		}

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -895,9 +895,13 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "outlines.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.outlines);
 	} else if (!strcasecmp(nodename, "allWorkspaces.windowSwitcher")) {
+		set_bool(content, &rc.window_switcher.allworkspaces);
 		if (parse_bool(content, -1) == true) {
 			rc.window_switcher.criteria &=
 				~LAB_VIEW_CRITERIA_CURRENT_WORKSPACE;
+		} else {
+			rc.window_switcher.criteria |=
+				LAB_VIEW_CRITERIA_CURRENT_WORKSPACE;
 		}
 
 	/* Remove this long term - just a friendly warning for now */
@@ -1155,6 +1159,7 @@ rcxml_init(void)
 	rc.window_switcher.show = true;
 	rc.window_switcher.preview = true;
 	rc.window_switcher.outlines = true;
+	rc.window_switcher.allworkspaces = false;
 	rc.window_switcher.criteria = LAB_VIEW_CRITERIA_CURRENT_WORKSPACE
 		| LAB_VIEW_CRITERIA_ROOT_TOPLEVEL
 		| LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -896,12 +896,9 @@ entry(xmlNode *node, char *nodename, char *content)
 		set_bool(content, &rc.window_switcher.outlines);
 	} else if (!strcasecmp(nodename, "allWorkspaces.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.allworkspaces);
-		if (parse_bool(content, -1) == true) {
+		if (rc.window_switcher.allworkspaces) {
 			rc.window_switcher.criteria &=
 				~LAB_VIEW_CRITERIA_CURRENT_WORKSPACE;
-		} else {
-			rc.window_switcher.criteria |=
-				LAB_VIEW_CRITERIA_CURRENT_WORKSPACE;
 		}
 
 	/* Remove this long term - just a friendly warning for now */

--- a/src/osd.c
+++ b/src/osd.c
@@ -230,18 +230,24 @@ get_type(struct view *view)
 {
 	switch (view->type) {
 	case LAB_XDG_SHELL_VIEW:
-		if (rc.window_switcher.all_workspaces) {
-			return "[W] ";
-		} else {
-			return "[xdg-shell]";
-		}
+		return "[xdg-shell]";
 #if HAVE_XWAYLAND
 	case LAB_XWAYLAND_VIEW:
-		if (rc.window_switcher.all_workspaces) {
-			return "[X] ";
-		} else {
-			return "[xwayland]";
-		}
+		return "[xwayland]";
+#endif
+	}
+	return "";
+}
+
+static const char *
+get_winfo(struct view *view)
+{
+	switch (view->type) {
+	case LAB_XDG_SHELL_VIEW:
+		return "[W] ";
+#if HAVE_XWAYLAND
+	case LAB_XWAYLAND_VIEW:
+		return "[X] ";
 #endif
 	}
 	return "";
@@ -385,7 +391,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 						buf_add(&buf, "   ");
 					}
 				}
-				buf_add(&buf, get_type(*view));
+				buf_add(&buf, get_winfo(*view));
 				if (rc.window_switcher.all_workspaces &&
 						wl_list_length(&server->outputs) > 1) {
 					buf_add(&buf, (*view)->output->wlr_output->name);

--- a/src/osd.c
+++ b/src/osd.c
@@ -230,10 +230,18 @@ get_type(struct view *view)
 {
 	switch (view->type) {
 	case LAB_XDG_SHELL_VIEW:
-		return "[W] ";
+		if (rc.window_switcher.allworkspaces) {
+			return "[W] ";
+		} else {
+			return "[xdg-shell]";
+		}
 #if HAVE_XWAYLAND
 	case LAB_XWAYLAND_VIEW:
-		return "[X] ";
+		if (rc.window_switcher.allworkspaces) {
+			return "[X] ";
+		} else {
+			return "[xwayland]";
+		}
 #endif
 	}
 	return "";
@@ -376,7 +384,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 				}
 				buf_add(&buf, get_type(*view));
 				if (rc.window_switcher.allworkspaces &&
-					wl_list_length(&server->outputs) > 1) {
+						wl_list_length(&server->outputs) > 1) {
 					buf_add(&buf, (*view)->output->wlr_output->name);
 				}
 				break;

--- a/src/osd.c
+++ b/src/osd.c
@@ -379,21 +379,19 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 				buf_add(&buf, get_type(*view));
 				break;
 			case LAB_FIELD_WINFO:
-				if (rc.window_switcher.all_workspaces) {
-					buf_add(&buf, (*view)->workspace->name);
-					if ((*view)->maximized) {
-						buf_add(&buf, " M ");
-					} else if ((*view)->minimized) {
-						buf_add(&buf, " m ");
-					} else if ((*view)->fullscreen) {
-						buf_add(&buf, " F ");
-					} else {
-						buf_add(&buf, "   ");
-					}
+				buf_add(&buf, (*view)->workspace->name);
+				if ((*view)->maximized) {
+					buf_add(&buf, " M ");
+				} else if ((*view)->minimized) {
+					buf_add(&buf, " m ");
+				} else if ((*view)->fullscreen) {
+					buf_add(&buf, " F ");
+				} else {
+					buf_add(&buf, "   ");
 				}
 				buf_add(&buf, get_winfo(*view));
-				if (rc.window_switcher.all_workspaces &&
-						wl_list_length(&server->outputs) > 1) {
+				if (wl_list_length(&server->outputs) > 1 && 
+						output_is_usable(*view->output)) {
 					buf_add(&buf, (*view)->output->wlr_output->name);
 				}
 				break;

--- a/src/osd.c
+++ b/src/osd.c
@@ -378,20 +378,24 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 			case LAB_FIELD_TYPE:
 				buf_add(&buf, get_type(*view));
 				break;
-			case LAB_FIELD_WINFO:
-				if (rc.window_switcher.all_workspaces) {
-					buf_add(&buf, (*view)->workspace->name);
-				}
-				if ((*view)->maximized) {
-					buf_add(&buf, " M ");
-				} else if ((*view)->minimized) {
-					buf_add(&buf, " m ");
-				} else if ((*view)->fullscreen) {
-					buf_add(&buf, " F ");
-				} else {
-					buf_add(&buf, "   ");
-				}
+			case LAB_FIELD_TYPE_SHORT:
 				buf_add(&buf, get_winfo(*view));
+				break;
+			case LAB_FIELD_WORKSPACE:
+				buf_add(&buf, (*view)->workspace->name);
+				break;
+			case LAB_FIELD_WIN_STATE:
+				if ((*view)->maximized) {
+					buf_add(&buf, "M");
+				} else if ((*view)->minimized) {
+					buf_add(&buf, "m");
+				} else if ((*view)->fullscreen) {
+					buf_add(&buf, "F");
+				} else {
+					buf_add(&buf, " ");
+				}
+				break;
+			case LAB_FIELD_OUTPUT:
 				if (wl_list_length(&server->outputs) > 1 &&
 						output_is_usable((*view)->output)) {
 					buf_add(&buf, (*view)->output->wlr_output->name);

--- a/src/osd.c
+++ b/src/osd.c
@@ -230,14 +230,14 @@ get_type(struct view *view)
 {
 	switch (view->type) {
 	case LAB_XDG_SHELL_VIEW:
-		if (rc.window_switcher.allworkspaces) {
+		if (rc.window_switcher.all_workspaces) {
 			return "[W] ";
 		} else {
 			return "[xdg-shell]";
 		}
 #if HAVE_XWAYLAND
 	case LAB_XWAYLAND_VIEW:
-		if (rc.window_switcher.allworkspaces) {
+		if (rc.window_switcher.all_workspaces) {
 			return "[X] ";
 		} else {
 			return "[xwayland]";
@@ -370,7 +370,10 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 
 			switch (field->content) {
 			case LAB_FIELD_TYPE:
-				if (rc.window_switcher.allworkspaces) {
+				buf_add(&buf, get_type(*view));
+				break;
+			case LAB_FIELD_WINFO:
+				if (rc.window_switcher.all_workspaces) {
 					buf_add(&buf, (*view)->workspace->name);
 					if ((*view)->maximized) {
 						buf_add(&buf, " M ");
@@ -383,7 +386,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 					}
 				}
 				buf_add(&buf, get_type(*view));
-				if (rc.window_switcher.allworkspaces &&
+				if (rc.window_switcher.all_workspaces &&
 						wl_list_length(&server->outputs) > 1) {
 					buf_add(&buf, (*view)->output->wlr_output->name);
 				}

--- a/src/osd.c
+++ b/src/osd.c
@@ -244,10 +244,10 @@ get_winfo(struct view *view)
 {
 	switch (view->type) {
 	case LAB_XDG_SHELL_VIEW:
-		return "[W] ";
+		return "[W]";
 #if HAVE_XWAYLAND
 	case LAB_XWAYLAND_VIEW:
-		return "[X] ";
+		return "[X]";
 #endif
 	}
 	return "";
@@ -399,6 +399,8 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 				if (wl_list_length(&server->outputs) > 1 &&
 						output_is_usable((*view)->output)) {
 					buf_add(&buf, (*view)->output->wlr_output->name);
+				} else {
+					buf_add(&buf, " ");
 				}
 				break;
 			case LAB_FIELD_IDENTIFIER:

--- a/src/osd.c
+++ b/src/osd.c
@@ -390,7 +390,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 					buf_add(&buf, "   ");
 				}
 				buf_add(&buf, get_winfo(*view));
-				if (wl_list_length(&server->outputs) > 1 && 
+				if (wl_list_length(&server->outputs) > 1 &&
 						output_is_usable((*view)->output)) {
 					buf_add(&buf, (*view)->output->wlr_output->name);
 				}

--- a/src/osd.c
+++ b/src/osd.c
@@ -379,7 +379,11 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 				buf_add(&buf, get_type(*view));
 				break;
 			case LAB_FIELD_WINFO:
-				buf_add(&buf, (*view)->workspace->name);
+				if (rc.window_switcher.all_workspaces) {
+					buf_add(&buf, (*view)->workspace->name);
+				} else {
+					buf_add(&buf, "    ");
+				}
 				if ((*view)->maximized) {
 					buf_add(&buf, " M ");
 				} else if ((*view)->minimized) {

--- a/src/osd.c
+++ b/src/osd.c
@@ -381,8 +381,6 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 			case LAB_FIELD_WINFO:
 				if (rc.window_switcher.all_workspaces) {
 					buf_add(&buf, (*view)->workspace->name);
-				} else {
-					buf_add(&buf, "    ");
 				}
 				if ((*view)->maximized) {
 					buf_add(&buf, " M ");

--- a/src/osd.c
+++ b/src/osd.c
@@ -230,10 +230,10 @@ get_type(struct view *view)
 {
 	switch (view->type) {
 	case LAB_XDG_SHELL_VIEW:
-		return "[xdg-shell]";
+		return "[W] ";
 #if HAVE_XWAYLAND
 	case LAB_XWAYLAND_VIEW:
-		return "[xwayland]";
+		return "[X] ";
 #endif
 	}
 	return "";
@@ -362,7 +362,23 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 
 			switch (field->content) {
 			case LAB_FIELD_TYPE:
+				if (rc.window_switcher.allworkspaces) {
+					buf_add(&buf, (*view)->workspace->name);
+					if ((*view)->maximized) {
+						buf_add(&buf, " M ");
+					} else if ((*view)->minimized) {
+						buf_add(&buf, " m ");
+					} else if ((*view)->fullscreen) {
+						buf_add(&buf, " F ");
+					} else {
+						buf_add(&buf, "   ");
+					}
+				}
 				buf_add(&buf, get_type(*view));
+				if (rc.window_switcher.allworkspaces &&
+					wl_list_length(&server->outputs) > 1) {
+					buf_add(&buf, (*view)->output->wlr_output->name);
+				}
 				break;
 			case LAB_FIELD_IDENTIFIER:
 				buf_add(&buf, get_app_id(*view));

--- a/src/osd.c
+++ b/src/osd.c
@@ -391,7 +391,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 				}
 				buf_add(&buf, get_winfo(*view));
 				if (wl_list_length(&server->outputs) > 1 && 
-						output_is_usable(*view->output)) {
+						output_is_usable((*view)->output)) {
 					buf_add(&buf, (*view)->output->wlr_output->name);
 				}
 				break;


### PR DESCRIPTION
This shortens xdg-shell/xwayland to single Upper case letter
adds workspace name and state (min, max, full)