### PR TITLE
Implement <resize><drawContents>

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -456,6 +456,11 @@ extending outward from the snapped edge.
 
 	Default is Never.
 
+*<resize><drawContents>* [yes|no]
+	Let the application redraw its contents while resizing. If disabled, an
+	outlined rectangle is shown to indicate the geometry of resized window.
+	Default is yes.
+
 ## KEYBOARD
 
 *<keyboard><numlock>* [on|off]

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -103,8 +103,12 @@
     <windowEdgeStrength>20</windowEdgeStrength>
   </resistance>
 
-  <!-- Show a simple resize and move indicator -->
-  <resize popupShow="Never" />
+  <resize>
+    <!-- Show a simple resize and move indicator -->
+    <popupShow>Never</popupShow>
+    <!-- Let client redraw its contents while resizing -->
+    <drawContents>yes</drawContents>
+  </resize>
 
   <focus>
     <followMouse>no</followMouse>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -118,6 +118,7 @@ struct rcxml {
 	enum tiling_events_mode snap_tiling_events_mode;
 
 	enum resize_indicator_mode resize_indicator;
+	bool resize_draw_contents;
 
 	struct {
 		int popuptime;

--- a/include/resize-outlines.h
+++ b/include/resize-outlines.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_RESIZE_OUTLINES_H
+#define LABWC_RESIZE_OUTLINES_H
+
+#include <wlr/util/box.h>
+
+struct view;
+
+void resize_outlines_update(struct view *view, struct wlr_box new_geo);
+void resize_outlines_finish(struct view *view);
+bool resize_outlines_enabled(struct view *view);
+
+#endif /* LABWC_RESIZE_OUTLINES_H */

--- a/include/view.h
+++ b/include/view.h
@@ -238,6 +238,10 @@ struct view {
 		struct wlr_scene_rect *background;
 		struct scaled_font_buffer *text;
 	} resize_indicator;
+	struct resize_outlines {
+		struct wlr_box view_geo;
+		struct multi_rect *rect;
+	} resize_outlines;
 
 	struct foreign_toplevel {
 		struct wlr_foreign_toplevel_handle_v1 *handle;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1030,6 +1030,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "Invalid value for <resize popupShow />");
 		}
+	} else if (!strcasecmp(nodename, "drawContents.resize")) {
+		set_bool(content, &rc.resize_draw_contents);
 	} else if (!strcasecmp(nodename, "mouseEmulation.tablet")) {
 		set_bool(content, &rc.tablet.force_mouse_emulation);
 	} else if (!strcasecmp(nodename, "mapToOutput.tablet")) {
@@ -1269,6 +1271,7 @@ rcxml_init(void)
 		| LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER;
 
 	rc.resize_indicator = LAB_RESIZE_INDICATOR_NEVER;
+	rc.resize_draw_contents = true;
 
 	rc.workspace_config.popuptime = INT_MIN;
 	rc.workspace_config.min_nr_workspaces = 1;

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -23,6 +23,7 @@
 #include "menu/menu.h"
 #include "regions.h"
 #include "resistance.h"
+#include "resize-outlines.h"
 #include "ssd.h"
 #include "view.h"
 
@@ -307,7 +308,11 @@ process_cursor_resize(struct server *server, uint32_t time)
 			server->grab_box.width - new_view_geo.width;
 	}
 
-	view_move_resize(view, new_view_geo);
+	if (rc.resize_draw_contents) {
+		view_move_resize(view, new_view_geo);
+	} else {
+		resize_outlines_update(view, new_view_geo);
+	}
 }
 
 void
@@ -1135,6 +1140,9 @@ cursor_finish_button_release(struct seat *seat)
 
 	if (server->input_mode == LAB_INPUT_STATE_MOVE
 			|| server->input_mode == LAB_INPUT_STATE_RESIZE) {
+		if (resize_outlines_enabled(server->grabbed_view)) {
+			resize_outlines_finish(server->grabbed_view);
+		}
 		/* Exit interactive move/resize mode */
 		interactive_finish(server->grabbed_view);
 		return true;

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ labwc_sources = files(
   'placement.c',
   'regions.c',
   'resistance.c',
+  'resize-outlines.c',
   'seat.c',
   'server.c',
   'session-lock.c',

--- a/src/resize-outlines.c
+++ b/src/resize-outlines.c
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <wlr/types/wlr_scene.h>
+#include "common/graphic-helpers.h"
+#include "ssd.h"
+#include "resize-outlines.h"
+#include "labwc.h"
+
+bool
+resize_outlines_enabled(struct view *view)
+{
+	return view->resize_outlines.rect
+		&& view->resize_outlines.rect->tree->node.enabled;
+}
+
+void
+resize_outlines_update(struct view *view, struct wlr_box new_geo)
+{
+	struct resize_outlines *outlines = &view->resize_outlines;
+
+	if (!outlines->rect) {
+		float *colors[3] = {
+			view->server->theme->osd_bg_color,
+			view->server->theme->osd_label_text_color,
+			view->server->theme->osd_bg_color,
+		};
+		int width = 1;
+		outlines->rect = multi_rect_create(
+			view->scene_tree, colors, width);
+	}
+
+	struct border margin = ssd_get_margin(view->ssd);
+	struct wlr_box box = {
+		.x = new_geo.x - margin.left,
+		.y = new_geo.y - margin.top,
+		.width = new_geo.width + margin.left + margin.right,
+		.height = new_geo.height + margin.top + margin.bottom,
+	};
+	multi_rect_set_size(outlines->rect, box.width, box.height);
+	wlr_scene_node_set_position(&outlines->rect->tree->node,
+		box.x - view->current.x, box.y - view->current.y);
+	wlr_scene_node_set_enabled(
+		&view->resize_outlines.rect->tree->node, true);
+
+	outlines->view_geo = new_geo;
+
+	resize_indicator_update(view);
+}
+
+void
+resize_outlines_finish(struct view *view)
+{
+	view_move_resize(view, view->resize_outlines.view_geo);
+	wlr_scene_node_set_enabled(
+		&view->resize_outlines.rect->tree->node, false);
+}

--- a/src/theme.c
+++ b/src/theme.c
@@ -66,6 +66,8 @@ struct rounded_corner_ctx {
 	enum corner corner;
 };
 
+#define zero_array(arr) memset(arr, 0, sizeof(arr))
+
 static struct lab_data_buffer *rounded_rect(struct rounded_corner_ctx *ctx);
 
 static void
@@ -533,8 +535,7 @@ theme_builtin(struct theme *theme, struct server *server)
 
 	/* inherit settings in post_processing() if not set elsewhere */
 	theme->osd_window_switcher_preview_border_width = INT_MIN;
-	memset(theme->osd_window_switcher_preview_border_color, 0,
-		sizeof(theme->osd_window_switcher_preview_border_color));
+	zero_array(theme->osd_window_switcher_preview_border_color);
 	theme->osd_window_switcher_preview_border_color[0][0] = FLT_MIN;
 
 	theme->osd_workspace_switcher_boxes_width = 20;
@@ -565,11 +566,9 @@ theme_builtin(struct theme *theme, struct server *server)
 	/* inherit settings in post_processing() if not set elsewhere */
 	theme->snapping_overlay_region.border_width = INT_MIN;
 	theme->snapping_overlay_edge.border_width = INT_MIN;
-	memset(theme->snapping_overlay_region.border_color, 0,
-		sizeof(theme->snapping_overlay_region.border_color));
+	zero_array(theme->snapping_overlay_region.border_color);
 	theme->snapping_overlay_region.border_color[0][0] = FLT_MIN;
-	memset(theme->snapping_overlay_edge.border_color, 0,
-		sizeof(theme->snapping_overlay_edge.border_color));
+	zero_array(theme->snapping_overlay_edge.border_color);
 	theme->snapping_overlay_edge.border_color[0][0] = FLT_MIN;
 
 	/* magnifier */


### PR DESCRIPTION
Closes #1328.

https://github.com/labwc/labwc/assets/22029524/e59a08f6-e3d1-4806-afb1-d95e3d4e8c74

The theme for the frame shown to indicate resized window when `<resize><drawcontents>` is set to no is configured with:
- `resize-frame.width`
- `resize-frame.color`

But I'm not sure about these names. Perhaps `resize.frame.{width,color}` or other names are better.

I initially implemented the frame as a combination of multi_rect and scene_rect like I did for snapping overlay, but I removed it for simplicity (we need to add `resize-frame.{bg,border}.enabled` and disable translucent scene_rect for pixman renderer).
If anyone wants it, I can move it back from [here](https://github.com/tokyo4j/labwc/tree/drawcontents-first).

The first commit adds `zero_array()` macro in `theme.c` to shorten the lengthy `memcpy()` calls like `memset(theme->snapping_overlay_region.border_color, 0, sizeof(theme->snapping_overlay_region.border_color))`.