### PR TITLE
session: Don't close a null dir in read_environment_dir

### DIFF
--- a/src/config/session.c
+++ b/src/config/session.c
@@ -118,18 +118,14 @@ read_environment_dir(const char *path_prefix)
 	DIR *envdir = opendir(path);
 
 	if (!envdir) {
-		if (errno == ENOENT) {
-			wlr_log(WLR_INFO,
-				"no %s.d directory found",
-				path_prefix);
-		} else {
+		if (errno != ENOENT) {
 			const char *err_msg = strerror(errno);
 			wlr_log(WLR_INFO,
 				"failed to read environment directory: %s",
 				err_msg ? err_msg : "reason unknown");
 		}
 
-		goto no_dir_cleanup;
+		goto env_dir_cleanup;
 	}
 
 	struct dirent *dirent;
@@ -148,7 +144,7 @@ read_environment_dir(const char *path_prefix)
 
 	closedir(envdir);
 
-no_dir_cleanup:
+env_dir_cleanup:
 	free(path);
 	return success;
 }

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -118,14 +118,18 @@ read_environment_dir(const char *path_prefix)
 	DIR *envdir = opendir(path);
 
 	if (!envdir) {
-		if (errno != ENOENT) {
+		if (errno == ENOENT) {
+			wlr_log(WLR_INFO,
+				"no %s.d directory found",
+				path_prefix);
+		} else {
 			const char *err_msg = strerror(errno);
 			wlr_log(WLR_INFO,
 				"failed to read environment directory: %s",
 				err_msg ? err_msg : "reason unknown");
 		}
 
-		goto env_dir_cleanup;
+		goto no_dir_cleanup;
 	}
 
 	struct dirent *dirent;
@@ -142,8 +146,9 @@ read_environment_dir(const char *path_prefix)
 		free(env_file_path);
 	}
 
-env_dir_cleanup:
 	closedir(envdir);
+
+no_dir_cleanup:
 	free(path);
 	return success;
 }


### PR DESCRIPTION
There was a cleanup path in read_environment_dir that called closedir() on a null DIR* from opendir(). This removes closedir() from that path.

We also log when environment.d doesn't exist, as opposed to only logging when another error occurred.