### PR TITLE
common: render text buffers with opaque background

### DIFF
--- a/include/common/font.h
+++ b/include/common/font.h
@@ -42,11 +42,12 @@ int font_width(struct font *font, const char *string);
  * @text: text to be generated as texture
  * @font: font description
  * @color: foreground color in rgba format
+ * @bg_color: background color in rgba format
  * @arrow: arrow (utf8) character to show or NULL for none
  */
 void font_buffer_create(struct lab_data_buffer **buffer, int max_width,
-	const char *text, struct font *font, float *color, const char *arrow,
-	double scale);
+	const char *text, struct font *font, const float *color,
+	const float *bg_color, const char *arrow, double scale);
 
 /**
  * font_finish - free some font related resources

--- a/include/common/graphic-helpers.h
+++ b/include/common/graphic-helpers.h
@@ -42,7 +42,7 @@ void multi_rect_set_size(struct multi_rect *rect, int width, int height);
  * Sets the cairo color.
  * Splits a float[4] single color array into its own arguments
  */
-void set_cairo_color(cairo_t *cairo, float *color);
+void set_cairo_color(cairo_t *cairo, const float *color);
 
 /* Draws a border with a specified line width */
 void draw_cairo_border(cairo_t *cairo, struct wlr_fbox fbox, double line_width);

--- a/include/common/scaled_font_buffer.h
+++ b/include/common/scaled_font_buffer.h
@@ -17,6 +17,7 @@ struct scaled_font_buffer {
 	char *text;
 	int max_width;
 	float color[4];
+	float bg_color[4];
 	char *arrow;
 	struct font font;
 	struct scaled_scene_buffer *scaled_buffer;
@@ -46,7 +47,8 @@ struct scaled_font_buffer *scaled_font_buffer_create(struct wlr_scene_tree *pare
  * - font and color the same
  */
 void scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
-	int max_width, struct font *font, float *color, const char *arrow);
+	int max_width, struct font *font, const float *color,
+	const float *bg_color, const char *arrow);
 
 /**
  * Update the max width of an existing auto scaling font buffer

--- a/src/common/font.c
+++ b/src/common/font.c
@@ -77,8 +77,8 @@ font_width(struct font *font, const char *string)
 
 void
 font_buffer_create(struct lab_data_buffer **buffer, int max_width,
-	const char *text, struct font *font, float *color, const char *arrow,
-	double scale)
+	const char *text, struct font *font, const float *color,
+	const float *bg_color, const char *arrow, double scale)
 {
 	/* Allow a minimum of one pixel each for text and arrow */
 	if (max_width < 2) {
@@ -113,6 +113,15 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 
 	cairo_t *cairo = (*buffer)->cairo;
 	cairo_surface_t *surf = cairo_get_target(cairo);
+
+	/*
+	 * Fill background color first - necessary for subpixel
+	 * rendering, which does not work properly on transparency
+	 */
+	set_cairo_color(cairo, bg_color);
+	cairo_rectangle(cairo, 0, 0, (*buffer)->unscaled_width,
+		(*buffer)->unscaled_height);
+	cairo_fill(cairo);
 
 	set_cairo_color(cairo, color);
 	cairo_move_to(cairo, 0, 0);

--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -83,7 +83,7 @@ draw_cairo_border(cairo_t *cairo, struct wlr_fbox fbox, double line_width)
 
 /* Sets the cairo color. Splits the single color channels */
 void
-set_cairo_color(cairo_t *cairo, float *c)
+set_cairo_color(cairo_t *cairo, const float *c)
 {
 	cairo_set_source_rgba(cairo, c[0], c[1], c[2], c[3]);
 }

--- a/src/common/scaled_font_buffer.c
+++ b/src/common/scaled_font_buffer.c
@@ -19,7 +19,7 @@ _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
 
 	/* Buffer gets free'd automatically along the backing wlr_buffer */
 	font_buffer_create(&buffer, self->max_width, self->text,
-		&self->font, self->color, self->arrow, scale);
+		&self->font, self->color, self->bg_color, self->arrow, scale);
 
 	self->width = buffer ? buffer->unscaled_width : 0;
 	self->height = buffer ? buffer->unscaled_height : 0;
@@ -64,8 +64,8 @@ scaled_font_buffer_create(struct wlr_scene_tree *parent)
 
 void
 scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
-		int max_width, struct font *font, float *color,
-		const char *arrow)
+		int max_width, struct font *font, const float *color,
+		const float *bg_color, const char *arrow)
 {
 	assert(self);
 	assert(text);
@@ -87,6 +87,7 @@ scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
 	self->font.slant = font->slant;
 	self->font.weight = font->weight;
 	memcpy(self->color, color, sizeof(self->color));
+	memcpy(self->bg_color, bg_color, sizeof(self->bg_color));
 	self->arrow = arrow ? xstrdup(arrow) : NULL;
 
 	/* Invalidate cache and force a new render */

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -205,9 +205,11 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 
 	/* Font buffers */
 	scaled_font_buffer_update(menuitem->normal.buffer, text, menuitem->native_width,
-		&rc.font_menuitem, theme->menu_items_text_color, arrow);
+		&rc.font_menuitem, theme->menu_items_text_color,
+		theme->menu_items_bg_color, arrow);
 	scaled_font_buffer_update(menuitem->selected.buffer, text, menuitem->native_width,
-		&rc.font_menuitem, theme->menu_items_active_text_color, arrow);
+		&rc.font_menuitem, theme->menu_items_active_text_color,
+		theme->menu_items_active_bg_color, arrow);
 
 	/* Center font nodes */
 	x = theme->menu_item_padding_x;

--- a/src/ssd/resize_indicator.c
+++ b/src/ssd/resize_indicator.c
@@ -199,7 +199,8 @@ resize_indicator_update(struct view *view)
 		(eff_height - indicator->height) / 2);
 
 	scaled_font_buffer_update(indicator->text, text, width, &rc.font_osd,
-		rc.theme->osd_label_text_color, NULL /* const char *arrow */);
+		rc.theme->osd_label_text_color, rc.theme->osd_bg_color,
+		NULL /* const char *arrow */);
 }
 
 void

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -334,7 +334,8 @@ ssd_update_title(struct ssd *ssd)
 	struct ssd_state_title *state = &ssd->state.title;
 	bool title_unchanged = state->text && !strcmp(title, state->text);
 
-	float *text_color;
+	const float *text_color;
+	const float *bg_color;
 	struct font *font = NULL;
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
@@ -346,10 +347,12 @@ ssd_update_title(struct ssd *ssd)
 		if (subtree == &ssd->titlebar.active) {
 			dstate = &state->active;
 			text_color = theme->window_active_label_text_color;
+			bg_color = theme->window_active_title_bg_color;
 			font = &rc.font_activewindow;
 		} else {
 			dstate = &state->inactive;
 			text_color = theme->window_inactive_label_text_color;
+			bg_color = theme->window_inactive_title_bg_color;
 			font = &rc.font_inactivewindow;
 		}
 
@@ -379,7 +382,7 @@ ssd_update_title(struct ssd *ssd)
 		if (part->buffer) {
 			scaled_font_buffer_update(part->buffer, title,
 				title_bg_width, font,
-				text_color, NULL);
+				text_color, bg_color, NULL);
 		}
 
 		/* And finally update the cache */


### PR DESCRIPTION
After a roundabout discussion[1] with wlroots devs, it's become apparent that subpixel text rendering (a.k.a. "ClearType") does not work properly when rendering over a transparent background, as labwc currently does.

Basically it comes down to the fact that the color of semi-transparent pixels (which is adjusted redder or bluer to compensate for RGB subpixel alignment) depends somewhat on background color. When rendering over transparency, the text engine doesn't know the intended background color and can't adjust the pixel colors correctly.

With Pango/Cairo, the end result can range from grayscale rendering (no subpixel rendering at all) to wrong/oversaturated colors (for example, bright pink pixels when rendering white text on blue background).

This change solves the issue by first filling the text buffer with an opaque background color before rendering the text over it. Currently, this is easy since the background is always a solid color. It may be a little more complex (but doable) if we implement gradients in future.

Note that GTK 4 (and to some degree, recent versions of Microsoft Windows) avoid this issue by disabling subpixel rendering altogether. I would much prefer that labwc NOT do this -- it results in noticeably blurrier text on non-retina LCD screens, which are still common.

[1] https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3822

Screenshots (zoom in to see detail):

White on blue, `WLR_RENDERER=vulkan`, before/after:
![vulkan-before](https://github.com/labwc/labwc/assets/1244737/142bdb55-ce4a-4744-b68d-f93cfd81a3df)
![vulkan-after](https://github.com/labwc/labwc/assets/1244737/174b6331-db82-49a2-9b5a-83e705543d7a)

Black on white, `WLR_RENDERER=pixman`, before/after:
![pixman-bw-before](https://github.com/labwc/labwc/assets/1244737/3431a9f3-9869-46b6-af28-b7b79cccb4b0)
![pixman-bw-after](https://github.com/labwc/labwc/assets/1244737/da593ba2-427d-4094-9b98-d7af14e21197)