### PR TITLE
menu: reset parser state in `menu_finish()`

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -960,6 +960,11 @@ void
 menu_finish(struct server *server)
 {
 	menu_free_from(server, NULL);
+
+	/* Reset state vars for starting fresh when Reload is triggered */
+	current_item = NULL;
+	current_item_action = NULL;
+	current_menu = NULL;
 }
 
 /* Sets selection (or clears selection if passing NULL) */


### PR DESCRIPTION
This fixes use-after-free in `fill_item()` on Reconfigure with invalid `menu.xml` like below:

```xml
<openbox_menu>
  <menu id="root-menu">
    <item id="rofi-run" label="Run command">
      <action name="Execute" command="rofi-run" />
    </item>
  </menu>
</openbox_menu>
```

Fixes #1776