### PR TITLE
input: always notify all tablet axis

### DIFF
--- a/include/input/tablet-tool.h
+++ b/include/input/tablet-tool.h
@@ -19,5 +19,6 @@ struct drawing_tablet_tool {
 
 void tablet_tool_init(struct seat *seat,
 	struct wlr_tablet_tool *wlr_tablet_tool);
+bool tablet_tool_has_focused_surface(struct seat *seat);
 
 #endif /* LABWC_TABLET_TOOL_H */

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -15,7 +15,12 @@ struct drawing_tablet {
 	struct wlr_tablet *tablet;
 	struct wlr_tablet_v2_tablet *tablet_v2;
 	double x, y;
+	double distance;
+	double pressure;
 	double tilt_x, tilt_y;
+	double rotation;
+	double slider;
+	double wheel_delta;
 	struct {
 		struct wl_listener proximity;
 		struct wl_listener axis;

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -18,6 +18,7 @@
 #include "input/gestures.h"
 #include "input/touch.h"
 #include "input/tablet-tool.h"
+#include "input/tablet-pad.h"
 #include "labwc.h"
 #include "layers.h"
 #include "menu/menu.h"
@@ -150,11 +151,8 @@ request_cursor_notify(struct wl_listener *listener, void *data)
 	 * when a tablet tool enters proximity on a tablet-capable surface.
 	 * See also `notify_motion()` in `input/tablet.c`.
 	 */
-	struct drawing_tablet_tool *tool;
-	wl_list_for_each(tool, &seat->tablet_tools, link) {
-		if (tool->tool_v2->focused_surface) {
-			return;
-		}
+	if (tablet_tool_has_focused_surface(seat)) {
+		return;
 	}
 
 	/*

--- a/src/input/tablet-tool.c
+++ b/src/input/tablet-tool.c
@@ -11,6 +11,19 @@
 #include "input/tablet-tool.h"
 #include "labwc.h"
 
+bool
+tablet_tool_has_focused_surface(struct seat *seat)
+{
+	struct drawing_tablet_tool *tool;
+	wl_list_for_each(tool, &seat->tablet_tools, link) {
+		if (tool->tool_v2->focused_surface) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static void
 handle_set_cursor(struct wl_listener *listener, void *data)
 {


### PR DESCRIPTION
Notify all axis based on the capabilities of the tablet tool. At least GTK applications expect this for e.g. smooth pressure or distance events. 

With this change, distance and pressure (which are supported by my stylus) are also butter-smooth when not moving (no x,y motion) the stylus in the "Touch and Drawing Tablets" demo in gtk3-demo. (I've discovered this demo just recently)

First commit is a small refactoring, move tablet specifics into the tablet files.   

PS: Krita is still fine with this changes and looks like Gnome/Mutter is doing the same:

Gnome/Mutter: 

```
[3010668.867] zwp_tablet_tool_v2@4278190083.motion(737.50781250, 465.45703125)
[3010668.876] zwp_tablet_tool_v2@4278190083.pressure(0)
[3010668.880] zwp_tablet_tool_v2@4278190083.distance(49151)
[3010668.883] zwp_tablet_tool_v2@4278190083.frame(4227700)
[3010677.038] zwp_tablet_tool_v2@4278190083.motion(764.26171875, 467.52734375)
[3010677.046] zwp_tablet_tool_v2@4278190083.pressure(0)
[3010677.049] zwp_tablet_tool_v2@4278190083.distance(54271)
[3010677.052] zwp_tablet_tool_v2@4278190083.frame(4227708)
[3010684.960] zwp_tablet_tool_v2@4278190083.motion(793.08593750, 470.39453125)
[3010684.969] zwp_tablet_tool_v2@4278190083.pressure(0)
[3010684.978] zwp_tablet_tool_v2@4278190083.distance(54271)
[3010684.981] zwp_tablet_tool_v2@4278190083.frame(4227716)
[3010690.962] zwp_tablet_tool_v2@4278190083.motion(822.23046875, 473.57812500)
[3010690.977] zwp_tablet_tool_v2@4278190083.pressure(0)
[3010690.981] zwp_tablet_tool_v2@4278190083.distance(54271)
```

Labwc with this PR:

```
[3294672.702] zwp_tablet_tool_v2@4278190081.motion(791.01171875, 531.44140625)
[3294672.737] zwp_tablet_tool_v2@4278190081.distance(50175)
[3294672.745] zwp_tablet_tool_v2@4278190081.pressure(0)
[3294672.750] zwp_tablet_tool_v2@4278190081.frame(4511704)
[3294680.681] zwp_tablet_tool_v2@4278190081.motion(816.17187500, 539.44140625)
[3294680.713] zwp_tablet_tool_v2@4278190081.distance(50175)
[3294680.721] zwp_tablet_tool_v2@4278190081.pressure(0)
[3294680.726] zwp_tablet_tool_v2@4278190081.frame(4511712)
[3294688.676] zwp_tablet_tool_v2@4278190081.motion(841.17578125, 547.12109375)
[3294688.708] zwp_tablet_tool_v2@4278190081.distance(50175)
[3294688.716] zwp_tablet_tool_v2@4278190081.pressure(0)
[3294688.721] zwp_tablet_tool_v2@4278190081.frame(4511720)
[3294696.635] zwp_tablet_tool_v2@4278190081.motion(865.53906250, 554.00000000)
[3294696.674] zwp_tablet_tool_v2@4278190081.distance(50175)
[3294696.684] zwp_tablet_tool_v2@4278190081.pressure(0)
[3294696.689] zwp_tablet_tool_v2@4278190081.frame(4511728)
```