### PR TITLE
feat: set squared SSD corners when SSD client is tiled and notified about being tiled

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -50,6 +50,7 @@ struct ssd {
 	 */
 	struct {
 		bool was_maximized;   /* To un-round corner buttons and toggle icon on maximize */
+		bool was_tiled_not_maximized;   /* To un-round corner buttons */
 		struct wlr_box geometry;
 		struct ssd_state_title {
 			char *text;

--- a/include/view.h
+++ b/include/view.h
@@ -495,6 +495,7 @@ void view_toggle_always_on_bottom(struct view *view);
 void view_toggle_visible_on_all_workspaces(struct view *view);
 
 bool view_is_tiled(struct view *view);
+bool view_is_tiled_and_notify_tiled(struct view *view);
 bool view_is_floating(struct view *view);
 void view_move_to_workspace(struct view *view, struct workspace *workspace);
 enum ssd_mode view_get_ssd_mode(struct view *view);

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -117,10 +117,15 @@ ssd_titlebar_create(struct ssd *ssd)
 
 	ssd_update_title(ssd);
 
-	if (view->maximized == VIEW_AXIS_BOTH) {
+	bool maximized = view->maximized == VIEW_AXIS_BOTH;
+	if (maximized) {
 		set_squared_corners(ssd, true);
 		set_maximize_alt_icon(ssd, true);
 		ssd->state.was_maximized = true;
+	}
+	if (view_is_tiled(view) && !maximized) {
+		set_squared_corners(ssd, true);
+		ssd->state.was_tiled_not_maximized = true;
 	}
 }
 
@@ -187,11 +192,16 @@ ssd_titlebar_update(struct ssd *ssd)
 	int width = view->current.width;
 	struct theme *theme = view->server->theme;
 
-	bool maximized = (view->maximized == VIEW_AXIS_BOTH);
-	if (ssd->state.was_maximized != maximized) {
-		set_squared_corners(ssd, maximized);
-		set_maximize_alt_icon(ssd, maximized);
+	bool maximized = view->maximized == VIEW_AXIS_BOTH;
+	bool tiled_not_maximized = view_is_tiled(ssd->view) && !maximized;
+	if (ssd->state.was_maximized != maximized
+			|| ssd->state.was_tiled_not_maximized != tiled_not_maximized) {
+		set_squared_corners(ssd, maximized || tiled_not_maximized);
+		if (ssd->state.was_maximized != maximized) {
+			set_maximize_alt_icon(ssd, maximized);
+		}
 		ssd->state.was_maximized = maximized;
+		ssd->state.was_tiled_not_maximized = tiled_not_maximized;
 	}
 
 	if (width == ssd->state.geometry.width) {

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -123,7 +123,7 @@ ssd_titlebar_create(struct ssd *ssd)
 		set_maximize_alt_icon(ssd, true);
 		ssd->state.was_maximized = true;
 	}
-	if (view_is_tiled(view) && !maximized) {
+	if (view_is_tiled_and_notify_tiled(view) && !maximized) {
 		set_squared_corners(ssd, true);
 		ssd->state.was_tiled_not_maximized = true;
 	}
@@ -193,7 +193,9 @@ ssd_titlebar_update(struct ssd *ssd)
 	struct theme *theme = view->server->theme;
 
 	bool maximized = view->maximized == VIEW_AXIS_BOTH;
-	bool tiled_not_maximized = view_is_tiled(ssd->view) && !maximized;
+	bool tiled_not_maximized = view_is_tiled_and_notify_tiled(ssd->view)
+		&& !maximized;
+
 	if (ssd->state.was_maximized != maximized
 			|| ssd->state.was_tiled_not_maximized != tiled_not_maximized) {
 		set_squared_corners(ssd, maximized || tiled_not_maximized);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -246,7 +246,7 @@ ssd_update_geometry(struct ssd *ssd)
 			ssd_extents_update(ssd);
 			ssd->state.geometry = current;
 		}
-		bool maximized = (ssd->view->maximized == VIEW_AXIS_BOTH);
+		bool maximized = ssd->view->maximized == VIEW_AXIS_BOTH;
 		if (ssd->state.was_maximized != maximized) {
 			ssd_border_update(ssd);
 			ssd_titlebar_update(ssd);
@@ -257,6 +257,12 @@ ssd_update_geometry(struct ssd *ssd)
 			 * proof this a bit we also set it here again.
 			 */
 			ssd->state.was_maximized = maximized;
+		}
+		bool tiled_and_not_maximized = view_is_tiled(ssd->view) && !maximized;
+		if (ssd->state.was_tiled_not_maximized != tiled_and_not_maximized) {
+			ssd_titlebar_update(ssd);
+			/* see above about being future proof */
+			ssd->state.was_tiled_not_maximized = tiled_and_not_maximized;
 		}
 		return;
 	}

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -248,8 +248,8 @@ ssd_update_geometry(struct ssd *ssd)
 		}
 		bool maximized = ssd->view->maximized == VIEW_AXIS_BOTH;
 		if (ssd->state.was_maximized != maximized) {
-			ssd_border_update(ssd);
 			ssd_titlebar_update(ssd);
+			ssd_border_update(ssd);
 			ssd_shadow_update(ssd);
 			/*
 			 * Not strictly necessary as ssd_titlebar_update()
@@ -261,14 +261,15 @@ ssd_update_geometry(struct ssd *ssd)
 		bool tiled_and_not_maximized = view_is_tiled(ssd->view) && !maximized;
 		if (ssd->state.was_tiled_not_maximized != tiled_and_not_maximized) {
 			ssd_titlebar_update(ssd);
+			ssd_border_update(ssd);
 			/* see above about being future proof */
 			ssd->state.was_tiled_not_maximized = tiled_and_not_maximized;
 		}
 		return;
 	}
 	ssd_extents_update(ssd);
-	ssd_border_update(ssd);
 	ssd_titlebar_update(ssd);
+	ssd_border_update(ssd);
 	ssd_shadow_update(ssd);
 	ssd->state.geometry = current;
 }

--- a/src/view.c
+++ b/src/view.c
@@ -1172,6 +1172,23 @@ view_is_tiled(struct view *view)
 }
 
 bool
+view_is_tiled_and_notify_tiled(struct view *view)
+{
+	switch (rc.snap_tiling_events_mode) {
+	case LAB_TILING_EVENTS_NEVER:
+		return false;
+	case LAB_TILING_EVENTS_REGION:
+		return view->tiled_region || view->tiled_region_evacuate;
+	case LAB_TILING_EVENTS_EDGE:
+		return view->tiled;
+	case LAB_TILING_EVENTS_ALWAYS:
+		return view_is_tiled(view);
+	}
+
+	return false;
+}
+
+bool
 view_is_floating(struct view *view)
 {
 	assert(view);


### PR DESCRIPTION
My attempt to solve https://github.com/labwc/labwc/issues/1862 ~Still draft to let this land slowly and give it some time for testing.~

With this PR, my SSD corners look and behave the same as CSD GTK corners which gives a beautiful consistent look.   
A side effect is unfortunately that the "rounded hover effect on square  buttons" can be seen (much) more often.

Closes https://github.com/labwc/labwc/issues/1862