### PR TITLE
Reload cursor theme and size on reconfigure

### DIFF
--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -119,6 +119,7 @@ void cursor_update_focus(struct server *server);
 void cursor_update_image(struct seat *seat);
 
 void cursor_init(struct seat *seat);
+void cursor_load(struct seat *seat);
 void cursor_emulate_move_absolute(struct seat *seat,
 		struct wlr_input_device *device,
 		double x, double y, uint32_t time_msec);

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1253,12 +1253,15 @@ cursor_frame(struct wl_listener *listener, void *data)
 }
 
 void
-cursor_init(struct seat *seat)
+cursor_load(struct seat *seat)
 {
 	const char *xcursor_theme = getenv("XCURSOR_THEME");
 	const char *xcursor_size = getenv("XCURSOR_SIZE");
 	uint32_t size = xcursor_size ? atoi(xcursor_size) : 24;
 
+	if (seat->xcursor_manager) {
+		wlr_xcursor_manager_destroy(seat->xcursor_manager);
+	}
 	seat->xcursor_manager = wlr_xcursor_manager_create(xcursor_theme, size);
 	wlr_xcursor_manager_load(seat->xcursor_manager, 1);
 
@@ -1293,6 +1296,12 @@ cursor_init(struct seat *seat)
 			"Cursor theme is missing cursor names, using fallback");
 		cursor_names = cursors_x11;
 	}
+}
+
+void
+cursor_init(struct seat *seat)
+{
+	cursor_load(seat);
 
 	/* Set the initial cursor image so the cursor is visible right away */
 	cursor_set(seat, LAB_CURSOR_DEFAULT);

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1297,7 +1297,7 @@ cursor_load(struct seat *seat)
 		cursor_names = cursors_x11;
 	}
 }
- 
+
 void
 cursor_init(struct seat *seat)
 {

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1297,7 +1297,7 @@ cursor_load(struct seat *seat)
 		cursor_names = cursors_x11;
 	}
 }
-
+ 
 void
 cursor_init(struct seat *seat)
 {

--- a/src/seat.c
+++ b/src/seat.c
@@ -529,6 +529,7 @@ seat_init(struct server *server)
 
 	seat->input_method_relay = input_method_relay_create(seat);
 
+	seat->xcursor_manager = NULL;
 	seat->cursor = wlr_cursor_create();
 	if (!seat->cursor) {
 		wlr_log(WLR_ERROR, "unable to create cursor");
@@ -571,6 +572,7 @@ seat_reconfigure(struct server *server)
 {
 	struct seat *seat = &server->seat;
 	struct input *input;
+	cursor_load(seat);
 	wl_list_for_each(input, &seat->inputs, link) {
 		switch (input->wlr_input_device->type) {
 		case WLR_INPUT_DEVICE_KEYBOARD:


### PR DESCRIPTION
As per https://github.com/labwc/labwc/issues/1587 - this seems to work for reloading cursor size and theme on a labwc --reconfigure.