### PR TITLE
ssd: allow ssd to be smaller than minimal size

### DIFF
--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -114,6 +114,7 @@ ssd_border_update(struct ssd *ssd)
 	int top_width = ssd->titlebar.height <= 0 || ssd->state.was_tiled_not_maximized
 		? full_width
 		: width - 2 * SSD_BUTTON_WIDTH;
+	top_width = MAX(0, top_width);
 	int top_x = ssd->titlebar.height <= 0 || ssd->state.was_tiled_not_maximized
 		? 0
 		: theme->border_width + SSD_BUTTON_WIDTH;

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -113,6 +113,9 @@ ssd_extents_update(struct ssd *ssd)
 	int side_width = full_width + extended_area * 2 - corner_size * 2;
 	int side_height = full_height + extended_area * 2 - corner_size * 2;
 
+	side_width = MAX(0, side_width);
+	side_height = MAX(0, side_height);
+
 	struct wlr_box part_box;
 	struct wlr_box result_box;
 	struct ssd_part *part;

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -131,7 +131,7 @@ set_shadow_part_geometry(struct ssd_part *part, int width, int height,
 		y = -titlebar_height + inset;
 		wlr_scene_node_set_position(part->node, x, y);
 		wlr_scene_buffer_set_dest_size(
-			scene_buf, visible_shadow_width, height - 2 * inset);
+			scene_buf, visible_shadow_width, MAX(0, height - 2 * inset));
 		wlr_scene_node_set_enabled(part->node, show_sides);
 		break;
 	case LAB_SSD_PART_BOTTOM:
@@ -139,7 +139,7 @@ set_shadow_part_geometry(struct ssd_part *part, int width, int height,
 		y = -titlebar_height + height;
 		wlr_scene_node_set_position(part->node, x, y);
 		wlr_scene_buffer_set_dest_size(
-			scene_buf, width - 2 * inset, visible_shadow_width);
+			scene_buf, MAX(0, width - 2 * inset), visible_shadow_width);
 		wlr_scene_node_set_enabled(part->node, show_topbottom);
 		break;
 	case LAB_SSD_PART_LEFT:
@@ -147,7 +147,7 @@ set_shadow_part_geometry(struct ssd_part *part, int width, int height,
 		y = -titlebar_height + inset;
 		wlr_scene_node_set_position(part->node, x, y);
 		wlr_scene_buffer_set_dest_size(
-			scene_buf, visible_shadow_width, height - 2 * inset);
+			scene_buf, visible_shadow_width, MAX(0, height - 2 * inset));
 		wlr_scene_node_set_enabled(part->node, show_sides);
 		break;
 	case LAB_SSD_PART_TOP:
@@ -155,7 +155,7 @@ set_shadow_part_geometry(struct ssd_part *part, int width, int height,
 		y = -titlebar_height - visible_shadow_width;
 		wlr_scene_node_set_position(part->node, x, y);
 		wlr_scene_buffer_set_dest_size(
-			scene_buf, width - 2 * inset, visible_shadow_width);
+			scene_buf, MAX(0, width - 2 * inset), visible_shadow_width);
 		wlr_scene_node_set_enabled(part->node, show_topbottom);
 		break;
 	default:

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -218,7 +218,8 @@ ssd_titlebar_update(struct ssd *ssd)
 			case LAB_SSD_PART_TITLEBAR:
 				wlr_scene_rect_set_size(
 					wlr_scene_rect_from_node(part->node),
-					width - SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT,
+					MAX(0, width -
+						SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT),
 					theme->title_height);
 				continue;
 			case LAB_SSD_BUTTON_ICONIFY:

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -230,16 +230,6 @@ ssd_update_geometry(struct ssd *ssd)
 	int eff_width = current.width;
 	int eff_height = view_effective_height(ssd->view, /* use_pending */ false);
 
-	if (eff_width > 0 && eff_width < LAB_MIN_VIEW_WIDTH) {
-		/*
-		 * Prevent negative values in calculations like
-		 * `width - SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT`
-		 */
-		wlr_log(WLR_ERROR,
-			"view width is smaller than its minimal value");
-		return;
-	}
-
 	if (eff_width == cached.width && eff_height == cached.height) {
 		if (current.x != cached.x || current.y != cached.y) {
 			/* Dynamically resize extents based on position and usable_area */


### PR DESCRIPTION
Another approach for #1762.

Note that I don't understand the logic of `ssd_*_update()`. I just fixed pixman errors while testing with [my test client with 1x1 geometry](https://github.com/tokyo4j/wayland-demo/tree/deco-1x1).

Fixes #1947.