### PR TITLE
feat: add partial tablet v2 protocol support

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -617,7 +617,7 @@ extending outward from the snapped edge.
 ## TABLET
 
 ```
-<tablet mapToOutput="" rotate="0">
+<tablet mapToOutput="" rotate="0" mouseEmulation="no">
   <area top="0.0" left="0.0" width="0.0" height="0.0" />
   <map button="Tip" to="Left" />
   <map button="Stylus" to="Right" />
@@ -657,21 +657,35 @@ extending outward from the snapped edge.
 	additionally setting top to "12.5", the active area is centered
 	vertically on the tablet surface.
 
+*<tablet mouseEmulation="" />* [yes|no]
+	The tablet can be forced to always use mouse emulation. This prevents
+	tablet specific restrictions, e.g. no support for drag-and-drop, but
+	also omits tablet specific features like reporting pen pressure.
+
 *<tablet><map button="" to="" />*
-	Tablet buttons emulate regular mouse buttons. If not specified
-	otherwise, the tip (Tip) is mapped to left mouse click, the first pen
-	button (Stylus) is mapped to right mouse button click and the second pen
-	button (Stylus2) emulates a middle mouse button click.
+	Pen buttons emulate regular mouse buttons. If not specified
+	otherwise, the first pen button (Stylus) is mapped to right mouse
+	button click and the second pen button (Stylus2) emulates a middle
+	mouse button click. For mouse emulation, the tip (Tip) is mapped to
+	left mouse click.
 
 	Supported map *buttons* are:
-	- Tip
+	- Tip (mouse emulation only)
 	- Stylus
 	- Stylus2
 	- Stylus3
 	- Pad
 	- Pad2..Pad9
 
-	See mouse section above for all supported *to* mouse buttons.
+	The stylus buttons (Stylus, Stylus2 and Stylus3) can be mapped *to*:
+	- Right
+	- Middle
+	- Side
+
+	The tablet pad buttons can be mapped to all available mouse buttons.
+	When using mouse emulation only, the tip and stylus buttons can also be
+	mapped to all available mouse buttons.
+	See mouse section above for all supported mouse buttons.
 
 ## LIBINPUT
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -497,11 +497,18 @@
     height are omitted or default (0.0), width/height will be set to
     the remaining width/height seen from top/left.
 
-    Tablet buttons emulate regular mouse buttons. The tablet *button* can
-    be set to any of [Tip|Stylus|Stylus2|Stylus3|Pad|Pad2|Pad3|..|Pad9].
-    Valid *to* mouse buttons are [Left|Right|Middle].
+    The tablet can be forced to always use mouse emulation. This prevents
+    tablet specific restrictions, e.g. no support for drag&drop, but also
+    omits tablet specific features like reporting pen pressure.
+
+    Pen buttons emulate regular mouse buttons. The pen *button* can be any
+    of [Stylus|Stylus2|Stylus3] and can be mapped to mouse buttons
+    [Right|Middle|Side]. Tablet pad buttons [Pad|Pad2|Pad3|..|Pad9] also
+    emulate regular mouse buttons and can be mapped to any mouse button.
+    When using mouse emulation, the pen tip [tip] and the stylus buttons
+    can be set to any available mouse button [Left|Right|Middle|..|Task].
   -->
-  <tablet mapToOutput="" rotate="0">
+  <tablet mapToOutput="" rotate="0" mouseEmulation="no">
     <!-- Active area dimensions are in mm -->
     <area top="0.0" left="0.0" width="0.0" height="0.0" />
     <map button="Tip" to="Left" />

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -94,6 +94,7 @@ struct rcxml {
 
 	/* graphics tablet */
 	struct tablet_config {
+		bool force_mouse_emulation;
 		char *output_name;
 		struct wlr_fbox box;
 		enum rotation rotation;

--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -118,6 +118,32 @@ void cursor_update_focus(struct server *server);
  */
 void cursor_update_image(struct seat *seat);
 
+/**
+ * Processes cursor motion. The return value indicates if a client
+ * should be notified. Parameters sx, sy holds the surface coordinates
+ * in that case.
+ */
+bool cursor_process_motion(struct server *server, uint32_t time, double *sx, double *sy);
+
+/**
+ * Processes cursor button press. The return value indicates if a client
+ * should be notified.
+ */
+bool cursor_process_button_press(struct seat *seat, uint32_t button, uint32_t time_msec);
+
+/**
+ * Processes cursor button release. The return value indicates if the client
+ * should be notified. Should be followed by cursor_finish_button_release()
+ * after notifying a client.
+ */
+bool cursor_process_button_release(struct seat *seat, uint32_t button, uint32_t time_msec);
+
+/**
+ * Finishes cursor button release. The return value indicates if an interactive
+ * move/resize had been finished. Should be called after notifying a client.
+ */
+bool cursor_finish_button_release(struct seat *seat);
+
 void cursor_init(struct seat *seat);
 void cursor_reload(struct seat *seat);
 void cursor_emulate_move_absolute(struct seat *seat,

--- a/include/input/tablet-tool.h
+++ b/include/input/tablet-tool.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_TABLET_TOOL_H
+#define LABWC_TABLET_TOOL_H
+
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_tablet_v2.h>
+
+struct seat;
+
+struct drawing_tablet_tool {
+	struct seat *seat;
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+	struct {
+		struct wl_listener set_cursor;
+		struct wl_listener destroy;
+	} handlers;
+};
+
+void tablet_tool_init(struct seat *seat,
+	struct wlr_tablet_tool *wlr_tablet_tool);
+
+#endif /* LABWC_TABLET_TOOL_H */

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -3,14 +3,17 @@
 #define LABWC_TABLET_H
 
 #include <wayland-server-core.h>
+#include <wlr/types/wlr_tablet_v2.h>
 
 struct seat;
 struct wlr_device;
 struct wlr_input_device;
 
 struct drawing_tablet {
+	struct wlr_input_device *wlr_input_device;
 	struct seat *seat;
 	struct wlr_tablet *tablet;
+	struct wlr_tablet_v2_tablet *tablet_v2;
 	double x, y;
 	struct {
 		struct wl_listener proximity;

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -15,6 +15,7 @@ struct drawing_tablet {
 	struct wlr_tablet *tablet;
 	struct wlr_tablet_v2_tablet *tablet_v2;
 	double x, y;
+	double tilt_x, tilt_y;
 	struct {
 		struct wl_listener proximity;
 		struct wl_listener axis;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -42,6 +42,7 @@
 #include <wlr/types/wlr_tearing_control_v1.h>
 #include <wlr/types/wlr_text_input_v3.h>
 #include <wlr/types/wlr_input_method_v2.h>
+#include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 #include "config/keybind.h"
 #include "config/rcxml.h"
@@ -332,6 +333,8 @@ struct server {
 
 	struct wlr_input_method_manager_v2 *input_method_manager;
 	struct wlr_text_input_manager_v3 *text_input_manager;
+
+	struct wlr_tablet_manager_v2 *tablet_manager;
 
 	/* Set when in cycle (alt-tab) mode */
 	struct osd_state {

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -16,6 +16,7 @@ wayland_scanner_server = generator(
 server_protocols = [
 	wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
 	wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
+	wl_protocol_dir / 'unstable/tablet/tablet-unstable-v2.xml',
 	wl_protocol_dir / 'staging/cursor-shape/cursor-shape-v1.xml',
 	wl_protocol_dir / 'staging/drm-lease/drm-lease-v1.xml',
 	wl_protocol_dir / 'staging/xwayland-shell/xwayland-shell-v1.xml',

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1020,6 +1020,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "Invalid value for <resize popupShow />");
 		}
+	} else if (!strcasecmp(nodename, "mouseEmulation.tablet")) {
+		set_bool(content, &rc.tablet.force_mouse_emulation);
 	} else if (!strcasecmp(nodename, "mapToOutput.tablet")) {
 		rc.tablet.output_name = xstrdup(content);
 	} else if (!strcasecmp(nodename, "rotate.tablet")) {
@@ -1229,6 +1231,7 @@ rcxml_init(void)
 	rc.doubleclick_time = 500;
 	rc.scroll_factor = 1.0;
 
+	rc.tablet.force_mouse_emulation = false;
 	rc.tablet.output_name = NULL;
 	rc.tablet.rotation = 0;
 	rc.tablet.box = (struct wlr_fbox){0};

--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -2,6 +2,7 @@ labwc_sources += files(
   'cursor.c',
   'tablet.c',
   'tablet-pad.c',
+  'tablet-tool.c',
   'gestures.c',
   'input.c',
   'keyboard.c',

--- a/src/input/tablet-tool.c
+++ b/src/input/tablet-tool.c
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/util/log.h>
+#include "common/macros.h"
+#include "common/mem.h"
+#include "config/rcxml.h"
+#include "input/cursor.h"
+#include "input/tablet-tool.h"
+#include "labwc.h"
+
+static void
+handle_destroy(struct wl_listener *listener, void *data)
+{
+	struct drawing_tablet_tool *tool =
+		wl_container_of(listener, tool, handlers.destroy);
+
+	wl_list_remove(&tool->handlers.set_cursor.link);
+	wl_list_remove(&tool->handlers.destroy.link);
+	free(tool);
+}
+
+void
+tablet_tool_init(struct seat *seat,
+		struct wlr_tablet_tool *wlr_tablet_tool)
+{
+	wlr_log(WLR_DEBUG, "setting up tablet tool");
+	struct drawing_tablet_tool *tool = znew(*tool);
+	tool->seat = seat;
+	tool->tool_v2 =
+		wlr_tablet_tool_create(seat->server->tablet_manager,
+			seat->seat, wlr_tablet_tool);
+	wlr_tablet_tool->data = tool;
+	wlr_log(WLR_INFO, "tablet tool capabilities:%s%s%s%s%s%s",
+		wlr_tablet_tool->tilt ? " tilt" : "",
+		wlr_tablet_tool->pressure ? " pressure" : "",
+		wlr_tablet_tool->distance ? " distance" : "",
+		wlr_tablet_tool->rotation ? " rotation" : "",
+		wlr_tablet_tool->slider ? " slider" : "",
+		wlr_tablet_tool->wheel ? " wheel" : "");
+	CONNECT_SIGNAL(wlr_tablet_tool, &tool->handlers, destroy);
+}

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -10,6 +10,7 @@
 #include "config/rcxml.h"
 #include "input/cursor.h"
 #include "input/tablet.h"
+#include "labwc.h"
 
 static bool
 tool_supports_absolute_motion(struct wlr_tablet_tool *tool)
@@ -168,8 +169,13 @@ tablet_init(struct seat *seat, struct wlr_input_device *wlr_device)
 	wlr_log(WLR_DEBUG, "setting up tablet");
 	struct drawing_tablet *tablet = znew(*tablet);
 	tablet->seat = seat;
+	tablet->wlr_input_device = wlr_device;
 	tablet->tablet = wlr_tablet_from_input_device(wlr_device);
 	tablet->tablet->data = tablet;
+	if (seat->server->tablet_manager) {
+		tablet->tablet_v2 = wlr_tablet_create(
+			seat->server->tablet_manager, seat->seat, wlr_device);
+	}
 	tablet->x = 0.0;
 	tablet->y = 0.0;
 	wlr_log(WLR_INFO, "tablet dimensions: %.2fmm x %.2fmm",

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -317,6 +317,29 @@ to_stylus_button(uint32_t button)
 }
 
 static void
+seat_pointer_end_grab(struct drawing_tablet_tool *tool,
+		struct wlr_surface *surface)
+{
+	if (!surface || !wlr_seat_pointer_has_grab(tool->seat->seat)) {
+		return;
+	}
+
+	struct wlr_xdg_surface *xdg_surface =
+		wlr_xdg_surface_try_from_wlr_surface(surface);
+	if (!xdg_surface || xdg_surface->role != WLR_XDG_SURFACE_ROLE_POPUP) {
+		/*
+		 * If we have an active popup grab (an open popup) and we are
+		 * not on the popup itself, end that grab to close the popup.
+		 * Contrary to pointer button notifications, a tablet button
+		 * notification sometimes doesn't end grabs automatically on
+		 * button notifications in another client (observed in GTK4),
+		 * so end the grab manually.
+		 */
+		wlr_seat_pointer_end_grab(tool->seat->seat);
+	}
+}
+
+static void
 handle_tip(struct wl_listener *listener, void *data)
 {
 	struct wlr_tablet_tool_tip_event *ev = data;
@@ -340,6 +363,7 @@ handle_tip(struct wl_listener *listener, void *data)
 			bool notify = cursor_process_button_press(tool->seat, BTN_LEFT,
 				ev->time_msec);
 			if (notify) {
+				seat_pointer_end_grab(tool, surface);
 				wlr_tablet_v2_tablet_tool_notify_down(tool->tool_v2);
 				wlr_tablet_tool_v2_start_implicit_grab(tool->tool_v2);
 			}
@@ -408,6 +432,9 @@ handle_button(struct wl_listener *listener, void *data)
 
 		uint32_t stylus_button = to_stylus_button(button);
 		if (stylus_button && stylus_button != BTN_TOOL_PEN) {
+			if (ev->state == WLR_BUTTON_PRESSED) {
+				seat_pointer_end_grab(tool, surface);
+			}
 			wlr_tablet_v2_tablet_tool_notify_button(tool->tool_v2,
 				stylus_button,
 				ev->state == WLR_BUTTON_PRESSED

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -91,7 +91,8 @@ tablet_get_coords(struct drawing_tablet *tablet, double *x, double *y)
 		rc.tablet.box, x, y);
 	adjust_for_rotation(rc.tablet.rotation, x, y);
 
-	if (!tablet->tablet_v2) {
+	if (rc.tablet.force_mouse_emulation
+			|| !tablet->tablet_v2) {
 		return NULL;
 	}
 
@@ -154,7 +155,8 @@ handle_proximity(struct wl_listener *listener, void *data)
 	double x, y;
 	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y);
 
-	if (tablet->seat->server->tablet_manager && !tool) {
+	if (!rc.tablet.force_mouse_emulation
+			&& tablet->seat->server->tablet_manager && !tool) {
 		/*
 		 * Unfortunately `wlr_tool` is only present in the events, so
 		 * use proximity for creating a `wlr_tablet_v2_tablet_tool`.

--- a/src/server.c
+++ b/src/server.c
@@ -16,6 +16,7 @@
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_viewporter.h>
+#include <wlr/types/wlr_tablet_v2.h>
 #if HAVE_XWAYLAND
 #include <wlr/xwayland.h>
 #include "xwayland-shell-v1-protocol.h"
@@ -549,6 +550,8 @@ server_init(struct server *server)
 	server->tearing_control = wlr_tearing_control_manager_v1_create(server->wl_display, 1);
 	server->tearing_new_object.notify = new_tearing_hint;
 	wl_signal_add(&server->tearing_control->events.new_object, &server->tearing_new_object);
+
+	server->tablet_manager = wlr_tablet_v2_create(server->wl_display);
 
 	layers_init(server);
 


### PR DESCRIPTION
As a follow up to https://github.com/labwc/labwc/issues/1672 and the ideas mentioned there, I ~played/hacked~ put this together. Running `gtk4-demo` and there the `Paint` demo, I can draw now in Stylus only mode and pen pressure is applied. So far so good.

~Looking at the general UI, just blindly switching from mouse emulation to tabled mode disables a lot of things that are imho not so easy to get correctly implemented, e.g. focus switch between applications, resize applications, drag & drop and surely a few others. That said, having a configuration switch like 'tablet-mode' (tablet-native|mouse-emulation) and/or an action 'toogle-tablet-mode' might be a way to mitigate this and allow a user to consciously switch between modes with all the consequences and restrictions applied.~ Actually this is now in a very usable state, see below. A switch for mouse emulation is also part of this PR.

~There are more tablet axis that aren't covered yet in this PR.~ I also haven’t done much testing with side businesses like disconnecting/reconnecting the tablet, multiple outputs, output mapping.

So, open for feedback (esp. with a real drawing app like Krita) and thoughts.

Status / TODO:

- [x] Tablet tool wiring/signalling 
- [x] Axis/proximity handling
- [x] Hovering between tablet-capable / non-tablet-capable surfaces / desktop
- [x]  Focus switching
- [x] Idle inhibit
- [x] Client cursors (set_cursor), tricky part...
- [x] Move/resize CSD applications
- [x] Out of surface scrolling
- [x] Button mapping (for non-tip)
- [x] Force-cursor-emulation configuration option
- [x] Add a few safety checks like tool type
- [ ] Drag n drop (if this turns out to be doable)
- [x] Document force-mouse-emulation and button mapping implications
- [x] Testing with device reconnects 
- [x] Testing with output mapping
- [ ] General testing
- [ ] Review, polish and reorganize commits
 
Currently known issues:
- Notify cursor from pointer and tablet can still interfere, noted on out-of-surface scrolling in GTK4 applications. The resize cursor shines through when scrolling out of surface.
- ~The scrollbar in VS-Code, when running as native Wayland application, only when being adjacent or above another window, jumps to the top when scrolling out of surface. This does not happen with VS-Code in XWayland or when the out of scrolling happens on the desktop.~ A similar issue can be seen with the volume slider in Shortwave/GTK4 (Slider on a popup, thus also scrolling out of surface above another surface).

Ideas:
- ~`wlr_tablet_v2_tablet_tool` has a `focused_surface` field which is updated on proximity-in/out.  May be we can use that one instead of our own `drawing_tablet_tool.focus_surface`.~ (Done)
-  Notify cursor interference could be solved by an early return in `request_cursor_notify` based on `drawing_tablet_tool.focus_surface`. Unfortunately that means we need to add and maintain the tool, the `focused_surface` or just a new `boolean tablet_tool_in_proximity` in `seat`.