### PR TITLE
Implement type filter for window rules

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -820,7 +820,7 @@ defined as shown below.
 <windowRules>
 
   <!-- Action -->
-  <windowRule identifier="" title="">
+  <windowRule identifier="" title="" type="">
     <action name=""/>
   </windowRule>
 
@@ -832,10 +832,10 @@ defined as shown below.
 
 *Criteria*
 
-*<windowRules><windowRule identifier="" title="" matchOnce="">*
+*<windowRules><windowRule identifier="" title="" type="" matchOnce="">*
 	Define a window rule for any window which matches the criteria defined
-	by the attributes *identifier* or *title*. If both are defined, AND
-	logic is used, so both have to match.
+	by the attributes *identifier*, *title*, or *type*. If more than one
+	is defined, AND logic is used, so all have to match.
 	Matching against patterns with '\*' (wildcard) and '?' (joker) is
 	supported. Pattern matching is case-insensitive.
 
@@ -843,6 +843,12 @@ defined as shown below.
 	for XWayland clients.
 
 	*title* is the title of the window.
+
+	*type* [desktop|dock|toolbar|menu|utility|splash|dialog|dropdown_menu|
+	popup_menu|tooltip|notification|combo|dnd|normal] relates to
+	NET_WM_WINDOW_TYPE for XWayland clients. Native wayland clients have
+	type "dialog" when they have a parent or a fixed size, or "normal"
+	otherwise.
 
 	*matchOnce* can be true|false. If true, the rule will only apply to the
 	first instance of the window with the specified identifier or title.

--- a/include/view.h
+++ b/include/view.h
@@ -67,6 +67,26 @@ enum view_wants_focus {
 	VIEW_WANTS_FOCUS_OFFER,
 };
 
+enum window_type {
+	/* https://specifications.freedesktop.org/wm-spec/wm-spec-1.4.html#idm45649101374512 */
+	NET_WM_WINDOW_TYPE_DESKTOP = 0,
+	NET_WM_WINDOW_TYPE_DOCK,
+	NET_WM_WINDOW_TYPE_TOOLBAR,
+	NET_WM_WINDOW_TYPE_MENU,
+	NET_WM_WINDOW_TYPE_UTILITY,
+	NET_WM_WINDOW_TYPE_SPLASH,
+	NET_WM_WINDOW_TYPE_DIALOG,
+	NET_WM_WINDOW_TYPE_DROPDOWN_MENU,
+	NET_WM_WINDOW_TYPE_POPUP_MENU,
+	NET_WM_WINDOW_TYPE_TOOLTIP,
+	NET_WM_WINDOW_TYPE_NOTIFICATION,
+	NET_WM_WINDOW_TYPE_COMBO,
+	NET_WM_WINDOW_TYPE_DND,
+	NET_WM_WINDOW_TYPE_NORMAL,
+
+	WINDOW_TYPE_LEN
+};
+
 struct view;
 struct wlr_surface;
 
@@ -113,6 +133,8 @@ struct view_impl {
 	enum view_wants_focus (*wants_focus)(struct view *self);
 	/* returns true if view reserves space at screen edge */
 	bool (*has_strut_partial)(struct view *self);
+	/* returns true if view declared itself a window type */
+	bool (*contains_window_type)(struct view *view, int32_t window_type);
 };
 
 struct view {
@@ -358,6 +380,7 @@ void view_array_append(struct server *server, struct wl_array *views,
 	enum lab_view_criteria criteria);
 
 enum view_wants_focus view_wants_focus(struct view *view);
+bool view_contains_window_type(struct view *view, enum window_type window_type);
 
 /**
  * view_edge_invert() - select the opposite of a provided edge

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -21,6 +21,7 @@ enum property {
 struct window_rule {
 	char *identifier;
 	char *title;
+	int window_type;
 	bool match_once;
 
 	enum window_rule_event event;

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -14,26 +14,6 @@ struct wlr_compositor;
 struct wlr_output;
 struct wlr_output_layout;
 
-enum atom {
-	/* https://specifications.freedesktop.org/wm-spec/wm-spec-1.4.html#idm45649101374512 */
-	NET_WM_WINDOW_TYPE_DESKTOP = 0,
-	NET_WM_WINDOW_TYPE_DOCK,
-	NET_WM_WINDOW_TYPE_TOOLBAR,
-	NET_WM_WINDOW_TYPE_MENU,
-	NET_WM_WINDOW_TYPE_UTILITY,
-	NET_WM_WINDOW_TYPE_SPLASH,
-	NET_WM_WINDOW_TYPE_DIALOG,
-	NET_WM_WINDOW_TYPE_DROPDOWN_MENU,
-	NET_WM_WINDOW_TYPE_POPUP_MENU,
-	NET_WM_WINDOW_TYPE_TOOLTIP,
-	NET_WM_WINDOW_TYPE_NOTIFICATION,
-	NET_WM_WINDOW_TYPE_COMBO,
-	NET_WM_WINDOW_TYPE_DND,
-	NET_WM_WINDOW_TYPE_NORMAL,
-
-	ATOM_LEN
-};
-
 static const char * const atom_names[] = {
 	"_NET_WM_WINDOW_TYPE_DESKTOP",
 	"_NET_WM_WINDOW_TYPE_DOCK",
@@ -52,10 +32,10 @@ static const char * const atom_names[] = {
 };
 
 static_assert(
-	ARRAY_SIZE(atom_names) == ATOM_LEN,
+	ARRAY_SIZE(atom_names) == WINDOW_TYPE_LEN,
 	"Xwayland atoms out of sync");
 
-extern xcb_atom_t atoms[ATOM_LEN];
+extern xcb_atom_t atoms[WINDOW_TYPE_LEN];
 
 struct xwayland_unmanaged {
 	struct server *server;
@@ -104,9 +84,6 @@ void xwayland_view_create(struct server *server,
 void xwayland_adjust_stacking_order(struct server *server);
 
 struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
-
-bool xwayland_surface_contains_window_type(
-	struct wlr_xwayland_surface *surface, enum atom window_type);
 
 void xwayland_server_init(struct server *server,
 	struct wlr_compositor *compositor);

--- a/src/view.c
+++ b/src/view.c
@@ -212,6 +212,16 @@ view_wants_focus(struct view *view)
 }
 
 bool
+view_contains_window_type(struct view *view, enum window_type window_type)
+{
+	assert(view);
+	if (view->impl->contains_window_type) {
+		return view->impl->contains_window_type(view, window_type);
+	}
+	return false;
+}
+
+bool
 view_is_focusable(struct view *view)
 {
 	assert(view);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -43,6 +43,28 @@ xdg_toplevel_from_view(struct view *view)
 	return xdg_surface->toplevel;
 }
 
+static bool
+xdg_toplevel_view_contains_window_type(struct view *view, int32_t window_type)
+{
+	assert(view);
+
+	struct wlr_xdg_toplevel *toplevel = xdg_toplevel_from_view(view);
+	struct wlr_xdg_toplevel_state *state = &toplevel->current;
+	bool is_dialog = (state->min_width != 0 && state->min_height != 0
+		&& (state->min_width == state->max_width
+		|| state->min_height == state->max_height))
+		|| toplevel->parent;
+
+	switch (window_type) {
+	case NET_WM_WINDOW_TYPE_NORMAL:
+		return !is_dialog;
+	case NET_WM_WINDOW_TYPE_DIALOG:
+		return is_dialog;
+	default:
+		return false;
+	}
+}
+
 static void
 handle_new_popup(struct wl_listener *listener, void *data)
 {
@@ -652,6 +674,7 @@ static const struct view_impl xdg_toplevel_view_impl = {
 	.move_to_back = view_impl_move_to_back,
 	.get_root = xdg_toplevel_view_get_root,
 	.append_children = xdg_toplevel_view_append_children,
+	.contains_window_type = xdg_toplevel_view_contains_window_type,
 };
 
 static void


### PR DESCRIPTION
This builds on #1490. I reverted the hard-coded rules for desktop windows for now. Instead I exposed the feature to users and added heuristics for xdg-shell, as [proposed by @Consolatis](https://github.com/labwc/labwc/compare/master...Consolatis:labwc:feature/window_rule_root_only). See also the [relevant openbox documentation](http://openbox.org/wiki/Help:Applications).

I personally want to use it like this:

```xml
<windowRule type="normal">
  <action name="Maximize"/>
</windowRule>
```

It works quite well, but not perfect. For example, the dialog to enter the primary password for thunderbird behaves correctly under xwayland, but not under native wayland. I intentionally kept the description of the internal heurustics in the docs vague so we can refine them later (e.g. based on size hints).