### PR TITLE
ForEach: initialize view query window_type correctly

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -306,6 +306,13 @@ enum lab_view_criteria {
 struct view *view_from_wlr_surface(struct wlr_surface *surface);
 
 /**
+ * view_query_create() - Create a new heap allocated view query with
+ * all members initialized to their default values (window_type = -1,
+ * NULL for strings)
+ */
+struct view_query *view_query_create(void);
+
+/**
  * view_query_free() - Free a given view query
  * @query: Query to be freed.
  */

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -313,7 +313,7 @@ fill_action_query(char *nodename, char *content, struct action *action)
 			action_arg_add_querylist(action, "query");
 			queries = action_get_querylist(action, "query");
 		}
-		current_view_query = znew(*current_view_query);
+		current_view_query = view_query_create();
 		wl_list_append(queries, &current_view_query->link);
 	}
 

--- a/src/view.c
+++ b/src/view.c
@@ -53,6 +53,14 @@ view_from_wlr_surface(struct wlr_surface *surface)
 	return NULL;
 }
 
+struct view_query *
+view_query_create(void)
+{
+	struct view_query *query = znew(*query);
+	query->window_type = -1;
+	return query;
+}
+
 void
 view_query_free(struct view_query *query)
 {


### PR DESCRIPTION
Before this patch, the window type would be checked even if not actually requested to do so.

Fixes:
- #1852