### PR TITLE
output: ensure we don't run into an assert() on VT switch

### DIFF
--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -55,7 +55,7 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output)
 		return false;
 	}
 	if (!wlr_output_commit(wlr_output)) {
-		wlr_log(WLR_ERROR, "Failed to commit output %s",
+		wlr_log(WLR_INFO, "Failed to commit output %s",
 			wlr_output->name);
 		return false;
 	}

--- a/src/output.c
+++ b/src/output.c
@@ -60,6 +60,17 @@ output_frame_notify(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	if (!output->scene_output) {
+		/*
+		 * TODO: This is a short term fix for issue #1667,
+		 *       a proper fix would require restructuring
+		 *       the life cycle of scene outputs, e.g.
+		 *       creating them on new_output_notify() only.
+		 */
+		wlr_log(WLR_INFO, "Failed to render new frame: no scene-output");
+		return;
+	}
+
 	struct wlr_output *wlr_output = output->wlr_output;
 	struct server *server = output->server;
 


### PR DESCRIPTION
Also reduce log spam from failed output commits that can happen for various reasons outside of our control.

Fixes:
- #1667

---

There is also a wip branch [here](https://github.com/Consolatis/labwc/tree/issue/1667_scene_output_assert) which tries to fix this more generally but I am not feeling confident enough with that one for the current point in the dev cycle.