### PR TITLE
input: notify idle manager when emulating cursor move

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1091,6 +1091,8 @@ void
 cursor_emulate_move_absolute(struct seat *seat, struct wlr_input_device *device,
 		double x, double y, uint32_t time_msec)
 {
+	idle_manager_notify_activity(seat->seat);
+
 	double lx, ly;
 	wlr_cursor_absolute_to_layout_coords(seat->cursor,
 		device, x, y, &lx, &ly);


### PR DESCRIPTION
Looks like we forgot that one earlier, contrary to emulating cursor buttons (https://github.com/labwc/labwc/blob/master/src/input/cursor.c#L1120) 

From https://github.com/labwc/labwc/issues/1672#issuecomment-2052534441 , found by @DynamoFox