### PR TITLE
feat: add ToggleTabletMouseEmulation action

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -286,6 +286,9 @@ Actions are used in menus and keyboard/mouse bindings.
 	decorations (including those for which the server-side titlebar has been
 	hidden) are not eligible for shading.
 
+*<action name="ToggleTabletMouseEmulation">*
+	Toggle mouse emulation for drawing tablets on or off.
+
 *<action name="ToggleMagnify">*
 	Toggle the screen magnifier on or off at the last magnification level
 	used.

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -684,6 +684,9 @@ extending outward from the snapped edge.
 	tablet specific restrictions, e.g. no support for drag-and-drop, but
 	also omits tablet specific features like reporting pen pressure.
 
+	Use the *ToggleTabletMouseEmulation* action for toggling between
+	mouse emulation on and off.
+
 *<tablet><map button="" to="" />*
 	Pen and pad buttons behave like regular mouse buttons.With mouse
 	emulation set to "no", which is the default, and if not	specified

--- a/src/action.c
+++ b/src/action.c
@@ -114,6 +114,7 @@ enum action_type {
 	ACTION_TYPE_SHADE,
 	ACTION_TYPE_UNSHADE,
 	ACTION_TYPE_TOGGLE_SHADE,
+	ACTION_TYPE_TOGGLE_TABLET_MOUSE_EMULATION,
 	ACTION_TYPE_TOGGLE_MAGNIFY,
 	ACTION_TYPE_ZOOM_IN,
 	ACTION_TYPE_ZOOM_OUT
@@ -172,6 +173,7 @@ const char *action_names[] = {
 	"Shade",
 	"Unshade",
 	"ToggleShade",
+	"ToggleTabletMouseEmulation",
 	"ToggleMagnify",
 	"ZoomIn",
 	"ZoomOut",
@@ -1110,6 +1112,9 @@ actions_run(struct view *activator, struct server *server,
 			if (view) {
 				view_set_shade(view, false);
 			}
+			break;
+		case ACTION_TYPE_TOGGLE_TABLET_MOUSE_EMULATION:
+			rc.tablet.force_mouse_emulation = !rc.tablet.force_mouse_emulation;
 			break;
 		case ACTION_TYPE_TOGGLE_MAGNIFY:
 			magnify_toggle(server);


### PR DESCRIPTION
Useful for switching between application-defined and mapped tablet  pad buttons. Also for quickly troubleshooting tablet behavior.

Probably not the most useful action, but simple implementation so why not.