### PR TITLE
Deprecate MoveToCursor

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -83,6 +83,9 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="MoveToCursor" />*
 	Move to be centered on cursor.
 	Tries to prevent any part of the window from going off-screen.
+	This action is deprecated from v0.7.3. To ensure your config works in
+	future labwc releases, please use:
+	*<action name="AutoPlace" policy="cursor">*
 
 *<action name="MoveRelative" x="" y="" />*
 	Move window relative to its current position. Positive value of x moves

--- a/src/action.c
+++ b/src/action.c
@@ -891,6 +891,9 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_MOVETO_CURSOR:
+			wlr_log(WLR_ERROR,
+				"Action MoveToCursor is deprecated. To ensure your config works in future labwc "
+				"releases, please use <action name=\"AutoPlace\" policy=\"cursor\">");
 			if (view) {
 				view_move_to_cursor(view);
 			}


### PR DESCRIPTION
Use `<action name="AutoPlace" policy="cursor"/>` instead.

Suggested-by: @tokyo4j

To be merged after PR #1785