### PR TITLE
session: abort process_line early if line contains no key

### DIFF
--- a/src/config/session.c
+++ b/src/config/session.c
@@ -45,18 +45,16 @@ process_line(char *line)
 	}
 	*p = '\0';
 	key = string_strip(line);
+	if (string_null_or_empty(key)) {
+		return;
+	}
 
 	struct buf value;
 	buf_init(&value);
 	buf_add(&value, string_strip(++p));
 	buf_expand_shell_variables(&value);
 	buf_expand_tilde(&value);
-	if (string_null_or_empty(key)) {
-		goto error;
-	}
-
 	setenv(key, value.buf, 1);
-error:
 	free(value.buf);
 }
 


### PR DESCRIPTION
I was going to make the `error` label more descriptive, but realized we don't even need the label. What's more, we can short-circuit some string parsing when would would just wind up ignoring the results.