### PR TITLE
Use pre-multiplied colors by default

### DIFF
--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -85,7 +85,19 @@ draw_cairo_border(cairo_t *cairo, struct wlr_fbox fbox, double line_width)
 void
 set_cairo_color(cairo_t *cairo, const float *c)
 {
-	cairo_set_source_rgba(cairo, c[0], c[1], c[2], c[3]);
+	/*
+	 * We are dealing with pre-multiplied colors
+	 * but cairo expects unmultiplied colors here
+	 */
+	float alpha = c[3];
+
+	if (alpha == 0.0f) {
+		cairo_set_source_rgba(cairo, 0, 0, 0, 0);
+		return;
+	}
+
+	cairo_set_source_rgba(cairo, c[0] / alpha, c[1] / alpha,
+		c[2] / alpha, alpha);
 }
 
 struct surface_context

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -16,7 +16,7 @@ create_overlay(struct seat *seat)
 	seat->overlay.tree = parent;
 	wlr_scene_node_set_enabled(&parent->node, false);
 	if (!wlr_renderer_is_pixman(server->renderer)) {
-		/* Hardware assisted rendering: Half transparent overlay */
+		/* Hardware assisted rendering: Half transparent overlay, pre-multiplied */
 		float color[4] = { 0.25, 0.25, 0.35, 0.5 };
 		seat->overlay.rect = wlr_scene_rect_create(parent, 0, 0, color);
 	} else {

--- a/src/theme.c
+++ b/src/theme.c
@@ -135,8 +135,8 @@ create_hover_fallback(struct theme *theme, const char *icon_name,
 		(width - icon_width) / 2, (height - icon_height) / 2);
 	cairo_paint(cairo);
 
-	/* Overlay (non-multiplied alpha) */
-	float overlay_color[4] = { 0.5f, 0.5f, 0.5f, 0.3f};
+	/* Overlay (pre-multiplied alpha) */
+	float overlay_color[4] = { 0.15f, 0.15f, 0.15f, 0.3f};
 	enum corner corner = corner_from_icon_name(icon_name);
 
 	if (corner == LAB_CORNER_UNKNOWN) {
@@ -406,6 +406,10 @@ parse_hexstr(const char *hex, float *rgba)
 	rgba[2] = (hex_to_dec(hex[5]) * 16 + hex_to_dec(hex[6])) / 255.0;
 	if (strlen(hex) > 7) {
 		rgba[3] = atoi(hex + 7) / 100.0;
+		/* Pre-multiply everything as expected by wlr_scene */
+		rgba[0] *= rgba[3];
+		rgba[1] *= rgba[3];
+		rgba[2] *= rgba[3];
 	} else {
 		rgba[3] = 1.0;
 	}


### PR DESCRIPTION
wlr_scene_rects expect their color to be pre-multiplied while cairo_set_source_rgba() expects them to not be pre-multiplied.
With this patch we now use premultiplied colors internally by default and then reverse it when setting cairo colors.

This ensures the titlebar uses a consistent color in case it was defined with some transparency by the user.

Fixes:
- #1684