### PR TITLE
xwayland: exclude unfocusable views from wlr-foreign-toplevel

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -654,7 +654,12 @@ xwayland_view_map(struct view *view)
 	}
 	view_maximize(view, axis, /*store_natural_geometry*/ true);
 
-	if (!view->toplevel.handle) {
+	/*
+	 * Exclude unfocusable views from wlr-foreign-toplevel. These
+	 * views (notifications, floating toolbars, etc.) should not be
+	 * shown in taskbars/docks/etc.
+	 */
+	if (!view->toplevel.handle && view_is_focusable(view)) {
 		init_foreign_toplevel(view);
 	}
 


### PR DESCRIPTION
These views (notifications, floating toolbars, etc.) should not be shown in taskbars/docks/etc. (which are the stated use-case of the wlr-foreign-toplevel protocol).

See also: https://github.com/jlindgren90/qmpanel/issues/7