### PR TITLE
cursor: reload cursor on Reconfigure

### DIFF
--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -119,7 +119,7 @@ void cursor_update_focus(struct server *server);
 void cursor_update_image(struct seat *seat);
 
 void cursor_init(struct seat *seat);
-void cursor_load(struct seat *seat);
+void cursor_reload(struct seat *seat);
 void cursor_emulate_move_absolute(struct seat *seat,
 		struct wlr_input_device *device,
 		double x, double y, uint32_t time_msec);

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -299,6 +299,7 @@ cursor_update_image(struct seat *seat)
 		 */
 		if (seat->seat->pointer_state.focused_surface) {
 			seat->server_cursor = LAB_CURSOR_DEFAULT;
+			wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager, "");
 			cursor_update_focus(seat->server);
 		}
 		return;
@@ -1254,7 +1255,7 @@ cursor_frame(struct wl_listener *listener, void *data)
 	wlr_seat_pointer_notify_frame(seat->seat);
 }
 
-void
+static void
 cursor_load(struct seat *seat)
 {
 	const char *xcursor_theme = getenv("XCURSOR_THEME");
@@ -1298,6 +1299,13 @@ cursor_load(struct seat *seat)
 			"Cursor theme is missing cursor names, using fallback");
 		cursor_names = cursors_x11;
 	}
+}
+
+void
+cursor_reload(struct seat *seat)
+{
+	cursor_load(seat);
+	cursor_update_image(seat);
 }
 
 void

--- a/src/seat.c
+++ b/src/seat.c
@@ -587,7 +587,7 @@ seat_reconfigure(struct server *server)
 {
 	struct seat *seat = &server->seat;
 	struct input *input;
-	cursor_load(seat);
+	cursor_reload(seat);
 	overlay_reconfigure(seat);
 	wl_list_for_each(input, &seat->inputs, link) {
 		switch (input->wlr_input_device->type) {


### PR DESCRIPTION
This gives instant feedback when changing cursor theme or size. It only works for server side cursors or clients using the cursor-shape protocol.

Fixes:
- #1619