### PR TITLE
xwayland: fix segv bug when starting game

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -766,7 +766,14 @@ static struct view *
 xwayland_view_get_root(struct view *view)
 {
 	struct wlr_xwayland_surface *root = top_parent_of(view);
-	return (struct view *)root->data;
+
+	/*
+	 * The case of root->data == NULL is unlikely, but has been reported
+	 * when starting XWayland games (for example 'Fall Guys'). It is
+	 * believed to be caused by setting override-redirect on the root
+	 * wlr_xwayland_surface making it not be associated with a view anymore.
+	 */
+	return (root && root->data) ? (struct view *)root->data : view;
 }
 
 static void


### PR DESCRIPTION
...for example `Fall Guys`. It is believed to be caused by setting override-redirect on an xwayland-surface with a child window, thus breaking the way root-toplevels are obtained.

```
    (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0)
    at pthread_kill.c:44
    at pthread_kill.c:78
    (fmt=0x7739d9f9bb68 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x5a76573f9222 "root", file=file@entry=0x5a76573f9606 "../labwc/src/view.c", line=line@entry=2013, function=function@entry=0x5a7657400320 <__PRETTY_FUNCTION__.14> "view_move_to_front") at assert.c:94
    (assertion=assertion@entry=0x5a76573f9222 "root", file=file@entry=0x5a76573f9606 "../labwc/src/view.c", line=line@entry=2013, function=function@entry=0x5a7657400320 <__PRETTY_FUNCTION__.14> "view_move_to_front") at assert.c:103
    at ../labwc/src/view.c:2013
    at ../labwc/src/view-impl-common.c:30
    at ../labwc/src/xwayland.c:677
    at ../wayland-1.22.0/src/wayland-server.c:2241
    (signal=signal@entry=0x5a7659025160, data=data@entry=0x5a7659024e90)
    at ../wayland-1.22.0/src/wayland-server.c:2241
    at ../subprojects/wlroots/types/wlr_compositor.c:493
    (cif=cif@entry=0x7ffc74d32530, fn=<optimized out>, rvalue=<optimized out>, avalue=<optimized out>, closure=closure@entry=0x0) at ../src/x86/ffi64.c:673
    (cif=cif@entry=0x7ffc74d32530, fn=<optimized out>, rvalue=rvalue@entry=0x0, avalue=avalue@entry=0x7ffc74d32600) at ../src/x86/ffi64.c:710
    (closure=closure@entry=0x5a7658f5adc0, target=<optimized out>,
    target@entry=0x5a7659025240, opcode=opcode@entry=6, data=<optimized out>,
    data@entry=0x5a7658609820, flags=2) at ../wayland-1.22.0/src/connection.c:1025
    (fd=<optimized out>, mask=<optimized out>, data=<optimized out>)
    at ../wayland-1.22.0/src/wayland-server.c:438
    (loop=0x5a7657816e60, timeout=timeout@entry=-1)
    at ../wayland-1.22.0/src/event-loop.c:1027
    at ../wayland-1.22.0/src/wayland-server.c:1493
    at ../labwc/src/main.c:179
```

Reported-by: @kode54