### PR TITLE
Disable magnifier for pixman renderer

### DIFF
--- a/include/magnifier.h
+++ b/include/magnifier.h
@@ -3,10 +3,11 @@
 #define LABWC_MAGNIFIER_H
 
 #include <stdbool.h>
-#include <wayland-server-core.h>
 
 struct server;
 struct output;
+struct wlr_buffer;
+struct wlr_box;
 
 enum magnify_dir {
 	MAGNIFY_INCREASE,

--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -2,15 +2,15 @@
 
 #include <assert.h>
 #include <wlr/types/wlr_output.h>
-#include "magnifier.h"
-#include "labwc.h"
-#include "theme.h"
 #include "common/macros.h"
+#include "labwc.h"
+#include "magnifier.h"
+#include "theme.h"
 
-bool magnify_on;
-double mag_scale = 0.0;
+static bool magnify_on;
+static double mag_scale = 0.0;
 
-#define CLAMP(in, lower, upper) MAX(MIN(in, upper), lower)
+#define CLAMP(in, lower, upper) MAX(MIN((in), (upper)), (lower))
 
 void
 magnify(struct output *output, struct wlr_buffer *output_buffer, struct wlr_box *damage)
@@ -241,10 +241,7 @@ output_wants_magnification(struct output *output)
 	return output_nearest_to_cursor(output->server) == output;
 }
 
-/*
- * Toggles magnification on and off
- */
-
+/* Toggles magnification on and off */
 void
 magnify_toggle(struct server *server)
 {
@@ -261,10 +258,7 @@ magnify_toggle(struct server *server)
 	}
 }
 
-/*
- * Increases and decreases magnification scale
- */
-
+/* Increases and decreases magnification scale */
 void
 magnify_set_scale(struct server *server, enum magnify_dir dir)
 {
@@ -290,13 +284,9 @@ magnify_set_scale(struct server *server, enum magnify_dir dir)
 	}
 }
 
-/*
- * Report whether magnification is enabled
- */
-
+/* Report whether magnification is enabled */
 bool
 is_magnify_on(void)
 {
 	return magnify_on;
 }
-


### PR DESCRIPTION
I tried magnifier and it works very nicely, but I found that magnifier becomes quite laggy and damage tracking doesn't work correctly when I enabled magnifier with `WLR_RENDERER=pixman`. So this PR disables magnifier for pixman renderer for now.

The first commit is just a minor refactor.
