### PR TITLE
input: prevent cursor notifications from pointer and tablet tool

### DIFF
--- a/include/input/tablet-tool.h
+++ b/include/input/tablet-tool.h
@@ -14,6 +14,7 @@ struct drawing_tablet_tool {
 		struct wl_listener set_cursor;
 		struct wl_listener destroy;
 	} handlers;
+	struct wl_list link; /* seat.tablet_tools */
 };
 
 void tablet_tool_init(struct seat *seat,

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -193,6 +193,8 @@ struct seat {
 	struct wl_listener touch_motion;
 	struct wl_listener touch_frame;
 
+	struct wl_list tablet_tools;
+
 	struct wl_listener constraint_commit;
 	struct wl_listener pressed_surface_destroy;
 

--- a/src/input/tablet-tool.c
+++ b/src/input/tablet-tool.c
@@ -40,6 +40,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 	struct drawing_tablet_tool *tool =
 		wl_container_of(listener, tool, handlers.destroy);
 
+	wl_list_remove(&tool->link);
 	wl_list_remove(&tool->handlers.set_cursor.link);
 	wl_list_remove(&tool->handlers.destroy.link);
 	free(tool);
@@ -65,4 +66,5 @@ tablet_tool_init(struct seat *seat,
 		wlr_tablet_tool->wheel ? " wheel" : "");
 	CONNECT_SIGNAL(tool->tool_v2, &tool->handlers, set_cursor);
 	CONNECT_SIGNAL(wlr_tablet_tool, &tool->handlers, destroy);
+	wl_list_insert(&seat->tablet_tools, &tool->link);
 }

--- a/src/seat.c
+++ b/src/seat.c
@@ -553,6 +553,8 @@ seat_init(struct server *server)
 	}
 	wlr_cursor_attach_output_layout(seat->cursor, server->output_layout);
 
+	wl_list_init(&seat->tablet_tools);
+
 	input_handlers_init(seat);
 }
 


### PR DESCRIPTION
... at the same time. Omit cursor notifications from a pointer when a tablet tool (stylus/pen) is in proximity. We expect to get cursor notifications from the tablet tool instead. A side effect from giving pointer focus on tablet proximity.

My suggestion to handle this glitch, which sound actually scarier than it is. I'm only seeing the "wrong" cursor when doing out-of-surface scrolling in GTK4 applications.

Follow up from https://github.com/labwc/labwc/pull/1678 and "draft" for now to let this sink in.