### PR TITLE
Update for wlroots 0.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,6 @@ jobs:
             container: archlinux:base-devel
             env:
               TARGET: 'sh -xe'
-              PKG_CONFIG_PATH: '/usr/lib/wlroots0.17/pkgconfig'
 
           - name: Debian
             os: ubuntu-latest
@@ -70,7 +69,7 @@ jobs:
         run: |
           pacman-key --init
           pacman -Syu --noconfirm
-          pacman -S --noconfirm git meson clang wlroots0.17 libdrm libinput \
+          pacman -S --noconfirm git meson clang wlroots libdrm libinput \
             wayland-protocols cairo pango libxml2 xorg-xwayland librsvg \
             libdisplay-info
 
@@ -92,7 +91,7 @@ jobs:
             sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
             pkg set -yn pkg:mesa-dri # hack to skip llvm dependency
             pkg install -y git meson gcc pkgconf cairo pango evdev-proto \
-              hwdata wayland-protocols wlroots017 libdisplay-info
+              hwdata wayland-protocols wlroots libdisplay-info
           run: echo "setup done"
 
       - name: Install Void Linux dependencies
@@ -106,7 +105,7 @@ jobs:
           xbps-install -Syu
           xbps-install -y git meson gcc clang pkg-config scdoc \
             cairo-devel glib-devel libpng-devel librsvg-devel libxml2-devel \
-            pango-devel wlroots0.17-devel gdb bash xorg-server-xwayland \
+            pango-devel wlroots0.18-devel gdb bash xorg-server-xwayland \
             dejavu-fonts-ttf
 
       # These build are executed on all runners

--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -11,7 +11,7 @@ struct seat;
 struct server;
 struct wlr_surface;
 struct wlr_scene_node;
-enum wlr_button_state;
+enum wl_pointer_button_state;
 
 /* Cursors used internally by labwc */
 enum lab_cursors {
@@ -150,7 +150,7 @@ void cursor_emulate_move_absolute(struct seat *seat,
 		struct wlr_input_device *device,
 		double x, double y, uint32_t time_msec);
 void cursor_emulate_button(struct seat *seat,
-		uint32_t button, enum wlr_button_state state, uint32_t time_msec);
+		uint32_t button, enum wl_pointer_button_state state, uint32_t time_msec);
 void cursor_finish(struct seat *seat);
 
 #endif /* LABWC_CURSOR_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -369,6 +369,7 @@ struct output {
 	struct wl_list link; /* server.outputs */
 	struct server *server;
 	struct wlr_output *wlr_output;
+	struct wlr_output_state pending;
 	struct wlr_scene_output *scene_output;
 	struct wlr_scene_tree *layer_tree[LAB_NR_LAYERS];
 	struct wlr_scene_tree *layer_popup_tree;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -229,7 +229,7 @@ struct server {
 	struct wlr_xdg_shell *xdg_shell;
 	struct wlr_layer_shell_v1 *layer_shell;
 
-	struct wl_listener new_xdg_surface;
+	struct wl_listener new_xdg_toplevel;
 	struct wl_listener new_layer_surface;
 
 	struct wl_listener kde_server_decoration;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -164,7 +164,6 @@ struct seat {
 	/* Used to prevent region snapping when starting a move with A-Left */
 	bool region_prevent_snap;
 
-	struct wl_client *active_client_while_inhibited;
 	struct wl_list inputs;
 	struct wl_listener new_input;
 	struct wl_listener focus_change;
@@ -241,10 +240,6 @@ struct server {
 	struct wl_listener xwayland_xwm_ready;
 	struct wl_listener xwayland_new_surface;
 #endif
-
-	struct wlr_input_inhibit_manager *input_inhibit;
-	struct wl_listener input_inhibit_activate;
-	struct wl_listener input_inhibit_deactivate;
 
 	struct wlr_xdg_activation_v1 *xdg_activation;
 	struct wl_listener xdg_activation_request;
@@ -430,7 +425,7 @@ void foreign_toplevel_update_outputs(struct view *view);
  *  - optionally raise above other views
  *
  * It's okay to call this function even if the view isn't mapped or the
- * session is locked/input is inhibited; it will simply do nothing.
+ * session is locked; it will simply do nothing.
  */
 void desktop_focus_view(struct view *view, bool raise);
 
@@ -513,13 +508,6 @@ void new_tearing_hint(struct wl_listener *listener, void *data);
 void server_init(struct server *server);
 void server_start(struct server *server);
 void server_finish(struct server *server);
-
-/*
- * wlroots "input inhibitor" extension (required for swaylock) blocks
- * any client other than the requesting client from receiving events
- */
-bool input_inhibit_blocks_surface(struct seat *seat,
-	struct wl_resource *resource);
 
 void create_constraint(struct wl_listener *listener, void *data);
 void constrain_cursor(struct server *server, struct wlr_pointer_constraint_v1

--- a/include/output-state.h
+++ b/include/output-state.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_OUTPUT_STATE_H
+#define LABWC_OUTPUT_STATE_H
+
+#include <stdbool.h>
+
+struct output;
+struct wlr_output;
+
+void output_state_init(struct output *output);
+
+/* Forward port of removed functions */
+
+bool wlr_output_test(struct wlr_output *wlr_output);
+
+bool wlr_output_commit(struct wlr_output *wlr_output);
+
+void wlr_output_enable(struct wlr_output *wlr_output, bool enabled);
+
+void wlr_output_set_mode(struct wlr_output *wlr_output,
+	struct wlr_output_mode *mode);
+
+void wlr_output_set_custom_mode(struct wlr_output *wlr_output,
+		int32_t width, int32_t height, int32_t refresh);
+
+void wlr_output_set_scale(struct wlr_output *wlr_output, float scale);
+
+void wlr_output_set_transform(struct wlr_output *wlr_output,
+	enum wl_output_transform transform);
+
+void wlr_output_enable_adaptive_sync(struct wlr_output *wlr_output,
+	bool enabled);
+
+#endif // LABWC_OUTPUT_STATE_H

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,7 @@ endif
 add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 
 wlroots = dependency(
-  'wlroots',
+  'wlroots-0.18',
   default_options: ['default_library=static', 'examples=false'],
   version: ['>=0.18.0', '<0.19.0'],
 )

--- a/meson.build
+++ b/meson.build
@@ -51,7 +51,7 @@ add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 wlroots = dependency(
   'wlroots',
   default_options: ['default_library=static', 'examples=false'],
-  version: ['>=0.17.0', '<0.18.0'],
+  version: ['>=0.18.0', '<0.19.0'],
 )
 
 wlroots_has_xwayland = wlroots.get_variable('have_xwayland') == 'true'

--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ wlroots = dependency(
 wlroots_has_xwayland = wlroots.get_variable('have_xwayland') == 'true'
 
 wayland_server = dependency('wayland-server', version: '>=1.19.0')
-wayland_protos = dependency('wayland-protocols')
+wayland_protos = dependency('wayland-protocols', version: '>=1.35')
 xkbcommon = dependency('xkbcommon')
 xcb = dependency('xcb', required: get_option('xwayland'))
 xcb_icccm = dependency('xcb-icccm', required: get_option('xwayland'))

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -16,7 +16,7 @@ wayland_scanner_server = generator(
 server_protocols = [
 	wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
 	wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
-	wl_protocol_dir / 'unstable/tablet/tablet-unstable-v2.xml',
+	wl_protocol_dir / 'stable/tablet/tablet-v2.xml',
 	wl_protocol_dir / 'staging/cursor-shape/cursor-shape-v1.xml',
 	wl_protocol_dir / 'staging/drm-lease/drm-lease-v1.xml',
 	wl_protocol_dir / 'staging/xwayland-shell/xwayland-shell-v1.xml',

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -5,7 +5,9 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/log.h>
 #include "common/scene-helpers.h"
+#include "labwc.h"
 #include "magnifier.h"
+#include "output-state.h"
 
 struct wlr_surface *
 lab_wlr_surface_from_node(struct wlr_scene_node *node)
@@ -57,7 +59,7 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 	 */
 	if (!wlr_output->needs_frame && !pixman_region32_not_empty(
 			&scene_output->damage_ring.current) && !wants_magnification) {
-		return false;
+		return true;
 	}
 
 	if (!wlr_scene_output_build_state(scene_output, state, NULL)) {
@@ -71,7 +73,7 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 		magnify(output, state->buffer, &additional_damage);
 	}
 
-	if (state == &wlr_output->pending) {
+	if (state == &output->pending) {
 		if (!wlr_output_commit(wlr_output)) {
 			wlr_log(WLR_INFO, "Failed to commit output %s",
 				wlr_output->name);

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -83,14 +83,6 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 		return false;
 	}
 
-	/*
-	 * FIXME: Remove the following line as soon as
-	 * https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4253
-	 * is merged. At that point wlr_scene handles damage tracking internally
-	 * again.
-	 */
-	wlr_damage_ring_rotate(&scene_output->damage_ring);
-
 	if (!wlr_box_empty(&additional_damage)) {
 		wlr_damage_ring_add_box(&scene_output->damage_ring, &additional_damage);
 	}

--- a/src/decorations/xdg-deco.c
+++ b/src/decorations/xdg-deco.c
@@ -7,9 +7,11 @@
 
 struct xdg_deco {
 	struct wlr_xdg_toplevel_decoration_v1 *wlr_xdg_decoration;
+	enum wlr_xdg_toplevel_decoration_v1_mode client_mode;
 	struct view *view;
 	struct wl_listener destroy;
 	struct wl_listener request_mode;
+	struct wl_listener surface_commit;
 };
 
 static void
@@ -18,7 +20,24 @@ xdg_deco_destroy(struct wl_listener *listener, void *data)
 	struct xdg_deco *xdg_deco = wl_container_of(listener, xdg_deco, destroy);
 	wl_list_remove(&xdg_deco->destroy.link);
 	wl_list_remove(&xdg_deco->request_mode.link);
+	if (xdg_deco->surface_commit.notify) {
+		wl_list_remove(&xdg_deco->surface_commit.link);
+		xdg_deco->surface_commit.notify = NULL;
+	}
 	free(xdg_deco);
+}
+
+static void
+handle_surface_commit(struct wl_listener *listener, void *data)
+{
+	struct xdg_deco *xdg_deco = wl_container_of(listener, xdg_deco, surface_commit);
+	struct wlr_xdg_toplevel_decoration_v1 *deco = xdg_deco->wlr_xdg_decoration;
+
+	if (deco->toplevel->base->initial_commit) {
+		wlr_xdg_toplevel_decoration_v1_set_mode(deco, xdg_deco->client_mode);
+		wl_list_remove(&xdg_deco->surface_commit.link);
+		xdg_deco->surface_commit.notify = NULL;
+	}
 }
 
 static void
@@ -46,8 +65,22 @@ xdg_deco_request_mode(struct wl_listener *listener, void *data)
 			"requested: %u", client_mode);
 	}
 
-	wlr_xdg_toplevel_decoration_v1_set_mode(xdg_deco->wlr_xdg_decoration,
-		client_mode);
+	/*
+	 * We may get multiple request_mode calls in an unitialized state.
+	 * Just update the last requested mode and only add the commit
+	 * handler on the first uninitialized state call.
+	 */
+	xdg_deco->client_mode = client_mode;
+
+	if (xdg_deco->wlr_xdg_decoration->toplevel->base->initialized) {
+		wlr_xdg_toplevel_decoration_v1_set_mode(xdg_deco->wlr_xdg_decoration,
+			client_mode);
+	} else if (!xdg_deco->surface_commit.notify) {
+		xdg_deco->surface_commit.notify = handle_surface_commit;
+		wl_signal_add(
+			&xdg_deco->wlr_xdg_decoration->toplevel->base->surface->events.commit,
+			&xdg_deco->surface_commit);
+	}
 	if (client_mode == WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE) {
 		view_set_ssd_mode(xdg_deco->view, LAB_SSD_MODE_FULL);
 	} else {

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -358,15 +358,6 @@ cursor_update_image(struct seat *seat)
 		cursor_names[cursor]);
 }
 
-bool
-input_inhibit_blocks_surface(struct seat *seat, struct wl_resource *resource)
-{
-	struct wl_client *inhibiting_client =
-		seat->active_client_while_inhibited;
-	return inhibiting_client
-		&& inhibiting_client != wl_resource_get_client(resource);
-}
-
 static bool
 update_pressed_surface(struct seat *seat, struct cursor_context *ctx)
 {
@@ -472,8 +463,7 @@ cursor_update_common(struct server *server, struct cursor_context *ctx,
 		return false;
 	}
 
-	if (ctx->surface && !input_inhibit_blocks_surface(seat,
-			ctx->surface->resource)) {
+	if (ctx->surface) {
 		/*
 		 * Cursor is over an input-enabled client surface.  The
 		 * cursor image will be set by request_cursor_notify()

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1333,7 +1333,7 @@ cursor_axis(struct wl_listener *listener, void *data)
 		wlr_seat_pointer_notify_axis(seat->seat, event->time_msec,
 			event->orientation, rc.scroll_factor * event->delta,
 			round(rc.scroll_factor * event->delta_discrete),
-			event->source);
+			event->source, event->relative_direction);
 	}
 }
 

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1153,7 +1153,7 @@ cursor_button(struct wl_listener *listener, void *data)
 
 	bool notify;
 	switch (event->state) {
-	case WLR_BUTTON_PRESSED:
+	case WL_POINTER_BUTTON_STATE_PRESSED:
 		notify = cursor_process_button_press(seat, event->button,
 			event->time_msec);
 		if (notify) {
@@ -1161,7 +1161,7 @@ cursor_button(struct wl_listener *listener, void *data)
 				event->button, event->state);
 		}
 		break;
-	case WLR_BUTTON_RELEASED:
+	case WL_POINTER_BUTTON_STATE_RELEASED:
 		notify = cursor_process_button_release(seat, event->button,
 			event->time_msec);
 		if (notify) {
@@ -1207,19 +1207,19 @@ cursor_emulate_move_absolute(struct seat *seat, struct wlr_input_device *device,
 
 void
 cursor_emulate_button(struct seat *seat, uint32_t button,
-		enum wlr_button_state state, uint32_t time_msec)
+		enum wl_pointer_button_state state, uint32_t time_msec)
 {
 	idle_manager_notify_activity(seat->seat);
 
 	bool notify;
 	switch (state) {
-	case WLR_BUTTON_PRESSED:
+	case WL_POINTER_BUTTON_STATE_PRESSED:
 		notify = cursor_process_button_press(seat, button, time_msec);
 		if (notify) {
 			wlr_seat_pointer_notify_button(seat->seat, time_msec, button, state);
 		}
 		break;
-	case WLR_BUTTON_RELEASED:
+	case WL_POINTER_BUTTON_STATE_RELEASED:
 		notify = cursor_process_button_release(seat, button, time_msec);
 		if (notify) {
 			wlr_seat_pointer_notify_button(seat->seat, time_msec, button, state);
@@ -1272,14 +1272,14 @@ handle_cursor_axis(struct server *server, struct cursor_context *ctx,
 			&server->seat.keyboard_group->keyboard);
 
 	enum direction direction = LAB_DIRECTION_INVALID;
-	if (event->orientation == WLR_AXIS_ORIENTATION_HORIZONTAL) {
+	if (event->orientation == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
 		int rel = compare_delta(event, &server->seat.smooth_scroll_offset.x);
 		if (rel < 0) {
 			direction = LAB_DIRECTION_LEFT;
 		} else if (rel > 0) {
 			direction = LAB_DIRECTION_RIGHT;
 		}
-	} else if (event->orientation == WLR_AXIS_ORIENTATION_VERTICAL) {
+	} else if (event->orientation == WL_POINTER_AXIS_VERTICAL_SCROLL) {
 		int rel = compare_delta(event, &server->seat.smooth_scroll_offset.y);
 		if (rel < 0) {
 			direction = LAB_DIRECTION_UP;

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -457,8 +457,7 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
 		if (cur_keybind && cur_keybind->on_release) {
 			key_state_bound_key_remove(event->keycode);
-			if (seat->server->session_lock_manager->locked
-					|| seat->active_client_while_inhibited) {
+			if (seat->server->session_lock_manager->locked) {
 				cur_keybind = NULL;
 				return true;
 			}
@@ -476,13 +475,10 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	}
 
 	/*
-	 * Ignore labwc keybindings if input is inhibited
+	 * Ignore labwc keybindings if the session is locked.
 	 * It's important to do this after key_state_set_pressed() to ensure
 	 * _all_ key press/releases are registered
 	 */
-	if (seat->active_client_while_inhibited) {
-		return false;
-	}
 	if (seat->server->session_lock_manager->locked) {
 		return false;
 	}

--- a/src/input/tablet-pad.c
+++ b/src/input/tablet-pad.c
@@ -116,7 +116,11 @@ handle_button(struct wl_listener *listener, void *data)
 	} else {
 		uint32_t button = tablet_get_mapped_button(ev->button);
 		if (button) {
-			cursor_emulate_button(pad->seat, button, ev->state, ev->time_msec);
+			cursor_emulate_button(pad->seat, button,
+				ev->state == WLR_BUTTON_PRESSED
+					? WL_POINTER_BUTTON_STATE_PRESSED
+					: WL_POINTER_BUTTON_STATE_RELEASED,
+				ev->time_msec);
 		}
 	}
 }

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -441,8 +441,8 @@ handle_tip(struct wl_listener *listener, void *data)
 			cursor_emulate_button(tablet->seat,
 				button,
 				ev->state == WLR_TABLET_TOOL_TIP_DOWN
-					? WLR_BUTTON_PRESSED
-					: WLR_BUTTON_RELEASED,
+					? WL_POINTER_BUTTON_STATE_PRESSED
+					: WL_POINTER_BUTTON_STATE_RELEASED,
 				ev->time_msec);
 		}
 	}
@@ -500,7 +500,11 @@ handle_button(struct wl_listener *listener, void *data)
 	} else {
 		if (button) {
 			is_down_mouse_emulation = ev->state == WLR_BUTTON_PRESSED;
-			cursor_emulate_button(tablet->seat, button, ev->state, ev->time_msec);
+			cursor_emulate_button(tablet->seat, button,
+				ev->state == WLR_BUTTON_PRESSED
+					? WL_POINTER_BUTTON_STATE_PRESSED
+					: WL_POINTER_BUTTON_STATE_RELEASED,
+				ev->time_msec);
 		}
 	}
 }

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -127,7 +127,7 @@ touch_down(struct wl_listener *listener, void *data)
 	} else {
 		cursor_emulate_move_absolute(seat, &event->touch->base,
 			event->x, event->y, event->time_msec);
-		cursor_emulate_button(seat, BTN_LEFT, WLR_BUTTON_PRESSED,
+		cursor_emulate_button(seat, BTN_LEFT, WL_POINTER_BUTTON_STATE_PRESSED,
 			event->time_msec);
 	}
 }
@@ -146,8 +146,8 @@ touch_up(struct wl_listener *listener, void *data)
 				wlr_seat_touch_notify_up(seat->seat, event->time_msec,
 					event->touch_id);
 			} else {
-				cursor_emulate_button(seat, BTN_LEFT, WLR_BUTTON_RELEASED,
-					event->time_msec);
+				cursor_emulate_button(seat, BTN_LEFT,
+					WL_POINTER_BUTTON_STATE_RELEASED, event->time_msec);
 			}
 			wl_list_remove(&touch_point->link);
 			zfree(touch_point);

--- a/src/layers.c
+++ b/src/layers.c
@@ -412,7 +412,7 @@ create_popup(struct wlr_xdg_popup *wlr_popup, struct wlr_scene_tree *parent)
 		LAB_NODE_DESC_LAYER_POPUP, popup);
 
 	popup->destroy.notify = popup_handle_destroy;
-	wl_signal_add(&wlr_popup->base->events.destroy, &popup->destroy);
+	wl_signal_add(&wlr_popup->events.destroy, &popup->destroy);
 
 	popup->new_popup.notify = popup_handle_new_popup;
 	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ labwc_sources = files(
   'osd.c',
   'osd-field.c',
   'output.c',
+  'output-state.c',
   'output-virtual.c',
   'overlay.c',
   'placement.c',

--- a/src/output-state.c
+++ b/src/output-state.c
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_output_management_v1.h>
+#include "labwc.h"
+#include "output-state.h"
+
+void
+output_state_init(struct output *output)
+{
+	wlr_output_state_init(&output->pending);
+
+	/*
+	 * As there is no direct way to convert an existing output
+	 * configuration to an output_state we first convert it
+	 * to a temporary output-management config and then apply
+	 * it to an empty wlr_output_state.
+	 */
+	struct wlr_output_configuration_v1 *backup_config =
+		wlr_output_configuration_v1_create();
+	struct wlr_output_configuration_head_v1 *backup_head =
+		wlr_output_configuration_head_v1_create(
+			backup_config, output->wlr_output);
+
+	wlr_output_head_v1_state_apply(&backup_head->state, &output->pending);
+	wlr_output_configuration_v1_destroy(backup_config);
+}
+
+bool
+wlr_output_test(struct wlr_output *wlr_output)
+{
+	struct output *output = wlr_output->data;
+	return wlr_output_test_state(wlr_output, &output->pending);
+}
+
+bool
+wlr_output_commit(struct wlr_output *wlr_output)
+{
+	struct output *output = wlr_output->data;
+	bool committed = wlr_output_commit_state(wlr_output, &output->pending);
+	if (committed) {
+		wlr_output_state_finish(&output->pending);
+		wlr_output_state_init(&output->pending);
+	} else {
+		wlr_log(WLR_ERROR, "Failed to commit frame");
+	}
+	return committed;
+}
+
+void
+wlr_output_enable(struct wlr_output *wlr_output, bool enabled)
+{
+	struct output *output = wlr_output->data;
+	wlr_output_state_set_enabled(&output->pending, enabled);
+}
+
+void
+wlr_output_set_mode(struct wlr_output *wlr_output, struct wlr_output_mode *mode)
+{
+	struct output *output = wlr_output->data;
+	wlr_output_state_set_mode(&output->pending, mode);
+}
+
+void
+wlr_output_set_custom_mode(struct wlr_output *wlr_output,
+		int32_t width, int32_t height, int32_t refresh)
+{
+	struct output *output = wlr_output->data;
+	wlr_output_state_set_custom_mode(&output->pending, width, height, refresh);
+}
+
+void
+wlr_output_set_scale(struct wlr_output *wlr_output, float scale)
+{
+	struct output *output = wlr_output->data;
+	wlr_output_state_set_scale(&output->pending, scale);
+}
+
+void
+wlr_output_set_transform(struct wlr_output *wlr_output,
+		enum wl_output_transform transform)
+{
+	struct output *output = wlr_output->data;
+	wlr_output_state_set_transform(&output->pending, transform);
+}
+
+void
+wlr_output_enable_adaptive_sync(struct wlr_output *wlr_output, bool enabled)
+{
+	struct output *output = wlr_output->data;
+	wlr_output_state_set_adaptive_sync_enabled(&output->pending, enabled);
+}

--- a/src/output.c
+++ b/src/output.c
@@ -431,7 +431,7 @@ output_init(struct server *server)
 	 * Create an output layout, which is a wlroots utility for working with
 	 * an arrangement of screens in a physical layout.
 	 */
-	server->output_layout = wlr_output_layout_create();
+	server->output_layout = wlr_output_layout_create(server->wl_display);
 	if (!server->output_layout) {
 		wlr_log(WLR_ERROR, "unable to create output layout");
 		exit(EXIT_FAILURE);

--- a/src/seat.c
+++ b/src/seat.c
@@ -637,11 +637,6 @@ seat_focus(struct seat *seat, struct wlr_surface *surface, bool is_lock_surface)
 		return;
 	}
 
-	/* Respect input inhibit (also used by some lock screens) */
-	if (input_inhibit_blocks_surface(seat, surface->resource)) {
-		return;
-	}
-
 	if (!wlr_seat_get_keyboard(seat->seat)) {
 		/*
 		 * wlr_seat_keyboard_notify_enter() sends wl_keyboard.modifiers,

--- a/src/seat.c
+++ b/src/seat.c
@@ -40,7 +40,7 @@ device_type_from_wlr_device(struct wlr_input_device *wlr_input_device)
 {
 	switch (wlr_input_device->type) {
 	case WLR_INPUT_DEVICE_TOUCH:
-	case WLR_INPUT_DEVICE_TABLET_TOOL:
+	case WLR_INPUT_DEVICE_TABLET:
 		return LAB_LIBINPUT_DEVICE_TOUCH;
 	default:
 		break;
@@ -397,7 +397,7 @@ seat_update_capabilities(struct seat *seat)
 			caps |= WL_SEAT_CAPABILITY_KEYBOARD;
 			break;
 		case WLR_INPUT_DEVICE_POINTER:
-		case WLR_INPUT_DEVICE_TABLET_TOOL:
+		case WLR_INPUT_DEVICE_TABLET:
 			caps |= WL_SEAT_CAPABILITY_POINTER;
 			break;
 		case WLR_INPUT_DEVICE_TOUCH:
@@ -438,7 +438,7 @@ new_input_notify(struct wl_listener *listener, void *data)
 	case WLR_INPUT_DEVICE_TOUCH:
 		input = new_touch(seat, device);
 		break;
-	case WLR_INPUT_DEVICE_TABLET_TOOL:
+	case WLR_INPUT_DEVICE_TABLET:
 		input = new_tablet(seat, device);
 		break;
 	case WLR_INPUT_DEVICE_TABLET_PAD:
@@ -609,7 +609,7 @@ seat_reconfigure(struct server *server)
 			configure_libinput(input->wlr_input_device);
 			map_touch_to_output(seat, input->wlr_input_device);
 			break;
-		case WLR_INPUT_DEVICE_TABLET_TOOL:
+		case WLR_INPUT_DEVICE_TABLET:
 			map_input_to_output(seat, input->wlr_input_device, rc.tablet.output_name);
 			break;
 		default:
@@ -759,7 +759,7 @@ seat_output_layout_changed(struct seat *seat)
 		case WLR_INPUT_DEVICE_TOUCH:
 			map_touch_to_output(seat, input->wlr_input_device);
 			break;
-		case WLR_INPUT_DEVICE_TABLET_TOOL:
+		case WLR_INPUT_DEVICE_TABLET:
 			map_input_to_output(seat, input->wlr_input_device, rc.tablet.output_name);
 			break;
 		default:

--- a/src/server.c
+++ b/src/server.c
@@ -542,8 +542,6 @@ server_finish(struct server *server)
 	wl_display_destroy_clients(server->wl_display);
 
 	seat_finish(server);
-	wlr_output_layout_destroy(server->output_layout);
-
 	wl_display_destroy(server->wl_display);
 
 	/* TODO: clean up various scene_tree nodes */

--- a/src/server.c
+++ b/src/server.c
@@ -291,7 +291,7 @@ server_init(struct server *server)
 	 * window if an x11 server is running.
 	 */
 	server->backend = wlr_backend_autocreate(
-		server->wl_display, &server->session);
+		server->wl_event_loop, &server->session);
 	if (!server->backend) {
 		wlr_log(WLR_ERROR, "unable to create backend");
 		fprintf(stderr, helpful_seat_error_message);
@@ -304,7 +304,8 @@ server_init(struct server *server)
 
 	if (!server->headless.backend) {
 		wlr_log(WLR_DEBUG, "manually creating headless backend");
-		server->headless.backend = wlr_headless_backend_create(server->wl_display);
+		server->headless.backend = wlr_headless_backend_create(
+			server->wl_event_loop);
 	} else {
 		wlr_log(WLR_DEBUG, "headless backend already exists");
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -29,6 +29,7 @@
 #include "labwc.h"
 #include "layers.h"
 #include "menu/menu.h"
+#include "output-state.h"
 #include "output-virtual.h"
 #include "regions.h"
 #include "resize-indicator.h"

--- a/src/server.c
+++ b/src/server.c
@@ -442,7 +442,6 @@ server_init(struct server *server)
 		wlr_log(WLR_ERROR, "unable to create presentation interface");
 		exit(EXIT_FAILURE);
 	}
-	wlr_scene_set_presentation(server->scene, presentation);
 
 	wlr_export_dmabuf_manager_v1_create(server->wl_display);
 	wlr_screencopy_manager_v1_create(server->wl_display);

--- a/src/tearing.c
+++ b/src/tearing.c
@@ -15,7 +15,7 @@ set_tearing_hint(struct wl_listener *listener, void *data)
 {
 	struct tearing_controller *controller = wl_container_of(listener, controller, set_hint);
 	struct view *view = view_from_wlr_surface(controller->tearing_control->surface);
-	if (view && controller->tearing_control->hint) {
+	if (view && controller->tearing_control->current) {
 		view->tearing_hint = true;
 	}
 }

--- a/src/view.c
+++ b/src/view.c
@@ -12,6 +12,7 @@
 #include "labwc.h"
 #include "menu/menu.h"
 #include "osd.h"
+#include "output-state.h"
 #include "placement.h"
 #include "regions.h"
 #include "resize-indicator.h"

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -101,7 +101,7 @@ xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup)
 	popup->wlr_popup = wlr_popup;
 
 	popup->destroy.notify = handle_xdg_popup_destroy;
-	wl_signal_add(&wlr_popup->base->events.destroy, &popup->destroy);
+	wl_signal_add(&wlr_popup->events.destroy, &popup->destroy);
 
 	popup->new_popup.notify = popup_handle_new_xdg_popup;
 	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -824,9 +824,9 @@ xdg_surface_new(struct wl_listener *listener, void *data)
 	xdg_surface->surface->data = tree;
 
 	view_connect_map(view, xdg_surface->surface);
-	CONNECT_SIGNAL(xdg_surface, view, destroy);
 
 	struct wlr_xdg_toplevel *toplevel = xdg_surface->toplevel;
+	CONNECT_SIGNAL(toplevel, view, destroy);
 	CONNECT_SIGNAL(toplevel, view, request_move);
 	CONNECT_SIGNAL(toplevel, view, request_resize);
 	CONNECT_SIGNAL(toplevel, view, request_minimize);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -743,19 +743,14 @@ xdg_activation_handle_request(struct wl_listener *listener, void *data)
  *     to help the popups find their parent nodes
  */
 static void
-xdg_surface_new(struct wl_listener *listener, void *data)
+xdg_toplevel_new(struct wl_listener *listener, void *data)
 {
 	struct server *server =
-		wl_container_of(listener, server, new_xdg_surface);
-	struct wlr_xdg_surface *xdg_surface = data;
+		wl_container_of(listener, server, new_xdg_toplevel);
+	struct wlr_xdg_toplevel *xdg_toplevel = data;
+	struct wlr_xdg_surface *xdg_surface = xdg_toplevel->base;
 
-	/*
-	 * We deal with popups in xdg-popup.c and layers.c as they have to be
-	 * treated differently
-	 */
-	if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
-		return;
-	}
+	assert(xdg_surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
 
 	wlr_xdg_surface_ping(xdg_surface);
 
@@ -850,8 +845,9 @@ xdg_shell_init(struct server *server)
 		wlr_log(WLR_ERROR, "unable to create the XDG shell interface");
 		exit(EXIT_FAILURE);
 	}
-	server->new_xdg_surface.notify = xdg_surface_new;
-	wl_signal_add(&server->xdg_shell->events.new_surface, &server->new_xdg_surface);
+
+	server->new_xdg_toplevel.notify = xdg_toplevel_new;
+	wl_signal_add(&server->xdg_shell->events.new_toplevel, &server->new_xdg_toplevel);
 
 	server->xdg_activation = wlr_xdg_activation_v1_create(server->wl_display);
 	if (!server->xdg_activation) {

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -42,7 +42,6 @@ handle_map(struct wl_listener *listener, void *data)
 	assert(!unmanaged->node);
 
 	/* Stack new surface on top */
-	wlr_xwayland_surface_restack(xsurface, NULL, XCB_STACK_MODE_ABOVE);
 	wl_list_append(&unmanaged->server->unmanaged_surfaces, &unmanaged->link);
 
 	CONNECT_SIGNAL(xsurface, unmanaged, set_geometry);

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -781,14 +781,6 @@ xwayland_view_move_to_front(struct view *view)
 	 */
 	wlr_xwayland_surface_restack(xwayland_surface_from_view(view),
 		NULL, XCB_STACK_MODE_ABOVE);
-
-	/* Restack unmanaged surfaces on top */
-	struct wl_list *list = &view->server->unmanaged_surfaces;
-	struct xwayland_unmanaged *u;
-	wl_list_for_each(u, list, link) {
-		wlr_xwayland_surface_restack(u->xwayland_surface,
-			NULL, XCB_STACK_MODE_ABOVE);
-	}
 }
 
 static void

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 811ca199c444525dc4d846d38f76554f1a9b48b0
+revision = 488a23c16908a83041cf28e134a6f149d831598d
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = fe8916fef0bd5d0846dfadd5f8c49ac57beedc9a
+revision = 1968ada2132237f5bf8e40b6bf903fbce76c0b40
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = d1b39b58432c471c16e09103fd2c7850e3c41950
+revision = 811ca199c444525dc4d846d38f76554f1a9b48b0
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 0.17
+revision = 3b4d7d2a926a0b65d3bad6649615c0b6a61c0336
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = ab924064f230cce2aea2e45bd113adea9d37f286
+revision = 98c708618ec09907748082850b2d4340fc63055e
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = fe429b2463f279a6274bb6f42a3e23525a3c97aa
+revision = 0.18
 
 [provide]
 dependency_names = wlroots-0.18

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 3b4d7d2a926a0b65d3bad6649615c0b6a61c0336
+revision = 5dd614b9adc97bf1c89c8e2ebe8504841f8635ea
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 488a23c16908a83041cf28e134a6f149d831598d
+revision = b821be5749061b0b73d777cb2fc74204cbf78278
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = cca2bfbe92205260c75a82ad6b6a7c5bae1599de
+revision = d1b39b58432c471c16e09103fd2c7850e3c41950
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 98c708618ec09907748082850b2d4340fc63055e
+revision = cca2bfbe92205260c75a82ad6b6a7c5bae1599de
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 5dd614b9adc97bf1c89c8e2ebe8504841f8635ea
+revision = f1762f428b0ef2989c81f57ea9e810403d34d946
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = d61ec694b352c0f21c06958c5ef0417f3e424e3c
+revision = c85838892d56111809aa2edb83a2f22428bfa806
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,7 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = b821be5749061b0b73d777cb2fc74204cbf78278
+revision = 4b4f76cc13574544216b59b3a9902b468b82108b
 
 [provide]
-dependency_names = wlroots
+dependency_names = wlroots-0.18
+wlroots-0.18=wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = f1762f428b0ef2989c81f57ea9e810403d34d946
+revision = d61ec694b352c0f21c06958c5ef0417f3e424e3c
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 4b4f76cc13574544216b59b3a9902b468b82108b
+revision = fe429b2463f279a6274bb6f42a3e23525a3c97aa
 
 [provide]
 dependency_names = wlroots-0.18

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 1968ada2132237f5bf8e40b6bf903fbce76c0b40
+revision = ab924064f230cce2aea2e45bd113adea9d37f286
 
 [provide]
 dependency_names = wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = c85838892d56111809aa2edb83a2f22428bfa806
+revision = fe8916fef0bd5d0846dfadd5f8c49ac57beedc9a
 
 [provide]
 dependency_names = wlroots


### PR DESCRIPTION
Same story as
- #626

This branch is not intended to be merged anytime soon but should allow to collaborate on chasing wlroots master.
As in the previous PR, feel free to push changes into this branch.

I suggest not using force pushes for now to reduce chances of accidentally overwriting something. If some existing commit should be amended just use `!fixup` or `[fixup]` or something along that line and refer to the subject of the commit to be amended (the hash may change due to rebases). We can remove that no-force-push restriction once we have a somewhat stable base to work with.

Like in #626 our goal should also be to make this PR as small as possible to reduce rebase conflicts with master. So if we can merge a commit in master that works for 0.17 and 0.18 without introducing any unnecessary complexity we should likely do that.

@ahesford @jlindgren90 @johanmalm 

Further information:
- breaking changes for 0.18: https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3760
- #1260

Current issues:
- [ ] https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4600 seems to implement a immediate scale event for surfaces within scene. We may be able to remove our downstream fix (4238d7fc33dc2c7c4ee4ecbac81decbc91833c1a) for that issue, @ahesford could say more about that

Nice to have:
- [ ] listen to `wlr_renderer.events.lost` to catch GPU resets and do a `Reconfigure` to reload all compositor side buffers
- [ ] explicit sync ([wlroots MR](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4262), [sway PR](https://github.com/swaywm/sway/pull/8156))
- [ ] icon spec ([wlroots MR](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4704))
- [ ] adaptive_sync_supported ([wlroots MR](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4650))

Fixed:
- [x] ~~parentless xdg popups are not be handled correctly~~ (misunderstanding of the new redundant xdg-shell new_popup event)
- [x] the commit messages and `wlroots.wrap` files do not yet contain the correct wlroots hash and might also be out of order, I only did the first step of getting labwc to work with current wlroots master.
- [x] the initial xdg_surface configure flow has been changed, compositors now need to do that on their own
- [x] xdg decorations must not be confirmed directly but only if `xdg_surface->initialized == true`, also needs storage of the requested deco mode or link from view to the deco object itself which can be used from the xdg commit handler
- [x] at least when running nested the rounded corners sometimes flicker on mouse movements and are then completely transparent (caused by a wlroots bug, [MR pending](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4655))
- [x] as wlroots removed `wlr_output->pending` we have to use the `wlr_output_state_()` variants everywhere. But to reduce unnecessary screen blanking during mode changes we likely want to keep using a shared pending state. Rather than changing everything around to that I added a new `src/output-state.c` file which provides wrappers for the old `wlr_output_set_()`functions. This massively reduces rebase conflicts.
- [x] we currently crash on `ctrl-c` in gdb when running nested, ~~needs investigation~~ this is a libwayland bug, fixed via [this MR](https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/366) but not yet released
- [x] `lab_wlr_scene_commit()` still contains a comment about handling damage, that was an issue in wlroots 0.17.x but might now have been fixed upstream, needs to be verified
- [x] The CI is currently not set up to deal with wlroots compilations, should be easy to fix
- [x] `WLR_SCENE_DEBUG_DAMAGE=highlight` damage tracking is pretty broken, [wlroots MR](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4654)

There might be more issues, only slightly tested.