### PR TITLE
feat: add tearing fullscreen options

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -187,7 +187,12 @@ Actions are used in menus and keyboard/mouse bindings.
 	original window. There can be multiple windows with this mode set.
 
 *<action name="ToggleTearing" />*
-	Toggles tearing for the focused window.
+	Toggles tearing for the focused window between enabled and disabled.
+	This overrides the preference (tearing hint) from the focused window.
+
+	Requires the config option 'allowTearing'. When 'allowTearing' is set
+	to 'fullscreen' or 'fullscreenForced', tearing will still only be
+	enabled if the active window is in fullscreen mode.
 
 *<action name="FocusOutput" output="HDMI-A-1" />*
 	Give focus to topmost window on given output and warp the cursor

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -185,9 +185,18 @@ this is for compatibility with Openbox.
 	*fullscreen* enables adaptive sync whenever a window is in fullscreen
 	mode.
 
-*<core><allowTearing>* [yes|no]
-	Allow tearing, if requested by the active window, to reduce input lag.
-	Default is no.
+*<core><allowTearing>* [yes|no|fullscreen|fullscreenForced]
+	Allow tearing to reduce input lag. Default is no.
+
+	*yes* allows tearing if requested by the active window.
+
+	*fullscreen* allows tearing if requested by the active window, but
+	only when the window is in fullscreen mode.
+
+	*fullscreenForced* enables tearing whenever the active window is in
+	fullscreen mode, whether or not the application has requested tearing.
+
+	Use the *ToggleTearing* action for forcefully enable tearing.
 
 	Note: Enabling this option with atomic mode setting is experimental. If
 	you experience undesirable side effects when tearing is allowed,

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -30,6 +30,13 @@ enum adaptive_sync_mode {
 	LAB_ADAPTIVE_SYNC_FULLSCREEN,
 };
 
+enum tearing_mode {
+	LAB_TEARING_DISABLED = 0,
+	LAB_TEARING_ENABLED,
+	LAB_TEARING_FULLSCREEN,
+	LAB_TEARING_FULLSCREEN_FORCED,
+};
+
 enum tiling_events_mode {
 	LAB_TILING_EVENTS_NEVER = 0,
 	LAB_TILING_EVENTS_REGION = 1 << 0,
@@ -54,7 +61,7 @@ struct rcxml {
 	bool xdg_shell_server_side_deco;
 	int gap;
 	enum adaptive_sync_mode adaptive_sync;
-	bool allow_tearing;
+	enum tearing_mode allow_tearing;
 	bool reuse_output_mode;
 	enum view_placement_policy placement_policy;
 	bool xwayland_persistence;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -531,6 +531,7 @@ struct output *output_nearest_to_cursor(struct server *server);
 bool output_is_usable(struct output *output);
 void output_update_usable_area(struct output *output);
 void output_update_all_usable_areas(struct server *server, bool layout_changed);
+bool output_get_tearing_allowance(struct output *output);
 struct wlr_box output_usable_area_in_layout_coords(struct output *output);
 struct wlr_box output_usable_area_scaled(struct output *output);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,

--- a/include/view.h
+++ b/include/view.h
@@ -30,6 +30,12 @@ enum ssd_preference {
 	LAB_SSD_PREF_SERVER,
 };
 
+enum three_state {
+	LAB_STATE_UNSPECIFIED = 0,
+	LAB_STATE_ENABLED,
+	LAB_STATE_DISABLED
+};
+
 /**
  * Directions in which a view can be maximized. "None" is used
  * internally to mean "not maximized" but is not valid in rc.xml.
@@ -187,6 +193,7 @@ struct view {
 	enum view_axis maximized;
 	bool fullscreen;
 	bool tearing_hint;
+	enum three_state force_tearing;
 	bool visible_on_all_workspaces;
 	enum view_edge tiled;
 	uint32_t edges_visible;  /* enum wlr_edges bitset */

--- a/src/action.c
+++ b/src/action.c
@@ -1109,9 +1109,22 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_TOGGLE_TEARING:
 			if (view) {
-				view->tearing_hint = !view->tearing_hint;
-				wlr_log(WLR_DEBUG, "tearing %sabled",
-					view->tearing_hint ? "en" : "dis");
+				switch (view->force_tearing) {
+				case LAB_STATE_UNSPECIFIED:
+					view->force_tearing =
+						output_get_tearing_allowance(view->output)
+							? LAB_STATE_DISABLED : LAB_STATE_ENABLED;
+					break;
+				case LAB_STATE_DISABLED:
+					view->force_tearing = LAB_STATE_ENABLED;
+					break;
+				case LAB_STATE_ENABLED:
+					view->force_tearing = LAB_STATE_DISABLED;
+					break;
+				}
+				wlr_log(WLR_ERROR, "force tearing %sabled",
+					view->force_tearing == LAB_STATE_ENABLED
+						? "en" : "dis");
 			}
 			break;
 		case ACTION_TYPE_TOGGLE_SHADE:

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -771,6 +771,20 @@ set_adaptive_sync_mode(const char *str, enum adaptive_sync_mode *variable)
 }
 
 static void
+set_tearing_mode(const char *str, enum tearing_mode *variable)
+{
+	if (!strcasecmp(str, "fullscreen")) {
+		*variable = LAB_TEARING_FULLSCREEN;
+	} else if (!strcasecmp(str, "fullscreenForced")) {
+		*variable = LAB_TEARING_FULLSCREEN_FORCED;
+	} else if (parse_bool(str, -1) == 1) {
+		*variable = LAB_TEARING_ENABLED;
+	} else {
+		*variable = LAB_TEARING_DISABLED;
+	}
+}
+
+static void
 entry(xmlNode *node, char *nodename, char *content)
 {
 	/* current <theme><font place=""></font></theme> */
@@ -884,7 +898,7 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "adaptiveSync.core")) {
 		set_adaptive_sync_mode(content, &rc.adaptive_sync);
 	} else if (!strcasecmp(nodename, "allowTearing.core")) {
-		set_bool(content, &rc.allow_tearing);
+		set_tearing_mode(content, &rc.allow_tearing);
 	} else if (!strcasecmp(nodename, "reuseOutputMode.core")) {
 		set_bool(content, &rc.reuse_output_mode);
 	} else if (!strcmp(nodename, "policy.placement")) {

--- a/src/tearing.c
+++ b/src/tearing.c
@@ -15,8 +15,15 @@ set_tearing_hint(struct wl_listener *listener, void *data)
 {
 	struct tearing_controller *controller = wl_container_of(listener, controller, set_hint);
 	struct view *view = view_from_wlr_surface(controller->tearing_control->surface);
-	if (view && controller->tearing_control->current) {
-		view->tearing_hint = true;
+	if (view) {
+		/*
+		 * tearing_control->current is actually an enum:
+		 * WP_TEARING_CONTROL_V1_PRESENTATION_HINT_VSYNC = 0
+		 * WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC = 1
+		 *
+		 * Using it as a bool here allows us to not ship the XML.
+		 */
+		view->tearing_hint = controller->tearing_control->current;
 	}
 }
 


### PR DESCRIPTION
This is a slightly different approach to https://github.com/labwc/labwc/pull/1568

Whereas https://github.com/labwc/labwc/pull/1568 (forcefully) enables tearing when the active window is full screen and still allows tearing for non-fullscreen windows when the window hints tearing, this PR interprets  the 'fullscreen' option  as a restriction on top of the existing allow tearing ('yes') option. So 'fullscreen' here means "allow tearing *only* in fullscreen state". Additionally  the toggle action overrides the application preference. So once you started toggling, the application preference is ignored. I hope I described this clearly in the docs as part of this PR. 

I'm using the gsync demo from https://github.com/labwc/labwc/pull/1568#issuecomment-1986931068 for testing. Starting this via wine, the tearing hint is set repeatedly by the application. I found it slightly confusing that the toggle action didn't allowed me to disable tearing (on master). Technically the toggle did disable tearing, but it got immediately overridden again by the window, so it looked liked the toggle had no effect. Hence the changed behavior to ignore the hint when toggle to tearing disabled.

What the 'fullscreen' option should do is a matter of preference.  The idea from https://github.com/labwc/labwc/pull/1568 where 'fullscreen' ignores the tearing hint, is still valid and may be this option should be available as well. Also not sure which interpretation makes the most sense. May be it depends on how wisely applications set the tearing hint. To my surprise, the tearing hint was set with wine and demo above (unless I screwed up and something is wrong with the tearing hint now).  

Open for thoughts and feedback.

cc: @Ph42oN @Faugus

PS: Most of this PR is still based on @Consolatis work, hence the Co-Authored in the commit message.