### PR TITLE
view: don't try to restore to very small width/height on unmaximize

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -841,10 +841,12 @@ view_store_natural_geometry(struct view *view)
 
 	/**
 	 * If an application was started maximized or fullscreened, its
-	 * natural_geometry width/height may still be zero in which case we set
-	 * some fallback values. This is the case with foot and Qt applications.
+	 * natural_geometry width/height may still be zero (or very small
+	 * values) in which case we set some fallback values. This is the case
+	 * with foot and some Qt/Tk applications.
 	 */
-	if (wlr_box_empty(&view->pending)) {
+	if (view->pending.width < LAB_MIN_VIEW_WIDTH
+			|| view->pending.height < LAB_MIN_VIEW_HEIGHT) {
 		set_fallback_geometry(view);
 	} else {
 		view->natural_geometry = view->pending;


### PR DESCRIPTION
Thonny (Python IDE made with Tk) may set the window geometry to 1x1 and maximizes the window before mapping. This set `view->natural_geometry` to 1x1, so labwc tried to restore the window geometry to it on unmaximize, causing validation errors in `ssd_update_geometry()` as its width and height are smaller than `LAB_MIN_VIEW_{WIDTH,HEIGHT}`.

This PR fixes it by not allowing geometries smaller than `LAB_MIN_VIEW_{WIDTH,HEIGHT}` in `view->natural_geometry`.

Closes #1921.