### PR TITLE
layer: try to set keyboard focus on map

### DIFF
--- a/src/layers.c
+++ b/src/layers.c
@@ -337,6 +337,7 @@ handle_map(struct wl_listener *listener, void *data)
 	if (wlr_output) {
 		output_update_usable_area(wlr_output->data);
 	}
+
 	/*
 	 * Since moving to the wlroots scene-graph API, there is no need to
 	 * call wlr_surface_send_enter() from here since that will be done
@@ -344,10 +345,8 @@ handle_map(struct wl_listener *listener, void *data)
 	 * the scene. See wlr_scene_surface_create() documentation.
 	 */
 
-	/*
-	 * Processing of keyboard-interactivity changes is done in the
-	 * commit-handler.
-	 */
+	struct seat *seat = &layer->server->seat;
+	layer_try_set_focus(seat, layer->scene_layer_surface->layer_surface);
 }
 
 static void


### PR DESCRIPTION
...for the following reasons:

1. We interpret 'normal input-focus semantics' for clients with on-demand keyboard interactivity to means that a surface receives input focus on cursor-button-press AND on map (the latter previously missing), just like a normal window would. In this regard, we do not differentiate between layers.

2. Most layer-surfaces set the keyboard interactivity at a similar time to their first (and normally only) map, so the absence of an explicit attempt to focus on map does not make a difference. However, for a long-running layer-shell client (such as lxqt-runner) which sets the interactivity on launch and then maps/unmaps many times throughout its lifetime, a specific focus-attempt is required on map to avoid the client itself having to keep resetting its interactivity to grab the keyboard on map.

3. Compositors like sway and river process focus (for clients with keyboard-interactivity)  in their map-handlers, so this makes for a common approach.

Fixes: #1653