### PR TITLE
xwayland: reset cursor image on cursor theme reload

### DIFF
--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -95,5 +95,7 @@ void xwayland_adjust_usable_area(struct view *view,
 
 void xwayland_update_workarea(struct server *server);
 
+void xwayland_reset_cursor(struct server *server);
+
 #endif /* HAVE_XWAYLAND */
 #endif /* LABWC_XWAYLAND_H */

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -26,6 +26,7 @@
 #include "resistance.h"
 #include "ssd.h"
 #include "view.h"
+#include "xwayland.h"
 
 #define LAB_CURSOR_SHAPE_V1_VERSION 1
 
@@ -1403,6 +1404,9 @@ void
 cursor_reload(struct seat *seat)
 {
 	cursor_load(seat);
+#if HAVE_XWAYLAND
+	xwayland_reset_cursor(seat->server);
+#endif
 	cursor_update_image(seat);
 }
 


### PR DESCRIPTION
As wlr_xwayland caches the pixel data when not yet started up due to the delayed lazy startup approach, we do have to re-set the xwayland cursor image when reloading the cursor theme. Otherwise the first X11 client connected will cause the xwayland server to use the cached (and destroyed) pixel data.

To reproduce:
- Compile with b_sanitize=address,undefined
- Start labwc (nothing in autostart that could create a X11 connection, e.g. no GTK or X11 application)
- Reconfigure
- Start some X11 client