### PR TITLE
docs: add example shutdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See [scope] for full details on implemented features.
 
 High-level summary of items that Labwc supports:
 
-- [x] Config files (rc.xml, autostart, environment, menu.xml)
+- [x] Config files (rc.xml, autostart, shutdown, environment, menu.xml)
 - [x] Theme files and xbm/png/svg icons
 - [x] Basic desktop and client menus
 - [x] HiDPI
@@ -182,7 +182,7 @@ prevent installing the wlroots headers:
 ## 3. Configuration
 
 User config files are located at `${XDG_CONFIG_HOME:-$HOME/.config/labwc/}`
-with the following five files being used: [rc.xml], [menu.xml], [autostart],
+with the following five files being used: [rc.xml], [menu.xml], [autostart], [shutdown],
 [environment] and [themerc-override].
 
 Run `labwc --reconfigure` to reload configuration and theme.
@@ -277,6 +277,7 @@ See [integration] for further details.
 [rc.xml]: docs/rc.xml.all
 [menu.xml]: docs/menu.xml
 [autostart]: docs/autostart
+[shutdown]: docs/shutdown
 [environment]: docs/environment
 [themerc-override]: docs/themerc
 [themerc]: docs/themerc

--- a/docs/README
+++ b/docs/README
@@ -3,6 +3,7 @@ Config layout for ~/.config/labwc/
 - environment
 - menu.xml
 - rc.xml
+- shutdown
 - themerc-override
 
 See `man labwc-config and `man labwc-theme` for further details.

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -30,6 +30,7 @@ install_data(
     'environment',
     'menu.xml',
     'README',
+    'shutdown',
     'themerc',
     'rc.xml',
     'rc.xml.all'

--- a/docs/shutdown
+++ b/docs/shutdown
@@ -1,0 +1,4 @@
+# Example shutdown file
+
+# This file is executed as a shell script when labwc is preparing to terminate itself.
+# For further details see labwc-config(5).


### PR DESCRIPTION
Closes #1809
_______________
Noticed the mentioned issue and maybe I can help with that?
Description is derived from the first sentence from the shutdown section in the man-page.