### PR TITLE
Initialize locale after reading ~/.config/environment

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -1,11 +1,18 @@
 i18n = import('i18n')
-add_project_arguments('-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
+
+add_project_arguments(
+  '-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
   '-DLOCALEDIR="' + get_option('prefix') / get_option('localedir') + '"',
-  language:'c')
-i18n.gettext(meson.project_name(),
-  args: ['--directory=' + source_root,
+  language:'c',
+)
+
+i18n.gettext(
+  meson.project_name(),
+  args: [
+    '--directory=' + source_root,
     '--add-comments=TRANSLATORS',
     '--keyword=_',
-    '--msgid-bugs=https://github.com/labwc/labwc/issues'],
-    preset: 'glib'
+    '--msgid-bugs=https://github.com/labwc/labwc/issues',
+  ],
+  preset: 'glib',
 )

--- a/src/main.c
+++ b/src/main.c
@@ -112,11 +112,6 @@ idle_callback(void *data)
 int
 main(int argc, char *argv[])
 {
-#if HAVE_NLS
-	setlocale(LC_ALL, "");
-	bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
-	textdomain(GETTEXT_PACKAGE);
-#endif
 	char *startup_cmd = NULL;
 	char *primary_client = NULL;
 	enum wlr_log_importance verbosity = WLR_ERROR;
@@ -173,6 +168,14 @@ main(int argc, char *argv[])
 	die_on_detecting_suid();
 
 	session_environment_init();
+
+#if HAVE_NLS
+	/* Initialize locale after setting env vars */
+	setlocale(LC_ALL, "");
+	bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
+	textdomain(GETTEXT_PACKAGE);
+#endif
+
 	rcxml_read(rc.config_file);
 
 	/*


### PR DESCRIPTION
Fixes #1901.

This makes the locale for client-menu items and workspace names follow the env var `LANG` defined in `~/.config/environments`.

The first commit is just a minor refactoring.