### PR TITLE
menu: move menu_tree to front

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -369,6 +369,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 	 * Set the z-positions to achieve the following order (from top to
 	 * bottom):
 	 *	- session lock layer
+	 *	- compositor menu
 	 *	- layer-shell popups
 	 *	- overlay layer
 	 *	- top layer
@@ -381,6 +382,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 	wlr_scene_node_raise_to_top(&output->layer_tree[2]->node);
 	wlr_scene_node_raise_to_top(&output->layer_tree[3]->node);
 	wlr_scene_node_raise_to_top(&output->layer_popup_tree->node);
+	wlr_scene_node_raise_to_top(&server->menu_tree->node);
 	wlr_scene_node_raise_to_top(&output->session_lock_tree->node);
 
 	/*

--- a/src/server.c
+++ b/src/server.c
@@ -423,6 +423,7 @@ server_init(struct server *server)
 	 * | Type              | Scene Tree       | Per Output | Example
 	 * | ----------------- | ---------------- | ---------- | -------
 	 * | ext-session       | lock-screen      | Yes        | swaylock
+	 * | compositor-menu   | menu_tree        | No         | root-menu
 	 * | layer-shell       | layer-popups     | Yes        |
 	 * | layer-shell       | overlay-layer    | Yes        |
 	 * | layer-shell       | top-layer        | Yes        | waybar
@@ -443,6 +444,11 @@ server_init(struct server *server)
 #if HAVE_XWAYLAND
 	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->tree);
 #endif
+
+	/*
+	 * menu_tree is moved to top in new_output_notify() when layer-shell
+	 * layers are positioned
+	 */
 	server->menu_tree = wlr_scene_tree_create(&server->scene->tree);
 
 	workspaces_init(server);


### PR DESCRIPTION
Also, always top-align submenus intead of inheriting the vertical alignment of their parent. This is consitent with Openbox behaviour.

Related-to: #1150