### PR TITLE
decorations: allow to globally disable titlebars

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -397,6 +397,10 @@ extending outward from the snapped edge.
 *<theme><cornerRadius>*
 	The radius of server side decoration top corners. Default is 8.
 
+*<theme><titlebar>* [yes|no]
+	Set this to 'no' to only keep a small border (and resize area)
+	around the window. Default is yes.
+
 *<theme><keepBorder>* [yes|no]
 	Even when disabling server side decorations via ToggleDecorations,
 	keep a small border (and resize area) around the window. Default is yes.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -23,6 +23,7 @@
   <theme>
     <name></name>
     <cornerRadius>8</cornerRadius>
+    <titlebar>yes</titlebar>
     <keepBorder>yes</keepBorder>
     <font place="ActiveWindow">
       <name>sans</name>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -63,6 +63,7 @@ struct rcxml {
 	/* theme */
 	char *theme_name;
 	int corner_radius;
+	bool ssd_titlebar;
 	bool ssd_keep_border;
 	struct font font_activewindow;
 	struct font font_inactivewindow;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -838,6 +838,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.theme_name = xstrdup(content);
 	} else if (!strcmp(nodename, "cornerradius.theme")) {
 		rc.corner_radius = atoi(content);
+	} else if (!strcmp(nodename, "titlebar.theme")) {
+		set_bool(content, &rc.ssd_titlebar);
 	} else if (!strcasecmp(nodename, "keepBorder.theme")) {
 		set_bool(content, &rc.ssd_keep_border);
 	} else if (!strcmp(nodename, "name.font.theme")) {
@@ -1146,6 +1148,7 @@ rcxml_init(void)
 	rc.placement_policy = LAB_PLACE_CENTER;
 
 	rc.xdg_shell_server_side_deco = true;
+	rc.ssd_titlebar = true;
 	rc.ssd_keep_border = true;
 	rc.corner_radius = 8;
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -735,6 +735,7 @@ xdg_surface_new(struct wl_listener *listener, void *data)
 	}
 
 	view->workspace = server->workspace_current;
+	view->ssd_titlebar_hidden = !rc.ssd_titlebar;
 	view->scene_tree = wlr_scene_tree_create(view->workspace->tree);
 	wlr_scene_node_set_enabled(&view->scene_tree->node, false);
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -869,6 +869,7 @@ xwayland_view_create(struct server *server,
 	xsurface->data = view;
 
 	view->workspace = server->workspace_current;
+	view->ssd_titlebar_hidden = !rc.ssd_titlebar;
 	view->scene_tree = wlr_scene_tree_create(view->workspace->tree);
 	node_descriptor_create(&view->scene_tree->node, LAB_NODE_DESC_VIEW, view);
 


### PR DESCRIPTION
Mostly for reference: This is my implementation for one of the ideas from #1728. While it does cover my main use case, it is very inflexible. Feel free to close this.