### PR TITLE
feat: add tablet v2 pad support

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -680,28 +680,39 @@ extending outward from the snapped edge.
 	also omits tablet specific features like reporting pen pressure.
 
 *<tablet><map button="" to="" />*
-	Pen buttons emulate regular mouse buttons. If not specified
-	otherwise, the first pen button (Stylus) is mapped to right mouse
-	button click and the second pen button (Stylus2) emulates a middle
-	mouse button click. For mouse emulation, the tip (Tip) is mapped to
-	left mouse click.
+	Pen and pad buttons behave like regular mouse buttons.With mouse
+	emulation set to "no", which is the default, and if not	specified
+	otherwise, the first pen button is mapped to the right mouse button,
+	the second pen button to the middle mouse button and a third pen
+	button is mapped to the side mouse button.
 
 	Supported map *buttons* are:
-	- Tip (mouse emulation only)
+	- Stylus
+	- Stylus2
+	- Stylus3
+
+	The stylus buttons can be mapped *to*:
+	- Right
+	- Middle
+	- Side
+
+	The tip cannot be remapped.
+
+	When using mouse emulation, all pen buttons emulate regular mouse
+	buttons. The tip, stylus and pad buttons can be mapped to all
+	available mouse	buttons. If not specified otherwise, the tip is
+	mapped to left mouse click, the first pen button (Stylus) is mapped
+	to right mouse button click and the second pen button (Stylus2)
+	emulates a middle mouse	button click.
+
+	Supported map *buttons* for mouse emulation are:
+	- Tip
 	- Stylus
 	- Stylus2
 	- Stylus3
 	- Pad
 	- Pad2..Pad9
 
-	The stylus buttons (Stylus, Stylus2 and Stylus3) can be mapped *to*:
-	- Right
-	- Middle
-	- Side
-
-	The tablet pad buttons can be mapped to all available mouse buttons.
-	When using mouse emulation only, the tip and stylus buttons can also be
-	mapped to all available mouse buttons.
 	See mouse section above for all supported mouse buttons.
 
 ## LIBINPUT

--- a/include/input/tablet-pad.h
+++ b/include/input/tablet-pad.h
@@ -3,6 +3,7 @@
 #define LABWC_TABLET_PAD_H
 
 #include <wayland-server-core.h>
+#include <wlr/types/wlr_tablet_v2.h>
 
 struct seat;
 struct wlr_device;
@@ -19,15 +20,24 @@ struct wlr_input_device;
 #define LAB_BTN_PAD9 0x8
 
 struct drawing_tablet_pad {
+	struct wlr_input_device *wlr_input_device;
 	struct seat *seat;
-	struct wlr_tablet_pad *tablet;
+	struct wlr_tablet_pad *pad;
+	struct wlr_tablet_v2_tablet_pad *pad_v2;
+	struct drawing_tablet *tablet;
+	struct wlr_surface *current_surface;
 	struct {
+		struct wl_listener current_surface_destroy;
 		struct wl_listener button;
+		struct wl_listener ring;
+		struct wl_listener strip;
 		struct wl_listener destroy;
 	} handlers;
 	struct wl_list link; /* seat.tablet_pads */
 };
 
 void tablet_pad_init(struct seat *seat, struct wlr_input_device *wlr_input_device);
+void tablet_pad_attach_tablet(struct seat *seat);
+void tablet_pad_enter_surface(struct seat *seat, struct wlr_surface *wlr_surface);
 
 #endif /* LABWC_TABLET_PAD_H */

--- a/include/input/tablet-pad.h
+++ b/include/input/tablet-pad.h
@@ -25,6 +25,7 @@ struct drawing_tablet_pad {
 		struct wl_listener button;
 		struct wl_listener destroy;
 	} handlers;
+	struct wl_list link; /* seat.tablet_pads */
 };
 
 void tablet_pad_init(struct seat *seat, struct wlr_input_device *wlr_input_device);

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -28,6 +28,7 @@ struct drawing_tablet {
 		struct wl_listener button;
 		struct wl_listener destroy;
 	} handlers;
+	struct wl_list link; /* seat.tablets */
 };
 
 void tablet_init(struct seat *seat, struct wlr_input_device *wlr_input_device);

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -193,7 +193,9 @@ struct seat {
 	struct wl_listener touch_motion;
 	struct wl_listener touch_frame;
 
+	struct wl_list tablets;
 	struct wl_list tablet_tools;
+	struct wl_list tablet_pads;
 
 	struct wl_listener constraint_commit;
 	struct wl_listener pressed_surface_destroy;

--- a/src/input/tablet-pad.c
+++ b/src/input/tablet-pad.c
@@ -30,6 +30,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 	struct drawing_tablet_pad *pad =
 		wl_container_of(listener, pad, handlers.destroy);
 
+	wl_list_remove(&pad->link);
 	wl_list_remove(&pad->handlers.button.link);
 	wl_list_remove(&pad->handlers.destroy.link);
 	free(pad);
@@ -45,4 +46,5 @@ tablet_pad_init(struct seat *seat, struct wlr_input_device *wlr_device)
 	pad->tablet->data = pad;
 	CONNECT_SIGNAL(pad->tablet, &pad->handlers, button);
 	CONNECT_SIGNAL(wlr_device, &pad->handlers, destroy);
+	wl_list_insert(&seat->tablet_pads, &pad->link);
 }

--- a/src/input/tablet-pad.c
+++ b/src/input/tablet-pad.c
@@ -1,27 +1,143 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <assert.h>
 #include <stdlib.h>
+#include <wlr/backend/libinput.h>
 #include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/util/log.h>
 #include "common/macros.h"
 #include "common/mem.h"
 #include "config/rcxml.h"
 #include "input/cursor.h"
 #include "input/tablet-pad.h"
+#include "input/tablet.h"
+#include "labwc.h"
+
+void
+tablet_pad_attach_tablet(struct seat *seat)
+{
+	/* reset all tablet - pad links */
+	struct drawing_tablet_pad *pad;
+	wl_list_for_each(pad, &seat->tablet_pads, link) {
+		pad->tablet = NULL;
+	}
+
+	/* loop over all tablets and all pads and link by device group */
+	struct drawing_tablet *tablet;
+	wl_list_for_each(tablet, &seat->tablets, link) {
+		struct libinput_device *tablet_device =
+			wlr_libinput_get_device_handle(tablet->wlr_input_device);
+		struct libinput_device_group *tablet_group =
+			libinput_device_get_device_group(tablet_device);
+
+		wl_list_for_each(pad, &seat->tablet_pads, link) {
+			struct libinput_device *pad_device =
+				wlr_libinput_get_device_handle(pad->wlr_input_device);
+			struct libinput_device_group *pad_group =
+				libinput_device_get_device_group(pad_device);
+
+			if (tablet_group == pad_group) {
+				wlr_log(WLR_DEBUG, "attach tablet to pad based on device group");
+				pad->tablet = tablet;
+			}
+		}
+	}
+}
+
+static void
+handle_surface_destroy(struct wl_listener *listener, void *data)
+{
+	struct drawing_tablet_pad *pad =
+		wl_container_of(listener, pad, handlers.current_surface_destroy);
+
+	pad->current_surface = NULL;
+	wl_list_remove(&pad->handlers.current_surface_destroy.link);
+}
+
+void
+tablet_pad_enter_surface(struct seat *seat, struct wlr_surface *surface)
+{
+	if (!surface) {
+		return;
+	}
+
+	struct drawing_tablet_pad *pad;
+	wl_list_for_each(pad, &seat->tablet_pads, link) {
+		/* pad needs a linked tablet and both need tablet-v2 support */
+		if (pad->tablet && pad->pad_v2 && pad->tablet->tablet_v2) {
+			if (pad->current_surface) {
+				wlr_tablet_v2_tablet_pad_notify_leave(pad->pad_v2,
+					pad->current_surface);
+
+				/* remove previous surface destroy handler */
+				wl_list_remove(&pad->handlers.current_surface_destroy.link);
+			}
+
+			pad->current_surface = surface;
+			wlr_tablet_v2_tablet_pad_notify_enter(pad->pad_v2,
+				pad->tablet->tablet_v2, surface);
+
+			/* signal surface destroy handler */
+			wl_signal_add(&pad->current_surface->events.destroy,
+				&pad->handlers.current_surface_destroy);
+			pad->handlers.current_surface_destroy.notify =
+				handle_surface_destroy;
+		}
+	}
+}
 
 static void
 handle_button(struct wl_listener *listener, void *data)
 {
-	struct drawing_tablet_pad *tablet_pad =
-		wl_container_of(listener, tablet_pad, handlers.button);
+	struct drawing_tablet_pad *pad =
+		wl_container_of(listener, pad, handlers.button);
 	struct wlr_tablet_pad_button_event *ev = data;
 
-	uint32_t button = tablet_get_mapped_button(ev->button);
-	if (!button) {
-		return;
+	if (!rc.tablet.force_mouse_emulation
+			&& pad->pad_v2 && pad->current_surface) {
+		wlr_tablet_v2_tablet_pad_notify_button(pad->pad_v2, ev->button,
+			ev->time_msec,
+			ev->state == WLR_BUTTON_PRESSED
+				? ZWP_TABLET_PAD_V2_BUTTON_STATE_PRESSED
+				: ZWP_TABLET_PAD_V2_BUTTON_STATE_RELEASED);
+	} else {
+		uint32_t button = tablet_get_mapped_button(ev->button);
+		if (button) {
+			cursor_emulate_button(pad->seat, button, ev->state, ev->time_msec);
+		}
 	}
+}
 
-	cursor_emulate_button(tablet_pad->seat, button, ev->state, ev->time_msec);
+static void
+handle_ring(struct wl_listener *listener, void *data)
+{
+	struct drawing_tablet_pad *pad =
+		wl_container_of(listener, pad, handlers.ring);
+	struct wlr_tablet_pad_ring_event *ev = data;
+
+	if (!rc.tablet.force_mouse_emulation
+			&& pad->pad_v2 && pad->current_surface) {
+		wlr_tablet_v2_tablet_pad_notify_ring(pad->pad_v2,
+			ev->ring, ev->position,
+			ev->source == WLR_TABLET_PAD_RING_SOURCE_FINGER,
+			ev->time_msec);
+	}
+}
+
+static void
+handle_strip(struct wl_listener *listener, void *data)
+{
+	struct drawing_tablet_pad *pad =
+		wl_container_of(listener, pad, handlers.strip);
+	struct wlr_tablet_pad_strip_event *ev = data;
+
+	if (!rc.tablet.force_mouse_emulation
+			&& pad->pad_v2 && pad->current_surface) {
+		wlr_tablet_v2_tablet_pad_notify_strip(pad->pad_v2,
+			ev->strip, ev->position,
+			ev->source == WLR_TABLET_PAD_STRIP_SOURCE_FINGER,
+			ev->time_msec);
+	}
 }
 
 static void
@@ -30,8 +146,13 @@ handle_destroy(struct wl_listener *listener, void *data)
 	struct drawing_tablet_pad *pad =
 		wl_container_of(listener, pad, handlers.destroy);
 
+	if (pad->current_surface) {
+		wl_list_remove(&pad->handlers.current_surface_destroy.link);
+	}
 	wl_list_remove(&pad->link);
 	wl_list_remove(&pad->handlers.button.link);
+	wl_list_remove(&pad->handlers.ring.link);
+	wl_list_remove(&pad->handlers.strip.link);
 	wl_list_remove(&pad->handlers.destroy.link);
 	free(pad);
 }
@@ -42,9 +163,17 @@ tablet_pad_init(struct seat *seat, struct wlr_input_device *wlr_device)
 	wlr_log(WLR_DEBUG, "setting up tablet pad");
 	struct drawing_tablet_pad *pad = znew(*pad);
 	pad->seat = seat;
-	pad->tablet = wlr_tablet_pad_from_input_device(wlr_device);
-	pad->tablet->data = pad;
-	CONNECT_SIGNAL(pad->tablet, &pad->handlers, button);
+	pad->wlr_input_device = wlr_device;
+	pad->pad = wlr_tablet_pad_from_input_device(wlr_device);
+	if (seat->server->tablet_manager) {
+		pad->pad_v2 = wlr_tablet_pad_create(
+			seat->server->tablet_manager, seat->seat, wlr_device);
+	}
+	pad->pad->data = pad;
+	CONNECT_SIGNAL(pad->pad, &pad->handlers, button);
+	CONNECT_SIGNAL(pad->pad, &pad->handlers, ring);
+	CONNECT_SIGNAL(pad->pad, &pad->handlers, strip);
 	CONNECT_SIGNAL(wlr_device, &pad->handlers, destroy);
 	wl_list_insert(&seat->tablet_pads, &pad->link);
+	tablet_pad_attach_tablet(pad->seat);
 }

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -470,7 +470,7 @@ handle_button(struct wl_listener *listener, void *data)
 	if (tool && !is_down_mouse_emulation && surface) {
 		idle_manager_notify_activity(tool->seat->seat);
 
-		if (button) {
+		if (button && ev->state == WLR_BUTTON_PRESSED) {
 			struct view *view = view_from_wlr_surface(surface);
 			struct mousebind *mousebind;
 			wl_list_for_each(mousebind, &rc.mousebinds, link) {

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -14,6 +14,7 @@
 #include "input/cursor.h"
 #include "input/tablet.h"
 #include "input/tablet-tool.h"
+#include "input/tablet-pad.h"
 #include "labwc.h"
 #include "idle.h"
 #include "action.h"
@@ -511,6 +512,8 @@ handle_destroy(struct wl_listener *listener, void *data)
 		wl_container_of(listener, tablet, handlers.destroy);
 
 	wl_list_remove(&tablet->link);
+	tablet_pad_attach_tablet(tablet->seat);
+
 	wl_list_remove(&tablet->handlers.tip.link);
 	wl_list_remove(&tablet->handlers.button.link);
 	wl_list_remove(&tablet->handlers.proximity.link);
@@ -548,5 +551,7 @@ tablet_init(struct seat *seat, struct wlr_input_device *wlr_device)
 	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, tip);
 	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, button);
 	CONNECT_SIGNAL(wlr_device, &tablet->handlers, destroy);
+
 	wl_list_insert(&seat->tablets, &tablet->link);
+	tablet_pad_attach_tablet(tablet->seat);
 }

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -510,6 +510,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 	struct drawing_tablet *tablet =
 		wl_container_of(listener, tablet, handlers.destroy);
 
+	wl_list_remove(&tablet->link);
 	wl_list_remove(&tablet->handlers.tip.link);
 	wl_list_remove(&tablet->handlers.button.link);
 	wl_list_remove(&tablet->handlers.proximity.link);
@@ -547,4 +548,5 @@ tablet_init(struct seat *seat, struct wlr_input_device *wlr_device)
 	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, tip);
 	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, button);
 	CONNECT_SIGNAL(wlr_device, &tablet->handlers, destroy);
+	wl_list_insert(&seat->tablets, &tablet->link);
 }

--- a/src/seat.c
+++ b/src/seat.c
@@ -504,6 +504,7 @@ focus_change_notify(struct wl_listener *listener, void *data)
 		}
 		if (view) {
 			view_set_activated(view, true);
+			tablet_pad_enter_surface(seat, surface);
 		}
 		server->active_view = view;
 	}

--- a/src/seat.c
+++ b/src/seat.c
@@ -553,7 +553,9 @@ seat_init(struct server *server)
 	}
 	wlr_cursor_attach_output_layout(seat->cursor, server->output_layout);
 
+	wl_list_init(&seat->tablets);
 	wl_list_init(&seat->tablet_tools);
+	wl_list_init(&seat->tablet_pads);
 
 	input_handlers_init(seat);
 }


### PR DESCRIPTION
Looking at the pad support in the tablet v2 protocol, this seems pretty straight forward and works with the "paint" demo in `gtk4-demo` by letting me use the pad buttons to change colors.

```
[ 142826.733] zwp_tablet_seat_v2@29.pad_added(new id zwp_tablet_pad_v2@4278190081)
[ 142826.734] zwp_tablet_pad_v2@4278190081.buttons(4)
[ 142826.735] zwp_tablet_pad_v2@4278190081.path("/sys/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4.2/1-4.2:1.0/0003:056A:0378.0005/input/input22/event5")
[ 142826.737] zwp_tablet_pad_v2@4278190081.group(new id zwp_tablet_pad_group_v2@4278190082)
[ 142826.738] zwp_tablet_pad_group_v2@4278190082.modes(1)
[ 142826.739] zwp_tablet_pad_group_v2@4278190082.buttons(array[16])
[ 142826.740] zwp_tablet_pad_group_v2@4278190082.done()
[ 142826.741] zwp_tablet_pad_v2@4278190081.done()
[ 143091.732] zwp_tablet_pad_v2@4278190081.enter(49, zwp_tablet_v2@4278190080, wl_surface@34)
[ 143091.760] zwp_tablet_pad_group_v2@4278190082.mode_switch(491748, 49, 0)
[ 151208.708] zwp_tablet_pad_v2@4278190081.leave(73, wl_surface@34)
[ 151208.711] zwp_tablet_pad_v2@4278190081.enter(74, zwp_tablet_v2@4278190080, wl_surface@56)
[ 151208.728] zwp_tablet_pad_group_v2@4278190082.mode_switch(609613, 74, 0)
[ 151209.181]  -> zwp_tablet_pad_v2@4278190081.set_feedback(1, "Black", 74)
[ 151209.186]  -> zwp_tablet_pad_v2@4278190081.set_feedback(2, "Pink", 74)
[ 151209.189]  -> zwp_tablet_pad_v2@4278190081.set_feedback(3, "Green", 74)
[ 154437.283] zwp_tablet_pad_v2@4278190081.button(5553838, 3, 1)
[ 154567.236] zwp_tablet_pad_v2@4278190081.button(5553968, 3, 0)
[ 159764.940] zwp_tablet_pad_v2@4278190081.leave(92, nil)
[ 159764.971] zwp_tablet_pad_v2@4278190081.enter(93, zwp_tablet_v2@4278190080, wl_surface@34)
[ 159765.023] zwp_tablet_pad_group_v2@4278190082.mode_switch(164874, 93, 0)
```

The way of linking by device group is directly from Sway. There is though an `attach_tablet` signal, but I don't know how this is supposed to be wired. I don't see this signal being emitted on my setup.

I don't have rings or strips on my tablet, so just theoretical, but inspired by Sway, implementation of those events.

Draft for now since there might be some rough edges and still needs some research regarding `attach_tablet`. Also needs some additions in the docs.

TODO:

- [x] Look at XWayland, does this actually work?
Seems to be ok and behaves the same now as stylus buttons
- [x] Should we fallback at all to emulate mouse button when mouse emulation is off? Currently we do that when no app has focus, but this only happens when the desktop is empty. Might just be confusing. Alternatively, may be we should always stick to mouse emulation for buttons when there are configured pad mappings?
-> I went for the same approach as for stylus buttons (but without the ability to change buttons)
- [ ] Find out what `attach_tablet` signal is about
- [x] Clarify button mapping in the docs

PS: PR https://github.com/labwc/labwc/pull/1883 is included, so https://github.com/labwc/labwc/pull/1883 has to go first.