### PR TITLE
docs: 80 column lines (where possible), drop trailing whitespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,7 +357,7 @@ Base both bugfixes and new features on `master`.
 
 Translators can create an account at [LXQt Weblate](https://translate.lxqt-project.org/projects/labwc/labwc/)
 and use the web interface. Adding new languages should work, otherwise the
-administrators can be contacted. Suggestions for improving existing translations 
+administrators can be contacted. Suggestions for improving existing translations
 can be added without account.
 
 ### Github Pull Request
@@ -378,7 +378,7 @@ translation strings under each English string.
 ## Coders
 
 Code contributors may need to update relevant files if their additions
-affect UI elements (at the moment only `src/menu/menu.c` and 
+affect UI elements (at the moment only `src/menu/menu.c` and
 `src/config/rcxml.c`). In this case the `po/labwc.pot` file needs to be
 updated so that translators can update their translations. Remember,
 many translators are _not_ coders!

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -176,10 +176,11 @@ Actions are used in menus and keyboard/mouse bindings.
 	Moves active window to other output, unless the window state is
 	fullscreen.
 
-	If *output* is specified, the window will be sent directly to the specified
-	output and *direction* is ignored. If *output* is omitted, *direction* may
-	be one of "left", "right", "up" or "down" to indicate that the window
-	should be moved to the next output in that direction (if one exists). 
+	If *output* is specified, the window will be sent directly to the
+	specified output and *direction* is ignored. If *output* is omitted,
+	*direction* may	be one of "left", "right", "up" or "down" to indicate
+	that the window	should be moved to the next output in that direction
+	(if one exists).
 
 	*wrap* [yes|no] When using the direction attribute, wrap around from
 	right-to-left or top-to-bottom, and vice versa. Default no.

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -300,14 +300,14 @@ extending outward from the snapped edge.
 	interactive moves. Default is 1.
 
 *<snapping><preview><enabled>* [yes|no]
-	Show a preview when snaping to a window to an edge. Default is yes.
+	Show a preview when snapping to a window to an edge. Default is yes.
 
 *<snapping><preview><delay><inner>*++
 *<snapping><preview><delay><outer>*
-	Sets the delay to show a preview when snapping a window to each type of edges.
-	Defaults are 500 ms.
-	*inner* edges are edges with an adjacent output and *outer* edges are edges
-	without an adjacent output.
+	Sets the delay to show a preview when snapping a window to each type of
+	edge. Defaults are 500 ms.
+	*inner* edges are edges with an adjacent output and *outer* edges are
+	edges without an adjacent output.
 
 *<snapping><topMaximize>* [yes|no]
 	If *yes*, an interactive move that snaps a window to the top edge will
@@ -351,7 +351,8 @@ extending outward from the snapped edge.
 
 *<desktops number=""><names><name>*
 	Define workspaces. A workspace covers all outputs. Workspaces can be
-	switched to with GoToDesktop and windows can be moved with SendToDesktop.
+	switched to with GoToDesktop and windows can be moved with
+	SendToDesktop.
 	See labwc-actions(5) for more information about their arguments.
 
 	The number attribute defines the minimum number of workspaces. Default
@@ -738,14 +739,14 @@ extending outward from the snapped edge.
 	after as well.
 
 *<libinput><device><clickMethod>* [none|buttonAreas|clickfinger]
-	Configure the method by which physical clicks on a touchpad are mapped to
-	mouse-button events.
+	Configure the method by which physical clicks on a touchpad are mapped
+	to mouse-button events.
 
 	The click methods available are:
 	- *buttonAreas* - The bottom of the touchpad is divided into distinct
-	  regions corresponding to left, middle and right buttons; clicking within
-	  the region will trigger the corresponding event. Clicking the main area
-	  further up produces a left button event.
+	  regions corresponding to left, middle and right buttons; clicking
+	  within the region will trigger the corresponding event. Clicking the
+	  main area further up produces a left button event.
 	- *clickfinger* - Clicking with one, two or three finger(s) will produce
 	  left, right or middle button event without regard to the location of a
 	  click.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -65,8 +65,8 @@
 
   <!--
     When using all workspaces option of window switcher, there are extra fields
-    that can be used, workspace (variable length), state (single space), 
-    type_short (3 spaces), output (variable length), and can be set up 
+    that can be used, workspace (variable length), state (single space),
+    type_short (3 spaces), output (variable length), and can be set up
     like this. Note: output only shows if more than one output available.
 
     <windowSwitcher show="yes" preview="no" outlines="no" allWorkspaces="yes">
@@ -77,7 +77,7 @@
         <field content="output" width="9%" />
         <field content="identifier" width="30%" />
         <field content="title" width="50%" />
-       </fields>  
+       </fields>
     </windowSwitcher>
   -->
 


### PR DESCRIPTION
with one typofix