### PR TITLE
Small fixes in `doc/themerc` and `docs/labwc-theme.5.scd`

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -155,16 +155,19 @@ elements are not listed here, but are supported.
 	Menu separator color. Default #888888.
 
 *osd.bg.color*
-	Background color of on-screen-display.
+	Background color of on-screen-display. Inherits
+	*window.active.title.bg.color* if not set.
 
 *osd.border.color*
-	Border color of on-screen-display.
+	Border color of on-screen-display. Inherits *osd.label.text.color* if not
+	set.
 
 *osd.border.width*
 	Border width of on-screen-display. Inherits *border.width* if not set.
 
 *osd.label.text.color*
-	Text color of on-screen-display.
+	Text color of on-screen-display. Inherits *window.active.label.text.color* if
+	not set.
 
 *osd.window-switcher.width*
 	Width of window switcher in pixels. Default is 600.

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -196,8 +196,9 @@ elements are not listed here, but are supported.
 	boxes. Default is 20.
 
 *border.color*
-	Set all border colors. This is obsolete, but supported for backward
-	compatibility as some themes still contain it.
+	Set both *window.active.border.color* and *window.inactive.border.color*.
+	This is obsolete, but supported for backward compatibility as some themes
+	still contain it.
 
 # BUTTONS
 

--- a/docs/themerc
+++ b/docs/themerc
@@ -55,7 +55,7 @@ menu.separator.padding.height: 3
 menu.separator.color: #888888
 
 # on screen display (window-cycle dialog)
-osd.bg.color: #dddda6
+osd.bg.color: #e1dedb
 osd.border.color: #000000
 osd.border.width: 1
 osd.label.text.color: #000000


### PR DESCRIPTION
- The default value of `osd.bg.color` is `#e1dedb`, as it falls back to `window.active.title.bg.color` (I may be missing some context here)
- "all border colors" in the description of `border.color` sounds like it includes `osd.border.color`