### PR TITLE
CI: enable gcc static analyzer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,17 @@ jobs:
             meson compile -C build-gcc-release
           ' | $TARGET
 
+      - name: Build with gcc - static analyzer
+        run: |
+          echo '
+            cd "$GITHUB_WORKSPACE"
+            export CC=gcc
+            meson setup build-gcc-static_analyzer -Dxwayland=enabled \
+              -Dstatic_analyzer=enabled --werror
+            meson compile -C build-gcc-static_analyzer
+          ' | $TARGET
+
+
       # Runtime tests, these run on Debian and Void only (the later due to libmusl being used)
       - name: Build with clang - release
         run: |

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -123,9 +123,9 @@ struct ssd_part *add_scene_button(
 	struct wlr_scene_tree *parent, float *bg_color,
 	struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer,
 	int x, struct view *view);
-void
-add_toggled_icon(struct wl_list *part_list, enum ssd_part_type type,
-		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer);
+void add_toggled_icon(struct ssd_button *button, struct wl_list *part_list,
+	enum ssd_part_type type, struct wlr_buffer *icon_buffer,
+	struct wlr_buffer *hover_buffer);
 struct ssd_part *add_scene_button_corner(
 	struct wl_list *part_list, enum ssd_part_type type,
 	enum ssd_part_type corner_type, struct wlr_scene_tree *parent,

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,10 @@ else
 endif
 conf_data.set10('HAVE_RSVG', have_rsvg)
 
+if get_option('static_analyzer').enabled()
+  add_project_arguments(['-fanalyzer'], language: 'c')
+endif
+
 msgfmt = find_program('msgfmt', required: get_option('nls'))
 if msgfmt.found()
   source_root = meson.current_source_dir()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,4 @@ option('man-pages', type: 'feature', value: 'auto', description: 'Generate and i
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('svg', type: 'feature', value: 'enabled', description: 'Enable svg window buttons')
 option('nls', type: 'feature', value: 'auto', description: 'Enable native language support')
+option('static_analyzer', type: 'feature', value: 'disabled', description: 'Run gcc static analyzer')

--- a/src/layers.c
+++ b/src/layers.c
@@ -422,6 +422,13 @@ popup_handle_new_popup(struct wl_listener *listener, void *data)
 	struct wlr_xdg_popup *wlr_popup = data;
 	struct lab_layer_popup *new_popup = create_popup(wlr_popup,
 		lab_layer_popup->scene_tree);
+
+	if (!new_popup) {
+		wl_resource_post_no_memory(wlr_popup->resource);
+		wlr_xdg_popup_destroy(wlr_popup);
+		return;
+	}
+
 	new_popup->output_toplevel_sx_box =
 		lab_layer_popup->output_toplevel_sx_box;
 }
@@ -481,6 +488,12 @@ handle_new_popup(struct wl_listener *listener, void *data)
 		.height = output_box.height,
 	};
 	struct lab_layer_popup *popup = create_popup(wlr_popup, surface->tree);
+	if (!popup) {
+		wl_resource_post_no_memory(wlr_popup->resource);
+		wlr_xdg_popup_destroy(wlr_popup);
+		return;
+	}
+
 	popup->output_toplevel_sx_box = output_toplevel_sx_box;
 
 	if (surface->layer_surface->current.layer

--- a/src/ssd/ssd_part.c
+++ b/src/ssd/ssd_part.c
@@ -194,12 +194,10 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 }
 
 void
-add_toggled_icon(struct wl_list *part_list, enum ssd_part_type type,
-		struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer)
+add_toggled_icon(struct ssd_button *button, struct wl_list *part_list,
+		enum ssd_part_type type, struct wlr_buffer *icon_buffer,
+		struct wlr_buffer *hover_buffer)
 {
-	struct ssd_part *part = ssd_get_part(part_list, type);
-	struct ssd_button *button = node_ssd_button_from_node(part->node);
-
 	/* Alternate icon */
 	struct wlr_box icon_geo = get_scale_box(icon_buffer,
 		SSD_BUTTON_WIDTH, rc.theme->title_height);

--- a/src/ssd/ssd_titlebar.c
+++ b/src/ssd/ssd_titlebar.c
@@ -99,11 +99,16 @@ ssd_titlebar_create(struct ssd *ssd)
 		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_ICONIFY, parent,
 			color, iconify_button_unpressed, iconify_button_hover,
 			width - SSD_BUTTON_WIDTH * 3, view);
-		add_scene_button(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE, parent,
+
+		/* Maximize button has an alternate state when maximized */
+		struct ssd_part *btn_max_root = add_scene_button(
+			&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE, parent,
 			color, maximize_button_unpressed, maximize_button_hover,
 			width - SSD_BUTTON_WIDTH * 2, view);
-		add_toggled_icon(&subtree->parts, LAB_SSD_BUTTON_MAXIMIZE,
+		struct ssd_button *btn_max = node_ssd_button_from_node(btn_max_root->node);
+		add_toggled_icon(btn_max, &subtree->parts, LAB_SSD_BUTTON_MAXIMIZE,
 			restore_button_unpressed, restore_button_hover);
+
 		add_scene_button_corner(&subtree->parts,
 			LAB_SSD_BUTTON_CLOSE, LAB_SSD_PART_CORNER_TOP_RIGHT, parent,
 			corner_top_right, close_button_unpressed, close_button_hover,


### PR DESCRIPTION
This may help uncover potential bugs in the future.
If we end up getting too many false positives we can still disable it again.