### PR TITLE
Window switcher, allow to use percent of monitor width.

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -165,6 +165,9 @@ elements are not listed here, but are supported.
 *osd.window-switcher.width*
 	Width of window switcher in pixels. Default is 600.
 
+*osd.window-switcher.width.percent*
+	Width of window switcher in percent. Default is 0. Max 100%
+
 *osd.window-switcher.padding*
 	Padding of window switcher in pixels. This is the space between the
 	window-switcher border and its items. Default is 4.

--- a/include/theme.h
+++ b/include/theme.h
@@ -71,6 +71,7 @@ struct theme {
 	float osd_label_text_color[4];
 
 	int osd_window_switcher_width;
+	int osd_window_switcher_width_percent;
 	int osd_window_switcher_padding;
 	int osd_window_switcher_item_padding_x;
 	int osd_window_switcher_item_padding_y;

--- a/src/osd.c
+++ b/src/osd.c
@@ -321,7 +321,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 	if (show_workspace) {
 		/* Center workspace indicator on the x axis */
 		int x = font_width(&rc.font_osd, workspace_name);
-		x = (theme->osd_window_switcher_width - x) / 2;
+		x = (w - x) / 2;
 		cairo_move_to(cairo, x, y + theme->osd_window_switcher_item_active_border_width);
 		PangoWeight weight = pango_font_description_get_weight(desc);
 		pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
@@ -432,7 +432,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 			struct wlr_fbox fbox = {
 				.x = theme->osd_border_width + theme->osd_window_switcher_padding,
 				.y = y,
-				.width = theme->osd_window_switcher_width
+				.width = w
 					- 2 * theme->osd_border_width
 					- 2 * theme->osd_window_switcher_padding,
 				.height = theme->osd_window_switcher_item_height,
@@ -459,7 +459,12 @@ display_osd(struct output *output, struct wl_array *views)
 	const char *workspace_name = server->workspace_current->name;
 
 	float scale = output->wlr_output->scale;
-	int w = theme->osd_window_switcher_width;
+	int w;
+	if (theme->osd_window_switcher_width_percent) {
+		w = output->wlr_output->width * theme->osd_window_switcher_width_percent / 100;
+	} else {
+		w = theme->osd_window_switcher_width;
+	}
 	int h = wl_array_len(views) * rc.theme->osd_window_switcher_item_height
 		+ 2 * rc.theme->osd_border_width
 		+ 2 * rc.theme->osd_window_switcher_padding;

--- a/src/theme.c
+++ b/src/theme.c
@@ -490,6 +490,7 @@ theme_builtin(struct theme *theme)
 	parse_hexstr("#888888", theme->menu_separator_color);
 
 	theme->osd_window_switcher_width = 600;
+	theme->osd_window_switcher_width_percent = 0;
 	theme->osd_window_switcher_padding = 4;
 	theme->osd_window_switcher_item_padding_x = 10;
 	theme->osd_window_switcher_item_padding_y = 1;
@@ -671,6 +672,9 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match_glob(key, "osd.window-switcher.width")) {
 		theme->osd_window_switcher_width = atoi(value);
+	}
+	if (match_glob(key, "osd.window-switcher.width.percent")) {
+		theme->osd_window_switcher_width_percent = atoi(value);
 	}
 	if (match_glob(key, "osd.window-switcher.padding")) {
 		theme->osd_window_switcher_padding = atoi(value);


### PR DESCRIPTION
OSD will size per monitor.  With this the width stays relative sized on my 4k as well as my 1080p monitor

example from my theme
osd.window-switcher.width.percent: 60%

Review and let me know what you think.