### PR TITLE
reuse query logic for window rules

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -304,6 +304,10 @@ Actions that execute other actions. Used in keyboard/mouse bindings.
 			XDG shell title for Wayland clients, WM_NAME for
 			XWayland clients.
 
+		*type*
+			Internal heuristics for Wayland clients,
+			NET_WM_WINDOW_TYPE for XWayland clients.
+
 		This argument is optional.
 
 	*then*

--- a/include/view.h
+++ b/include/view.h
@@ -262,6 +262,7 @@ struct view_query {
 	struct wl_list link;
 	char *identifier;
 	char *title;
+	int window_type;
 };
 
 struct xdg_toplevel_view {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -314,6 +314,8 @@ fill_action_query(char *nodename, char *content, struct action *action)
 		current_view_query->identifier = xstrdup(content);
 	} else if (!strcasecmp(nodename, "title")) {
 		current_view_query->title = xstrdup(content);
+	} else if (!strcmp(nodename, "type")) {
+		current_view_query->window_type = parse_window_type(content);
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -80,6 +80,11 @@ view_matches_query(struct view *view, struct view_query *query)
 		match &= match_glob(query->title, title);
 	}
 
+	if (match && query->window_type >= 0) {
+		empty = false;
+		match &= view_contains_window_type(view, query->window_type);
+	}
+
 	return !empty && match;
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -71,13 +71,13 @@ view_matches_query(struct view *view, struct view_query *query)
 	const char *identifier = view_get_string_prop(view, "app_id");
 	if (match && query->identifier) {
 		empty = false;
-		match &= match_glob(query->identifier, identifier);
+		match &= identifier && match_glob(query->identifier, identifier);
 	}
 
 	const char *title = view_get_string_prop(view, "title");
 	if (match && query->title) {
 		empty = false;
-		match &= match_glob(query->title, title);
+		match &= title && match_glob(query->title, title);
 	}
 
 	if (match && query->window_type >= 0) {


### PR DESCRIPTION
I noticed that `view_matches_criteria()` and `view_matches_query()` are basically the same, so I reused some code. This builds on #1731  to avoid merge conflcts.