### PR TITLE
src/common/buf.c: enhance the buffer API

### DIFF
--- a/include/common/buf.h
+++ b/include/common/buf.h
@@ -45,4 +45,23 @@ void buf_init(struct buf *s);
  */
 void buf_add(struct buf *s, const char *data);
 
+/**
+ * buf_add_char - add single char to C string buffer
+ * @s: buffer
+ * @data: char to be added
+ */
+void buf_add_char(struct buf *s, char data);
+
+/**
+ * buf_clear - clear the buffer, internal allocations are preserved
+ * @s: buffer
+ */
+void buf_clear(struct buf *s);
+
+/**
+ * buf_reset - reset the buffer, internal allocations are free'd
+ * @s: buffer
+ */
+void buf_reset(struct buf *s);
+
 #endif /* LABWC_BUF_H */


### PR DESCRIPTION
There is at least one user of the buffer API that reuses a single buffer by just resetting `buf.len` to `0`. This works as long as the new user of the buffer actually adds something to the buffer.

However, if we don't add anything but still provide `buf.buf` to a consumer, the old content will be re-used.

This patch thus adds two new clearing variants to the buffer API:
- `buf_clear()` which doesn't reset the internal allocations
- `buf_reset()` which does free the internal allocations

Additionally, this patch makes `buf_add_char()` public which allows adding single characters to an existing buffer. This will be used in a future PR which implements custom format strings for the OSD.

---

Background:
- https://github.com/labwc/labwc/pull/1623#discussion_r1525966047

This PR doesn't change any logic (other than some new asserts) and merely adds the new functions to reduce the risk of merge conflicts with #1623.

I also don't particularly like the various `free(buf.buf)` statements by consumers of the API as it requires knowledge of the buffer internals by the consumer. Do we want an additional `buf_destroy()` or something similar?