### PR TITLE
Remove subprojects/seatd.wrap as no longer needed

### DIFF
--- a/subprojects/seatd.wrap
+++ b/subprojects/seatd.wrap
@@ -1,4 +1,0 @@
-[wrap-git]
-url=https://git.sr.ht/~kennylevinsen/seatd
-revision=0.6.4
-


### PR DESCRIPTION
IIRC this was just a prop for building wlroots when the move to seatd happened and it wasn't yet common in repos.