### PR TITLE
Add CycleNearRegion action

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -125,10 +125,10 @@ Actions are used in menus and keyboard/mouse bindings.
 	Resize and move the active window back to its untiled or unmaximized
 	position if it had been maximized or tiled to a direction or region.
 
-*<action name="NextWindow" workspace="current" output="all" identifier="all" />*++
-*<action name="PreviousWindow" workspace="current" output="all" identifier="all" />*++
-*<action name="NextWindowImmediate" workspace="current" output="all" identifier="all" />*++
-*<action name="PreviousWindowImmediate" workspace="current" output="all" identifier="all" />*++
+*<action name="NextWindow" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" />*++
+*<action name="PreviousWindow" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" />*++
+*<action name="NextWindowImmediate" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" />*++
+*<action name="PreviousWindowImmediate" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" />*++
 	Cycle focus to next/previous window, respectively.
 
 	Default keybinds for NextWindow and PreviousWindow are Alt-Tab and
@@ -137,6 +137,8 @@ Actions are used in menus and keyboard/mouse bindings.
 
 	NextWindowImmediate and PreviousWindowImmediate skip the Window Switcher
 	and OSD, useful for binding to keys without modifiers.
+	Window Switcher filters are fixed when cycling starts; the Immediate actions
+	re-evaluate their filters on every invocation.
 
 	*workspace* [all|current]
 	This determines whether to cycle through windows on all workspaces or
@@ -149,6 +151,37 @@ Actions are used in menus and keyboard/mouse bindings.
 	*identifier* [all|current]
 	This determines whether to cycle through all windows or only windows of
 	the same application as the currently focused window. Default is "all".
+
+	*region* [name[|name...]]
+	This restricts cycling to windows assigned to one or more named regions. Use
+	the "|" character to separate multiple names; a window may match any listed
+	region. Whitespace around each name is ignored. Non-zero overlap percentages
+	additionally match windows based on their geometry. Regions on each window's
+	output are used, allowing this filter to be combined with the _output_ filter.
+	If omitted, windows are not filtered by region. See labwc-config(5) for
+	information on defining regions.
+
+	*windowOverlapPercent* [0-100]
+	This is the minimum percentage of the window area that must lie inside the
+	region. Default is 0, which disables this geometric check.
+
+	*regionOverlapPercent* [0-100]
+	This is the minimum percentage of the region area that must lie inside the
+	window. Default is 0, which disables this geometric check.
+
+	A window explicitly assigned to any listed region always matches. Other windows
+	match when either enabled overlap threshold is met for any listed region. Thus
+	the default behavior is exact region-assignment matching.
+
+	For example, a keypad binding can switch immediately within any of three
+	left-side regions without starting the Window Switcher:
+
+```
+<keybind key="W-KP_7">
+  <action name="NextWindowImmediate"
+    region="top-left|left|bottom-left" />
+</keybind>
+```
 
 *<action name="Reconfigure" />*
 	Re-load configuration and theme files.

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -125,10 +125,10 @@ Actions are used in menus and keyboard/mouse bindings.
 	Resize and move the active window back to its untiled or unmaximized
 	position if it had been maximized or tiled to a direction or region.
 
-*<action name="NextWindow" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" />*++
-*<action name="PreviousWindow" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" />*++
-*<action name="NextWindowImmediate" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" />*++
-*<action name="PreviousWindowImmediate" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" />*++
+*<action name="NextWindow" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" topmostFirst="no" />*++
+*<action name="PreviousWindow" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" topmostFirst="no" />*++
+*<action name="NextWindowImmediate" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" topmostFirst="no" />*++
+*<action name="PreviousWindowImmediate" workspace="current" output="all" identifier="all" region="value" windowOverlapPercent="0" regionOverlapPercent="0" topmostFirst="no" />*++
 	Cycle focus to next/previous window, respectively.
 
 	Default keybinds for NextWindow and PreviousWindow are Alt-Tab and
@@ -151,6 +151,13 @@ Actions are used in menus and keyboard/mouse bindings.
 	*identifier* [all|current]
 	This determines whether to cycle through all windows or only windows of
 	the same application as the currently focused window. Default is "all".
+
+	*topmostFirst* [yes|no]
+	When set to yes, initially select the topmost window matching all filters if
+	it is not already focused. If it is already focused, select the next or
+	previous matching window as usual. For NextWindow and PreviousWindow, this
+	only affects the initial selection when the Window Switcher begins; Immediate
+	actions perform the check on every invocation. Default is no.
 
 	*region* [name[|name...]]
 	This restricts cycling to windows assigned to one or more named regions. Use
@@ -179,7 +186,7 @@ Actions are used in menus and keyboard/mouse bindings.
 ```
 <keybind key="W-KP_7">
   <action name="NextWindowImmediate"
-    region="top-left|left|bottom-left" />
+    region="top-left|left|bottom-left" topmostFirst="yes" />
 </keybind>
 ```
 

--- a/include/cycle.h
+++ b/include/cycle.h
@@ -49,6 +49,9 @@ struct cycle_filter {
 	enum cycle_workspace_filter workspace;
 	enum cycle_output_filter output;
 	enum cycle_app_id_filter app_id;
+	const char *region_names;
+	int window_overlap_percent;
+	int region_overlap_percent;
 };
 
 struct cycle_state {
@@ -61,6 +64,7 @@ struct cycle_state {
 	struct wlr_scene_node *preview_dummy;
 	struct lab_scene_rect *preview_outline;
 	struct cycle_filter filter;
+	char *region_names; /* Owned storage for filter.region_names */
 };
 
 struct cycle_osd_output {
@@ -89,6 +93,9 @@ struct buf;
 struct view;
 struct server;
 struct wlr_scene_node;
+
+/* Validate a pipe-separated region expression against configured regions */
+bool cycle_regions_are_valid(const char *region_names);
 
 /* Begin window switcher */
 void cycle_begin(enum lab_cycle_dir direction,

--- a/include/cycle.h
+++ b/include/cycle.h
@@ -99,7 +99,7 @@ bool cycle_regions_are_valid(const char *region_names);
 
 /* Begin window switcher */
 void cycle_begin(enum lab_cycle_dir direction,
-	struct cycle_filter filter);
+	struct cycle_filter filter, bool topmost_first);
 
 /* Cycle the selected view in the window switcher */
 void cycle_step(enum lab_cycle_dir direction);
@@ -112,7 +112,7 @@ void cycle_reinitialize(void);
 
 /* Immediately cycle to next/previous window */
 void cycle_immediate(enum lab_cycle_dir direction,
-	struct cycle_filter filter);
+	struct cycle_filter filter, bool topmost_first);
 
 /* Focus the clicked window and close OSD */
 void cycle_on_cursor_release(struct wlr_scene_node *node);

--- a/src/action.c
+++ b/src/action.c
@@ -394,6 +394,10 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			}
 			goto cleanup;
 		}
+		if (!strcasecmp(argument, "topmostFirst")) {
+			action_arg_add_bool(action, argument, parse_bool(content, false));
+			goto cleanup;
+		}
 		if (!strcasecmp(argument, "region")) {
 			action_arg_add_str(action, argument, content);
 			goto cleanup;
@@ -1195,7 +1199,8 @@ run_action(struct view *view, struct action *action,
 		if (server.input_mode == LAB_INPUT_STATE_CYCLE) {
 			cycle_step(dir);
 		} else {
-			cycle_begin(dir, filter);
+			bool topmost_first = action_get_bool(action, "topmostFirst", false);
+			cycle_begin(dir, filter, topmost_first);
 		}
 		break;
 	}
@@ -1204,7 +1209,8 @@ run_action(struct view *view, struct action *action,
 		enum lab_cycle_dir dir = (action->type == ACTION_TYPE_NEXT_WINDOW_IMMEDIATE) ?
 			LAB_CYCLE_DIR_FORWARD : LAB_CYCLE_DIR_BACKWARD;
 		struct cycle_filter filter = cycle_filter_from_action(action);
-		cycle_immediate(dir, filter);
+		bool topmost_first = action_get_bool(action, "topmostFirst", false);
+		cycle_immediate(dir, filter, topmost_first);
 		break;
 	}
 	case ACTION_TYPE_RECONFIGURE:

--- a/src/action.c
+++ b/src/action.c
@@ -2,6 +2,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include "action.h"
 #include <assert.h>
+#include <errno.h>
 #include <signal.h>
 #include <string.h>
 #include <strings.h>
@@ -288,6 +289,23 @@ action_get_actionlist(struct action *action, const char *key)
 	return arg ? &arg->value : NULL;
 }
 
+static bool
+parse_percentage(const char *content, int *percentage)
+{
+	assert(content);
+	assert(percentage);
+
+	errno = 0;
+	char *end;
+	long value = strtol(content, &end, 10);
+	if (errno == ERANGE || end == content || *end != '\0'
+			|| value < 0 || value > 100) {
+		return false;
+	}
+	*percentage = value;
+	return true;
+}
+
 void
 action_arg_from_xml_node(struct action *action, const char *nodename, const char *content)
 {
@@ -372,6 +390,22 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 				action_arg_add_int(action, argument, CYCLE_APP_ID_CURRENT);
 			} else {
 				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+					action_names[action->type], argument, content);
+			}
+			goto cleanup;
+		}
+		if (!strcasecmp(argument, "region")) {
+			action_arg_add_str(action, argument, content);
+			goto cleanup;
+		}
+		if (!strcasecmp(argument, "windowOverlapPercent")
+				|| !strcasecmp(argument, "regionOverlapPercent")) {
+			int percentage;
+			if (parse_percentage(content, &percentage)) {
+				action_arg_add_int(action, argument, percentage);
+			} else {
+				wlr_log(WLR_ERROR, "Invalid argument for action %s: "
+					"'%s' (%s); expected an integer from 0 to 100",
 					action_names[action->type], argument, content);
 			}
 			goto cleanup;
@@ -622,7 +656,7 @@ action_branches_are_valid(struct action *action)
 	return true;
 }
 
-/* Checks for *required* arguments */
+/* Check required arguments and values that need post-parse validation */
 bool
 action_is_valid(struct action *action)
 {
@@ -641,6 +675,12 @@ action_is_valid(struct action *action)
 		arg_name = "direction";
 		arg_type = LAB_ACTION_ARG_INT;
 		break;
+	case ACTION_TYPE_NEXT_WINDOW:
+	case ACTION_TYPE_PREVIOUS_WINDOW:
+	case ACTION_TYPE_NEXT_WINDOW_IMMEDIATE:
+	case ACTION_TYPE_PREVIOUS_WINDOW_IMMEDIATE:
+		return cycle_regions_are_valid(
+			action_get_str(action, "region", NULL));
 	case ACTION_TYPE_SHOW_MENU:
 		arg_name = "menu";
 		break;
@@ -1054,6 +1094,22 @@ warp_cursor(struct view *view, const char *to, const char *x, const char *y)
 	cursor_update_focus();
 }
 
+static struct cycle_filter
+cycle_filter_from_action(struct action *action)
+{
+	return (struct cycle_filter) {
+		.workspace = action_get_int(action, "workspace",
+			rc.window_switcher.workspace_filter),
+		.output = action_get_int(action, "output", CYCLE_OUTPUT_ALL),
+		.app_id = action_get_int(action, "identifier", CYCLE_APP_ID_ALL),
+		.region_names = action_get_str(action, "region", NULL),
+		.window_overlap_percent = CLAMP(
+			action_get_int(action, "windowOverlapPercent", 0), 0, 100),
+		.region_overlap_percent = CLAMP(
+			action_get_int(action, "regionOverlapPercent", 0), 0, 100),
+	};
+}
+
 static void
 run_action(struct view *view, struct action *action,
 	struct cursor_context *ctx)
@@ -1135,14 +1191,7 @@ run_action(struct view *view, struct action *action,
 	case ACTION_TYPE_PREVIOUS_WINDOW: {
 		enum lab_cycle_dir dir = (action->type == ACTION_TYPE_NEXT_WINDOW) ?
 			LAB_CYCLE_DIR_FORWARD : LAB_CYCLE_DIR_BACKWARD;
-		struct cycle_filter filter = {
-			.workspace = action_get_int(action, "workspace",
-				rc.window_switcher.workspace_filter),
-			.output = action_get_int(action, "output",
-				CYCLE_OUTPUT_ALL),
-			.app_id = action_get_int(action, "identifier",
-				CYCLE_APP_ID_ALL),
-		};
+		struct cycle_filter filter = cycle_filter_from_action(action);
 		if (server.input_mode == LAB_INPUT_STATE_CYCLE) {
 			cycle_step(dir);
 		} else {
@@ -1154,14 +1203,7 @@ run_action(struct view *view, struct action *action,
 	case ACTION_TYPE_PREVIOUS_WINDOW_IMMEDIATE: {
 		enum lab_cycle_dir dir = (action->type == ACTION_TYPE_NEXT_WINDOW_IMMEDIATE) ?
 			LAB_CYCLE_DIR_FORWARD : LAB_CYCLE_DIR_BACKWARD;
-		struct cycle_filter filter = {
-			.workspace = action_get_int(action, "workspace",
-				rc.window_switcher.workspace_filter),
-			.output = action_get_int(action, "output",
-				CYCLE_OUTPUT_ALL),
-			.app_id = action_get_int(action, "identifier",
-				CYCLE_APP_ID_ALL),
-		};
+		struct cycle_filter filter = cycle_filter_from_action(action);
 		cycle_immediate(dir, filter);
 		break;
 	}

--- a/src/cycle/cycle.c
+++ b/src/cycle/cycle.c
@@ -85,6 +85,19 @@ get_first_view(struct wl_list *views)
 	return view;
 }
 
+/* Return the topmost view in the filtered cycle list. */
+static struct view *
+get_topmost_cycle_view(void)
+{
+	struct view *view;
+	wl_list_for_each(view, &server.views, link) {
+		if (view->cycle_link.next) {
+			return view;
+		}
+	}
+	return NULL;
+}
+
 void
 cycle_reinitialize(void)
 {
@@ -164,7 +177,7 @@ restore_preview_node(void)
 
 void
 cycle_begin(enum lab_cycle_dir direction,
-		struct cycle_filter filter)
+		struct cycle_filter filter, bool topmost_first)
 {
 	if (server.input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
 		return;
@@ -175,15 +188,21 @@ cycle_begin(enum lab_cycle_dir direction,
 	}
 
 	struct view *active_view = server.active_view;
-	if (active_view && active_view->cycle_link.next) {
-		/* Select the active view if it's in the cycle list */
-		server.cycle.selected_view = active_view;
+	struct view *topmost_view = get_topmost_cycle_view();
+	assert(topmost_view);
+	if (topmost_first && topmost_view != active_view) {
+		server.cycle.selected_view = topmost_view;
 	} else {
-		/* Otherwise, select the first view in the cycle list */
-		server.cycle.selected_view = get_first_view(&server.cycle.views);
+		if (active_view && active_view->cycle_link.next) {
+			/* Select the active view if it's in the cycle list */
+			server.cycle.selected_view = active_view;
+		} else {
+			/* Otherwise, select the first view in the cycle list */
+			server.cycle.selected_view = get_first_view(&server.cycle.views);
+		}
+		/* Pre-select the next view in the given direction */
+		server.cycle.selected_view = get_next_selected_view(direction);
 	}
-	/* Pre-select the next view in the given direction */
-	server.cycle.selected_view = get_next_selected_view(direction);
 
 	seat_focus_override_begin(&server.seat,
 		LAB_INPUT_STATE_CYCLE, LAB_CURSOR_DEFAULT);
@@ -512,11 +531,24 @@ view_matches_cycle_filter(struct view *view, struct cycle_context *context)
 	return view_matches_cycle_regions(view, &context->filter);
 }
 
+static struct view *
+get_topmost_matching_view(struct cycle_context *context)
+{
+	struct view *view;
+	wl_list_for_each(view, &server.views, link) {
+		if (view_matches_cycle_filter(view, context)) {
+			return view;
+		}
+	}
+	return NULL;
+}
+
 static struct wl_list *prev(struct wl_list *elm) { return elm->prev; }
 static struct wl_list *next(struct wl_list *elm) { return elm->next; }
 
 void
-cycle_immediate(enum lab_cycle_dir direction, struct cycle_filter filter)
+cycle_immediate(enum lab_cycle_dir direction, struct cycle_filter filter,
+		bool topmost_first)
 {
 	if (wl_list_empty(&server.views)) {
 		return;
@@ -527,18 +559,33 @@ cycle_immediate(enum lab_cycle_dir direction, struct cycle_filter filter)
 		return;
 	}
 
-	struct wl_list *head = &server.views;
-	struct wl_list *(*iter)(struct wl_list *list);
-	iter = direction == LAB_CYCLE_DIR_FORWARD ? next : prev;
-
-	struct wl_list *from = (direction == LAB_CYCLE_DIR_FORWARD) && server.active_view
-		? &server.active_view->link : head;
-
-	for (struct wl_list *elm = iter(from); elm != head; elm = iter(elm)) {
-		struct view *view = wl_container_of(elm, view, link);
-		if (!view_matches_cycle_filter(view, &context)) {
-			continue;
+	struct view *selected_view = NULL;
+	if (topmost_first) {
+		struct view *topmost_view = get_topmost_matching_view(&context);
+		if (topmost_view != server.active_view) {
+			selected_view = topmost_view;
 		}
+	}
+
+	if (!selected_view) {
+		struct wl_list *head = &server.views;
+		struct wl_list *(*iter)(struct wl_list *list);
+		iter = direction == LAB_CYCLE_DIR_FORWARD ? next : prev;
+
+		struct wl_list *from =
+			(direction == LAB_CYCLE_DIR_FORWARD) && server.active_view
+			? &server.active_view->link : head;
+
+		for (struct wl_list *elm = iter(from); elm != head; elm = iter(elm)) {
+			struct view *view = wl_container_of(elm, view, link);
+			if (view_matches_cycle_filter(view, &context)) {
+				selected_view = view;
+				break;
+			}
+		}
+	}
+
+	if (selected_view) {
 		if (server.active_view && direction == LAB_CYCLE_DIR_FORWARD) {
 			/*
 			 * When cycling forward, the current active view needs to be
@@ -547,8 +594,7 @@ cycle_immediate(enum lab_cycle_dir direction, struct cycle_filter filter)
 			 */
 			view_move_to_back(server.active_view);
 		}
-		desktop_focus_view(view, true);
-		break;
+		desktop_focus_view(selected_view, true);
 	}
 	cursor_update_focus();
 }

--- a/src/cycle/cycle.c
+++ b/src/cycle/cycle.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "cycle.h"
 #include <assert.h>
+#include <ctype.h>
+#include <string.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
@@ -13,6 +15,7 @@
 #include "labwc.h"
 #include "node.h"
 #include "output.h"
+#include "regions.h"
 #include "scaled-buffer/scaled-font-buffer.h"
 #include "scaled-buffer/scaled-icon-buffer.h"
 #include "ssd.h"
@@ -96,9 +99,14 @@ cycle_reinitialize(void)
 	struct view *selected_view_prev =
 		get_next_selected_view(LAB_CYCLE_DIR_BACKWARD);
 	struct cycle_filter filter = cycle->filter;
+	char *region_names = filter.region_names
+		? xstrdup(filter.region_names) : NULL;
+	filter.region_names = region_names;
 
 	destroy_cycle();
-	if (init_cycle(filter)) {
+	bool initialized = init_cycle(filter);
+	zfree(region_names);
+	if (initialized) {
 		/*
 		 * Preserve the selected view (or its previous view) if it's
 		 * still in the cycle list
@@ -344,6 +352,166 @@ get_cycle_app_id(struct cycle_filter *filter)
 	return NULL;
 }
 
+struct cycle_context {
+	struct cycle_filter filter;
+	enum lab_view_criteria criteria;
+	uint64_t outputs;
+	const char *app_id;
+};
+
+static bool
+cycle_region_name_next(const char **cursor, const char **name, size_t *length)
+{
+	if (!*cursor) {
+		return false;
+	}
+
+	const char *begin = *cursor;
+	const char *separator = strchr(begin, '|');
+	const char *end = separator ? separator : begin + strlen(begin);
+	*cursor = separator ? separator + 1 : NULL;
+
+	while (begin < end && isspace((unsigned char)*begin)) {
+		++begin;
+	}
+	while (end > begin && isspace((unsigned char)end[-1])) {
+		--end;
+	}
+	*name = begin;
+	*length = end - begin;
+	return true;
+}
+
+static struct region *
+cycle_region_from_name(struct wl_list *regions, const char *name, size_t length)
+{
+	struct region *region;
+	wl_list_for_each(region, regions, link) {
+		if (strlen(region->name) == length
+				&& !strncmp(region->name, name, length)) {
+			return region;
+		}
+	}
+	return NULL;
+}
+
+bool
+cycle_regions_are_valid(const char *region_names)
+{
+	if (!region_names) {
+		return true;
+	}
+
+	const char *cursor = region_names;
+	const char *name;
+	size_t length;
+	while (cycle_region_name_next(&cursor, &name, &length)) {
+		if (!length || !cycle_region_from_name(&rc.regions, name, length)) {
+			int log_length = length > 128 ? 128 : (int)length;
+			wlr_log(WLR_ERROR, "Invalid window switcher region: '%.*s%s'",
+				log_length, name, length > 128 ? "..." : "");
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool
+cycle_context_init(struct cycle_context *context, struct cycle_filter filter)
+{
+	if (!cycle_regions_are_valid(filter.region_names)) {
+		return false;
+	}
+
+	*context = (struct cycle_context) {
+		.filter = filter,
+		.criteria = get_view_criteria(&filter),
+		.outputs = get_outputs_by_filter(filter.output),
+		.app_id = get_cycle_app_id(&filter),
+	};
+	return true;
+}
+
+static bool
+view_is_assigned_to_cycle_region(struct view *view, struct region *region)
+{
+	if (view->tiled_region
+			&& !strcmp(view->tiled_region->name, region->name)) {
+		return true;
+	}
+	return view->tiled_region_evacuate
+		&& !strcmp(view->tiled_region_evacuate, region->name);
+}
+
+static bool
+overlap_meets_threshold(double overlap_area, double area, int percent)
+{
+	return percent > 0 && area > 0
+		&& overlap_area * 100.0 >= area * (double)percent;
+}
+
+static bool
+view_matches_cycle_region(struct view *view, struct region *region,
+		struct cycle_filter *filter)
+{
+	if (view_is_assigned_to_cycle_region(view, region)) {
+		return true;
+	}
+
+	struct wlr_box overlap;
+	if (!wlr_box_intersection(&overlap, &view->current, &region->geo)) {
+		return false;
+	}
+	double overlap_area = (double)overlap.width * (double)overlap.height;
+	double view_area = (double)view->current.width * (double)view->current.height;
+	double region_area = (double)region->geo.width * (double)region->geo.height;
+
+	return overlap_meets_threshold(overlap_area, view_area,
+			filter->window_overlap_percent)
+		|| overlap_meets_threshold(overlap_area, region_area,
+			filter->region_overlap_percent);
+}
+
+static bool
+view_matches_cycle_regions(struct view *view, struct cycle_filter *filter)
+{
+	if (!filter->region_names) {
+		return true;
+	}
+	if (!output_is_usable(view->output)) {
+		return false;
+	}
+
+	const char *cursor = filter->region_names;
+	const char *name;
+	size_t length;
+	while (cycle_region_name_next(&cursor, &name, &length)) {
+		struct region *region = cycle_region_from_name(
+			&view->output->regions, name, length);
+		if (region && view_matches_cycle_region(view, region, filter)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool
+view_matches_cycle_filter(struct view *view, struct cycle_context *context)
+{
+	if (!view_matches_criteria(view, context->criteria)) {
+		return false;
+	}
+	if (context->filter.output != CYCLE_OUTPUT_ALL
+			&& (!view->output || !(context->outputs & view->output->id_bit))) {
+		return false;
+	}
+	if (context->app_id
+			&& (!view->app_id || strcmp(view->app_id, context->app_id))) {
+		return false;
+	}
+	return view_matches_cycle_regions(view, &context->filter);
+}
+
 static struct wl_list *prev(struct wl_list *elm) { return elm->prev; }
 static struct wl_list *next(struct wl_list *elm) { return elm->next; }
 
@@ -354,9 +522,10 @@ cycle_immediate(enum lab_cycle_dir direction, struct cycle_filter filter)
 		return;
 	}
 
-	enum lab_view_criteria criteria = get_view_criteria(&filter);
-	uint64_t cycle_outputs = get_outputs_by_filter(filter.output);
-	const char *cycle_app_id = get_cycle_app_id(&filter);
+	struct cycle_context context;
+	if (!cycle_context_init(&context, filter)) {
+		return;
+	}
 
 	struct wl_list *head = &server.views;
 	struct wl_list *(*iter)(struct wl_list *list);
@@ -367,15 +536,7 @@ cycle_immediate(enum lab_cycle_dir direction, struct cycle_filter filter)
 
 	for (struct wl_list *elm = iter(from); elm != head; elm = iter(elm)) {
 		struct view *view = wl_container_of(elm, view, link);
-		if (!view_matches_criteria(view, criteria)) {
-			continue;
-		}
-		if (filter.output != CYCLE_OUTPUT_ALL) {
-			if (!view->output || !(cycle_outputs & view->output->id_bit)) {
-				continue;
-			}
-		}
-		if (cycle_app_id && strcmp(view->app_id, cycle_app_id) != 0) {
+		if (!view_matches_cycle_filter(view, &context)) {
 			continue;
 		}
 		if (server.active_view && direction == LAB_CYCLE_DIR_FORWARD) {
@@ -396,18 +557,14 @@ cycle_immediate(enum lab_cycle_dir direction, struct cycle_filter filter)
 static bool
 init_cycle(struct cycle_filter filter)
 {
-	enum lab_view_criteria criteria = get_view_criteria(&filter);
-	uint64_t cycle_outputs = get_outputs_by_filter(filter.output);
-	const char *cycle_app_id = get_cycle_app_id(&filter);
+	struct cycle_context context;
+	if (!cycle_context_init(&context, filter)) {
+		return false;
+	}
 
 	struct view *view;
-	for_each_view(view, &server.views, criteria) {
-		if (filter.output != CYCLE_OUTPUT_ALL) {
-			if (!view->output || !(cycle_outputs & view->output->id_bit)) {
-				continue;
-			}
-		}
-		if (cycle_app_id && strcmp(view->app_id, cycle_app_id) != 0) {
+	wl_list_for_each(view, &server.views, link) {
+		if (!view_matches_cycle_filter(view, &context)) {
 			continue;
 		}
 
@@ -421,6 +578,9 @@ init_cycle(struct cycle_filter filter)
 		wlr_log(WLR_DEBUG, "no views to switch between");
 		return false;
 	}
+	server.cycle.region_names = filter.region_names
+		? xstrdup(filter.region_names) : NULL;
+	filter.region_names = server.cycle.region_names;
 	server.cycle.filter = filter;
 
 	if (rc.window_switcher.osd.show) {
@@ -496,6 +656,8 @@ destroy_cycle(void)
 		wl_list_remove(&view->cycle_link);
 		view->cycle_link = (struct wl_list){0};
 	}
+
+	zfree(server.cycle.region_names);
 
 	server.cycle = (struct cycle_state){0};
 	wl_list_init(&server.cycle.views);


### PR DESCRIPTION
CycleInRegion (edit: now CycleNearRegion) will cycle the focus between all views that are "mostly" within the given region.

The implementation defines mostly as at least 80% of the view being within the region's geometry, or 80% of the region's geometry being in the view's geometry.

See https://github.com/labwc/labwc/issues/1001#issuecomment-2125118483 for more information and an example config that uses the numeric keypad to define, move and focus windows to corner/side/center regions.

Closes #1001