### PR TITLE
Implement Decorate/Undecorate

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -117,7 +117,7 @@ Actions are used in menus and keyboard/mouse bindings.
 	upper-left corner of the window associated with the action. Default is
 	yes.
 
-*<action name="ToggleDecorations" />*
+*<action name="ToggleDecorations" keepBorder="value" />*
 	Toggle decorations of focused window.
 
 	This is a 3-state action which can be executed multiple times:
@@ -125,14 +125,18 @@ Actions are used in menus and keyboard/mouse bindings.
 	- Remaining decorations will be disabled
 	- Decorations will be shown normally
 
-	By disabling the theme configuration 'keepBorder' the first step
-	will be removed and the action only toggles between on and off.
+	*keepBorder* [yes|no] If set to no, the first step will be removed and
+	the action only toggles between on and off. Default is the theme
+	configuration of the same name.
 
 *<action name="Decorate" />*
 	Enable decorations of focused window.
 
-*<action name="Undecorate" />*
+*<action name="Undecorate" keepBorder="value" />*
 	Disable decorations of focused window.
+
+	*keepBorder* [yes|no] Keep a small border (and resize area) around the
+	window. Default is the theme configuration of the same name.
 
 *<action name="ToggleFullscreen" />*
 	Toggle fullscreen state of focused window.

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -128,6 +128,12 @@ Actions are used in menus and keyboard/mouse bindings.
 	By disabling the theme configuration 'keepBorder' the first step
 	will be removed and the action only toggles between on and off.
 
+*<action name="Decorate" />*
+	Enable decorations of focused window.
+
+*<action name="Undecorate" />*
+	Disable decorations of focused window.
+
 *<action name="ToggleFullscreen" />*
 	Toggle fullscreen state of focused window.
 

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -65,7 +65,7 @@ void ssd_set_active(struct ssd *ssd, bool active);
 void ssd_update_title(struct ssd *ssd);
 void ssd_update_geometry(struct ssd *ssd);
 void ssd_destroy(struct ssd *ssd);
-void ssd_titlebar_hide(struct ssd *ssd);
+void ssd_set_titlebar(struct ssd *ssd, bool enabled);
 
 void ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable);
 void ssd_enable_shade(struct ssd *ssd, bool enable);

--- a/include/view.h
+++ b/include/view.h
@@ -30,6 +30,12 @@ enum ssd_preference {
 	LAB_SSD_PREF_SERVER,
 };
 
+enum ssd_mode {
+	LAB_SSD_MODE_NONE,
+	LAB_SSD_MODE_BORDER,
+	LAB_SSD_MODE_FULL
+};
+
 /**
  * Directions in which a view can be maximized. "None" is used
  * internally to mean "not maximized" but is not valid in rc.xml.
@@ -452,7 +458,7 @@ void view_toggle_visible_on_all_workspaces(struct view *view);
 bool view_is_tiled(struct view *view);
 bool view_is_floating(struct view *view);
 void view_move_to_workspace(struct view *view, struct workspace *workspace);
-void view_set_decorations(struct view *view, bool decorations);
+void view_set_decorations(struct view *view, enum ssd_mode mode);
 void view_toggle_fullscreen(struct view *view);
 void view_invalidate_last_layout_geometry(struct view *view);
 void view_adjust_for_layout_change(struct view *view);

--- a/include/view.h
+++ b/include/view.h
@@ -446,7 +446,7 @@ void view_maximize(struct view *view, enum view_axis axis,
 	bool store_natural_geometry);
 void view_set_fullscreen(struct view *view, bool fullscreen);
 void view_toggle_maximize(struct view *view, enum view_axis axis);
-void view_toggle_decorations(struct view *view);
+void view_toggle_decorations(struct view *view, bool keep_border);
 
 bool view_is_always_on_top(struct view *view);
 bool view_is_always_on_bottom(struct view *view);

--- a/src/action.c
+++ b/src/action.c
@@ -812,7 +812,9 @@ actions_run(struct view *activator, struct server *server,
 			if (view) {
 				bool keep_border = action_get_bool(
 					action, "keepBorder", rc.ssd_keep_border);
-				if (keep_border) {
+				if (!view->ssd_enabled) {
+					/* do not add a border to CSD windows */
+				} else if (keep_border) {
 					view_set_decorations(view, LAB_SSD_MODE_BORDER);
 				} else {
 					view_set_decorations(view, LAB_SSD_MODE_NONE);

--- a/src/action.c
+++ b/src/action.c
@@ -79,6 +79,8 @@ enum action_type {
 	ACTION_TYPE_MAXIMIZE,
 	ACTION_TYPE_TOGGLE_FULLSCREEN,
 	ACTION_TYPE_TOGGLE_DECORATIONS,
+	ACTION_TYPE_DECORATE,
+	ACTION_TYPE_UNDECORATE,
 	ACTION_TYPE_TOGGLE_ALWAYS_ON_TOP,
 	ACTION_TYPE_TOGGLE_ALWAYS_ON_BOTTOM,
 	ACTION_TYPE_TOGGLE_OMNIPRESENT,
@@ -132,6 +134,8 @@ const char *action_names[] = {
 	"Maximize",
 	"ToggleFullscreen",
 	"ToggleDecorations",
+	"Decorate",
+	"Undecorate",
 	"ToggleAlwaysOnTop",
 	"ToggleAlwaysOnBottom",
 	"ToggleOmnipresent",
@@ -788,6 +792,16 @@ actions_run(struct view *activator, struct server *server,
 		case ACTION_TYPE_TOGGLE_DECORATIONS:
 			if (view) {
 				view_toggle_decorations(view);
+			}
+			break;
+		case ACTION_TYPE_DECORATE:
+			if (view) {
+				view_set_decorations(view, LAB_SSD_MODE_FULL);
+			}
+			break;
+		case ACTION_TYPE_UNDECORATE:
+			if (view) {
+				view_set_decorations(view, LAB_SSD_MODE_NONE);
 			}
 			break;
 		case ACTION_TYPE_TOGGLE_ALWAYS_ON_TOP:

--- a/src/action.c
+++ b/src/action.c
@@ -344,6 +344,13 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			goto cleanup;
 		}
 		break;
+	case ACTION_TYPE_TOGGLE_DECORATIONS:
+	case ACTION_TYPE_UNDECORATE:
+		if (!strcasecmp(argument, "keepBorder")) {
+			action_arg_add_bool(action, argument, parse_bool(content, true));
+			goto cleanup;
+		}
+		break;
 	case ACTION_TYPE_RESIZE_RELATIVE:
 		if (!strcmp(argument, "left") || !strcmp(argument, "right") ||
 				!strcmp(argument, "top") || !strcmp(argument, "bottom")) {
@@ -791,7 +798,9 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_TOGGLE_DECORATIONS:
 			if (view) {
-				view_toggle_decorations(view);
+				bool keep_border = action_get_bool(
+					action, "keepBorder", rc.ssd_keep_border);
+				view_toggle_decorations(view, keep_border);
 			}
 			break;
 		case ACTION_TYPE_DECORATE:
@@ -801,7 +810,13 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_UNDECORATE:
 			if (view) {
-				view_set_decorations(view, LAB_SSD_MODE_NONE);
+				bool keep_border = action_get_bool(
+					action, "keepBorder", rc.ssd_keep_border);
+				if (keep_border) {
+					view_set_decorations(view, LAB_SSD_MODE_BORDER);
+				} else {
+					view_set_decorations(view, LAB_SSD_MODE_NONE);
+				}
 			}
 			break;
 		case ACTION_TYPE_TOGGLE_ALWAYS_ON_TOP:

--- a/src/decorations/kde-deco.c
+++ b/src/decorations/kde-deco.c
@@ -52,8 +52,11 @@ handle_mode(struct wl_listener *listener, void *data)
 			"requested: %u", client_mode);
 	}
 
-	view_set_decorations(kde_deco->view,
-		kde_deco->view->ssd_preference == LAB_SSD_PREF_SERVER);
+	if (kde_deco->view->ssd_preference == LAB_SSD_PREF_SERVER) {
+		view_set_decorations(kde_deco->view, LAB_SSD_MODE_FULL);
+	} else {
+		view_set_decorations(kde_deco->view, LAB_SSD_MODE_NONE);
+	}
 }
 
 static void

--- a/src/decorations/xdg-deco.c
+++ b/src/decorations/xdg-deco.c
@@ -48,8 +48,11 @@ xdg_deco_request_mode(struct wl_listener *listener, void *data)
 
 	wlr_xdg_toplevel_decoration_v1_set_mode(xdg_deco->wlr_xdg_decoration,
 		client_mode);
-	view_set_decorations(xdg_deco->view,
-		client_mode == WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+	if (client_mode == WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE) {
+		view_set_decorations(xdg_deco->view, LAB_SSD_MODE_FULL);
+	} else {
+		view_set_decorations(xdg_deco->view, LAB_SSD_MODE_NONE);
+	}
 }
 
 static void

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -190,7 +190,7 @@ ssd_create(struct view *view, bool active)
 	ssd_titlebar_create(ssd);
 	if (view->ssd_titlebar_hidden) {
 		/* Ensure we keep the old state on Reconfigure or when exiting fullscreen */
-		ssd_titlebar_hide(ssd);
+		ssd_set_titlebar(ssd, false);
 	}
 	ssd->margin = ssd_thickness(view);
 	ssd_set_active(ssd, active);
@@ -254,13 +254,13 @@ ssd_update_geometry(struct ssd *ssd)
 }
 
 void
-ssd_titlebar_hide(struct ssd *ssd)
+ssd_set_titlebar(struct ssd *ssd, bool enabled)
 {
-	if (!ssd || !ssd->titlebar.tree->node.enabled) {
+	if (!ssd || ssd->titlebar.tree->node.enabled == enabled) {
 		return;
 	}
-	wlr_scene_node_set_enabled(&ssd->titlebar.tree->node, false);
-	ssd->titlebar.height = 0;
+	wlr_scene_node_set_enabled(&ssd->titlebar.tree->node, enabled);
+	ssd->titlebar.height = enabled ? ssd->view->server->theme->title_height : 0;
 	ssd_border_update(ssd);
 	ssd_extents_update(ssd);
 	ssd->margin = ssd_thickness(ssd->view);

--- a/src/view.c
+++ b/src/view.c
@@ -1194,12 +1194,11 @@ view_toggle_maximize(struct view *view, enum view_axis axis)
 }
 
 void
-view_toggle_decorations(struct view *view)
+view_toggle_decorations(struct view *view, bool keep_border)
 {
 	assert(view);
 
-	if (rc.ssd_keep_border && view->ssd_enabled
-			&& !view->ssd_titlebar_hidden) {
+	if (keep_border && view->ssd_enabled && !view->ssd_titlebar_hidden) {
 		view_set_decorations(view, LAB_SSD_MODE_BORDER);
 	} else if (view->ssd_enabled) {
 		view_set_decorations(view, LAB_SSD_MODE_NONE);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -577,7 +577,11 @@ xdg_toplevel_view_map(struct view *view)
 
 		init_foreign_toplevel(view);
 
-		view_set_decorations(view, has_ssd(view));
+		if (has_ssd(view)) {
+			view_set_decorations(view, LAB_SSD_MODE_FULL);
+		} else {
+			view_set_decorations(view, LAB_SSD_MODE_NONE);
+		}
 
 		/*
 		 * Set initial "pending" dimensions (may be modified by

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -420,8 +420,11 @@ handle_request_maximize(struct wl_listener *listener, void *data)
 		 * Set decorations early to avoid changing geometry
 		 * after maximize (reduces visual glitches).
 		 */
-		view_set_decorations(view,
-			want_deco(xwayland_surface_from_view(view)));
+		if (want_deco(xwayland_surface_from_view(view))) {
+			view_set_decorations(view, LAB_SSD_MODE_FULL);
+		} else {
+			view_set_decorations(view, LAB_SSD_MODE_NONE);
+		}
 	}
 	view_toggle_maximize(view, VIEW_AXIS_BOTH);
 }
@@ -493,7 +496,11 @@ handle_set_decorations(struct wl_listener *listener, void *data)
 		wl_container_of(listener, xwayland_view, set_decorations);
 	struct view *view = &xwayland_view->base;
 
-	view_set_decorations(view, want_deco(xwayland_view->xwayland_surface));
+	if (want_deco(xwayland_view->xwayland_surface)) {
+		view_set_decorations(view, LAB_SSD_MODE_FULL);
+	} else {
+		view_set_decorations(view, LAB_SSD_MODE_NONE);
+	}
 }
 
 static void
@@ -643,7 +650,11 @@ xwayland_view_map(struct view *view)
 	 */
 	view_set_fullscreen(view, xwayland_surface->fullscreen);
 	if (!view->been_mapped) {
-		view_set_decorations(view, want_deco(xwayland_surface));
+		if (want_deco(xwayland_surface)) {
+			view_set_decorations(view, LAB_SSD_MODE_FULL);
+		} else {
+			view_set_decorations(view, LAB_SSD_MODE_NONE);
+		}
 	}
 	enum view_axis axis = VIEW_AXIS_NONE;
 	if (xwayland_surface->maximized_horz) {


### PR DESCRIPTION
This is an alternative approach for #1724 as proposed by @ahesford. This approach is so different that I thought a new pull request makes more sense.

This keeps backwards compatibility and thereby also the confusion about SSD and titlebar. I still think the other approach is cleaner. But as far as I was able to figure out, both can accomplish the same.

I was not sure how to handle the situation in which a window has no SSD and a user uses `Undecorate` with `keepBorder="yes"`: My first instinct was to make this idempotent, i.e. you end up in the same state no matter where you started from, in this case: borders. On the other hand, it is a bit weird that a call to `Undecorate` actually adds decorations.

My original motivation for this is that I want to remove title bars by default (without adding borders to CSD windows). This is only possible with the latter approach.  It is still possible to get something idempotent by calling `Decorate` first. So that's what I ended up with.

I hope you get why I think the other approach is cleaner.