### PR TITLE
overlay: s/preview/overlay/ and draw filled/outlined rectangle independently

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -322,12 +322,12 @@ extending outward from the snapped edge.
 	SnapToEdge action for that edge. A *range* of 0 disables snapping via
 	interactive moves. Default is 1.
 
-*<snapping><preview><enabled>* [yes|no]
-	Show a preview when snapping to a window to an edge. Default is yes.
+*<snapping><overlay><enabled>* [yes|no]
+	Show an overlay when snapping to a window to an edge. Default is yes.
 
-*<snapping><preview><delay><inner>*++
-*<snapping><preview><delay><outer>*
-	Sets the delay to show a preview when snapping a window to each type of
+*<snapping><overlay><delay><inner>*++
+*<snapping><overlay><delay><outer>*
+	Sets the delay to show an overlay when snapping a window to each type of
 	edge. Defaults are 500 ms.
 	*inner* edges are edges with an adjacent output and *outer* edges are
 	edges without an adjacent output.

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -210,39 +210,39 @@ elements are not listed here, but are supported.
 	Height of boxes in workspace switcher in pixels. Setting to 0 disables
 	boxes. Default is 20.
 
-*snapping.preview.region.fill* [yes|no]
-	Show a filled rectangle as the preview when a window is snapped to a region.
+*snapping.overlay.region.fill* [yes|no]
+	Show a filled rectangle as an overlay when a window is snapped to a region.
 	Otherwise, an outlined rectangle is shown instead.
 	If software rendering is used, an outlined rectangle is always shown.
 
-*snapping.preview.edge.fill* [yes|no]
-	Show a filled rectangle as the preview when a window is snapped to an edge.
+*snapping.overlay.edge.fill* [yes|no]
+	Show a filled rectangle as an overlay when a window is snapped to an edge.
 	Otherwise, an outlined rectangle is shown instead.
 	If software rendering is used, an outlined rectangle is always shown.
 
-*snapping.preview.region.bg.color*
-	Color of a filled rectangle shown as the preview when a window is snapped to
+*snapping.overlay.region.bg.color*
+	Color of a filled rectangle shown as an overlay when a window is snapped to
 	a region. Default is #8080b380.
 
-*snapping.preview.edge.bg.color*
-	Color of a filled rectangle shown as the preview when a window is snapped to
+*snapping.overlay.edge.bg.color*
+	Color of a filled rectangle shown as an overlay when a window is snapped to
 	an edge. Default is #8080b380.
 
-*snapping.preview.region.border.width*
-	Border width of an outlined rectangle shown as the preview when a window is
+*snapping.overlay.region.border.width*
+	Border width of an outlined rectangle shown as an overlay when a window is
 	snapped to a region. Inherits `osd.border.width` if not set.
 
-*snapping.preview.edge.border.width*
+*snapping.overlay.edge.border.width*
 	Border width of an outlined rectangle shown as the preview when a window is
 	snapped to an edge. Inherits `osd.border.width` if not set.
 
-*snapping.preview.region.border.color*
-	Color(s) of an outlined rectangle shown as the preview when a window is
+*snapping.overlay.region.border.color*
+	Color(s) of an outlined rectangle shown as an overlay when a window is
 	snapped to a region. Possible values and the default value are the same as
 	those of *osd.window-switcher.preview.border.color*.
 
-*snapping.preview.edge.border.color*
-	Color(s) of an outlined rectangle shown as the preview when a window is
+*snapping.overlay.edge.border.color*
+	Color(s) of an outlined rectangle shown as an overlay when a window is
 	snapped to an edge. Possible values and the default value are the same as
 	those of *osd.window-switcher.preview.border.color*.
 

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -210,15 +210,25 @@ elements are not listed here, but are supported.
 	Height of boxes in workspace switcher in pixels. Setting to 0 disables
 	boxes. Default is 20.
 
-*snapping.overlay.region.fill* [yes|no]
+*snapping.overlay.region.bg.enabled* [yes|no]
 	Show a filled rectangle as an overlay when a window is snapped to a region.
-	Otherwise, an outlined rectangle is shown instead.
-	If software rendering is used, an outlined rectangle is always shown.
+	Default is yes for hardware-based renderers and no for software-based
+	renderers.
 
-*snapping.overlay.edge.fill* [yes|no]
+*snapping.overlay.edge.bg.enabled* [yes|no]
 	Show a filled rectangle as an overlay when a window is snapped to an edge.
-	Otherwise, an outlined rectangle is shown instead.
-	If software rendering is used, an outlined rectangle is always shown.
+	Default is yes for hardware-based renderer and no for software-based
+	renderers.
+
+*snapping.overlay.region.border.enabled* [yes|no]
+	Show an outlined rectangle as an overlay when a window is snapped to a
+	region. Default is no for hardware-based renderers and yes for software-based
+	renderers.
+
+*snapping.overlay.edge.border.enabled* [yes|no]
+	Show an outlined rectangle as an overlay when a window is snapped to an edge.
+	Default is no for hardware-based renderer and yes for software-based
+	renderers.
 
 *snapping.overlay.region.bg.color*
 	Color of a filled rectangle shown as an overlay when a window is snapped to

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -114,9 +114,9 @@
   <snapping>
     <!-- Set range to 0 to disable window snapping completely -->
     <range>1</range>
-    <preview enabled="yes">
+    <overlay enabled="yes">
       <delay inner="500" outer="500" />
-    </preview>
+    </overlay>
     <topMaximize>yes</topMaximize>
     <notifyClient>always</notifyClient>
   </snapping>

--- a/docs/themerc
+++ b/docs/themerc
@@ -74,11 +74,11 @@ osd.window-switcher.preview.border.color: #dddda6,#000000,#dddda6
 osd.workspace-switcher.boxes.width: 20
 osd.workspace-switcher.boxes.height: 20
 
-snapping.preview.region.fill: yes
-snapping.preview.edge.fill: yes
-snapping.preview.region.bg.color: #8080b380
-snapping.preview.edge.bg.color: #8080b380
-snapping.preview.region.border.width: 1
-snapping.preview.edge.border.width: 1
-snapping.preview.region.border.color: #dddda6,#000000,#dddda6
-snapping.preview.edge.border.color: #dddda6,#000000,#dddda6
+snapping.overlay.region.fill: yes
+snapping.overlay.edge.fill: yes
+snapping.overlay.region.bg.color: #8080b380
+snapping.overlay.edge.bg.color: #8080b380
+snapping.overlay.region.border.width: 1
+snapping.overlay.edge.border.width: 1
+snapping.overlay.region.border.color: #dddda6,#000000,#dddda6
+snapping.overlay.edge.border.color: #dddda6,#000000,#dddda6

--- a/docs/themerc
+++ b/docs/themerc
@@ -74,8 +74,18 @@ osd.window-switcher.preview.border.color: #dddda6,#000000,#dddda6
 osd.workspace-switcher.boxes.width: 20
 osd.workspace-switcher.boxes.height: 20
 
-snapping.overlay.region.fill: yes
-snapping.overlay.edge.fill: yes
+# Default values for following options change depending on the rendering
+# backend. For software-based renderers, *.bg.enabled is "no" and
+# *.border.enabled is "yes" if not set. For hardware-based renderers,
+# *.bg.enabled is "yes" and *.border.enabled is "no" if not set.
+# Setting *.bg.enabled to "yes" for software-based renderer with translucent
+# background color may severely impact performance.
+#
+# snapping.overlay.region.bg.enabled:
+# snapping.overlay.edge.bg.enabled:
+# snapping.overlay.region.border.enabled:
+# snapping.overlay.edge.border.enabled:
+
 snapping.overlay.region.bg.color: #8080b380
 snapping.overlay.edge.bg.color: #8080b380
 snapping.overlay.region.border.width: 1

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -107,9 +107,9 @@ struct rcxml {
 
 	/* window snapping */
 	int snap_edge_range;
-	bool snap_preview_enabled;
-	int snap_preview_delay_inner;
-	int snap_preview_delay_outer;
+	bool snap_overlay_enabled;
+	int snap_overlay_delay_inner;
+	int snap_overlay_delay_outer;
 	bool snap_top_maximize;
 	enum tiling_events_mode snap_tiling_events_mode;
 

--- a/include/overlay.h
+++ b/include/overlay.h
@@ -8,14 +8,13 @@
 #include "view.h"
 
 struct overlay_rect {
-	struct wlr_scene_node *node;
-	bool fill;
-	union {
-		/* if fill is true */
-		struct wlr_scene_rect *scene_rect;
-		/* if fill is false */
-		struct multi_rect *pixman_rect;
-	};
+	struct wlr_scene_tree *tree;
+
+	bool bg_enabled;
+	struct wlr_scene_rect *bg_rect;
+
+	bool border_enabled;
+	struct multi_rect *border_rect;
 };
 
 struct overlay {

--- a/include/theme.h
+++ b/include/theme.h
@@ -17,6 +17,14 @@ enum lab_justification {
 	LAB_JUSTIFY_RIGHT,
 };
 
+struct theme_snapping_overlay {
+	bool bg_enabled;
+	bool border_enabled;
+	float bg_color[4];
+	int border_width;
+	float border_color[3][4];
+};
+
 struct theme {
 	int border_width;
 	int padding_height;
@@ -82,16 +90,8 @@ struct theme {
 	int osd_workspace_switcher_boxes_width;
 	int osd_workspace_switcher_boxes_height;
 
-	bool snapping_overlay_region_fill;
-	bool snapping_overlay_edge_fill;
-
-	float snapping_overlay_region_bg_color[4];
-	float snapping_overlay_edge_bg_color[4];
-
-	int snapping_overlay_region_border_width;
-	int snapping_overlay_edge_border_width;
-	float snapping_overlay_region_border_color[3][4];
-	float snapping_overlay_edge_border_color[3][4];
+	struct theme_snapping_overlay
+		snapping_overlay_region, snapping_overlay_edge;
 
 	/* textures */
 	struct lab_data_buffer *button_close_active_unpressed;
@@ -128,13 +128,16 @@ struct theme {
 	int osd_window_switcher_item_height;
 };
 
+struct server;
+
 /**
  * theme_init - read openbox theme and generate button textures
  * @theme: theme data
+ * @server: server
  * @theme_name: theme-name in <theme-dir>/<theme-name>/openbox-3/themerc
  * Note <theme-dir> is obtained in theme-dir.c
  */
-void theme_init(struct theme *theme, const char *theme_name);
+void theme_init(struct theme *theme, struct server *server, const char *theme_name);
 
 /**
  * theme_finish - free button textures

--- a/include/theme.h
+++ b/include/theme.h
@@ -82,16 +82,16 @@ struct theme {
 	int osd_workspace_switcher_boxes_width;
 	int osd_workspace_switcher_boxes_height;
 
-	bool snapping_preview_region_fill;
-	bool snapping_preview_edge_fill;
+	bool snapping_overlay_region_fill;
+	bool snapping_overlay_edge_fill;
 
-	float snapping_preview_region_bg_color[4];
-	float snapping_preview_edge_bg_color[4];
+	float snapping_overlay_region_bg_color[4];
+	float snapping_overlay_edge_bg_color[4];
 
-	int snapping_preview_region_border_width;
-	int snapping_preview_edge_border_width;
-	float snapping_preview_region_border_color[3][4];
-	float snapping_preview_edge_border_color[3][4];
+	int snapping_overlay_region_border_width;
+	int snapping_overlay_edge_border_width;
+	float snapping_overlay_region_border_color[3][4];
+	float snapping_overlay_edge_border_color[3][4];
 
 	/* textures */
 	struct lab_data_buffer *button_close_active_unpressed;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -929,12 +929,12 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.window_edge_strength = atoi(content);
 	} else if (!strcasecmp(nodename, "range.snapping")) {
 		rc.snap_edge_range = atoi(content);
-	} else if (!strcasecmp(nodename, "enabled.preview.snapping")) {
-		set_bool(content, &rc.snap_preview_enabled);
-	} else if (!strcasecmp(nodename, "inner.delay.preview.snapping")) {
-		rc.snap_preview_delay_inner = atoi(content);
-	} else if (!strcasecmp(nodename, "outer.delay.preview.snapping")) {
-		rc.snap_preview_delay_outer = atoi(content);
+	} else if (!strcasecmp(nodename, "enabled.overlay.snapping")) {
+		set_bool(content, &rc.snap_overlay_enabled);
+	} else if (!strcasecmp(nodename, "inner.delay.overlay.snapping")) {
+		rc.snap_overlay_delay_inner = atoi(content);
+	} else if (!strcasecmp(nodename, "outer.delay.overlay.snapping")) {
+		rc.snap_overlay_delay_outer = atoi(content);
 	} else if (!strcasecmp(nodename, "topMaximize.snapping")) {
 		set_bool(content, &rc.snap_top_maximize);
 	} else if (!strcasecmp(nodename, "notifyClient.snapping")) {
@@ -1218,9 +1218,9 @@ rcxml_init(void)
 	rc.window_edge_strength = 20;
 
 	rc.snap_edge_range = 1;
-	rc.snap_preview_enabled = true;
-	rc.snap_preview_delay_inner = 500;
-	rc.snap_preview_delay_outer = 500;
+	rc.snap_overlay_enabled = true;
+	rc.snap_overlay_delay_inner = 500;
+	rc.snap_overlay_delay_outer = 500;
 	rc.snap_top_maximize = true;
 	rc.snap_tiling_events_mode = LAB_TILING_EVENTS_ALWAYS;
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -138,13 +138,13 @@ get_special(struct server *server, struct wlr_scene_node *node)
 	if (node == &server->seat.drag.icons->node) {
 		return "seat->drag.icons";
 	}
-	if (server->seat.overlay.region_rect.node
-			&& node == server->seat.overlay.region_rect.node) {
+	if (server->seat.overlay.region_rect.tree
+			&& node == &server->seat.overlay.region_rect.tree->node) {
 		/* Created on-demand */
 		return "seat->overlay.region_rect";
 	}
-	if (server->seat.overlay.edge_rect.node
-			&& node == server->seat.overlay.edge_rect.node) {
+	if (server->seat.overlay.edge_rect.tree
+			&& node == &server->seat.overlay.edge_rect.tree->node) {
 		/* Created on-demand */
 		return "seat->overlay.edge_rect";
 	}
@@ -219,17 +219,23 @@ dump_tree(struct server *server, struct wlr_scene_node *node,
 	}
 	printf("%.*s %*c %4d  %4d  [%p]\n", max_width - 1, type, padding, ' ', x, y, node);
 
+	struct multi_rect *osd_preview_outline =
+		server->osd_state.preview_outline;
+	struct multi_rect *region_snapping_overlay_outline =
+		server->seat.overlay.region_rect.border_rect;
+	struct multi_rect *edge_snapping_overlay_outline =
+		server->seat.overlay.edge_rect.border_rect;
 	if ((IGNORE_MENU && node == &server->menu_tree->node)
 			|| (IGNORE_SSD && last_view
 				&& ssd_debug_is_root_node(last_view->ssd, node))
-			|| (IGNORE_OSD_PREVIEW_OUTLINE && server->osd_state.preview_outline
-				&& node == &server->osd_state.preview_outline->tree->node)
-			|| (IGNORE_SNAPPING_PREVIEW_OUTLINE && server->seat.overlay.region_rect.node
-				&& !server->seat.overlay.region_rect.fill
-				&& node == server->seat.overlay.region_rect.node)
-			|| (IGNORE_SNAPPING_PREVIEW_OUTLINE && server->seat.overlay.edge_rect.node
-				&& !server->seat.overlay.edge_rect.fill
-				&& node == server->seat.overlay.edge_rect.node)) {
+			|| (IGNORE_OSD_PREVIEW_OUTLINE && osd_preview_outline
+				&& node == &osd_preview_outline->tree->node)
+			|| (IGNORE_SNAPPING_PREVIEW_OUTLINE
+				&& region_snapping_overlay_outline
+				&& node == &region_snapping_overlay_outline->tree->node)
+			|| (IGNORE_SNAPPING_PREVIEW_OUTLINE
+				&& edge_snapping_overlay_outline
+				&& node == &edge_snapping_overlay_outline->tree->node)) {
 		printf("%*c%s\n", pos + 4 + INDENT_SIZE, ' ', "<skipping children>");
 		return;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -171,7 +171,7 @@ main(int argc, char *argv[])
 	server_start(&server);
 
 	struct theme theme = { 0 };
-	theme_init(&theme, rc.theme_name);
+	theme_init(&theme, &server, rc.theme_name);
 	rc.theme = &theme;
 	server.theme = &theme;
 

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -48,15 +48,15 @@ void overlay_reconfigure(struct seat *seat)
 
 	struct theme *theme = seat->server->theme;
 	create_overlay_rect(seat, &seat->overlay.region_rect,
-		theme->snapping_preview_region_fill,
-		theme->snapping_preview_region_bg_color,
-		theme->snapping_preview_region_border_width,
-		theme->snapping_preview_region_border_color);
+		theme->snapping_overlay_region_fill,
+		theme->snapping_overlay_region_bg_color,
+		theme->snapping_overlay_region_border_width,
+		theme->snapping_overlay_region_border_color);
 	create_overlay_rect(seat, &seat->overlay.edge_rect,
-		theme->snapping_preview_edge_fill,
-		theme->snapping_preview_edge_bg_color,
-		theme->snapping_preview_edge_border_width,
-		theme->snapping_preview_edge_border_color);
+		theme->snapping_overlay_edge_fill,
+		theme->snapping_overlay_edge_bg_color,
+		theme->snapping_overlay_edge_border_width,
+		theme->snapping_overlay_edge_border_color);
 }
 
 static void
@@ -188,7 +188,7 @@ static void
 show_edge_overlay(struct seat *seat, enum view_edge edge,
 		struct output *output)
 {
-	if (!rc.snap_preview_enabled) {
+	if (!rc.snap_overlay_enabled) {
 		return;
 	}
 	if (seat->overlay.active.edge == edge
@@ -201,9 +201,9 @@ show_edge_overlay(struct seat *seat, enum view_edge edge,
 
 	int delay;
 	if (edge_has_adjacent_output_from_cursor(seat, output, edge)) {
-		delay = rc.snap_preview_delay_inner;
+		delay = rc.snap_overlay_delay_inner;
 	} else {
-		delay = rc.snap_preview_delay_outer;
+		delay = rc.snap_overlay_delay_outer;
 	}
 
 	if (delay > 0) {

--- a/src/server.c
+++ b/src/server.c
@@ -51,7 +51,7 @@ reload_config_and_theme(struct server *server)
 	rcxml_finish();
 	rcxml_read(rc.config_file);
 	theme_finish(server->theme);
-	theme_init(server->theme, rc.theme_name);
+	theme_init(server->theme, server, rc.theme_name);
 
 	struct view *view;
 	wl_list_for_each(view, &server->views, link) {

--- a/src/theme.c
+++ b/src/theme.c
@@ -538,21 +538,21 @@ theme_builtin(struct theme *theme)
 	theme->osd_border_color[0] = FLT_MIN;
 	theme->osd_label_text_color[0] = FLT_MIN;
 
-	theme->snapping_preview_region_fill = true;
-	theme->snapping_preview_edge_fill = true;
+	theme->snapping_overlay_region_fill = true;
+	theme->snapping_overlay_edge_fill = true;
 
-	parse_hexstr("#8080b380", theme->snapping_preview_region_bg_color);
-	parse_hexstr("#8080b380", theme->snapping_preview_edge_bg_color);
+	parse_hexstr("#8080b380", theme->snapping_overlay_region_bg_color);
+	parse_hexstr("#8080b380", theme->snapping_overlay_edge_bg_color);
 
 	/* inherit settings in post_processing() if not set elsewhere */
-	theme->snapping_preview_region_border_width = INT_MIN;
-	theme->snapping_preview_edge_border_width = INT_MIN;
-	memset(theme->snapping_preview_region_border_color, 0,
-		sizeof(theme->snapping_preview_region_border_color));
-	theme->snapping_preview_region_border_color[0][0] = FLT_MIN;
-	memset(theme->snapping_preview_edge_border_color, 0,
-		sizeof(theme->snapping_preview_edge_border_color));
-	theme->snapping_preview_edge_border_color[0][0] = FLT_MIN;
+	theme->snapping_overlay_region_border_width = INT_MIN;
+	theme->snapping_overlay_edge_border_width = INT_MIN;
+	memset(theme->snapping_overlay_region_border_color, 0,
+		sizeof(theme->snapping_overlay_region_border_color));
+	theme->snapping_overlay_region_border_color[0][0] = FLT_MIN;
+	memset(theme->snapping_overlay_edge_border_color, 0,
+		sizeof(theme->snapping_overlay_edge_border_color));
+	theme->snapping_overlay_edge_border_color[0][0] = FLT_MIN;
 }
 
 static void
@@ -754,29 +754,29 @@ entry(struct theme *theme, const char *key, const char *value)
 	if (match_glob(key, "osd.label.text.color")) {
 		parse_hexstr(value, theme->osd_label_text_color);
 	}
-	if (match_glob(key, "snapping.preview.region.fill")) {
-		theme->snapping_preview_region_fill = parse_bool(value, true);
+	if (match_glob(key, "snapping.overlay.region.fill")) {
+		theme->snapping_overlay_region_fill = parse_bool(value, true);
 	}
-	if (match_glob(key, "snapping.preview.edge.fill")) {
-		theme->snapping_preview_edge_fill = parse_bool(value, true);
+	if (match_glob(key, "snapping.overlay.edge.fill")) {
+		theme->snapping_overlay_edge_fill = parse_bool(value, true);
 	}
-	if (match_glob(key, "snapping.preview.region.bg.color")) {
-		parse_hexstr(value, theme->snapping_preview_region_bg_color);
+	if (match_glob(key, "snapping.overlay.region.bg.color")) {
+		parse_hexstr(value, theme->snapping_overlay_region_bg_color);
 	}
-	if (match_glob(key, "snapping.preview.edge.bg.color")) {
-		parse_hexstr(value, theme->snapping_preview_edge_bg_color);
+	if (match_glob(key, "snapping.overlay.edge.bg.color")) {
+		parse_hexstr(value, theme->snapping_overlay_edge_bg_color);
 	}
-	if (match_glob(key, "snapping.preview.region.border.width")) {
-		theme->snapping_preview_region_border_width = atoi(value);
+	if (match_glob(key, "snapping.overlay.region.border.width")) {
+		theme->snapping_overlay_region_border_width = atoi(value);
 	}
-	if (match_glob(key, "snapping.preview.edge.border.width")) {
-		theme->snapping_preview_edge_border_width = atoi(value);
+	if (match_glob(key, "snapping.overlay.edge.border.width")) {
+		theme->snapping_overlay_edge_border_width = atoi(value);
 	}
-	if (match_glob(key, "snapping.preview.region.border.color")) {
-		parse_hexstrs(value, theme->snapping_preview_region_border_color);
+	if (match_glob(key, "snapping.overlay.region.border.color")) {
+		parse_hexstrs(value, theme->snapping_overlay_region_border_color);
 	}
-	if (match_glob(key, "snapping.preview.edge.border.color")) {
-		parse_hexstrs(value, theme->snapping_preview_edge_border_color);
+	if (match_glob(key, "snapping.overlay.edge.border.color")) {
+		parse_hexstrs(value, theme->snapping_overlay_edge_border_color);
 	}
 }
 
@@ -1113,21 +1113,21 @@ post_processing(struct theme *theme)
 			theme->osd_window_switcher_preview_border_color);
 	}
 
-	if (theme->snapping_preview_region_border_width == INT_MIN) {
-		theme->snapping_preview_region_border_width =
+	if (theme->snapping_overlay_region_border_width == INT_MIN) {
+		theme->snapping_overlay_region_border_width =
 			theme->osd_border_width;
 	}
-	if (theme->snapping_preview_edge_border_width == INT_MIN) {
-		theme->snapping_preview_edge_border_width =
+	if (theme->snapping_overlay_edge_border_width == INT_MIN) {
+		theme->snapping_overlay_edge_border_width =
 			theme->osd_border_width;
 	}
-	if (theme->snapping_preview_region_border_color[0][0] == FLT_MIN) {
+	if (theme->snapping_overlay_region_border_color[0][0] == FLT_MIN) {
 		fill_colors_with_osd_theme(theme,
-			theme->snapping_preview_region_border_color);
+			theme->snapping_overlay_region_border_color);
 	}
-	if (theme->snapping_preview_edge_border_color[0][0] == FLT_MIN) {
+	if (theme->snapping_overlay_edge_border_color[0][0] == FLT_MIN) {
 		fill_colors_with_osd_theme(theme,
-			theme->snapping_preview_edge_border_color);
+			theme->snapping_overlay_edge_border_color);
 	}
 }
 


### PR DESCRIPTION
Resolves #1735

As now whether to draw a filled rectangle or an outlined rectangle is independently configured, I added `snapping.overlay.[region|edge].stroke`.

However, I'm thinking of replacing `*.fill`/`*.stroke` with `*.bg.enabled`/`*.border.enabled`. I think this will make it easier to understand.

Another approach is removing `*.fill`/`*.stroke` and letting users disable them by setting `*.bg.color` to `#0000000` and `*.border.width` to `0`.

Give me your opinions.