### PR TITLE
IME: Fix some issues about IME popups

### DIFF
--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -391,6 +391,8 @@ handle_input_method_new_popup_surface(struct wl_listener *listener, void *data)
 	node_descriptor_create(&popup->tree->node, LAB_NODE_DESC_IME_POPUP, NULL);
 
 	wl_list_insert(&relay->popups, &popup->link);
+
+	update_popup_position(popup);
 }
 
 static void

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -354,6 +354,7 @@ handle_popup_surface_destroy(struct wl_listener *listener, void *data)
 {
 	struct input_method_popup *popup =
 		wl_container_of(listener, popup, destroy);
+	wlr_scene_node_destroy(&popup->tree->node);
 	wl_list_remove(&popup->destroy.link);
 	wl_list_remove(&popup->commit.link);
 	wl_list_remove(&popup->link);


### PR DESCRIPTION
Fixes issues reported in #1871.

The first commit fixes a bug that multiple IME popup scene-nodes can be created if `wl_surface` is not destroyed when `input_popup_surface_v2` is destroyed.

The second commit fixes a flicker when IME popup is created with its surface mapped.

Here are videos showing the bug when I run the program provided in #1871 ([source](https://github.com/user-attachments/files/15531817/ime-test.zip))

Before this PR:

https://github.com/labwc/labwc/assets/22029524/72d04363-edf5-4de8-b67e-168ca64af9c6

After the first commit (flicker appears at 0:14):

https://github.com/labwc/labwc/assets/22029524/772ca60c-dbd6-40c2-ac6c-6b7c763591a4
