### PR TITLE
view: update top layer visibility on map

### DIFF
--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -46,6 +46,12 @@ view_impl_map(struct view *view)
 		}
 	}
 
+	/*
+	 * Some clients (e.g. Steam's Big Picture Mode window) request
+	 * fullscreen before mapping.
+	 */
+	desktop_update_top_layer_visiblity(view->server);
+
 	wlr_log(WLR_DEBUG, "[map] identifier=%s, title=%s\n",
 		view_get_string_prop(view, "app_id"),
 		view_get_string_prop(view, "title"));


### PR DESCRIPTION
Fixes #1752.

Steam's Big Picture mode runs in fullscreen mode, but requests it before being mapped.
When a client requests fullscreen mode, `desktop_update_top_layer_visiblity()` checks if there's a fullscreen window in the output to determine the top layer should be hidden or not, but unmapped views are always ignored.
So `desktop_update_top_layer_visiblity()` should be called also on map. 

Not sure this is following the spec.