### PR TITLE
Only respond to modifier-only keybindings on release

### DIFF
--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -20,6 +20,7 @@ struct keybind {
 	int keycodes_layout;
 	struct wl_list actions;  /* struct action.link */
 	struct wl_list link;     /* struct rcxml.keybinds */
+	bool mod_only;           /* set if only modifier keys used */
 };
 
 /**

--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -20,7 +20,7 @@ struct keybind {
 	int keycodes_layout;
 	struct wl_list actions;  /* struct action.link */
 	struct wl_list link;     /* struct rcxml.keybinds */
-	bool mod_only;           /* set if only modifier keys used */
+	bool on_release;         /* set if only modifier keys used */
 };
 
 /**

--- a/include/input/keyboard.h
+++ b/include/input/keyboard.h
@@ -20,5 +20,6 @@ void keyboard_set_numlock(struct wlr_keyboard *keyboard);
 void keyboard_update_layout(struct seat *seat, xkb_layout_index_t layout);
 void keyboard_cancel_keybind_repeat(struct keyboard *keyboard);
 bool keyboard_any_modifiers_pressed(struct wlr_keyboard *keyboard);
+bool keyboard_is_modifier_key(xkb_keysym_t sym);
 
 #endif /* LABWC_KEYBOARD_H */

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -122,8 +122,8 @@ keybind_create(const char *keybind)
 	xkb_keysym_t sym;
 	struct keybind *k = znew(*k);
 	xkb_keysym_t keysyms[MAX_KEYSYMS];
+	bool mod_only = TRUE;
 	gchar **symnames = g_strsplit(keybind, "-", -1);
-	k->mod_only = TRUE;
 	for (size_t i = 0; symnames[i]; i++) {
 		char *symname = symnames[i];
 		uint32_t modifier = parse_modifier(symname);
@@ -132,7 +132,7 @@ keybind_create(const char *keybind)
 		} else {
 			sym = xkb_keysym_from_name(symname, XKB_KEYSYM_CASE_INSENSITIVE);
 			if (!keyboard_is_modifier_key(sym)) {
-				k->mod_only = FALSE;
+				mod_only = FALSE;
 			}
 			if (sym == XKB_KEY_NoSymbol && g_utf8_strlen(symname, -1) == 1) {
 				/*
@@ -168,6 +168,7 @@ keybind_create(const char *keybind)
 	if (!k) {
 		return NULL;
 	}
+	k->mod_only = mod_only;
 	wl_list_append(&rc.keybinds, &k->link);
 	k->keysyms = xmalloc(k->keysyms_len * sizeof(xkb_keysym_t));
 	memcpy(k->keysyms, keysyms, k->keysyms_len * sizeof(xkb_keysym_t));

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -131,7 +131,9 @@ keybind_create(const char *keybind)
 			k->modifiers |= modifier;
 		} else {
 			sym = xkb_keysym_from_name(symname, XKB_KEYSYM_CASE_INSENSITIVE);
-			if (!keyboard_is_modifier_key (sym)) k->mod_only = FALSE;
+			if (!keyboard_is_modifier_key(sym)) {
+				k->mod_only = FALSE;
+			}
 			if (sym == XKB_KEY_NoSymbol && g_utf8_strlen(symname, -1) == 1) {
 				/*
 				 * xkb_keysym_from_name() only handles a legacy set of single

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -122,7 +122,7 @@ keybind_create(const char *keybind)
 	xkb_keysym_t sym;
 	struct keybind *k = znew(*k);
 	xkb_keysym_t keysyms[MAX_KEYSYMS];
-	bool mod_only = TRUE;
+	bool on_release = true;
 	gchar **symnames = g_strsplit(keybind, "-", -1);
 	for (size_t i = 0; symnames[i]; i++) {
 		char *symname = symnames[i];
@@ -132,7 +132,7 @@ keybind_create(const char *keybind)
 		} else {
 			sym = xkb_keysym_from_name(symname, XKB_KEYSYM_CASE_INSENSITIVE);
 			if (!keyboard_is_modifier_key(sym)) {
-				mod_only = FALSE;
+				on_release = false;
 			}
 			if (sym == XKB_KEY_NoSymbol && g_utf8_strlen(symname, -1) == 1) {
 				/*
@@ -168,7 +168,7 @@ keybind_create(const char *keybind)
 	if (!k) {
 		return NULL;
 	}
-	k->mod_only = mod_only;
+	k->on_release = on_release;
 	wl_list_append(&rc.keybinds, &k->link);
 	k->keysyms = xmalloc(k->keysyms_len * sizeof(xkb_keysym_t));
 	memcpy(k->keysyms, keysyms, k->keysyms_len * sizeof(xkb_keysym_t));

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -10,6 +10,7 @@
 #include "common/mem.h"
 #include "config/keybind.h"
 #include "config/rcxml.h"
+#include "input/keyboard.h"
 #include "labwc.h"
 
 uint32_t
@@ -122,6 +123,7 @@ keybind_create(const char *keybind)
 	struct keybind *k = znew(*k);
 	xkb_keysym_t keysyms[MAX_KEYSYMS];
 	gchar **symnames = g_strsplit(keybind, "-", -1);
+	k->mod_only = TRUE;
 	for (size_t i = 0; symnames[i]; i++) {
 		char *symname = symnames[i];
 		uint32_t modifier = parse_modifier(symname);
@@ -129,6 +131,7 @@ keybind_create(const char *keybind)
 			k->modifiers |= modifier;
 		} else {
 			sym = xkb_keysym_from_name(symname, XKB_KEYSYM_CASE_INSENSITIVE);
+			if (!keyboard_is_modifier_key (sym)) k->mod_only = FALSE;
 			if (sym == XKB_KEY_NoSymbol && g_utf8_strlen(symname, -1) == 1) {
 				/*
 				 * xkb_keysym_from_name() only handles a legacy set of single

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -38,7 +38,7 @@ struct keyinfo {
 
 static bool should_cancel_cycling_on_next_key_release;
 
-struct keybind *cur_keybind = NULL;
+struct keybind *cur_keybind;
 
 static void
 change_vt(struct server *server, unsigned int vt)

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -412,7 +412,7 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 		if (cur_keybind && cur_keybind->on_release) {
 			key_state_bound_key_remove(event->keycode);
 			if (seat->active_client_while_inhibited
-					|| seat->server->session_lock) {
+					|| seat->server->session_lock_manager->locked) {
 				cur_keybind = NULL;
 				return true;
 			}

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -415,7 +415,6 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 				cur_keybind = NULL;
 				return false;
 			}
-			key_state_store_pressed_key_as_bound(event->keycode);
 			actions_run(NULL, server, &cur_keybind->actions, 0);
 			cur_keybind = NULL;
 			return true;
@@ -459,15 +458,17 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	 */
 	cur_keybind =
 		match_keybinding(server, &keyinfo, keyboard->is_virtual);
-	if (cur_keybind && !cur_keybind->mod_only) {
+	if (cur_keybind) {
 		/*
 		 * Update key-state before action_run() because the action
 		 * might lead to seat_focus() in which case we pass the
 		 * 'pressed-sent' keys to the new surface.
 		 */
 		key_state_store_pressed_key_as_bound(event->keycode);
-		actions_run(NULL, server, &cur_keybind->actions, 0);
-		cur_keybind = NULL;
+		if (!cur_keybind->mod_only) {
+			actions_run(NULL, server, &cur_keybind->actions, 0);
+			cur_keybind = NULL;
+		}
 		return true;
 	}
 

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -410,6 +410,11 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 
 	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
 		if (cur_keybind && cur_keybind->mod_only) {
+			if (seat->active_client_while_inhibited
+					|| seat->server->session_lock) {
+				cur_keybind = NULL;
+				return false;
+			}
 			key_state_store_pressed_key_as_bound(event->keycode);
 			actions_run(NULL, server, &cur_keybind->actions, 0);
 			cur_keybind = NULL;


### PR DESCRIPTION
This is a possible fix for https://github.com/labwc/labwc/issues/1756

I have modified the keybinding code so that a flag is set in the keybinding data structure if the keybinding only involves modifier keys.

If this flag is set for a particular keybinding, then that keybinding is detected on key press and stored, and executed on key release if no other (non-modifier) keybinding has executed in the meantime.

This fixes my immediate problem, that of wanting Win+cursor to activate snap behaviour, and Win on its own to launch the application menu, but I have no idea if this is the best way to do this. It seems to work for me, though!