### PR TITLE
NLS: translate "Workspaces" in rcxml.c. closes #1630

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,9 +377,10 @@ translation strings under each English string.
 ## Coders
 
 Code contributors may need to update relevant files if their additions
-affect UI elements (at the moment only `src/menu/menu.c`). In this case
-the `po/labwc.pot` file needs to be updated so that translators can
-update their translations. Remember, many translators are _not_ coders!
+affect UI elements (at the moment only `src/menu/menu.c` and 
+`src/config/rcxml.c`). In this case the `po/labwc.pot` file needs to be
+updated so that translators can update their translations. Remember,
+many translators are _not_ coders!
 
 The process is fairly trivial however does involve some manual steps.
 
@@ -390,13 +391,13 @@ generated .pot file in the next step.
 2. From the root of the repository run this:
 
 ```
-xgettext --keyword=_ --language=C --add-comments -o po/labwc.pot src/menu/menu.c
+xgettext --keyword=_ --language=C --add-comments -o po/labwc.pot src/menu/menu.c src/config/rcxml.c
 ```
 
 This generates a new pot file at `po/labwc.pot`
 
-3. Copy the header from the original `labwc.pot` to the new one, check
-for sanity and commit.
+3. Copy the header from the original `labwc.pot` to the new one, keeping
+the newly generated dates, check for sanity and commit.
 
 # Upversion
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,1 +1,2 @@
 src/menu/menu.c
+src/config/rcxml.c

--- a/po/ar.po
+++ b/po/ar.po
@@ -20,54 +20,54 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "إعادة تهيئة"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "أخرج"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "صغّر"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "كبّر"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "ملء الشاشة"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "طي/إلغاء طي"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "إخف الإطار"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "دائمًا في القمة"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "أنقل يسارا"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "أنقل يمينا"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "أظهر في مساحات العمل دائما"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "مساحة عمل"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "غلق"

--- a/po/cs.po
+++ b/po/cs.po
@@ -16,54 +16,54 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Překonfigurovat"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Odejít"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimalizovat"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Maximalizovat"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Na celou obrazovku"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Rolovat nahoru/dolů"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Dekorace"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Vždy nahoře"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Posunout doleva"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Posunout doprava"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Vždy na viditelné Pracovní Ploše"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Pracovní Plocha"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Zavřít"

--- a/po/de.po
+++ b/po/de.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Rekonfigurieren"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Beenden"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimieren"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Maximieren"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Vollbild"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Hoch/Runterrollen"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Dekorationen"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Immer im Vordergrund"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "nach links"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "nach rechts"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Immer auf aktiver Arbeitsfläche"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Arbeitsfläche"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Schließen"

--- a/po/es.po
+++ b/po/es.po
@@ -18,54 +18,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Reconfigurar"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Salir"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Maximizar"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr ""
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Decoraciones"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Siempre encima"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Mover a la izquierda"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Mover a la derecha"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Siempre en un espacio de trabajo visible"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Espacio de trabajo"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Cerrar"

--- a/po/et.po
+++ b/po/et.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Seadista uuesti"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Välju"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Vähenda"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Suurenda"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Täisekraanivaade"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Keri üles/alla"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Akende välimus"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Alati kõige peal"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Tõsta vasakule"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Tõsta paremale"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Alati nähtav töölaual"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Töölaud"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Sulge"

--- a/po/eu.po
+++ b/po/eu.po
@@ -18,54 +18,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Berriz konfiguratu"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Irten"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimizatu"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Maximizatu"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Pantaila osoa"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr ""
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Apaingarriak"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Beti gainean"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Mugitu ezkerrera"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Mugitu eskuinera"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Beti ikusgai dagoen lan-eremuan"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Langunea"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Itxi"

--- a/po/fi.po
+++ b/po/fi.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr ""
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Poistu"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr ""
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr ""
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr ""
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr ""
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr ""
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr ""
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr ""
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr ""
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr ""
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr ""
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -18,54 +18,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Reconfigurar"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Saír"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Maximizar"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr ""
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Decoracións"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Sempre enriba"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Mover á esquerda"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Mover á dereita"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Sempre no espazo de traballo visible"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Espazo de traballo"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Pechar"

--- a/po/hu.po
+++ b/po/hu.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Rekonfigurál"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Kilépés"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Kis méret"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Teljes méret"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Teljes képernyő"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Felhúz / Legördül"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Dekorációk"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Mindig felül"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Balra dokkol"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Jobbra dokkol"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Kitűz"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Munkaasztal"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Bezárás"

--- a/po/id.po
+++ b/po/id.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Atur Ulang"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Keluar"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Sembunyikan"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Perluas Jendela"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Tampil Menyeluruh"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Gulir atas/bawah"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Dekorasi"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Selalu di Muka"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Geser ke Kiri"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Geser ke Kanan"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Selalu pada Ruang Kerja yang Terlihat"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Ruang Kerja"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Tutup"

--- a/po/it.po
+++ b/po/it.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Riconfigura"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Esci"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimizza"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Massimizza"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Schermo intero"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Arrotola/srotola"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Decorazioni"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Sempre sopra"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Sposta a sinistra"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Sposta a destra"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Sempre sull'area di lavoro visibile"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Area di lavoro"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Chiudi"

--- a/po/ja.po
+++ b/po/ja.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "再設定"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "終了"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "最小化"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "最大化"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "フルスクリーン"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "折りたたむ/広げる"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "デコレーション"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "常に最前面に表示"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "左に移動"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "右に移動"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "現在のワークスペースに常に表示"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "ワークスペース"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "閉じる"

--- a/po/ka.po
+++ b/po/ka.po
@@ -18,56 +18,56 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "თავიდან მორგება"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "გასვლა"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "ჩაკეცვა"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "გადიდება"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "მთელ ეკრანზე"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr ""
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "დეკორაციები"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 #, fuzzy
 #| msgid "Always On Top"
 msgid "Always on Top"
 msgstr "ყოველთვისყველაზეზემოდან"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "მარცხნივ გაწევა"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "მარჯვნივ გაწევა"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr ""
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "სამუშაო ადგილი"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "დახურვა"

--- a/po/labwc.pot
+++ b/po/labwc.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: labwc\n"
 "Report-Msgid-Bugs-To: https://github.com/labwc/labwc/issues\n"
-"POT-Creation-Date: 2024-01-15 16:00-0500\n"
+"POT-Creation-Date: 2024-03-17 11:06+1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,54 +17,54 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr ""
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr ""
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr ""
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr ""
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr ""
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr ""
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr ""
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr ""
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr ""
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr ""
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr ""
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr ""
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -21,54 +21,54 @@ msgstr ""
 "1 : 2);\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Konfigūruoti iš naujo"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Išeiti"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Suskleisti"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Išskleisti"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Visas ekranas"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Užraityti/atraityti"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Dekoracijos"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Visada viršuje"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Perkelti kairėn"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Perkelti dešinėn"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Visada matomoje darbo srityje"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Darbo sritis"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Užverti"

--- a/po/nl.po
+++ b/po/nl.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Opnieuw instellen"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Afsluiten"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimaliseren"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Maximaliseren"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Schermvullende weergave"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Op-/Afrollen"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Decoraties"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Altijd bovenaan"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Naar links verplaatsen"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Naar rechts verplaatsen"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Altijd op zichtbaar werkblad"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Werkblad"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Sluiten"

--- a/po/pa.po
+++ b/po/pa.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "ਮੁੜ-ਸੰਰਚਨਾ ਕਰੋ"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "ਬਾਹਰ"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "ਘੱਟੋ-ਘੱਟ"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "ਵੱਧ ਤੋਂ ਵੱਧ"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "ਪੂਰੀ ਸਕਰੀਨ"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "ਉੱਤੇ/ਹੇਠਾਂ ਸਕਰਾਓ"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "ਸਜਾਵਟ"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "ਹਮੇਸ਼ਾਂ ਉੱਤੇ ਰੱਖੋ"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "ਖੱਬੇ ਭੇਜੋ"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "ਸੱਜੇ ਭੇਜੋ"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "ਹਮੇਸ਼ਾਂ ਦਿੱਖ ਵਰਕਸਪੇਸ ਉੱਤੇ"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "ਵਰਕਸਪੇਸ"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "ਬੰਦ ਕਰੋ"

--- a/po/pl.po
+++ b/po/pl.po
@@ -20,54 +20,54 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Rekonfiguruj"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Wyjdź"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimalizuj"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Maksymalizuj"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Pełny ekran"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Zwiń w górę/w dół"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Dekoracje"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Zawsze na wierzchu"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Przenieś w lewo"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Przenieś w prawo"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Zawsze na widocznym obszarze roboczym"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Przestrzeń robocza"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Zamknij"

--- a/po/pt.po
+++ b/po/pt.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Reconfigurar"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Sair"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Maximizar"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Tela Cheia"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Rolar para cima/baixo"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Decorações"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Sempre no Topo"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Mover para a esquerda"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Mover para a direita"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Sempre Visível na Área de Trabalho"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Área de Trabalho"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Fechar"

--- a/po/ru.po
+++ b/po/ru.po
@@ -20,54 +20,54 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Перенастроить"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Выход"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Свернуть"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Развернуть"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "На весь экран"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Свернуть/развернуть в заголовок"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Декорации"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Всегда на переднем плане"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Переместить влево"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Переместить вправо"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "На всех рабочих пространствах"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Рабочее пространство"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Закрыть"

--- a/po/sv.po
+++ b/po/sv.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Konfigurera om"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Avsluta"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Minimera"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Maximera"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Fullskärm"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Rulla upp/ned"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Dekorationer"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Alltid överst"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Flytta till vänster"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Flytta till höger"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Alltid på aktiv arbetsyta"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Arbetsyta"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Stäng"

--- a/po/tr.po
+++ b/po/tr.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Yeniden Yapılandır"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Çıkış"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Küçült"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Büyüt"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "Tam Ekran"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Yukarı/aşağı katla"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Süslemeler"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Her Zaman Üstte"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Sola taşı"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Sağa taşı"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Her Zaman Görünür Çalışma Alanında"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Çalışma Alanı"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Kapat"

--- a/po/uk.po
+++ b/po/uk.po
@@ -20,54 +20,54 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "Переналаштувати"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "Вихід"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "Згорнути"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "Розгорнути"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "На весь екран"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "Згорнути/розгорнути"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "Декорації"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "Завжди зверху"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "Перемістити ліворуч"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "Перемістити праворуч"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "Завжди на видимому робочому просторі"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "Робочий простір"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "Закрити"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -19,54 +19,54 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:697
+#: src/menu/menu.c:704
 msgid "Reconfigure"
 msgstr "配置重载"
 
-#: src/menu/menu.c:699
+#: src/menu/menu.c:706
 msgid "Exit"
 msgstr "退出"
 
-#: src/menu/menu.c:715
+#: src/menu/menu.c:722
 msgid "Minimize"
 msgstr "最小化"
 
-#: src/menu/menu.c:717
+#: src/menu/menu.c:724
 msgid "Maximize"
 msgstr "最大化"
 
-#: src/menu/menu.c:719
+#: src/menu/menu.c:726
 msgid "Fullscreen"
 msgstr "全屏"
 
-#: src/menu/menu.c:721
+#: src/menu/menu.c:728
 msgid "Roll up/down"
 msgstr "滚动 上/下"
 
-#: src/menu/menu.c:723
+#: src/menu/menu.c:730
 msgid "Decorations"
 msgstr "装饰"
 
-#: src/menu/menu.c:725
+#: src/menu/menu.c:732
 msgid "Always on Top"
 msgstr "最上层显示"
 
-#: src/menu/menu.c:730
+#: src/menu/menu.c:737
 msgid "Move left"
 msgstr "左移"
 
-#: src/menu/menu.c:737
+#: src/menu/menu.c:744
 msgid "Move right"
 msgstr "右移"
 
-#: src/menu/menu.c:742
+#: src/menu/menu.c:749
 msgid "Always on Visible Workspace"
 msgstr "始终在可见工作区"
 
-#: src/menu/menu.c:745
+#: src/menu/menu.c:752 src/config/rcxml.c:1384
 msgid "Workspace"
 msgstr "工作区"
 
-#: src/menu/menu.c:748
+#: src/menu/menu.c:755
 msgid "Close"
 msgstr "关闭"

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1381,7 +1381,7 @@ post_processing(void)
 	int nr_workspaces = wl_list_length(&rc.workspace_config.workspaces);
 	if (nr_workspaces < rc.workspace_config.min_nr_workspaces) {
 		if (!rc.workspace_config.prefix) {
-			rc.workspace_config.prefix = xstrdup("Workspace");
+			rc.workspace_config.prefix = xstrdup( _("Workspace") );
 		}
 		struct workspace *workspace;
 		for (int i = nr_workspaces; i < rc.workspace_config.min_nr_workspaces; i++) {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1381,7 +1381,7 @@ post_processing(void)
 	int nr_workspaces = wl_list_length(&rc.workspace_config.workspaces);
 	if (nr_workspaces < rc.workspace_config.min_nr_workspaces) {
 		if (!rc.workspace_config.prefix) {
-			rc.workspace_config.prefix = xstrdup( _("Workspace") );
+			rc.workspace_config.prefix = xstrdup( _("Workspace"));
 		}
 		struct workspace *workspace;
 		for (int i = nr_workspaces; i < rc.workspace_config.min_nr_workspaces; i++) {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1381,7 +1381,7 @@ post_processing(void)
 	int nr_workspaces = wl_list_length(&rc.workspace_config.workspaces);
 	if (nr_workspaces < rc.workspace_config.min_nr_workspaces) {
 		if (!rc.workspace_config.prefix) {
-			rc.workspace_config.prefix = xstrdup( _("Workspace"));
+			rc.workspace_config.prefix = xstrdup(_("Workspace"));
 		}
 		struct workspace *workspace;
 		for (int i = nr_workspaces; i < rc.workspace_config.min_nr_workspaces; i++) {


### PR DESCRIPTION
Translators - no need to update as "Workspaces" is already covered in `menu.c` and gettext is smart enough to re-use it.

I took the liberty to update all the comments in the `po` files too. tested about 6 locales and all works, including RTL in Arabic (https://github.com/labwc/labwc/issues/1630#issuecomment-2002306206). Would appreciate some CJK testing as I don't have those fonts, but there should be no problem.