### PR TITLE
menu: capitalize Roll Up/Down

### DIFF
--- a/docs/menu.xml
+++ b/docs/menu.xml
@@ -12,7 +12,7 @@
   <item label="Fullscreen">
     <action name="ToggleFullscreen" />
   </item>
-  <item label="Roll up/down">
+  <item label="Roll Up/Down">
     <action name="ToggleShade" />
   </item>
   <item label="Decorations">
@@ -26,10 +26,10 @@
     if there is only a single workspace available.
   -->
   <menu id="workspaces" label="Workspace">
-    <item label="Move left">
+    <item label="Move Left">
       <action name="SendToDesktop" to="left" />
     </item>
-    <item label="Move right">
+    <item label="Move Right">
       <action name="SendToDesktop" to="right" />
     </item>
     <separator />

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -845,7 +845,7 @@ init_windowmenu(struct server *server)
 		fill_item("name.action", "ToggleMaximize");
 		current_item = item_create(menu, _("Fullscreen"), false);
 		fill_item("name.action", "ToggleFullscreen");
-		current_item = item_create(menu, _("Roll up/down"), false);
+		current_item = item_create(menu, _("Roll Up/Down"), false);
 		fill_item("name.action", "ToggleShade");
 		current_item = item_create(menu, _("Decorations"), false);
 		fill_item("name.action", "ToggleDecorations");
@@ -854,14 +854,14 @@ init_windowmenu(struct server *server)
 
 		/* Workspace sub-menu */
 		struct menu *workspace_menu = menu_create(server, "workspaces", "");
-		current_item = item_create(workspace_menu, _("Move left"), false);
+		current_item = item_create(workspace_menu, _("Move Left"), false);
 		/*
 		 * <action name="SendToDesktop"><follow> is true by default so
 		 * GoToDesktop will be called as part of the action.
 		 */
 		fill_item("name.action", "SendToDesktop");
 		fill_item("to.action", "left");
-		current_item = item_create(workspace_menu, _("Move right"), false);
+		current_item = item_create(workspace_menu, _("Move Right"), false);
 		fill_item("name.action", "SendToDesktop");
 		fill_item("to.action", "right");
 		current_item = separator_create(workspace_menu, "");


### PR DESCRIPTION
...because it seems like better English and is more consistent with other menu entries.

Same for 'Move Left' and 'Move Right'