### PR TITLE
cursor: implement <menu><hideDelay>

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -891,6 +891,24 @@ situation.
 	can be caused by *<margin>* settings or exclusive layer-shell clients
 	such as panels.
 
+## MENU
+
+```
+<menu>
+  <ignoreButtonReleasePeriod>250</ignoreButtonReleasePeriod>
+</menu>
+```
+
+*<menu><ignoreButtonReleasePeriod>*
+	How long (in milliseconds) the initial button release event is ignored
+	for. The reason for this logic and behaviour is to avoid a fast
+	press-move-release sequence indended to just open the menu resulting in
+	the closure of the menu or the selection of (typically the first) menu
+	item. This behaviour only affects the first button-release. It is not
+	anticipated that most users will want to change this, but the config
+	option has been exposed for unusual use-cases. It is equivalent to
+	Openbox's `<hideDelay>`. Default is 250 ms.
+
 ## ENVIRONMENT VARIABLES
 
 *XCURSOR_THEME* and *XCURSOR_SIZE* are supported to set cursor theme

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -586,4 +586,7 @@
     </windowRules>
   -->
 
+  <menu>
+    <ignoreButtonReleasePeriod>250</ignoreButtonReleasePeriod>
+  </menu>
 </labwc_config>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -137,6 +137,9 @@ struct rcxml {
 	} window_switcher;
 
 	struct wl_list window_rules; /* struct window_rule.link */
+
+	/* Menu */
+	unsigned int menu_ignore_button_release_period;
 };
 
 extern struct rcxml rc;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1034,6 +1034,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "Missing 'button' argument for tablet button mapping");
 		}
+	} else if (!strcasecmp(nodename, "ignoreButtonReleasePeriod.menu")) {
+		rc.menu_ignore_button_release_period = atoi(content);
 	}
 }
 
@@ -1238,6 +1240,8 @@ rcxml_init(void)
 
 	rc.workspace_config.popuptime = INT_MIN;
 	rc.workspace_config.min_nr_workspaces = 1;
+
+	rc.menu_ignore_button_release_period = 250;
 }
 
 static void

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -929,12 +929,17 @@ handle_press_mousebinding(struct server *server, struct cursor_context *ctx,
 	return consumed_by_frame_context;
 }
 
+static uint32_t press_msec;
+
 static void
 cursor_button_press(struct seat *seat, uint32_t button,
 		enum wlr_button_state button_state, uint32_t time_msec)
 {
 	struct server *server = seat->server;
 	struct cursor_context ctx = get_cursor_context(server);
+
+	/* Used on next button release to check if it can close menu or select menu item */
+	press_msec = time_msec;
 
 	/* Determine closest resize edges in case action is Resize */
 	uint32_t resize_edges = cursor_get_resize_edges(seat->cursor, &ctx);
@@ -946,6 +951,11 @@ cursor_button_press(struct seat *seat, uint32_t button,
 	}
 
 	if (server->input_mode == LAB_INPUT_STATE_MENU) {
+		/*
+		 * If menu was already opened on press, set a very small value
+		 * so subsequent release always closes menu or selects menu item.
+		 */
+		press_msec = 0;
 		return;
 	}
 
@@ -1011,12 +1021,15 @@ cursor_button_release(struct seat *seat, uint32_t button,
 	seat_reset_pressed(seat);
 
 	if (server->input_mode == LAB_INPUT_STATE_MENU) {
-		if (ctx.type == LAB_SSD_MENU) {
-			menu_call_selected_actions(server);
-		} else {
-			menu_close_root(server);
-			cursor_update_common(server, &ctx, time_msec,
-				/*cursor_has_moved*/ false);
+		/* TODO: take into account overflow of time_msec */
+		if (time_msec - press_msec > rc.menu_ignore_button_release_period) {
+			if (ctx.type == LAB_SSD_MENU) {
+				menu_call_selected_actions(server);
+			} else {
+				menu_close_root(server);
+				cursor_update_common(server, &ctx, time_msec,
+					/*cursor_has_moved*/ false);
+			}
 		}
 		return;
 	}


### PR DESCRIPTION
This fixes the UX degradation introduced by #1751 that the menu is closed or an action is executed unexpectedly when the cursor is moved a bit while clicking, by requiring a delay to close the menu or execute an action in a single sequence of button press & release.

I'm not sure just copying the name `hideDelay` from Openbox is the best option, as it also delays running action.

As we're in cooldown period, maybe we should postpone this fix and revert #1751 for now.