### PR TITLE
menu: ignore <item> without parent <menu>

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -605,6 +605,11 @@ xml_tree_walk(xmlNode *node, struct server *server)
 			continue;
 		}
 		if (!strcasecmp((char *)n->name, "item")) {
+			if (!current_menu) {
+				wlr_log(WLR_ERROR,
+					"ignoring <item> without parent <menu>");
+				continue;
+			}
 			in_item = true;
 			traverse(n, server);
 			in_item = false;


### PR DESCRIPTION
...to avoid assert() in item_create() because current_menu is NULL.

Reproduce crash with...

    <?xml version="1.0" encoding="utf-8"?>
    <openbox_menu>
      <item label="foo"/>
    </openbox_menu>