### PR TITLE
view: fix top-layer not showing with minimized full-screen view

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -233,6 +233,9 @@ desktop_update_top_layer_visiblity(struct server *server)
 	enum lab_view_criteria criteria =
 		LAB_VIEW_CRITERIA_CURRENT_WORKSPACE | LAB_VIEW_CRITERIA_FULLSCREEN;
 	for_each_view(view, &server->views, criteria) {
+		if (view->minimized) {
+			continue;
+		}
 		if (!output_is_usable(view->output)) {
 			continue;
 		}

--- a/src/view.c
+++ b/src/view.c
@@ -648,6 +648,11 @@ view_minimize(struct view *view, bool minimized)
 	struct view *root = view_get_root(view);
 	_minimize(root, minimized);
 	minimize_sub_views(root, minimized);
+
+	/* Enable top-layer when full-screen views are minimized */
+	if (view->fullscreen && view->output) {
+		desktop_update_top_layer_visiblity(view->server);
+	}
 }
 
 bool


### PR DESCRIPTION
If a full-screen window is minimized, top-layer views like waybar are kept hidden. This PR tries to fix this behavior.

I noticed this with some Wine games when they minimized themselves after losing focus (for instance by using the window switcher), but of course it's easy to reproduce once you know about it.