### PR TITLE
window-rules: add ignoreConfigureRequest

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -875,7 +875,11 @@ situation.
 	on-screen-display).
 
 *<windowRules><windowRule ignoreFocusRequest="">* [yes|no|default]
-	*ignoreFocusRequest* prevent window to activate itself.
+	*ignoreFocusRequest* prevents window to activate itself.
+
+*<windowRules><windowRule ignoreConfigureRequest="">* [yes|no|default]
+	*ignoreConfigureRequest* prevents a X11 window to position and size
+	itself.
 
 *<windowRules><windowRule fixedPosition="">* [yes|no|default]
 	*fixedPosition* disallows interactive move/resize and prevents

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -31,6 +31,7 @@ struct window_rule {
 	enum property skip_taskbar;
 	enum property skip_window_switcher;
 	enum property ignore_focus_request;
+	enum property ignore_configure_request;
 	enum property fixed_position;
 
 	struct wl_list link; /* struct rcxml.window_rules */

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -209,6 +209,8 @@ fill_window_rule(char *nodename, char *content)
 		set_property(content, &current_window_rule->skip_window_switcher);
 	} else if (!strcasecmp(nodename, "ignoreFocusRequest")) {
 		set_property(content, &current_window_rule->ignore_focus_request);
+	} else if (!strcasecmp(nodename, "ignoreConfigureRequest")) {
+		set_property(content, &current_window_rule->ignore_configure_request);
 	} else if (!strcasecmp(nodename, "fixedPosition")) {
 		set_property(content, &current_window_rule->fixed_position);
 

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -114,6 +114,10 @@ window_rules_get_property(struct view *view, const char *property)
 					&& !strcasecmp(property, "ignoreFocusRequest")) {
 				return rule->ignore_focus_request;
 			}
+			if (rule->ignore_configure_request
+					&& !strcasecmp(property, "ignoreConfigureRequest")) {
+				return rule->ignore_configure_request;
+			}
 			if (rule->fixed_position
 					&& !strcasecmp(property, "fixedPosition")) {
 				return rule->fixed_position;

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -377,8 +377,10 @@ handle_request_configure(struct wl_listener *listener, void *data)
 		wl_container_of(listener, xwayland_view, request_configure);
 	struct view *view = &xwayland_view->base;
 	struct wlr_xwayland_surface_configure_event *event = data;
+	bool ignore_configure_requests = window_rules_get_property(
+		view, "ignoreConfigureRequest") == LAB_PROP_TRUE;
 
-	if (view_is_floating(view)) {
+	if (view_is_floating(view) && !ignore_configure_requests) {
 		/* Honor client configure requests for floating views */
 		struct wlr_box box = {.x = event->x, .y = event->y,
 			.width = event->width, .height = event->height};


### PR DESCRIPTION
This allows to ignore X11 client side configure requests like positioning and resizing and can be used to fight some X11 applications that persist to have their windows spawn at specific places and sizes.

Fixes:
- #1446

---

I don't really like the runtime `strcmp()` calls with the rules, at some point we could consider moving those to enums instead.