### PR TITLE
Add labwc to XDG_CURRENT_DESKTOP to support a portals.conf

### DIFF
--- a/data/labwc-portals.conf
+++ b/data/labwc-portals.conf
@@ -1,0 +1,2 @@
+[preferred]
+default=wlr;*

--- a/data/labwc.desktop
+++ b/data/labwc.desktop
@@ -4,4 +4,4 @@ Comment=A wayland stacking compositor
 Exec=labwc
 Icon=labwc
 Type=Application
-DesktopNames=wlroots
+DesktopNames=labwc;wlroots

--- a/docs/environment
+++ b/docs/environment
@@ -60,13 +60,13 @@
 
 ##
 ## This allows xdg-desktop-portal-wlr to function (e.g. for screen-recording).
-## It is automatically set to "wlroots" by labwc though, so it is only
+## It is automatically set to "labwc:wlroots" by labwc though, so it is only
 ## included here for completeness. Again, labwc will not over-write an
 ## already set environment variable, so if you need it set to something else,
 ## then uncomment and adjust.
 ##
 
-# XDG_CURRENT_DESKTOP=wlroots
+# XDG_CURRENT_DESKTOP=labwc:wlroots
 
 ##
 ## This causes a virtual output to be created automatically whenever there

--- a/meson.build
+++ b/meson.build
@@ -140,6 +140,8 @@ executable(
 
 install_data('data/labwc.desktop', install_dir: get_option('datadir') / 'wayland-sessions')
 
+install_data('data/labwc-portals.conf', install_dir: get_option('datadir') / 'xdg-desktop-portal')
+
 icons = ['labwc-symbolic.svg', 'labwc.svg']
 foreach icon : icons
   icon_path = join_paths('data', icon)

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -223,7 +223,7 @@ session_environment_init(void)
 	 * May be overridden either by already having a value set or by the user
 	 * supplied environment file.
 	 */
-	setenv("XDG_CURRENT_DESKTOP", "wlroots", 0);
+	setenv("XDG_CURRENT_DESKTOP", "labwc:wlroots", 0);
 
 	/*
 	 * Set default for _JAVA_AWT_WM_NONREPARENTING so that Java applications


### PR DESCRIPTION
The previous `UseIn` key was deprecated in xdg-desktop-portal 1.17/1.18. It has been superceded by the portals.conf structure so that each desktop can configure the precise desired structure for portals. In addition, support was added to the Desktop Entry Specifications to support a `DesktopNames` key that login managers will use to set XDG_CURRENT_DESKTOP.

* [portals.conf Documentation](https://github.com/flatpak/xdg-desktop-portal/blob/main/doc/portals.conf.rst.in)
* [Example sway-portals.conf](https://salsa.debian.org/swaywm-team/sway/-/blob/debian/sid/debian/sway-portals.conf)
* [Desktop Entry Specifications](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)

Ref: flatpak/xdg-desktop-portal#955