### PR TITLE
ssd_titlebar.c: don't pass negative value to wlr_scene_rect_set_size()

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -3,14 +3,15 @@
 #define LABWC_VIEW_H
 
 #include "config.h"
+#include "ssd.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <wayland-util.h>
 #include <wlr/util/box.h>
 #include <xkbcommon/xkbcommon.h>
 
-#define LAB_MIN_VIEW_WIDTH  100
-#define LAB_MIN_VIEW_HEIGHT  60
+#define LAB_MIN_VIEW_WIDTH (SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT)
+#define LAB_MIN_VIEW_HEIGHT 60
 
 /*
  * In labwc, a view is a container for surfaces which can be moved around by

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -229,6 +229,16 @@ ssd_update_geometry(struct ssd *ssd)
 	int eff_width = current.width;
 	int eff_height = view_effective_height(ssd->view, /* use_pending */ false);
 
+	if (eff_width > 0 && eff_width < LAB_MIN_VIEW_WIDTH) {
+		/*
+		 * Prevent negative values in calculations like
+		 * `width - SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT`
+		 */
+		wlr_log(WLR_ERROR,
+			"view width is smaller than its minimal value");
+		return;
+	}
+
 	if (eff_width == cached.width && eff_height == cached.height) {
 		if (current.x != cached.x || current.y != cached.y) {
 			/* Dynamically resize extents based on position and usable_area */


### PR DESCRIPTION
I noticed following error was printed when a view is resized to minimum width.
I re-installed pixman Arch Linux package with symbols to debug it and found this is due to a negative value passed to `wlr_scene_rect_set_size()`. 

```
*** BUG ***
In pixman_region32_union_rect: Invalid rectangle passed
Set a breakpoint on '_pixman_log_error' to debug
```