### PR TITLE
view: implement `cascade` placement policy

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -276,9 +276,9 @@ Actions are used in menus and keyboard/mouse bindings.
 *<action name="AutoPlace" policy="value"/>*
 	Reposition the window according to the desired placement policy.
 
-	*policy* [automatic|cursor|center] Use the specified policy, which has
-	the same meaning as the corresponding value for *<placement><policy>*.
-	Default is automatic.
+	*policy* [automatic|cursor|center|cascade] Use the specified policy,
+	which has the same meaning as the corresponding value for
+	*<placement><policy>*. Default is automatic.
 
 *<action name="Shade" />*++
 *<action name="Unshade" />*++

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -203,12 +203,22 @@ this is for compatibility with Openbox.
 
 ## PLACEMENT
 
-*<placement><policy>* [center|automatic|cursor]
+*<placement><policy>* [center|automatic|cursor|cascade]
 	Specify a placement policy for new windows. The "center" policy will
 	always place windows at the center of the active output. The "automatic"
 	policy will try to place new windows in such a way that they will
 	have minimal overlap with existing windows. The "cursor" policy will
-	center new windows under the cursor. Default is "center".
+	center new windows under the cursor. The "cascade" policy will try to
+	place new windows at the center of the active output, but possibly
+	shifts its position to bottom-right not to cover existing windows.
+	Default is "center".
+
+*<placement><cascadeOffset><x>*++
+*<placement><cascadeOffset><y>*
+	Specify the offset by which a new window can be shifted from an existing
+	window when <placement><policy> is "cascade". These values must be positive.
+	Default is the height of titlebar (the sum of *titlebar.height* and
+	*border.width* from theme) plus 5 for both *x* and *y*.
 
 ## WINDOW SWITCHER
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -18,6 +18,11 @@
 
   <placement>
     <policy>center</policy>
+    <!--
+      When <placement><policy> is "cascade", the offset for cascading new
+      windows can be overwritten like this:
+      <cascadeOffset x="40" y="30" />
+    -->
   </placement>
 
   <!-- <font><theme> can be defined without an attribute to set all places -->

--- a/include/common/box.h
+++ b/include/common/box.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_BOX_H
+#define LABWC_BOX_H
+
+#include <wlr/util/box.h>
+
+bool
+box_contains(struct wlr_box *box_super, struct wlr_box *box_sub);
+
+bool
+box_intersects(struct wlr_box *box_a, struct wlr_box *box_b);
+
+/* Returns the bounding box of 2 boxes */
+void
+box_union(struct wlr_box *box_dest, struct wlr_box *box_a, struct wlr_box *box_b);
+
+#endif /* LABWC_BOX_H */

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -19,7 +19,8 @@ enum view_placement_policy {
 	LAB_PLACE_INVALID = 0,
 	LAB_PLACE_CENTER,
 	LAB_PLACE_CURSOR,
-	LAB_PLACE_AUTOMATIC
+	LAB_PLACE_AUTOMATIC,
+	LAB_PLACE_CASCADE,
 };
 
 enum adaptive_sync_mode {
@@ -56,6 +57,8 @@ struct rcxml {
 	bool reuse_output_mode;
 	enum view_placement_policy placement_policy;
 	bool xwayland_persistence;
+	int placement_cascade_offset_x;
+	int placement_cascade_offset_y;
 
 	/* focus */
 	bool focus_follow_mouse;

--- a/src/common/box.c
+++ b/src/common/box.c
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <assert.h>
+#include "common/box.h"
+#include "common/macros.h"
+
+bool
+box_contains(struct wlr_box *box_super, struct wlr_box *box_sub)
+{
+	if (wlr_box_empty(box_super) || wlr_box_empty(box_sub)) {
+		return false;
+	}
+	return box_super->x <= box_sub->x
+		&& box_super->x + box_super->width >= box_sub->x + box_sub->width
+		&& box_super->y <= box_sub->y
+		&& box_super->y + box_super->height >= box_sub->y + box_sub->height;
+}
+
+bool
+box_intersects(struct wlr_box *box_a, struct wlr_box *box_b)
+{
+	if (wlr_box_empty(box_a) || wlr_box_empty(box_b)) {
+		return false;
+	}
+	return box_a->x < box_b->x + box_b->width
+		&& box_b->x < box_a->x + box_a->width
+		&& box_a->y < box_b->y + box_b->height
+		&& box_b->y < box_a->y + box_a->height;
+}
+
+void
+box_union(struct wlr_box *box_dest, struct wlr_box *box_a, struct wlr_box *box_b)
+{
+	if (wlr_box_empty(box_a)) {
+		*box_dest = *box_b;
+		return;
+	}
+	if (wlr_box_empty(box_b)) {
+		*box_dest = *box_a;
+		return;
+	}
+	int x1 = MIN(box_a->x, box_b->x);
+	int y1 = MIN(box_a->y, box_b->y);
+	int x2 = MAX(box_a->x + box_a->width, box_b->x + box_b->width);
+	int y2 = MAX(box_a->y + box_a->height, box_b->y + box_b->height);
+	box_dest->x = x1;
+	box_dest->y = y1;
+	box_dest->width = x2 - x1;
+	box_dest->height = y2 - y1;
+}

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -1,4 +1,5 @@
 labwc_sources += files(
+	'box.c',
   'buf.c',
   'dir.c',
   'fd-util.c',

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -901,6 +901,10 @@ entry(xmlNode *node, char *nodename, char *content)
 		}
 	} else if (!strcasecmp(nodename, "xwaylandPersistence.core")) {
 		set_bool(content, &rc.xwayland_persistence);
+	} else if (!strcasecmp(nodename, "x.cascadeOffset.placement")) {
+		rc.placement_cascade_offset_x = atoi(content);
+	} else if (!strcasecmp(nodename, "y.cascadeOffset.placement")) {
+		rc.placement_cascade_offset_y = atoi(content);
 	} else if (!strcmp(nodename, "name.theme")) {
 		rc.theme_name = xstrdup(content);
 	} else if (!strcmp(nodename, "cornerradius.theme")) {
@@ -1229,6 +1233,8 @@ rcxml_init(void)
 	has_run = true;
 
 	rc.placement_policy = LAB_PLACE_CENTER;
+	rc.placement_cascade_offset_x = 0;
+	rc.placement_cascade_offset_y = 0;
 
 	rc.xdg_shell_server_side_deco = true;
 	rc.ssd_keep_border = true;

--- a/src/edges.c
+++ b/src/edges.c
@@ -5,6 +5,7 @@
 #include <wlr/util/edges.h>
 #include <wlr/util/box.h>
 #include "common/border.h"
+#include "common/box.h"
 #include "common/macros.h"
 #include "config/rcxml.h"
 #include "edges.h"
@@ -466,9 +467,8 @@ edges_find_outputs(struct border *nearest_edges, struct view *view,
 		struct wlr_box usable =
 			output_usable_area_in_layout_coords(o);
 
-		struct wlr_box ol;
-		if (!wlr_box_intersection(&ol, &origin, &usable) &&
-				!wlr_box_intersection(&ol, &target, &usable)) {
+		if (!box_intersects(&origin, &usable)
+				&& !box_intersects(&target, &usable)) {
 			continue;
 		}
 


### PR DESCRIPTION
This is what I suggested in https://github.com/labwc/labwc/pull/1772#issuecomment-2093799066.

This adds following settings:
```xml
<placement>
  <policy>cascade</policy>
  <cascadeOffset x="40" y="30" />
</placement>
```

`cascade` policy places a new window at the center of the screen like `center` policy, but possibly shifts its position to bottom-right so the new window doesn't cover existing windows.
Its algorithm is copied from Kwin ([link](https://github.com/KDE/kwin/blob/df9f8f8346b5b7645578e37365dabb1a7b02ca5a/src/placement.cpp#L589)), combined with some helper functions I added (`wlr_box_contains()`, `wlr_box_intersects()` and `wlr_box_union()`).

https://github.com/labwc/labwc/assets/22029524/df90c7d2-7fa3-4550-8fa9-eb2d83a709dc

I think this policy achieves a good balance of predictability and visibility when opening multiple windows.

But please treat this PR as just a suggestion. In KDE, this was proposed in 2003 ([link](https://bugs.kde.org/show_bug.cgi?id=58063)) and implemented as an enhancement in `center` policy in 2022. So adding this to labwc may also require some discussion as well.

And I also want to emphasize I agree with @jlindgren90's comment in #1772:

> I recall Metacity had a design goal of having just one placement scheme that was "good enough" for most use cases -- it would be nice if we could achieve that.

So, closing this PR and seeking another way that fits our goal better is welcome. Then maybe I can personally maintain a patch and use `cascade` policy until we manage to make an alternative.