### PR TITLE
xwayland: allow persistence

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -194,6 +194,13 @@ this is for compatibility with Openbox.
 	be used with labwc the preferred mode of the monitor is used instead.
 	Default is no.
 
+*<core><xwaylandPersistence>* [yes|no]
+	Keep XWayland alive even when no clients are connected, rather than
+	using a "lazy" policy that allows the server to launch on demand and die
+	when it is no longer needed. Default is no.
+
+	Note: changing this setting requires a restart of labwc.
+
 ## PLACEMENT
 
 *<placement><policy>* [center|automatic|cursor]

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -13,6 +13,7 @@
     <adaptiveSync>no</adaptiveSync>
     <allowTearing>no</allowTearing>
     <reuseOutputMode>no</reuseOutputMode>
+    <xwaylandPersistence>no</xwaylandPersistence>
   </core>
 
   <placement>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -55,6 +55,7 @@ struct rcxml {
 	bool allow_tearing;
 	bool reuse_output_mode;
 	enum view_placement_policy placement_policy;
+	bool xwayland_persistence;
 
 	/* focus */
 	bool focus_follow_mouse;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -899,6 +899,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		if (rc.placement_policy == LAB_PLACE_INVALID) {
 			rc.placement_policy = LAB_PLACE_CENTER;
 		}
+	} else if (!strcasecmp(nodename, "xwaylandPersistence.core")) {
+		set_bool(content, &rc.xwayland_persistence);
 	} else if (!strcmp(nodename, "name.theme")) {
 		rc.theme_name = xstrdup(content);
 	} else if (!strcmp(nodename, "cornerradius.theme")) {

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -6,6 +6,7 @@
 #include "common/array.h"
 #include "common/macros.h"
 #include "common/mem.h"
+#include "config/rcxml.h"
 #include "labwc.h"
 #include "node.h"
 #include "ssd.h"
@@ -1052,7 +1053,8 @@ void
 xwayland_server_init(struct server *server, struct wlr_compositor *compositor)
 {
 	server->xwayland =
-		wlr_xwayland_create(server->wl_display, compositor, true);
+		wlr_xwayland_create(server->wl_display,
+			compositor, /* lazy */ !rc.xwayland_persistence);
 	if (!server->xwayland) {
 		wlr_log(WLR_ERROR, "cannot create xwayland server");
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
This seems to work as expected, keeping the server alive indefinitely at launch rather than allowing it to die.
- Changing the configuration option and reconfiguring does not change the behavior, because the wlroots xwayland object is still the same as was created at launch. Changing the behavior requires a compositor restart. Do we care? Attempting to fix this would seem to require terminating the X server, which could be catastrophic for any connected clients.
- Is there a better name or placement for the configuration option?

Closes: #1958.