### PR TITLE
Resolve errors from clangd

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -2,6 +2,7 @@
 #ifndef LABWC_ACTION_H
 #define LABWC_ACTION_H
 
+#include <stdbool.h>
 #include <wayland-util.h>
 
 struct view;

--- a/include/button/common.h
+++ b/include/button/common.h
@@ -2,6 +2,8 @@
 #ifndef LABWC_BUTTON_COMMON_H
 #define LABWC_BUTTON_COMMON_H
 
+#include <stddef.h>
+
 /**
  * button_filename() - Get full filename for button.
  * @name: The name of the button (for example 'iconify.xbm').

--- a/include/common/scaled_scene_buffer.h
+++ b/include/common/scaled_scene_buffer.h
@@ -2,11 +2,11 @@
 #ifndef LABWC_SCALED_SCENE_BUFFER_H
 #define LABWC_SCALED_SCENE_BUFFER_H
 
+#include <wayland-server-core.h>
+
 #define LAB_SCALED_BUFFER_MAX_CACHE 2
 
-struct wl_list;
 struct wlr_buffer;
-struct wl_listener;
 struct wlr_scene_tree;
 struct lab_data_buffer;
 struct scaled_scene_buffer;

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -2,6 +2,8 @@
 #ifndef LABWC_DEFAULT_BINDINGS_H
 #define LABWC_DEFAULT_BINDINGS_H
 
+#include <stddef.h>
+
 static struct key_combos {
 	const char *binding, *action;
 	struct {

--- a/include/config/touch.h
+++ b/include/config/touch.h
@@ -3,6 +3,7 @@
 #define LABWC_TOUCH_CONFIG_H
 
 #include <stdint.h>
+#include <wayland-util.h>
 
 struct touch_config_entry {
 	char *device_name;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -46,7 +46,6 @@
 #include "config/keybind.h"
 #include "config/rcxml.h"
 #include "input/cursor.h"
-#include "input/ime.h"
 #include "overlay.h"
 #include "regions.h"
 #include "session-lock.h"

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -2,6 +2,9 @@
 #ifndef LABWC_WINDOW_RULES_H
 #define LABWC_WINDOW_RULES_H
 
+#include <stdbool.h>
+#include <wayland-util.h>
+
 enum window_rule_event {
 	LAB_WINDOW_RULE_EVENT_ON_FIRST_MAP = 0,
 };

--- a/src/debug.c
+++ b/src/debug.c
@@ -4,6 +4,7 @@
 #include "common/graphic-helpers.h"
 #include "common/scene-helpers.h"
 #include "debug.h"
+#include "input/ime.h"
 #include "labwc.h"
 #include "node.h"
 #include "ssd.h"

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -7,6 +7,7 @@
 #include <wlr/interfaces/wlr_keyboard.h>
 #include "action.h"
 #include "idle.h"
+#include "input/ime.h"
 #include "input/keyboard.h"
 #include "input/key-state.h"
 #include "labwc.h"

--- a/src/seat.c
+++ b/src/seat.c
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_touch.h>
 #include <wlr/util/log.h>
 #include "common/mem.h"
+#include "input/ime.h"
 #include "input/tablet.h"
 #include "input/tablet_pad.h"
 #include "input/input.h"


### PR DESCRIPTION
I switched to clangd from VSCode's intellisense today and it showed me some errors regarding headers.

- Added headers like <stddef.h> for `NULL`, <wayland-util.h> for `wl_link` and <stdbool.h> for `bool`.
- Fixed circular dependency of `labwc.h` and `ime.h`