### PR TITLE
Distinguish between "should it be decorated" and "should it use SSD"

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -118,13 +118,13 @@ Actions are used in menus and keyboard/mouse bindings.
 	yes.
 
 *<action name="ToggleDecorations" />*
-	Toggle decorations of focused window.
+	Toggle server side decorations of focused window.
 
 *<action name="Decorate" />*
-	Enable decorations of focused window.
+	Enable server side decorations of focused window.
 
 *<action name="Undecorate" />*
-	Disable decorations of focused window.
+	Disable server side decorations of focused window.
 
 *<action name="ToggleFullscreen" />*
 	Toggle fullscreen state of focused window.

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -129,9 +129,9 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="ToggleTitlebar" />*
 	Toggle titlebar of focused window.
 
-	If the 'keepBorder' configuration option is enabled (as in the default
-	configuraton), then a border will be left as the only decorations around the
-	window.
+	A border will be left as the only decorations around the window.
+	If you completely want to remove all server side decorations, use
+	'ToggleDecorations' instead.
 
 	This has no effect on windows that do not have server side decorations.
 

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -120,14 +120,6 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="ToggleDecorations" />*
 	Toggle decorations of focused window.
 
-	This is a 3-state action which can be executed multiple times:
-	- Only the titlebar will be hidden, borders and resize area are kept
-	- Remaining decorations will be disabled
-	- Decorations will be shown normally
-
-	By disabling the theme configuration 'keepBorder' the first step
-	will be removed and the action only toggles between on and off.
-
 *<action name="ToggleFullscreen" />*
 	Toggle fullscreen state of focused window.
 

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -120,6 +120,12 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="ToggleDecorations" />*
 	Toggle decorations of focused window.
 
+*<action name="Decorate" />*
+	Enable decorations of focused window.
+
+*<action name="Undecorate" />*
+	Disable decorations of focused window.
+
 *<action name="ToggleFullscreen" />*
 	Toggle fullscreen state of focused window.
 

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -126,6 +126,23 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="Undecorate" />*
 	Disable server side decorations of focused window.
 
+*<action name="ToggleTitlebar" />*
+	Toggle titlebar of focused window.
+
+	If the 'keepBorder' configuration option is enabled (as in the default
+	configuraton), then a border will be left as the only decorations around the
+	window.
+
+	This has no effect on windows that do not have server side decorations.
+
+*<action name="ShowTitlebar" />*
+	Hide titlebar of focused window.
+	See 'ToggleTitlebar' for details.
+
+*<action name="HideTitlebar" />*
+	Show titlebar of focused window.
+	See 'ToggleTitlebar' for details.
+
 *<action name="ToggleFullscreen" />*
 	Toggle fullscreen state of focused window.
 

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -398,8 +398,9 @@ extending outward from the snapped edge.
 	The radius of server side decoration top corners. Default is 8.
 
 *<theme><keepBorder>* [yes|no]
-	Even when disabling server side decorations via ToggleDecorations,
-	keep a small border (and resize area) around the window. Default is yes.
+	Keep a small border (and resize area) even for undecorated windows. Default is yes.
+
+	This has no effect on windows that do not have server side decorations.
 
 *<theme><font place="">*
 	The font to use for a specific element of a window, menu or OSD.

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -397,11 +397,6 @@ extending outward from the snapped edge.
 *<theme><cornerRadius>*
 	The radius of server side decoration top corners. Default is 8.
 
-*<theme><keepBorder>* [yes|no]
-	Keep a small border (and resize area) even for undecorated windows. Default is yes.
-
-	This has no effect on windows that do not have server side decorations.
-
 *<theme><font place="">*
 	The font to use for a specific element of a window, menu or OSD.
 	Places can be any of:

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -23,7 +23,6 @@
   <theme>
     <name></name>
     <cornerRadius>8</cornerRadius>
-    <keepBorder>yes</keepBorder>
     <font place="ActiveWindow">
       <name>sans</name>
       <size>10</size>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -63,7 +63,6 @@ struct rcxml {
 	/* theme */
 	char *theme_name;
 	int corner_radius;
-	bool ssd_keep_border;
 	struct font font_activewindow;
 	struct font font_inactivewindow;
 	struct font font_menuitem;

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -65,7 +65,7 @@ void ssd_set_active(struct ssd *ssd, bool active);
 void ssd_update_title(struct ssd *ssd);
 void ssd_update_geometry(struct ssd *ssd);
 void ssd_destroy(struct ssd *ssd);
-void ssd_titlebar_hide(struct ssd *ssd);
+void ssd_set_titlebar(struct ssd *ssd, bool enabled);
 
 void ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable);
 void ssd_enable_shade(struct ssd *ssd, bool enable);

--- a/include/view.h
+++ b/include/view.h
@@ -452,6 +452,7 @@ bool view_is_tiled(struct view *view);
 bool view_is_floating(struct view *view);
 void view_move_to_workspace(struct view *view, struct workspace *workspace);
 void view_set_decorations(struct view *view, bool decorations);
+void view_set_titlebar(struct view *view, bool enabled);
 void view_toggle_fullscreen(struct view *view);
 void view_invalidate_last_layout_geometry(struct view *view);
 void view_adjust_for_layout_change(struct view *view);

--- a/include/view.h
+++ b/include/view.h
@@ -440,7 +440,6 @@ void view_maximize(struct view *view, enum view_axis axis,
 	bool store_natural_geometry);
 void view_set_fullscreen(struct view *view, bool fullscreen);
 void view_toggle_maximize(struct view *view, enum view_axis axis);
-void view_toggle_decorations(struct view *view);
 
 bool view_is_always_on_top(struct view *view);
 bool view_is_always_on_bottom(struct view *view);

--- a/src/action.c
+++ b/src/action.c
@@ -81,6 +81,9 @@ enum action_type {
 	ACTION_TYPE_TOGGLE_DECORATIONS,
 	ACTION_TYPE_DECORATE,
 	ACTION_TYPE_UNDECORATE,
+	ACTION_TYPE_TOGGLE_TITLEBAR,
+	ACTION_TYPE_SHOW_TITLEBAR,
+	ACTION_TYPE_HIDE_TITLEBAR,
 	ACTION_TYPE_TOGGLE_ALWAYS_ON_TOP,
 	ACTION_TYPE_TOGGLE_ALWAYS_ON_BOTTOM,
 	ACTION_TYPE_TOGGLE_OMNIPRESENT,
@@ -136,6 +139,9 @@ const char *action_names[] = {
 	"ToggleDecorations",
 	"Decorate",
 	"Undecorate",
+	"ToggleTitlebar",
+	"ShowTitlebar",
+	"HideTitlebar",
 	"ToggleAlwaysOnTop",
 	"ToggleAlwaysOnBottom",
 	"ToggleOmnipresent",
@@ -802,6 +808,21 @@ actions_run(struct view *activator, struct server *server,
 		case ACTION_TYPE_UNDECORATE:
 			if (view) {
 				view_set_decorations(view, false);
+			}
+			break;
+		case ACTION_TYPE_TOGGLE_TITLEBAR:
+			if (view) {
+				view_set_titlebar(view, view->ssd_titlebar_hidden);
+			}
+			break;
+		case ACTION_TYPE_SHOW_TITLEBAR:
+			if (view) {
+				view_set_titlebar(view, true);
+			}
+			break;
+		case ACTION_TYPE_HIDE_TITLEBAR:
+			if (view) {
+				view_set_titlebar(view, false);
 			}
 			break;
 		case ACTION_TYPE_TOGGLE_ALWAYS_ON_TOP:

--- a/src/action.c
+++ b/src/action.c
@@ -79,6 +79,8 @@ enum action_type {
 	ACTION_TYPE_MAXIMIZE,
 	ACTION_TYPE_TOGGLE_FULLSCREEN,
 	ACTION_TYPE_TOGGLE_DECORATIONS,
+	ACTION_TYPE_DECORATE,
+	ACTION_TYPE_UNDECORATE,
 	ACTION_TYPE_TOGGLE_ALWAYS_ON_TOP,
 	ACTION_TYPE_TOGGLE_ALWAYS_ON_BOTTOM,
 	ACTION_TYPE_TOGGLE_OMNIPRESENT,
@@ -132,6 +134,8 @@ const char *action_names[] = {
 	"Maximize",
 	"ToggleFullscreen",
 	"ToggleDecorations",
+	"Decorate",
+	"Undecorate",
 	"ToggleAlwaysOnTop",
 	"ToggleAlwaysOnBottom",
 	"ToggleOmnipresent",
@@ -787,7 +791,17 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_TOGGLE_DECORATIONS:
 			if (view) {
-				view_toggle_decorations(view);
+				view_set_decorations(view, !view->ssd_enabled);
+			}
+			break;
+		case ACTION_TYPE_DECORATE:
+			if (view) {
+				view_set_decorations(view, true);
+			}
+			break;
+		case ACTION_TYPE_UNDECORATE:
+			if (view) {
+				view_set_decorations(view, false);
 			}
 			break;
 		case ACTION_TYPE_TOGGLE_ALWAYS_ON_TOP:

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -838,8 +838,6 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.theme_name = xstrdup(content);
 	} else if (!strcmp(nodename, "cornerradius.theme")) {
 		rc.corner_radius = atoi(content);
-	} else if (!strcasecmp(nodename, "keepBorder.theme")) {
-		set_bool(content, &rc.ssd_keep_border);
 	} else if (!strcmp(nodename, "name.font.theme")) {
 		fill_font(nodename, content, font_place);
 	} else if (!strcmp(nodename, "size.font.theme")) {
@@ -1146,7 +1144,6 @@ rcxml_init(void)
 	rc.placement_policy = LAB_PLACE_CENTER;
 
 	rc.xdg_shell_server_side_deco = true;
-	rc.ssd_keep_border = true;
 	rc.corner_radius = 8;
 
 	init_font_defaults(&rc.font_activewindow);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -33,10 +33,6 @@ ssd_thickness(struct view *view)
 		return (struct border){ 0 };
 	}
 
-	if (!rc.ssd_keep_border && view->ssd_titlebar_hidden) {
-		return (struct border){ 0 };
-	}
-
 	struct theme *theme = view->server->theme;
 
 	if (view->maximized == VIEW_AXIS_BOTH) {

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -190,7 +190,7 @@ ssd_create(struct view *view, bool active)
 	ssd_titlebar_create(ssd);
 	if (view->ssd_titlebar_hidden) {
 		/* Ensure we keep the old state on Reconfigure or when exiting fullscreen */
-		ssd_titlebar_hide(ssd);
+		ssd_set_titlebar(ssd, false);
 	}
 	ssd->margin = ssd_thickness(view);
 	ssd_set_active(ssd, active);
@@ -254,13 +254,13 @@ ssd_update_geometry(struct ssd *ssd)
 }
 
 void
-ssd_titlebar_hide(struct ssd *ssd)
+ssd_set_titlebar(struct ssd *ssd, bool enabled)
 {
-	if (!ssd || !ssd->titlebar.tree->node.enabled) {
+	if (!ssd || ssd->titlebar.tree->node.enabled == enabled) {
 		return;
 	}
-	wlr_scene_node_set_enabled(&ssd->titlebar.tree->node, false);
-	ssd->titlebar.height = 0;
+	wlr_scene_node_set_enabled(&ssd->titlebar.tree->node, enabled);
+	ssd->titlebar.height = enabled ? ssd->view->server->theme->title_height : 0;
 	ssd_border_update(ssd);
 	ssd_extents_update(ssd);
 	ssd->margin = ssd_thickness(ssd->view);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -33,6 +33,10 @@ ssd_thickness(struct view *view)
 		return (struct border){ 0 };
 	}
 
+	if (!rc.ssd_keep_border && view->ssd_titlebar_hidden) {
+		return (struct border){ 0 };
+	}
+
 	struct theme *theme = view->server->theme;
 
 	if (view->maximized == VIEW_AXIS_BOTH) {

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -72,14 +72,6 @@ ssd_border_update(struct ssd *ssd)
 		ssd->margin = ssd_thickness(ssd->view);
 	}
 
-	if (!rc.ssd_keep_border && view->ssd_titlebar_hidden) {
-		if (ssd->border.tree->node.enabled) {
-			wlr_scene_node_set_enabled(&ssd->border.tree->node, false);
-			ssd->margin = ssd_thickness(ssd->view);
-		}
-		return;
-	}
-
 	if (view->maximized == VIEW_AXIS_BOTH) {
 		return;
 	} else if (!ssd->border.tree->node.enabled) {

--- a/src/ssd/ssd_border.c
+++ b/src/ssd/ssd_border.c
@@ -72,6 +72,14 @@ ssd_border_update(struct ssd *ssd)
 		ssd->margin = ssd_thickness(ssd->view);
 	}
 
+	if (!rc.ssd_keep_border && view->ssd_titlebar_hidden) {
+		if (ssd->border.tree->node.enabled) {
+			wlr_scene_node_set_enabled(&ssd->border.tree->node, false);
+			ssd->margin = ssd_thickness(ssd->view);
+		}
+		return;
+	}
+
 	if (view->maximized == VIEW_AXIS_BOTH) {
 		return;
 	} else if (!ssd->border.tree->node.enabled) {

--- a/src/view.c
+++ b/src/view.c
@@ -1198,24 +1198,6 @@ view_toggle_decorations(struct view *view)
 {
 	assert(view);
 
-	/* Reject decoration toggles when shaded */
-	if (view->shaded) {
-		return;
-	}
-
-	if (rc.ssd_keep_border && view->ssd_enabled && view->ssd
-			&& !view->ssd_titlebar_hidden) {
-		/*
-		 * ssd_titlebar_hidden has to be set before calling
-		 * ssd_titlebar_hide() to make ssd_thickness() happy.
-		 */
-		view->ssd_titlebar_hidden = true;
-		ssd_titlebar_hide(view->ssd);
-		if (!view_is_floating(view)) {
-			view_apply_special_geometry(view);
-		}
-		return;
-	}
 	view_set_decorations(view, !view->ssd_enabled);
 }
 
@@ -1313,7 +1295,6 @@ view_set_decorations(struct view *view, bool decorations)
 			decorate(view);
 		} else {
 			undecorate(view);
-			view->ssd_titlebar_hidden = false;
 		}
 		if (!view_is_floating(view)) {
 			view_apply_special_geometry(view);

--- a/src/view.c
+++ b/src/view.c
@@ -1193,14 +1193,6 @@ view_toggle_maximize(struct view *view, enum view_axis axis)
 	}
 }
 
-void
-view_toggle_decorations(struct view *view)
-{
-	assert(view);
-
-	view_set_decorations(view, !view->ssd_enabled);
-}
-
 bool
 view_is_always_on_top(struct view *view)
 {

--- a/src/view.c
+++ b/src/view.c
@@ -1295,6 +1295,30 @@ view_set_decorations(struct view *view, bool decorations)
 }
 
 void
+view_set_titlebar(struct view *view, bool enabled)
+{
+	/* Reject decoration toggles when shaded */
+	if (view->shaded) {
+		return;
+	}
+
+	if (enabled == !view->ssd_titlebar_hidden) {
+		return;
+	}
+
+	/*
+	 * ssd_titlebar_hidden has to be set before calling
+	 * ssd_titlebar_hide() to make ssd_thickness() happy.
+	 */
+	view->ssd_titlebar_hidden = !enabled;
+	ssd_set_titlebar(view->ssd, enabled);
+
+	if (!view_is_floating(view)) {
+		view_apply_special_geometry(view);
+	}
+}
+
+void
 view_toggle_fullscreen(struct view *view)
 {
 	assert(view);


### PR DESCRIPTION
The `ToggleDecorations` action in Openbox was used to decide whether decorations should be drawn or not. The `keepBorder` setting is used to decide whether "undecorated" windows should still have a border or not.

In Wayland this is more complicated because we have to consider client side decorations (CSD) in addition to the traditional server side decorations (SSD).

Initially, `ToggleDecorations` in labwc toggled SSD on and off. Since support for `keepBorder` was added in #876, `ToggleDecorations` cycles through full SSD, only borders, and no SSD. This approach has some issues:

- Whether SSD is enabled initially is negotiated for each window individually, there is no way to know what `<windowRule><action name="ToggleDecorations"/>` would do.
- It is not clear which of the 3 states the `Decorate` and `Undecorate` actions are supposed to transition to

My proposal is to split this into two different topics: `ToggleDecorations`, `Decorate`, and `Undecorate` toggle SSD on and off, like before. Adding `Decorate` and `Undecorate` allows to target a specific state without needing to know the initial state.

In addition to that, the new set of actions `ToggleTitlebar`, `ShowTitlebar`, and `HideTitlebar` can be used to modify the SSD. If `keepBorder` is off, the border will be hidden along with the titlebar.

This gives us all the combinations there are. However, there is some redundancy:

- `HideTitlebar` with `keepBorder=no` is effectively the same as `Undecorate`
- `<windowRules><action name="Undecorate">` is effectively the same as `<windowRule serverDecoration="no"/>`

i therefore went ahead and removed `keepBorder` again. I did not remove `serverDecoration` because I figured that it is more performant/causes less flicker than the corresponding actions.

Some examples:

```xml
<!-- hide titlebar for all windows -->
<windowRule identifier="*">
  <action name="HideTitlebar"/>
</windowRule>

<!-- hide titlebar on maximize -->
<keybind key="W-Up">
  <action name="HideTitlebar"/>
  <action name="Maximize"/>
</keybind>
```