### PR TITLE
osd: prevent handling cursor actions in preview mode

### DIFF
--- a/src/foreign.c
+++ b/src/foreign.c
@@ -34,6 +34,12 @@ handle_request_activate(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, toplevel.activate);
 	// struct wlr_foreign_toplevel_handle_v1_activated_event *event = data;
+
+	if (view->server->osd_state.cycle_view) {
+		wlr_log(WLR_INFO, "Preventing focus request while in window switcher");
+		return;
+	}
+
 	/* In a multi-seat world we would select seat based on event->seat here. */
 	desktop_focus_view(view, /*raise*/ true);
 }

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -529,7 +529,8 @@ process_cursor_motion(struct server *server, uint32_t time)
 		dnd_icons_move(seat, seat->cursor->x, seat->cursor->y);
 	}
 
-	if ((ctx.view || ctx.surface) && rc.focus_follow_mouse) {
+	if ((ctx.view || ctx.surface) && rc.focus_follow_mouse
+			&& !server->osd_state.cycle_view) {
 		desktop_focus_view_or_surface(seat, ctx.view, ctx.surface,
 			rc.raise_on_focus);
 	}
@@ -806,6 +807,10 @@ static bool
 handle_release_mousebinding(struct server *server,
 		struct cursor_context *ctx, uint32_t button)
 {
+	if (server->osd_state.cycle_view) {
+		return false;
+	}
+
 	struct mousebind *mousebind;
 	bool consumed_by_frame_context = false;
 
@@ -892,6 +897,10 @@ static bool
 handle_press_mousebinding(struct server *server, struct cursor_context *ctx,
 		uint32_t button, uint32_t resize_edges)
 {
+	if (server->osd_state.cycle_view) {
+		return false;
+	}
+
 	struct mousebind *mousebind;
 	bool double_click = is_double_click(rc.doubleclick_time, button, ctx);
 	bool consumed_by_frame_context = false;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -684,6 +684,11 @@ xdg_activation_handle_request(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	if (view->server->osd_state.cycle_view) {
+		wlr_log(WLR_INFO, "Preventing focus request while in window switcher");
+		return;
+	}
+
 	wlr_log(WLR_DEBUG, "Activating surface");
 	desktop_focus_view(view, /*raise*/ true);
 }

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -399,6 +399,11 @@ handle_request_activate(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	if (view->server->osd_state.cycle_view) {
+		wlr_log(WLR_INFO, "Preventing focus request while in window switcher");
+		return;
+	}
+
 	desktop_focus_view(view, /*raise*/ true);
 }
 


### PR DESCRIPTION
Fixes:
- #1640

Other than fixing that bug It also doesn't make sense to allow control of windows from within the window switcher in the first place. Testing appreciated.