### PR TITLE
[RFC] config: use automatic placement by default

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -196,12 +196,12 @@ this is for compatibility with Openbox.
 
 ## PLACEMENT
 
-*<placement><policy>* [center|automatic|cursor]
-	Specify a placement policy for new windows. The "center" policy will
-	always place windows at the center of the active output. The "automatic"
-	policy will try to place new windows in such a way that they will
-	have minimal overlap with existing windows. The "cursor" policy will
-	center new windows under the cursor. Default is "center".
+*<placement><policy>* [automatic|center|cursor]
+	Specify a placement policy for new windows. The "automatic" policy will
+	try to place new windows in such a way that they will have minimal
+	overlap with existing windows. The "center" policy will always place
+	windows at the center of the active output. The "cursor" policy will
+	center new windows under the cursor. Default is "automatic".
 
 ## WINDOW SWITCHER
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -16,7 +16,7 @@
   </core>
 
   <placement>
-    <policy>center</policy>
+    <policy>automatic</policy>
   </placement>
 
   <!-- <font><theme> can be defined without an attribute to set all places -->

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -871,12 +871,12 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "reuseOutputMode.core")) {
 		set_bool(content, &rc.reuse_output_mode);
 	} else if (!strcmp(nodename, "policy.placement")) {
-		if (!strcmp(content, "automatic")) {
-			rc.placement_policy = LAB_PLACE_AUTOMATIC;
+		if (!strcmp(content, "center")) {
+			rc.placement_policy = LAB_PLACE_CENTER;
 		} else if (!strcmp(content, "cursor")) {
 			rc.placement_policy = LAB_PLACE_CURSOR;
 		} else {
-			rc.placement_policy = LAB_PLACE_CENTER;
+			rc.placement_policy = LAB_PLACE_AUTOMATIC;
 		}
 	} else if (!strcmp(nodename, "name.theme")) {
 		rc.theme_name = xstrdup(content);


### PR DESCRIPTION
Automatic placement has been in place for a couple of releases now, and I think it makes the compositor much more usable to have windows try to avoid collisions rather than centering everything. Maybe it's time to switch the default policy.