### PR TITLE
osd: add theme settings for window-switcher preview

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -190,6 +190,18 @@ elements are not listed here, but are supported.
 	Border width of the selection box in the window switcher in pixels.
 	Default is 2.
 
+*osd.window-switcher.preview.border.width*
+	Border width of the outlines shown as the preview of the window selected by
+	window switcher. Inherits *osd.border.width* if not set.
+
+*osd.window-switcher.preview.border.color*
+	Color(s) of the outlines shown as the preview of the window selected by
+	window switcher. Possible value is a color or up to 3 colors separated
+	by commas (e.g. "#ffffff,#000000,#ffffff"). When multiple colors are
+	specified, a multi-line rectangle with each line having the specified color
+	is drawn. If not set, this inherits the on-screen-display theme
+	("[*osd.bg.color*],[*osd.label.text.color*],[*osd.bg.color*]").
+
 *osd.workspace-switcher.boxes.width*
 	Width of boxes in workspace switcher in pixels. Setting to 0 disables
 	boxes. Default is 20.
@@ -226,15 +238,13 @@ elements are not listed here, but are supported.
 
 *snapping.preview.region.border.color*
 	Color(s) of an outlined rectangle shown as the preview when a window is
-	snapped to a region. Possible value is a color or up to 3 colors separated
-	by commas (e.g. "#ffffff,#000000,#ffffff"). When multiple colors are
-	specified, a multi-line rectangle with each line having the specified color
-	is drawn. If not set, this inherits the on-screen-display theme
-	("[*osd.bg.color*],[*osd.label.text.color*],[*osd.bg.color*]").
+	snapped to a region. Possible values and the default value are the same as
+	those of *osd.window-switcher.preview.border.color*.
 
 *snapping.preview.edge.border.color*
 	Color(s) of an outlined rectangle shown as the preview when a window is
-	snapped to an edge. See *snapping.preview.region.border.color* for details.
+	snapped to an edge. Possible values and the default value are the same as
+	those of *osd.window-switcher.preview.border.color*.
 
 *border.color*
 	Set both *window.active.border.color* and *window.inactive.border.color*.

--- a/docs/themerc
+++ b/docs/themerc
@@ -68,6 +68,8 @@ osd.window-switcher.padding: 4
 osd.window-switcher.item.padding.x: 10
 osd.window-switcher.item.padding.y: 1
 osd.window-switcher.item.active.border.width: 2
+osd.window-switcher.preview.border.width: 1
+osd.window-switcher.preview.border.color: #dddda6,#000000,#dddda6
 
 osd.workspace-switcher.boxes.width: 20
 osd.workspace-switcher.boxes.height: 20

--- a/include/theme.h
+++ b/include/theme.h
@@ -76,6 +76,8 @@ struct theme {
 	int osd_window_switcher_item_padding_y;
 	int osd_window_switcher_item_active_border_width;
 	bool osd_window_switcher_width_is_percent;
+	int osd_window_switcher_preview_border_width;
+	float osd_window_switcher_preview_border_color[3][4];
 
 	int osd_workspace_switcher_boxes_width;
 	int osd_workspace_switcher_boxes_height;

--- a/src/osd.c
+++ b/src/osd.c
@@ -38,11 +38,11 @@ osd_update_preview_outlines(struct view *view)
 	struct server *server = view->server;
 	struct multi_rect *rect = view->server->osd_state.preview_outline;
 	if (!rect) {
-		int line_width = server->theme->osd_border_width;
+		int line_width = server->theme->osd_window_switcher_preview_border_width;
 		float *colors[] = {
-			server->theme->osd_bg_color,
-			server->theme->osd_label_text_color,
-			server->theme->osd_bg_color
+			server->theme->osd_window_switcher_preview_border_color[0],
+			server->theme->osd_window_switcher_preview_border_color[1],
+			server->theme->osd_window_switcher_preview_border_color[2],
 		};
 		rect = multi_rect_create(&server->scene->tree, colors, line_width);
 		wlr_scene_node_place_above(&rect->tree->node, &server->menu_tree->node);

--- a/src/theme.c
+++ b/src/theme.c
@@ -523,6 +523,12 @@ theme_builtin(struct theme *theme)
 	theme->osd_window_switcher_item_padding_y = 1;
 	theme->osd_window_switcher_item_active_border_width = 2;
 
+	/* inherit settings in post_processing() if not set elsewhere */
+	theme->osd_window_switcher_preview_border_width = INT_MIN;
+	memset(theme->osd_window_switcher_preview_border_color, 0,
+		sizeof(theme->osd_window_switcher_preview_border_color));
+	theme->osd_window_switcher_preview_border_color[0][0] = FLT_MIN;
+
 	theme->osd_workspace_switcher_boxes_width = 20;
 	theme->osd_workspace_switcher_boxes_height = 20;
 
@@ -732,6 +738,12 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match_glob(key, "osd.window-switcher.item.active.border.width")) {
 		theme->osd_window_switcher_item_active_border_width = atoi(value);
+	}
+	if (match_glob(key, "osd.window-switcher.preview.border.width")) {
+		theme->osd_window_switcher_preview_border_width = atoi(value);
+	}
+	if (match_glob(key, "osd.window-switcher.preview.border.color")) {
+		parse_hexstrs(value, theme->osd_window_switcher_preview_border_color);
 	}
 	if (match_glob(key, "osd.workspace-switcher.boxes.width")) {
 		theme->osd_workspace_switcher_boxes_width = atoi(value);
@@ -1091,6 +1103,14 @@ post_processing(struct theme *theme)
 	if (theme->osd_window_switcher_width_is_percent) {
 		theme->osd_window_switcher_width =
 			MIN(theme->osd_window_switcher_width, 100);
+	}
+	if (theme->osd_window_switcher_preview_border_width == INT_MIN) {
+		theme->osd_window_switcher_preview_border_width =
+			theme->osd_border_width;
+	}
+	if (theme->osd_window_switcher_preview_border_color[0][0] == FLT_MIN) {
+		fill_colors_with_osd_theme(theme,
+			theme->osd_window_switcher_preview_border_color);
 	}
 
 	if (theme->snapping_preview_region_border_width == INT_MIN) {


### PR DESCRIPTION
Adds theme settings like:

```
osd.window-switcher.preview.border.width: 2
osd.window-switcher.preview.border.color: #ffffff,#00a2ff,#ffffff
```

![20240416_02h56m34s_grim](https://github.com/labwc/labwc/assets/22029524/5f85cec0-4070-40a6-b2f1-910e47ed8ee2)

![20240416_02h56m53s_grim](https://github.com/labwc/labwc/assets/22029524/9ac6e82f-00fe-4085-baa6-13f29092182a)
