### PR TITLE
 overlay: make overlay's style and colors configurable

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -205,6 +205,34 @@ elements are not listed here, but are supported.
 	Otherwise, an outlined rectangle is shown instead.
 	If software rendering is used, an outlined rectangle is always shown.
 
+*snapping.preview.region.bg.color*
+	Color of a filled rectangle shown as the preview when a window is snapped to
+	a region. Default is #8080b380.
+
+*snapping.preview.edge.bg.color*
+	Color of a filled rectangle shown as the preview when a window is snapped to
+	an edge. Default is #8080b380.
+
+*snapping.preview.region.border.width*
+	Border width of an outlined rectangle shown as the preview when a window is
+	snapped to a region. Inherits `osd.border.width` if not set.
+
+*snapping.preview.edge.border.width*
+	Border width of an outlined rectangle shown as the preview when a window is
+	snapped to an edge. Inherits `osd.border.width` if not set.
+
+*snapping.preview.region.border.color*
+	Color(s) of an outlined rectangle shown as the preview when a window is
+	snapped to a region. Possible value is a color or up to 3 colors separated
+	by commas (e.g. "#ffffff,#000000,#ffffff"). When multiple colors are
+	specified, a multi-line rectangle with each line having the specified color
+	is drawn. If not set, this inherits the on-screen-display theme
+	("[*osd.bg.color*],[*osd.label.text.color*],[*osd.bg.color*]").
+
+*snapping.preview.edge.border.color*
+	Color(s) of an outlined rectangle shown as the preview when a window is
+	snapped to an edge. See *snapping.preview.region.border.color* for details.
+
 *border.color*
 	Set all border colors. This is obsolete, but supported for backward
 	compatibility as some themes still contain it.

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -195,6 +195,16 @@ elements are not listed here, but are supported.
 	Height of boxes in workspace switcher in pixels. Setting to 0 disables
 	boxes. Default is 20.
 
+*snapping.preview.region.fill* [yes|no]
+	Show a filled rectangle as the preview when a window is snapped to a region.
+	Otherwise, an outlined rectangle is shown instead.
+	If software rendering is used, an outlined rectangle is always shown.
+
+*snapping.preview.edge.fill* [yes|no]
+	Show a filled rectangle as the preview when a window is snapped to an edge.
+	Otherwise, an outlined rectangle is shown instead.
+	If software rendering is used, an outlined rectangle is always shown.
+
 *border.color*
 	Set all border colors. This is obsolete, but supported for backward
 	compatibility as some themes still contain it.

--- a/docs/themerc
+++ b/docs/themerc
@@ -71,3 +71,6 @@ osd.window-switcher.item.active.border.width: 2
 
 osd.workspace-switcher.boxes.width: 20
 osd.workspace-switcher.boxes.height: 20
+
+snapping.preview.region.fill: yes
+snapping.preview.edge.fill: yes

--- a/docs/themerc
+++ b/docs/themerc
@@ -74,3 +74,9 @@ osd.workspace-switcher.boxes.height: 20
 
 snapping.preview.region.fill: yes
 snapping.preview.edge.fill: yes
+snapping.preview.region.bg.color: #8080b380
+snapping.preview.edge.bg.color: #8080b380
+snapping.preview.region.border.width: 1
+snapping.preview.edge.border.width: 1
+snapping.preview.region.border.color: #dddda6,#000000,#dddda6
+snapping.preview.edge.border.color: #dddda6,#000000,#dddda6

--- a/include/overlay.h
+++ b/include/overlay.h
@@ -7,12 +7,19 @@
 #include "regions.h"
 #include "view.h"
 
-struct overlay {
-	struct wlr_scene_tree *tree;
+struct overlay_rect {
+	struct wlr_scene_node *node;
+	bool fill;
 	union {
-		struct wlr_scene_rect *rect;
+		/* if fill is true */
+		struct wlr_scene_rect *scene_rect;
+		/* if fill is false */
 		struct multi_rect *pixman_rect;
 	};
+};
+
+struct overlay {
+	struct overlay_rect region_rect, edge_rect;
 
 	/* Represents currently shown or delayed overlay */
 	struct {
@@ -28,6 +35,7 @@ struct overlay {
 	struct wl_event_source *timer;
 };
 
+void overlay_reconfigure(struct seat *seat);
 /* Calls overlay_hide() internally if there's no overlay to show */
 void overlay_update(struct seat *seat);
 /* This function must be called when server->grabbed_view is destroyed */

--- a/include/theme.h
+++ b/include/theme.h
@@ -80,6 +80,9 @@ struct theme {
 	int osd_workspace_switcher_boxes_width;
 	int osd_workspace_switcher_boxes_height;
 
+	bool snapping_preview_region_fill;
+	bool snapping_preview_edge_fill;
+
 	/* textures */
 	struct lab_data_buffer *button_close_active_unpressed;
 	struct lab_data_buffer *button_maximize_active_unpressed;

--- a/include/theme.h
+++ b/include/theme.h
@@ -83,6 +83,14 @@ struct theme {
 	bool snapping_preview_region_fill;
 	bool snapping_preview_edge_fill;
 
+	float snapping_preview_region_bg_color[4];
+	float snapping_preview_edge_bg_color[4];
+
+	int snapping_preview_region_border_width;
+	int snapping_preview_edge_border_width;
+	float snapping_preview_region_border_color[3][4];
+	float snapping_preview_edge_border_color[3][4];
+
 	/* textures */
 	struct lab_data_buffer *button_close_active_unpressed;
 	struct lab_data_buffer *button_maximize_active_unpressed;

--- a/src/debug.c
+++ b/src/debug.c
@@ -18,6 +18,7 @@
 #define IGNORE_SSD true
 #define IGNORE_MENU true
 #define IGNORE_OSD_PREVIEW_OUTLINE true
+#define IGNORE_SNAPPING_PREVIEW_OUTLINE true
 
 static struct view *last_view;
 
@@ -136,10 +137,15 @@ get_special(struct server *server, struct wlr_scene_node *node)
 	if (node == &server->seat.drag.icons->node) {
 		return "seat->drag.icons";
 	}
-	if (server->seat.overlay.tree
-			&& node == &server->seat.overlay.tree->node) {
+	if (server->seat.overlay.region_rect.node
+			&& node == server->seat.overlay.region_rect.node) {
 		/* Created on-demand */
-		return "seat->overlay";
+		return "seat->overlay.region_rect";
+	}
+	if (server->seat.overlay.edge_rect.node
+			&& node == server->seat.overlay.edge_rect.node) {
+		/* Created on-demand */
+		return "seat->overlay.edge_rect";
 	}
 	if (server->seat.input_method_relay->popup_tree
 			&& node == &server->seat.input_method_relay->popup_tree->node) {
@@ -216,7 +222,13 @@ dump_tree(struct server *server, struct wlr_scene_node *node,
 			|| (IGNORE_SSD && last_view
 				&& ssd_debug_is_root_node(last_view->ssd, node))
 			|| (IGNORE_OSD_PREVIEW_OUTLINE && server->osd_state.preview_outline
-				&& node == &server->osd_state.preview_outline->tree->node)) {
+				&& node == &server->osd_state.preview_outline->tree->node)
+			|| (IGNORE_SNAPPING_PREVIEW_OUTLINE && server->seat.overlay.region_rect.node
+				&& !server->seat.overlay.region_rect.fill
+				&& node == server->seat.overlay.region_rect.node)
+			|| (IGNORE_SNAPPING_PREVIEW_OUTLINE && server->seat.overlay.edge_rect.node
+				&& !server->seat.overlay.edge_rect.fill
+				&& node == server->seat.overlay.edge_rect.node)) {
 		printf("%*c%s\n", pos + 4 + INDENT_SIZE, ' ', "<skipping children>");
 		return;
 	}

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -52,10 +52,8 @@ show_overlay(struct seat *seat, struct wlr_box *box)
 		multi_rect_set_size(seat->overlay.pixman_rect,
 			box->width, box->height);
 	}
-	if (node->parent != view->scene_tree->node.parent) {
-		wlr_scene_node_reparent(node, view->scene_tree->node.parent);
-		wlr_scene_node_place_below(node, &view->scene_tree->node);
-	}
+	wlr_scene_node_reparent(node, view->scene_tree->node.parent);
+	wlr_scene_node_place_below(node, &view->scene_tree->node);
 	wlr_scene_node_set_position(node, box->x, box->y);
 	wlr_scene_node_set_enabled(node, true);
 
@@ -225,7 +223,5 @@ overlay_hide(struct seat *seat)
 	struct wlr_scene_node *node = &seat->overlay.tree->node;
 
 	wlr_scene_node_set_enabled(node, false);
-	if (node->parent != &server->scene->tree) {
-		wlr_scene_node_reparent(node, &server->scene->tree);
-	}
+	wlr_scene_node_reparent(node, &server->scene->tree);
 }

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -6,7 +6,8 @@
 #include "view.h"
 
 static void
-create_overlay_rect(struct seat *seat, struct overlay_rect *rect, int fill)
+create_overlay_rect(struct seat *seat, struct overlay_rect *rect, int fill,
+		float bg_color[4], int border_width, float border_colors[3][4])
 {
 	struct server *server = seat->server;
 
@@ -18,20 +19,18 @@ create_overlay_rect(struct seat *seat, struct overlay_rect *rect, int fill)
 
 	if (rect->fill) {
 		/* Create a filled rectangle */
-		float color[4] = { 0.25, 0.25, 0.35, 0.5 };
 		rect->scene_rect = wlr_scene_rect_create(&server->scene->tree,
-			0, 0, color);
+			0, 0, bg_color);
 		rect->node = &rect->scene_rect->node;
 	} else {
 		/* Create outlines */
-		int line_width = server->theme->osd_border_width;
 		float *colors[3] = {
-			server->theme->osd_bg_color,
-			server->theme->osd_label_text_color,
-			server->theme->osd_bg_color
+			border_colors[0],
+			border_colors[1],
+			border_colors[2],
 		};
 		rect->pixman_rect = multi_rect_create(&server->scene->tree,
-			colors, line_width);
+			colors, border_width);
 		rect->node = &rect->pixman_rect->tree->node;
 	}
 
@@ -49,9 +48,15 @@ void overlay_reconfigure(struct seat *seat)
 
 	struct theme *theme = seat->server->theme;
 	create_overlay_rect(seat, &seat->overlay.region_rect,
-		theme->snapping_preview_region_fill);
+		theme->snapping_preview_region_fill,
+		theme->snapping_preview_region_bg_color,
+		theme->snapping_preview_region_border_width,
+		theme->snapping_preview_region_border_color);
 	create_overlay_rect(seat, &seat->overlay.edge_rect,
-		theme->snapping_preview_edge_fill);
+		theme->snapping_preview_edge_fill,
+		theme->snapping_preview_edge_bg_color,
+		theme->snapping_preview_edge_border_width,
+		theme->snapping_preview_edge_border_color);
 }
 
 static void

--- a/src/seat.c
+++ b/src/seat.c
@@ -587,6 +587,7 @@ seat_reconfigure(struct server *server)
 	struct seat *seat = &server->seat;
 	struct input *input;
 	cursor_load(seat);
+	overlay_reconfigure(seat);
 	wl_list_for_each(input, &seat->inputs, link) {
 		switch (input->wlr_input_device->type) {
 		case WLR_INPUT_DEVICE_KEYBOARD:

--- a/src/theme.c
+++ b/src/theme.c
@@ -24,6 +24,7 @@
 #include "common/graphic-helpers.h"
 #include "common/match.h"
 #include "common/mem.h"
+#include "common/parse-bool.h"
 #include "common/string-helpers.h"
 #include "config/rcxml.h"
 #include "button/button-png.h"
@@ -520,6 +521,9 @@ theme_builtin(struct theme *theme)
 	theme->osd_border_width = INT_MIN;
 	theme->osd_border_color[0] = FLT_MIN;
 	theme->osd_label_text_color[0] = FLT_MIN;
+
+	theme->snapping_preview_region_fill = true;
+	theme->snapping_preview_edge_fill = true;
 }
 
 static void
@@ -714,6 +718,12 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match_glob(key, "osd.label.text.color")) {
 		parse_hexstr(value, theme->osd_label_text_color);
+	}
+	if (match_glob(key, "snapping.preview.region.fill")) {
+		theme->snapping_preview_region_fill = parse_bool(value, true);
+	}
+	if (match_glob(key, "snapping.preview.edge.fill")) {
+		theme->snapping_preview_edge_fill = parse_bool(value, true);
 	}
 }
 


### PR DESCRIPTION
This PR adds following theme settings:
- `snapping-preview.region.area.color`
- `snapping-preview.edge.area.color`
- `snapping-preview.region.rect-type` (`Auto|Area|Outlines`)
- `snapping-preview.edge.rect-type` (`Auto|Area|Outlines`)

I named the theme entry `rect-type` to make `labwc-theme.5.scd` easy to follow, but maybe it should be just `type`.

I restructured `struct overlay` to allow independent styles for region/edge snapping overlay.
I also added `inactivate_overlay()` as a refactoring.

In the future, maybe we can also make the colors of outlines configurable like:
`snapping-preview.region.outlines.colors: #ffffff,#000000,#ffffff`
In that case, I think the colors of OSD preview should also be configurable.