### PR TITLE
Add support for security-context-v1

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -851,7 +851,8 @@ defined as shown below.
 
 *Criteria*
 
-*<windowRules><windowRule identifier="" title="" type="" matchOnce="">*
+*<windowRules><windowRule identifier="" title="" sandboxEngine=""
+sandboxAppId="" type="" matchOnce="">*
 	Define a window rule for any window which matches the criteria defined
 	by the attributes *identifier*, *title*, or *type*. If more than one
 	is defined, AND logic is used, so all have to match.
@@ -862,6 +863,11 @@ defined as shown below.
 	for XWayland clients.
 
 	*title* is the title of the window.
+
+	*sandboxEngine* is a sandbox engine name from the security context.
+
+	*sandboxAppId* is a sandbox-specific identifier for an application
+	from the security context.
 
 	*type* [desktop|dock|toolbar|menu|utility|splash|dialog|dropdown_menu|
 	popup_menu|tooltip|notification|combo|dnd|normal] relates to

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -552,8 +552,8 @@
 
   <!--
     # Window Rules
-    #   - Criteria can consist of 'identifier' or 'title' or both (in which
-    #     case AND logic is used).
+    #   - Criteria can consist of 'identifier', 'title', 'sandboxEngine' or
+    #     'sandboxAppId'. AND logic is used when multiple options are specified.
     #   - 'identifier' relates to app_id for native Wayland windows and
     #     WM_CLASS for XWayland clients.
     #   - Criteria can also contain `matchOnce="true"` meaning that the rule

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -335,6 +335,7 @@ struct server {
 	struct wlr_text_input_manager_v3 *text_input_manager;
 
 	struct wlr_tablet_manager_v2 *tablet_manager;
+	struct wlr_security_context_manager_v1 *security_context_manager_v1;
 
 	/* Set when in cycle (alt-tab) mode */
 	struct osd_state {

--- a/include/view.h
+++ b/include/view.h
@@ -267,6 +267,8 @@ struct view_query {
 	char *identifier;
 	char *title;
 	int window_type;
+	char *sandbox_engine;
+	char *sandbox_app_id;
 };
 
 struct xdg_toplevel_view {

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -25,6 +25,8 @@ struct window_rule {
 	char *identifier;
 	char *title;
 	int window_type;
+	char *sandbox_engine;
+	char *sandbox_app_id;
 	bool match_once;
 
 	enum window_rule_event event;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -189,6 +189,12 @@ fill_window_rule(char *nodename, char *content)
 		current_window_rule->window_type = parse_window_type(content);
 	} else if (!strcasecmp(nodename, "matchOnce")) {
 		set_bool(content, &current_window_rule->match_once);
+	} else if (!strcasecmp(nodename, "sandboxEngine")) {
+		free(current_window_rule->sandbox_engine);
+		current_window_rule->sandbox_engine = xstrdup(content);
+	} else if (!strcasecmp(nodename, "sandboxAppId")) {
+		free(current_window_rule->sandbox_app_id);
+		current_window_rule->sandbox_app_id = xstrdup(content);
 
 	/* Event */
 	} else if (!strcmp(nodename, "event")) {
@@ -323,6 +329,10 @@ fill_action_query(char *nodename, char *content, struct action *action)
 		current_view_query->title = xstrdup(content);
 	} else if (!strcmp(nodename, "type")) {
 		current_view_query->window_type = parse_window_type(content);
+	} else if (!strcasecmp(nodename, "sandboxEngine")) {
+		current_view_query->sandbox_engine = xstrdup(content);
+	} else if (!strcasecmp(nodename, "sandboxAppId")) {
+		current_view_query->sandbox_app_id = xstrdup(content);
 	}
 }
 
@@ -1508,6 +1518,8 @@ rule_destroy(struct window_rule *rule)
 	wl_list_remove(&rule->link);
 	zfree(rule->identifier);
 	zfree(rule->title);
+	zfree(rule->sandbox_engine);
+	zfree(rule->sandbox_app_id);
 	action_list_free(&rule->actions);
 	zfree(rule);
 }
@@ -1576,7 +1588,8 @@ validate(void)
 	/* Window-rule criteria */
 	struct window_rule *rule, *rule_tmp;
 	wl_list_for_each_safe(rule, rule_tmp, &rc.window_rules, link) {
-		if (!rule->identifier && !rule->title && rule->window_type < 0) {
+		if (!rule->identifier && !rule->title && rule->window_type < 0
+				&& !rule->sandbox_engine && !rule->sandbox_app_id) {
 			wlr_log(WLR_ERROR, "Deleting rule %p as it has no criteria", rule);
 			rule_destroy(rule);
 		}

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -34,6 +34,8 @@ view_matches_criteria(struct window_rule *rule, struct view *view)
 	query.identifier = rule->identifier;
 	query.title = rule->title;
 	query.window_type = rule->window_type;
+	query.sandbox_engine = rule->sandbox_engine;
+	query.sandbox_app_id = rule->sandbox_app_id;
 
 	if (rule->match_once && other_instances_exist(view, &query)) {
 		return false;


### PR DESCRIPTION
This adds support for the [security-context-v1](https://wayland.app/protocols/security-context-v1) protocol. It is used by sandbox engines to restrict the features that sandboxed connections can use. For example, it is currently supported by Flatpak.

The implementation is based on the Sway code but adapted to Labwc. The `sandbox_engine` and `sandbox_app_id` parameters are added to window rules in order to be able to apply different rules for sandboxed clients.

The easiest way to test it is probably to take a recent version of Flatpak. Use it to run a Wayland application (for example, Firefox) with `WAYLAND_DEBUG` enabled and check for `wp_security_context` in the logs.