### PR TITLE
Fix release keybindings being triggered after mouse bindings

### DIFF
--- a/include/input/keyboard.h
+++ b/include/input/keyboard.h
@@ -9,6 +9,8 @@ struct seat;
 struct keyboard;
 struct wlr_keyboard;
 
+extern struct keybind *cur_keybind;
+
 void keyboard_reset_current_keybind(void);
 void keyboard_configure(struct seat *seat, struct wlr_keyboard *kb,
 	bool is_virtual);

--- a/include/input/keyboard.h
+++ b/include/input/keyboard.h
@@ -9,8 +9,6 @@ struct seat;
 struct keyboard;
 struct wlr_keyboard;
 
-extern struct keybind *cur_keybind;
-
 void keyboard_reset_current_keybind(void);
 void keyboard_configure(struct seat *seat, struct wlr_keyboard *kb,
 	bool is_virtual);

--- a/src/action.c
+++ b/src/action.c
@@ -177,6 +177,8 @@ const char *action_names[] = {
 	NULL
 };
 
+extern struct keybind *cur_keybind;
+
 void
 action_arg_add_str(struct action *action, const char *key, const char *value)
 {
@@ -706,6 +708,8 @@ actions_run(struct view *activator, struct server *server,
 		wlr_log(WLR_ERROR, "empty actions");
 		return;
 	}
+
+	cur_keybind = NULL;
 
 	struct view *view;
 	struct action *action;

--- a/src/action.c
+++ b/src/action.c
@@ -708,7 +708,8 @@ actions_run(struct view *activator, struct server *server,
 		return;
 	}
 
-	cur_keybind = NULL;
+	/* This cancels any pending on-release keybinds */
+	keyboard_reset_current_keybind ();
 
 	struct view *view;
 	struct action *action;

--- a/src/action.c
+++ b/src/action.c
@@ -24,6 +24,7 @@
 #include "ssd.h"
 #include "view.h"
 #include "workspaces.h"
+#include "input/keyboard.h"
 
 enum action_arg_type {
 	LAB_ACTION_ARG_STR = 0,
@@ -176,8 +177,6 @@ const char *action_names[] = {
 	"ZoomOut",
 	NULL
 };
-
-extern struct keybind *cur_keybind;
 
 void
 action_arg_add_str(struct action *action, const char *key, const char *value)

--- a/src/action.c
+++ b/src/action.c
@@ -709,7 +709,7 @@ actions_run(struct view *activator, struct server *server,
 	}
 
 	/* This cancels any pending on-release keybinds */
-	keyboard_reset_current_keybind ();
+	keyboard_reset_current_keybind();
 
 	struct view *view;
 	struct action *action;

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -38,7 +38,7 @@ struct keyinfo {
 
 static bool should_cancel_cycling_on_next_key_release;
 
-struct keybind *cur_keybind;
+static struct keybind *cur_keybind;
 
 /* Called on --reconfigure to prevent segfault when handling release keybinds */
 void

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -38,7 +38,7 @@ struct keyinfo {
 
 static bool should_cancel_cycling_on_next_key_release;
 
-static struct keybind *cur_keybind;
+struct keybind *cur_keybind;
 
 /* Called on --reconfigure to prevent segfault when handling release keybinds */
 void
@@ -438,7 +438,6 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 				return true;
 			}
 			actions_run(NULL, server, &cur_keybind->actions, 0);
-			cur_keybind = NULL;
 			return true;
 		} else {
 			return handle_key_release(server, event->keycode);
@@ -488,8 +487,6 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 		key_state_store_pressed_key_as_bound(event->keycode);
 		if (!cur_keybind->on_release) {
 			actions_run(NULL, server, &cur_keybind->actions, 0);
-			/* This cancels any pending on-release keybinds */
-			cur_keybind = NULL;
 		}
 		return true;
 	}


### PR DESCRIPTION
This fixes the problem where if a mousebinding uses a modifier key which has an onRelease binding, the mousebinding does not cancel the pending onRelease binding if it is triggered.

The approach is to clear the pending release binding whenever any bound action occurs, which means it only needs to take place at one point in the code.

There may be other issues here which I have not considered, but this appears to fix the problem for me without breaking any other bindings - more testing and/or advice much appreciated.