### PR TITLE
xdg: support xdg-shell v3 with popup repositioning

### DIFF
--- a/include/layers.h
+++ b/include/layers.h
@@ -32,6 +32,7 @@ struct lab_layer_popup {
 	struct wl_listener commit;
 	struct wl_listener destroy;
 	struct wl_listener new_popup;
+	struct wl_listener reposition;
 };
 
 void layers_init(struct server *server);

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -14,7 +14,7 @@
 #include "window-rules.h"
 #include "workspaces.h"
 
-#define LAB_XDG_SHELL_VERSION (2)
+#define LAB_XDG_SHELL_VERSION (3)
 #define CONFIGURE_TIMEOUT_MS 100
 
 static struct xdg_toplevel_view *


### PR DESCRIPTION
See https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3514 which added support on the wlroots side.

We now re-run popup positioning (for both xdg-shell and layer-shell popups) when the "reposition" event is received. This allows popups that change size (such as qmpanel's applications menu) to be positioned correctly.

xdg-shell v3 also gives the compositor some additional "hints" for popup positioning (reactive, parent_size, and parent_configure_serial) which are available but we don't make use of currently.