### PR TITLE
session-lock: fix some bugs related to keyboard focus etc.

### DIFF
--- a/include/session-lock.h
+++ b/include/session-lock.h
@@ -19,7 +19,7 @@ struct session_lock_manager {
 	struct wlr_session_lock_v1 *lock;
 	bool locked;
 
-	struct wl_list session_lock_outputs;
+	struct wl_list lock_outputs;
 
 	struct wl_listener new_lock;
 	struct wl_listener destroy;

--- a/include/session-lock.h
+++ b/include/session-lock.h
@@ -10,6 +10,8 @@ struct server;
 struct session_lock_manager {
 	struct server *server;
 	struct wlr_session_lock_manager_v1 *wlr_manager;
+	/* View re-focused on unlock */
+	struct view *last_active_view;
 	struct wlr_surface *focused;
 	/*
 	 * When not locked: lock=NULL, locked=false

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -287,6 +287,7 @@ handle_lock_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&manager->lock_destroy.link);
 	wl_list_remove(&manager->lock_unlock.link);
 	wl_list_remove(&manager->lock_new_surface.link);
+	manager->lock = NULL;
 }
 
 static void
@@ -323,6 +324,7 @@ handle_new_session_lock(struct wl_listener *listener, void *data)
 	wl_signal_add(&lock->events.destroy, &manager->lock_destroy);
 
 	manager->locked = true;
+	manager->lock = lock;
 	wlr_session_lock_v1_send_locked(lock);
 }
 

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -276,12 +276,6 @@ handle_lock_destroy(struct wl_listener *listener, void *data)
 	struct session_lock_manager *manager =
 		wl_container_of(listener, manager, lock_destroy);
 
-	float *black = (float[4]) { 0.f, 0.f, 0.f, 1.f };
-	struct session_lock_output *lock_output;
-	wl_list_for_each(lock_output, &manager->session_lock_outputs, link) {
-		wlr_scene_rect_set_color(lock_output->background, black);
-	}
-
 	wl_list_remove(&manager->lock_destroy.link);
 	wl_list_remove(&manager->lock_unlock.link);
 	wl_list_remove(&manager->lock_new_surface.link);

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -318,6 +318,7 @@ handle_new_session_lock(struct wl_listener *listener, void *data)
 
 	/* Remember the focused view to restore it on unlock */
 	manager->last_active_view = manager->server->active_view;
+	seat_focus_surface(&manager->server->seat, NULL);
 
 	struct output *output;
 	wl_list_for_each(output, &manager->server->outputs, link) {

--- a/src/view.c
+++ b/src/view.c
@@ -2396,6 +2396,10 @@ view_destroy(struct view *view)
 		server->active_view = NULL;
 	}
 
+	if (server->session_lock_manager->last_active_view == view) {
+		server->session_lock_manager->last_active_view = NULL;
+	}
+
 	if (server->last_raised_view == view) {
 		server->last_raised_view = NULL;
 	}


### PR DESCRIPTION
- Fix #1943
- Fix a bug I introduced in #1858 that allowed multiple clients to lock the screen.
- Clear keyboard focus on lock so keyboard events are never sent to normal surfaces once the screen is locked, even when the session-lock client haven't mapped its surface yet.