### PR TITLE
magnifier: fix flickering on simultaneous gamma changes

### DIFF
--- a/include/common/scene-helpers.h
+++ b/include/common/scene-helpers.h
@@ -7,6 +7,7 @@
 struct wlr_scene_node;
 struct wlr_surface;
 struct wlr_scene_output;
+struct wlr_output_state;
 
 struct wlr_surface *lab_wlr_surface_from_node(struct wlr_scene_node *node);
 
@@ -18,6 +19,7 @@ struct wlr_surface *lab_wlr_surface_from_node(struct wlr_scene_node *node);
 struct wlr_scene_node *lab_wlr_scene_get_prev_node(struct wlr_scene_node *node);
 
 /* A variant of wlr_scene_output_commit() that respects wlr_output->pending */
-bool lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output);
+bool lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
+	struct wlr_output_state *output_state);
 
 #endif /* LABWC_SCENE_HELPERS_H */

--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -96,7 +96,7 @@ magnify(struct output *output, struct wlr_buffer *output_buffer, struct wlr_box 
 
 	/* (Re)create the temporary buffer if required */
 	if (tmp_buffer && (tmp_buffer->width != width || tmp_buffer->height != height)) {
-		wlr_log(WLR_DEBUG, "tmp buffer size changed, dropping");
+		wlr_log(WLR_DEBUG, "tmp magnifier buffer size changed, dropping");
 		assert(tmp_texture);
 		wlr_texture_destroy(tmp_texture);
 		wlr_buffer_drop(tmp_buffer);
@@ -117,7 +117,7 @@ magnify(struct output *output, struct wlr_buffer *output_buffer, struct wlr_box 
 		tmp_texture = wlr_texture_from_buffer(server->renderer, tmp_buffer);
 	}
 	if (!tmp_texture) {
-		wlr_log(WLR_ERROR, "Failed to allocate temporary texture");
+		wlr_log(WLR_ERROR, "Failed to allocate temporary magnifier texture");
 		wlr_buffer_drop(tmp_buffer);
 		tmp_buffer = NULL;
 		return;
@@ -209,7 +209,7 @@ magnify(struct output *output, struct wlr_buffer *output_buffer, struct wlr_box 
 	};
 	wlr_render_pass_add_texture(tmp_render_pass, &opts);
 	if (!wlr_render_pass_submit(tmp_render_pass)) {
-		wlr_log(WLR_ERROR, "Failed to submit render pass");
+		wlr_log(WLR_ERROR, "Failed to submit magnifier render pass");
 		goto cleanup;
 	}
 


### PR DESCRIPTION
Gamma changes take another code path and thus did not render the magnifier.
This patch adds the magnfifier to the gamma code path and also slightly refactors the gamma handling.

Fixes:
- #1905

---

Completely untested.