### PR TITLE
src/config/rcxml.c: ensure parent action is available

### DIFF
--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -289,6 +289,11 @@ fill_region(char *nodename, char *content)
 static void
 fill_action_query(char *nodename, char *content, struct action *action)
 {
+	if (!action) {
+		wlr_log(WLR_ERROR, "No parent action for query: %s=%s", nodename, content);
+		return;
+	}
+
 	string_truncate_at_pattern(nodename, ".keybind.keyboard");
 	string_truncate_at_pattern(nodename, ".mousebind.context.mouse");
 
@@ -325,6 +330,11 @@ static void
 fill_child_action(char *nodename, char *content, struct action *parent,
 	const char *branch_name)
 {
+	if (!parent) {
+		wlr_log(WLR_ERROR, "No parent action for branch: %s=%s", nodename, content);
+		return;
+	}
+
 	string_truncate_at_pattern(nodename, ".keybind.keyboard");
 	string_truncate_at_pattern(nodename, ".mousebind.context.mouse");
 	string_truncate_at_pattern(nodename, ".then.action");


### PR DESCRIPTION
Before this patch, having a branch or query with an invalid or missing parent action would trigger an assert when trying to access the parent. This patch ensures that we bail out instead.

Reported-by: fuyukai via IRC (thanks)

---
Backtrace:

```
00:00:00.000 [../labwc-0.7.1/src/config/rcxml.c:366] expect <action name=""> element first. nodename: 'name.acttion' content: 'ForEach'
labwc: ../labwc-0.7.1/src/action.c:231: action_get_arg: Assertion `action' failed.

Program received signal SIGABRT, Aborted.
0x00007ffff70ab82c in ?? () from /usr/lib64/libc.so.6
(gdb) bt
#0  0x00007ffff70ab82c in ??? () at /usr/lib64/libc.so.6
#1  0x00007ffff70587ba in raise () at /usr/lib64/libc.so.6
#2  0x00007ffff70404f7 in abort () at /usr/lib64/libc.so.6
#3  0x00007ffff7040417 in ??? () at /usr/lib64/libc.so.6
#4  0x00007ffff7050ab3 in __assert_fail () at /usr/lib64/libc.so.6
#5  0x000055555557102c in action_get_arg (action=action@entry=0x0, key=key@entry=0x5555555688ee "then", type=type@entry=LAB_ACTION_ARG_ACTION_LIST) at ../labwc-0.7.1/src/action.c:231
#6  0x00005555555712ae in action_get_actionlist (action=action@entry=0x0, key=key@entry=0x5555555688ee "then") at ../labwc-0.7.1/src/action.c:273
#7  0x000055555558de38 in fill_child_action (nodename=0x5555555a31e0 <buffer> "name.action.then.acttion", content=0x5555555d7f40 "MoveToOutput", parent=0x0, branch_name=0x5555555688ee "then")
    at ../labwc-0.7.1/src/config/rcxml.c:313
#8  0x000055555558eb20 in entry (node=0x5555555d7ec0, content=0x5555555d7f40 "MoveToOutput", nodename=0x5555555a31e0 <buffer> "name.action.then.acttion") at ../labwc-0.7.1/src/config/rcxml.c:724
#9  process_node (node=node@entry=0x5555555d7ec0) at ../labwc-0.7.1/src/config/rcxml.c:980
#10 traverse (n=n@entry=0x5555555d7ec0) at ../labwc-0.7.1/src/config/rcxml.c:990
#11 0x000055555559071e in xml_tree_walk (node=<optimized out>) at ../labwc-0.7.1/src/config/rcxml.c:1070
#12 0x000055555558e379 in traverse (n=n@entry=0x5555555d7db0) at ../labwc-0.7.1/src/config/rcxml.c:992
#13 0x000055555559071e in xml_tree_walk (node=<optimized out>) at ../labwc-0.7.1/src/config/rcxml.c:1070
#14 0x000055555558e398 in traverse (n=n@entry=0x5555555d7830) at ../labwc-0.7.1/src/config/rcxml.c:994
#15 0x000055555559092f in xml_tree_walk (node=<optimized out>) at ../labwc-0.7.1/src/config/rcxml.c:1060
#16 0x000055555558e398 in traverse (n=n@entry=0x5555555d75c0) at ../labwc-0.7.1/src/config/rcxml.c:994
#17 0x000055555559071e in xml_tree_walk (node=<optimized out>) at ../labwc-0.7.1/src/config/rcxml.c:1070
#18 0x000055555558e398 in traverse (n=n@entry=0x5555555d7350) at ../labwc-0.7.1/src/config/rcxml.c:994
#19 0x000055555559077f in xml_tree_walk (node=<optimized out>) at ../labwc-0.7.1/src/config/rcxml.c:1012
#20 0x000055555558e398 in traverse (n=n@entry=0x5555555ccc50) at ../labwc-0.7.1/src/config/rcxml.c:994
#21 0x000055555559071e in xml_tree_walk (node=<optimized out>) at ../labwc-0.7.1/src/config/rcxml.c:1070
#22 0x000055555558e398 in traverse (n=n@entry=0x5555555c6220) at ../labwc-0.7.1/src/config/rcxml.c:994
#23 0x000055555559071e in xml_tree_walk (node=<optimized out>) at ../labwc-0.7.1/src/config/rcxml.c:1070
#24 0x000055555559097c in rcxml_parse_xml (b=<optimized out>) at ../labwc-0.7.1/src/config/rcxml.c:1083
#25 0x0000555555590c81 in rcxml_read (filename=<optimized out>) at ../labwc-0.7.1/src/config/rcxml.c:1614
#26 0x0000555555577316 in main (argc=<optimized out>, argv=0x7fffffffd0c8) at ../labwc-0.7.1/src/main.c:141
```