### PR TITLE
ssd: allow ssd to be smaller than minimal size

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -59,6 +59,8 @@ struct ssd {
 		} title;
 	} state;
 
+	struct wlr_scene_rect *view_background;
+
 	/* An invisible area around the view which allows resizing */
 	struct ssd_sub_tree extents;
 

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -82,7 +82,7 @@ ssd_border_update(struct ssd *ssd)
 
 	struct theme *theme = view->server->theme;
 
-	int width = view->current.width;
+	int width = MAX(view->current.width, LAB_MIN_VIEW_WIDTH);
 	int height = view_effective_height(view, /* use_pending */ false);
 	int full_width = width + 2 * theme->border_width;
 

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -104,7 +104,7 @@ ssd_extents_update(struct ssd *ssd)
 
 	struct theme *theme = view->server->theme;
 
-	int width = view->current.width;
+	int width = MAX(view->current.width, LAB_MIN_VIEW_WIDTH);
 	int height = view_effective_height(view, /* use_pending */ false);
 	int full_height = height + theme->border_width * 2 + ssd->titlebar.height;
 	int full_width = width + 2 * theme->border_width;

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -169,7 +169,7 @@ set_shadow_geometry(struct ssd *ssd)
 	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
 	int titlebar_height = ssd->titlebar.height;
-	int width = view->current.width;
+	int width = MAX(view->current.width, LAB_MIN_VIEW_WIDTH);
 	int height = view_effective_height(view, false) + titlebar_height;
 
 	struct ssd_part *part;

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -210,6 +210,8 @@ ssd_titlebar_update(struct ssd *ssd)
 		return;
 	}
 
+	int title_bar_width = MAX(0, width - SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT);
+
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
 	FOR_EACH_STATE(ssd, subtree) {
@@ -218,25 +220,25 @@ ssd_titlebar_update(struct ssd *ssd)
 			case LAB_SSD_PART_TITLEBAR:
 				wlr_scene_rect_set_size(
 					wlr_scene_rect_from_node(part->node),
-					width - SSD_BUTTON_WIDTH * SSD_BUTTON_COUNT,
+					title_bar_width,
 					theme->title_height);
 				continue;
 			case LAB_SSD_BUTTON_ICONIFY:
 				if (is_direct_child(part->node, subtree)) {
 					wlr_scene_node_set_position(part->node,
-						width - SSD_BUTTON_WIDTH * 3, 0);
+						title_bar_width + 1 * SSD_BUTTON_WIDTH, 0);
 				}
 				continue;
 			case LAB_SSD_BUTTON_MAXIMIZE:
 				if (is_direct_child(part->node, subtree)) {
 					wlr_scene_node_set_position(part->node,
-						width - SSD_BUTTON_WIDTH * 2, 0);
+						title_bar_width + 2 * SSD_BUTTON_WIDTH, 0);
 				}
 				continue;
 			case LAB_SSD_PART_CORNER_TOP_RIGHT:
 				if (is_direct_child(part->node, subtree)) {
 					wlr_scene_node_set_position(part->node,
-						width - SSD_BUTTON_WIDTH * 1, 0);
+						title_bar_width + 3 * SSD_BUTTON_WIDTH, 0);
 				}
 				continue;
 			default:


### PR DESCRIPTION
With 2603dbf labwc refused to update ssd geometry when its geometry is smaller than minimal size in order to prevent passing negative values in wlr_scene_rect_set_size(), but it made ssd for small windows like workrave ugly. So this commit fixes the negative values for each call to wlr_scene_rect_set_size() individually rather than just early-return in ssd_update_geometry().

---

Follow-up from
- #1949