### PR TITLE
[wip] Add ToggleSnapToEdge

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -461,6 +461,7 @@ void view_grow_to_edge(struct view *view, enum view_edge direction);
 void view_shrink_to_edge(struct view *view, enum view_edge direction);
 void view_snap_to_edge(struct view *view, enum view_edge direction,
 	bool across_outputs, bool store_natural_geometry);
+void view_toggle_snap_to_edge(struct view *view, enum view_edge direction);
 void view_snap_to_region(struct view *view, struct region *region, bool store_natural_geometry);
 void view_move_to_output(struct view *view, struct output *output);
 

--- a/src/view.c
+++ b/src/view.c
@@ -1841,6 +1841,20 @@ view_edge_parse(const char *direction)
 }
 
 void
+view_toggle_snap_to_edge(struct view *view, enum view_edge edge)
+{
+	assert(view);
+
+	if (view->tiled != edge) {
+		view_snap_to_edge(view, edge, /*across_outputs*/ true,
+			/*store_natural_geometry*/ true);
+	} else {
+		view_restore_to(view, view->natural_geometry);
+		view_set_untiled(view);
+	}
+}
+
+void
 view_snap_to_edge(struct view *view, enum view_edge edge,
 			bool across_outputs, bool store_natural_geometry)
 {


### PR DESCRIPTION
This allows to replace the usual maximize behavior that does not respect gaps with SnapToEdge direction="center" which does respect gaps. It can be bound to the SSD Maximize button and Title double click handlers in rc.xml.

Missing:
- [ ] docs
- [ ] some enum for `<snapping topMaximize="yes|no">` like `yes|no|respectGaps`
- [ ] an entry in the website FAQ like "How to make maximize respect gaps"

Ref: https://www.reddit.com/r/labwc/comments/1brvsj8/

---

Not sure when I'll be working on this again, if somebody else wants to take this over feel free.

To test:
```xml
<labwc_config>

    <keyboard>
        <default />
        <keybind key="W-a">
            <action name="ToggleSnapToEdge" direction="center" />
        </keybind>
    </keyboard>

    <mouse>
        <default />
        <context name="Maximize">
            <mousebind button="Left" action="Click">
                <action name="ToggleSnapToEdge" direction="center" />
            </mousebind>
        </context>

        <context name="Title">
            <mousebind button="Left" action="DoubleClick">
                <action name="ToggleSnapToEdge" direction="center" />
            </mousebind>
        </context>
    </mouse>

</labwc_config>
```