### PR TITLE
Window switcher, allow to use percent of monitor width.

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -164,6 +164,8 @@ elements are not listed here, but are supported.
 
 *osd.window-switcher.width*
 	Width of window switcher in pixels. Default is 600.
+	Width can also be percent of the width of the monitor.
+	% is mandatory as last character, max 100%
 
 *osd.window-switcher.padding*
 	Padding of window switcher in pixels. This is the space between the

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -165,7 +165,7 @@ elements are not listed here, but are supported.
 *osd.window-switcher.width*
 	Width of window switcher in pixels. Default is 600.
 	Width can also be percent of the width of the monitor.
-	% is mandatory as last character, max 100%
+	% is mandatory as last character in this case, max 100%
 
 *osd.window-switcher.padding*
 	Padding of window switcher in pixels. This is the space between the

--- a/docs/themerc
+++ b/docs/themerc
@@ -60,7 +60,10 @@ osd.border.color: #000000
 osd.border.width: 1
 osd.label.text.color: #000000
 
+# width can be set as percent (of screen width)
+# example 50% or 75% instead of 600, max 100%
 osd.window-switcher.width: 600
+
 osd.window-switcher.padding: 4
 osd.window-switcher.item.padding.x: 10
 osd.window-switcher.item.padding.y: 1

--- a/include/theme.h
+++ b/include/theme.h
@@ -112,6 +112,7 @@ struct theme {
 
 	/* not set in rc.xml/themerc, but derived from font & padding_height */
 	int osd_window_switcher_item_height;
+	bool osd_width_should_parse_as_percentage;
 };
 
 /**

--- a/src/osd.c
+++ b/src/osd.c
@@ -321,7 +321,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 	if (show_workspace) {
 		/* Center workspace indicator on the x axis */
 		int x = font_width(&rc.font_osd, workspace_name);
-		x = (theme->osd_window_switcher_width - x) / 2;
+		x = (w - x) / 2;
 		cairo_move_to(cairo, x, y + theme->osd_window_switcher_item_active_border_width);
 		PangoWeight weight = pango_font_description_get_weight(desc);
 		pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
@@ -432,7 +432,7 @@ render_osd(struct server *server, cairo_t *cairo, int w, int h,
 			struct wlr_fbox fbox = {
 				.x = theme->osd_border_width + theme->osd_window_switcher_padding,
 				.y = y,
-				.width = theme->osd_window_switcher_width
+				.width = w
 					- 2 * theme->osd_border_width
 					- 2 * theme->osd_window_switcher_padding,
 				.height = theme->osd_window_switcher_item_height,
@@ -460,6 +460,9 @@ display_osd(struct output *output, struct wl_array *views)
 
 	float scale = output->wlr_output->scale;
 	int w = theme->osd_window_switcher_width;
+	if (theme->osd_width_should_parse_as_percentage) {
+		w = output->wlr_output->width * theme->osd_window_switcher_width / 100;
+	}
 	int h = wl_array_len(views) * rc.theme->osd_window_switcher_item_height
 		+ 2 * rc.theme->osd_border_width
 		+ 2 * rc.theme->osd_window_switcher_padding;

--- a/src/theme.c
+++ b/src/theme.c
@@ -494,6 +494,7 @@ theme_builtin(struct theme *theme)
 	theme->osd_window_switcher_item_padding_x = 10;
 	theme->osd_window_switcher_item_padding_y = 1;
 	theme->osd_window_switcher_item_active_border_width = 2;
+	theme->osd_width_should_parse_as_percentage = false;
 
 	theme->osd_workspace_switcher_boxes_width = 20;
 	theme->osd_workspace_switcher_boxes_height = 20;

--- a/src/theme.c
+++ b/src/theme.c
@@ -678,9 +678,8 @@ entry(struct theme *theme, const char *key, const char *value)
 			theme->osd_width_should_parse_as_percentage = true;
 		}
 		theme->osd_window_switcher_width = atoi(value);
-		if (theme->osd_width_should_parse_as_percentage &&
-				theme->osd_window_switcher_width > 100) {
-			theme->osd_window_switcher_width = 100;
+		if (theme->osd_window_switcher_width < 0) {
+			theme->osd_window_switcher_width = 0;
 		}
 	}
 	if (match_glob(key, "osd.window-switcher.padding")) {
@@ -1017,6 +1016,10 @@ post_processing(struct theme *theme)
 	}
 	if (theme->osd_workspace_switcher_boxes_height == 0) {
 		theme->osd_workspace_switcher_boxes_width = 0;
+	}
+	if (theme->osd_width_should_parse_as_percentage) {
+		theme->osd_window_switcher_width = 
+			MIN(theme->osd_window_switcher_width, 100);
 	}
 }
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -1018,7 +1018,7 @@ post_processing(struct theme *theme)
 		theme->osd_workspace_switcher_boxes_width = 0;
 	}
 	if (theme->osd_width_should_parse_as_percentage) {
-		theme->osd_window_switcher_width = 
+		theme->osd_window_switcher_width =
 			MIN(theme->osd_window_switcher_width, 100);
 	}
 }

--- a/src/theme.c
+++ b/src/theme.c
@@ -670,6 +670,12 @@ entry(struct theme *theme, const char *key, const char *value)
 		parse_hexstr(value, theme->osd_border_color);
 	}
 	if (match_glob(key, "osd.window-switcher.width")) {
+		theme->osd_width_should_parse_as_percentage = false;
+		char *p = strrchr(value, '%');
+		if (p) {
+			*p = '\0';
+			theme->osd_width_should_parse_as_percentage = true;
+		}
 		theme->osd_window_switcher_width = atoi(value);
 	}
 	if (match_glob(key, "osd.window-switcher.padding")) {

--- a/src/theme.c
+++ b/src/theme.c
@@ -677,6 +677,10 @@ entry(struct theme *theme, const char *key, const char *value)
 			theme->osd_width_should_parse_as_percentage = true;
 		}
 		theme->osd_window_switcher_width = atoi(value);
+		if (theme->osd_width_should_parse_as_percentage &&
+				theme->osd_window_switcher_width > 100) {
+			theme->osd_window_switcher_width = 100;
+		}
 	}
 	if (match_glob(key, "osd.window-switcher.padding")) {
 		theme->osd_window_switcher_padding = atoi(value);


### PR DESCRIPTION
OSD will size per monitor. With this the width stays relative sized on my 4k as well as my 1080p monitor

example from my theme
osd.window-switcher.width: 60%

Accidentally deleted last PR. ~rolls eyes~ 

Ready for review, I think