### PR TITLE
feat: support relative tablet motion

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -730,6 +730,24 @@ extending outward from the snapped edge.
 
 	See mouse section above for all supported mouse buttons.
 
+## TABLET TOOL
+
+```
+<tabletTool motion="absolute" relativeMotionSensitivity="1" />
+```
+
+*<tabletTool motion="">* [absolute|relative]
+	All tablet tools, except of type mouse and lens, use "absolute"
+	positioning by default. The *motion* attribute allows to set tools
+	to relative motion instead. Positioning for a tablet mouse or
+	tablet lens cannot be changed, those tools always use relative mode.
+
+*<tabletTool relativeMotionSensitivity="">*
+	When using relative motion, *relativeMotionSensitivity* controls
+	the speed of the cursor. Using a value lower than 1.0 decreases the
+	speed, using a value greater than 1.0 increases the speed of the
+	cursor. The default is "1.0".
+
 ## LIBINPUT
 
 ```

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -522,6 +522,16 @@
   </tablet>
 
   <!--
+    All tablet tools, except of type mouse and lens, use absolute
+    positioning by default. The *motion* attribute allows to set tools
+    to relative motion instead. When using relative motion,
+    *relativeMotionSensitivity* controls the speed of the cursor. Using
+    a value lower than 1.0 decreases the speed, using a value greater than
+    1.0 increases the speed of the cursor.
+  -->
+  <tabletTool motion="absolute" relativeMotionSensitivity="1.0" />
+
+  <!--
     The *category* attribute is optional and can be set to touch, touchpad,
     non-touch, default or the name of a device. You can obtain device names by
     running *libinput list-devices* as root or member of the input group.

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -11,6 +11,7 @@
 #include "common/font.h"
 #include "config/touch.h"
 #include "config/tablet.h"
+#include "config/tablet-tool.h"
 #include "config/libinput.h"
 #include "resize-indicator.h"
 #include "theme.h"
@@ -102,6 +103,9 @@ struct rcxml {
 		uint16_t button_map_count;
 		struct button_map_entry button_map[BUTTON_MAP_MAX];
 	} tablet;
+	struct tablet_tool_config {
+		enum motion motion;
+	} tablet_tool;
 
 	/* libinput */
 	struct wl_list libinput_categories;

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -105,6 +105,7 @@ struct rcxml {
 	} tablet;
 	struct tablet_tool_config {
 		enum motion motion;
+		double relative_motion_sensitivity;
 	} tablet_tool;
 
 	/* libinput */

--- a/include/config/tablet-tool.h
+++ b/include/config/tablet-tool.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_TABLET_TOOL_CONFIG_H
+#define LABWC_TABLET_TOOL_CONFIG_H
+
+#include <stdint.h>
+
+enum motion {
+	LAB_TABLET_MOTION_ABSOLUTE = 0,
+	LAB_TABLET_MOTION_RELATIVE,
+};
+
+enum motion tablet_parse_motion(const char *name);
+
+#endif /* LABWC_TABLET_TOOL_CONFIG_H */

--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -146,6 +146,9 @@ bool cursor_finish_button_release(struct seat *seat);
 
 void cursor_init(struct seat *seat);
 void cursor_reload(struct seat *seat);
+void cursor_emulate_move(struct seat *seat,
+		struct wlr_input_device *device,
+		double dx, double dy, uint32_t time_msec);
 void cursor_emulate_move_absolute(struct seat *seat,
 		struct wlr_input_device *device,
 		double x, double y, uint32_t time_msec);

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -9,12 +9,18 @@ struct seat;
 struct wlr_device;
 struct wlr_input_device;
 
+enum lab_tablet_motion_mode {
+	LAB_TABLET_MOTION_ABSOLUTE = 0,
+	LAB_TABLET_MOTION_RELATIVE,
+};
+
 struct drawing_tablet {
 	struct wlr_input_device *wlr_input_device;
 	struct seat *seat;
 	struct wlr_tablet *tablet;
 	struct wlr_tablet_v2_tablet *tablet_v2;
-	double x, y;
+	enum lab_tablet_motion_mode motion_mode;
+	double x, y, dx, dy;
 	double distance;
 	double pressure;
 	double tilt_x, tilt_y;

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -9,17 +9,12 @@ struct seat;
 struct wlr_device;
 struct wlr_input_device;
 
-enum lab_tablet_motion_mode {
-	LAB_TABLET_MOTION_ABSOLUTE = 0,
-	LAB_TABLET_MOTION_RELATIVE,
-};
-
 struct drawing_tablet {
 	struct wlr_input_device *wlr_input_device;
 	struct seat *seat;
 	struct wlr_tablet *tablet;
 	struct wlr_tablet_v2_tablet *tablet_v2;
-	enum lab_tablet_motion_mode motion_mode;
+	enum motion motion_mode;
 	double x, y, dx, dy;
 	double distance;
 	double pressure;

--- a/src/config/meson.build
+++ b/src/config/meson.build
@@ -5,5 +5,6 @@ labwc_sources += files(
   'mousebind.c',
   'touch.c',
   'tablet.c',
+  'tablet-tool.c',
   'libinput.c',
 )

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1063,6 +1063,9 @@ entry(xmlNode *node, char *nodename, char *content)
 		}
 	} else if (!strcasecmp(nodename, "motion.tabletTool")) {
 		rc.tablet_tool.motion = tablet_parse_motion(content);
+	} else if (!strcasecmp(nodename, "relativeMotionSensitivity.tabletTool")) {
+		rc.tablet_tool.relative_motion_sensitivity =
+			tablet_get_dbl_if_positive(content, "relativeMotionSensitivity");
 	} else if (!strcasecmp(nodename, "ignoreButtonReleasePeriod.menu")) {
 		rc.menu_ignore_button_release_period = atoi(content);
 	} else if (!strcasecmp(nodename, "width.magnifier")) {
@@ -1255,6 +1258,7 @@ rcxml_init(void)
 	rc.tablet.box = (struct wlr_fbox){0};
 	tablet_load_default_button_mappings();
 	rc.tablet_tool.motion = LAB_TABLET_MOTION_ABSOLUTE;
+	rc.tablet_tool.relative_motion_sensitivity = 1.0;
 
 	rc.repeat_rate = 25;
 	rc.repeat_delay = 600;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1061,6 +1061,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "Missing 'button' argument for tablet button mapping");
 		}
+	} else if (!strcasecmp(nodename, "motion.tabletTool")) {
+		rc.tablet_tool.motion = tablet_parse_motion(content);
 	} else if (!strcasecmp(nodename, "ignoreButtonReleasePeriod.menu")) {
 		rc.menu_ignore_button_release_period = atoi(content);
 	} else if (!strcasecmp(nodename, "width.magnifier")) {
@@ -1252,6 +1254,7 @@ rcxml_init(void)
 	rc.tablet.rotation = 0;
 	rc.tablet.box = (struct wlr_fbox){0};
 	tablet_load_default_button_mappings();
+	rc.tablet_tool.motion = LAB_TABLET_MOTION_ABSOLUTE;
 
 	rc.repeat_rate = 25;
 	rc.repeat_delay = 600;

--- a/src/config/tablet-tool.c
+++ b/src/config/tablet-tool.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include <strings.h>
+#include <wlr/util/log.h>
+#include "config/tablet-tool.h"
+
+enum motion
+tablet_parse_motion(const char *name)
+{
+	if (!strcasecmp(name, "Absolute")) {
+		return LAB_TABLET_MOTION_ABSOLUTE;
+	} else if (!strcasecmp(name, "Relative")) {
+		return LAB_TABLET_MOTION_RELATIVE;
+	}
+	wlr_log(WLR_ERROR, "Invalid value for tablet motion: %s", name);
+	return LAB_TABLET_MOTION_ABSOLUTE;
+}

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1184,18 +1184,9 @@ cursor_button(struct wl_listener *listener, void *data)
 }
 
 void
-cursor_emulate_move_absolute(struct seat *seat, struct wlr_input_device *device,
-		double x, double y, uint32_t time_msec)
+cursor_emulate_move(struct seat *seat, struct wlr_input_device *device,
+		double dx, double dy, uint32_t time_msec)
 {
-	idle_manager_notify_activity(seat->seat);
-
-	double lx, ly;
-	wlr_cursor_absolute_to_layout_coords(seat->cursor,
-		device, x, y, &lx, &ly);
-
-	double dx = lx - seat->cursor->x;
-	double dy = ly - seat->cursor->y;
-
 	if (!dx && !dy) {
 		wlr_log(WLR_DEBUG, "dropping useless cursor_emulate: %.10f,%.10f", dx, dy);
 		return;
@@ -1213,6 +1204,22 @@ cursor_emulate_move_absolute(struct seat *seat, struct wlr_input_device *device,
 		wlr_seat_pointer_notify_motion(seat->seat, time_msec, sx, sy);
 	}
 	wlr_seat_pointer_notify_frame(seat->seat);
+}
+
+void
+cursor_emulate_move_absolute(struct seat *seat, struct wlr_input_device *device,
+		double x, double y, uint32_t time_msec)
+{
+	idle_manager_notify_activity(seat->seat);
+
+	double lx, ly;
+	wlr_cursor_absolute_to_layout_coords(seat->cursor,
+		device, x, y, &lx, &ly);
+
+	double dx = lx - seat->cursor->x;
+	double dy = ly - seat->cursor->y;
+
+	cursor_emulate_move(seat, device, dx, dy, time_msec);
 }
 
 void

--- a/src/input/tablet-pad.c
+++ b/src/input/tablet-pad.c
@@ -183,6 +183,10 @@ tablet_pad_init(struct seat *seat, struct wlr_input_device *wlr_device)
 			seat->server->tablet_manager, seat->seat, wlr_device);
 	}
 	pad->pad->data = pad;
+	wlr_log(WLR_INFO, "tablet pad capabilities: %zu button(s) %zu strip(s) %zu ring(s)",
+		pad->pad->button_count,
+		pad->pad->strip_count,
+		pad->pad->ring_count);
 	CONNECT_SIGNAL(pad->pad, &pad->handlers, button);
 	CONNECT_SIGNAL(pad->pad, &pad->handlers, ring);
 	CONNECT_SIGNAL(pad->pad, &pad->handlers, strip);

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -20,7 +20,7 @@
 #include "action.h"
 
 static enum motion
-tool_motion_mode(struct wlr_tablet_tool *tool)
+tool_motion_mode(enum motion motion, struct wlr_tablet_tool *tool)
 {
 	/*
 	 * Absolute positioning doesn't make sense
@@ -31,7 +31,7 @@ tool_motion_mode(struct wlr_tablet_tool *tool)
 	case WLR_TABLET_TOOL_TYPE_LENS:
 		return LAB_TABLET_MOTION_RELATIVE;
 	default:
-		return LAB_TABLET_MOTION_ABSOLUTE;
+		return motion;
 	}
 }
 
@@ -235,7 +235,8 @@ handle_proximity(struct wl_listener *listener, void *data)
 	struct drawing_tablet_tool *tool = ev->tool->data;
 
 	if (ev->state == WLR_TABLET_TOOL_PROXIMITY_IN) {
-		tablet->motion_mode = tool_motion_mode(ev->tool);
+		tablet->motion_mode =
+			tool_motion_mode(rc.tablet_tool.motion, ev->tool);
 	}
 
 	/*

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -19,7 +19,7 @@
 #include "idle.h"
 #include "action.h"
 
-static enum lab_tablet_motion_mode
+static enum motion
 tool_motion_mode(struct wlr_tablet_tool *tool)
 {
 	/*

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -19,15 +19,19 @@
 #include "idle.h"
 #include "action.h"
 
-static bool
-tool_supports_absolute_motion(struct wlr_tablet_tool *tool)
+static enum lab_tablet_motion_mode
+tool_motion_mode(struct wlr_tablet_tool *tool)
 {
+	/*
+	 * Absolute positioning doesn't make sense
+	 * for tablet mouses and lenses.
+	 */
 	switch (tool->type) {
 	case WLR_TABLET_TOOL_TYPE_MOUSE:
 	case WLR_TABLET_TOOL_TYPE_LENS:
-		return false;
+		return LAB_TABLET_MOTION_RELATIVE;
 	default:
-		return true;
+		return LAB_TABLET_MOTION_ABSOLUTE;
 	}
 }
 
@@ -108,29 +112,47 @@ adjust_for_rotation_relative(enum rotation rotation, double *dx, double *dy)
 }
 
 static struct wlr_surface*
-tablet_get_coords(struct drawing_tablet *tablet, double *x, double *y)
+tablet_get_coords(struct drawing_tablet *tablet, double *x, double *y, double *dx, double *dy)
 {
 	*x = tablet->x;
 	*y = tablet->y;
+	*dx = tablet->dx;
+	*dy = tablet->dy;
 	adjust_for_tablet_area(tablet->tablet->width_mm, tablet->tablet->height_mm,
 		rc.tablet.box, x, y);
 	adjust_for_rotation(rc.tablet.rotation, x, y);
+	adjust_for_rotation_relative(rc.tablet.rotation, dx, dy);
 
 	if (rc.tablet.force_mouse_emulation
 			|| !tablet->tablet_v2) {
 		return NULL;
 	}
 
-	/* Convert coordinates: first [0, 1] => layout, then layout => surface */
-	double lx, ly;
-	wlr_cursor_absolute_to_layout_coords(tablet->seat->cursor,
-		tablet->wlr_input_device, *x, *y, &lx, &ly);
+	/* convert coordinates: first [0, 1] => layout, then layout => surface */
+
+	/* initialize here to avoid a maybe-uninitialized compiler warning */
+	double lx = -1, ly = -1;
+	switch (tablet->motion_mode) {
+	case LAB_TABLET_MOTION_ABSOLUTE:
+		wlr_cursor_absolute_to_layout_coords(tablet->seat->cursor,
+			tablet->wlr_input_device, *x, *y, &lx, &ly);
+		break;
+	case LAB_TABLET_MOTION_RELATIVE:
+		/*
+		 * Deltas dx,dy will be directly passed into wlr_cursor_move,
+		 * so we can add those directly here to determine our future
+		 * position.
+		 */
+		lx = tablet->seat->cursor->x + *dx;
+		ly = tablet->seat->cursor->y + *dy;
+		break;
+	}
 
 	double sx, sy;
 	struct wlr_scene_node *node =
 		wlr_scene_node_at(&tablet->seat->server->scene->tree.node, lx, ly, &sx, &sy);
 
-	/* Find the surface and return it if it accepts tablet events */
+	/* find the surface and return it if it accepts tablet events */
 	struct wlr_surface *surface = lab_wlr_surface_from_node(node);
 
 	if (surface && !wlr_surface_accepts_tablet_v2(tablet->tablet_v2, surface)) {
@@ -141,7 +163,8 @@ tablet_get_coords(struct drawing_tablet *tablet, double *x, double *y)
 
 static void
 notify_motion(struct drawing_tablet *tablet, struct drawing_tablet_tool *tool,
-		struct wlr_surface *surface, double x, double y, uint32_t time)
+		struct wlr_surface *surface, double x, double y, double dx, double dy,
+		uint32_t time)
 {
 	idle_manager_notify_activity(tool->seat->seat);
 
@@ -153,8 +176,16 @@ notify_motion(struct drawing_tablet *tablet, struct drawing_tablet_tool *tool,
 			tablet->tablet_v2, surface);
 	}
 
-	wlr_cursor_warp_absolute(tablet->seat->cursor,
-		tablet->wlr_input_device, x, y);
+	switch (tablet->motion_mode) {
+	case LAB_TABLET_MOTION_ABSOLUTE:
+		wlr_cursor_warp_absolute(tablet->seat->cursor,
+			tablet->wlr_input_device, x, y);
+		break;
+	case LAB_TABLET_MOTION_RELATIVE:
+		wlr_cursor_move(tablet->seat->cursor,
+			tablet->wlr_input_device, dx, dy);
+		break;
+	}
 
 	double sx, sy;
 	bool notify = cursor_process_motion(tablet->seat->server, time, &sx, &sy);
@@ -203,18 +234,22 @@ handle_proximity(struct wl_listener *listener, void *data)
 	struct drawing_tablet *tablet = ev->tablet->data;
 	struct drawing_tablet_tool *tool = ev->tool->data;
 
-	if (!tool_supports_absolute_motion(ev->tool)) {
-		if (ev->state == WLR_TABLET_TOOL_PROXIMITY_IN) {
-			wlr_log(WLR_INFO, "ignoring not supporting tablet tool");
-		}
-		return;
+	if (ev->state == WLR_TABLET_TOOL_PROXIMITY_IN) {
+		tablet->motion_mode = tool_motion_mode(ev->tool);
 	}
+
+	/*
+	 * Reset relative coordinates, we don't want to move the
+	 * cursor on proximity-in for relative positioning.
+	 */
+	tablet->dx = 0;
+	tablet->dy = 0;
 
 	tablet->x = ev->x;
 	tablet->y = ev->y;
 
-	double x, y;
-	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y);
+	double x, y, dx, dy;
+	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);
 
 	if (!rc.tablet.force_mouse_emulation
 			&& tablet->seat->server->tablet_manager && !tool) {
@@ -231,7 +266,7 @@ handle_proximity(struct wl_listener *listener, void *data)
 	 */
 	if (tool && surface) {
 		if (tool->tool_v2 && ev->state == WLR_TABLET_TOOL_PROXIMITY_IN) {
-			notify_motion(tablet, tool, surface, x, y, ev->time_msec);
+			notify_motion(tablet, tool, surface, x, y, dx, dy, ev->time_msec);
 		}
 		if (tool->tool_v2 && ev->state == WLR_TABLET_TOOL_PROXIMITY_OUT) {
 			wlr_tablet_v2_tablet_tool_notify_proximity_out(tool->tool_v2);
@@ -248,18 +283,22 @@ handle_axis(struct wl_listener *listener, void *data)
 	struct drawing_tablet *tablet = ev->tablet->data;
 	struct drawing_tablet_tool *tool = ev->tool->data;
 
-	if (!tool_supports_absolute_motion(ev->tool)) {
-		return;
-	}
-
+	/*
+	 * Reset relative coordinates. If those axes aren't updated,
+	 * the delta is zero.
+	 */
+	tablet->dx = 0;
+	tablet->dy = 0;
 	tablet->tilt_x = 0;
 	tablet->tilt_y = 0;
 
 	if (ev->updated_axes & WLR_TABLET_TOOL_AXIS_X) {
 		tablet->x = ev->x;
+		tablet->dx = ev->dx;
 	}
 	if (ev->updated_axes & WLR_TABLET_TOOL_AXIS_Y) {
 		tablet->y = ev->y;
+		tablet->dy = ev->dy;
 	}
 	if (ev->updated_axes & WLR_TABLET_TOOL_AXIS_DISTANCE) {
 		tablet->distance = ev->distance;
@@ -283,8 +322,8 @@ handle_axis(struct wl_listener *listener, void *data)
 		tablet->wheel_delta = ev->wheel_delta;
 	}
 
-	double x, y;
-	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y);
+	double x, y, dx, dy;
+	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);
 
 	/*
 	 * We are sending tablet notifications on the following conditions:
@@ -301,7 +340,7 @@ handle_axis(struct wl_listener *listener, void *data)
 			&& tablet->seat->server->input_mode == LAB_INPUT_STATE_PASSTHROUGH)
 			|| wlr_tablet_tool_v2_has_implicit_grab(tool->tool_v2))) {
 		/* motion seems to be supported by all tools */
-		notify_motion(tablet, tool, surface, x, y, ev->time_msec);
+		notify_motion(tablet, tool, surface, x, y, dx, dy, ev->time_msec);
 
 		/* notify about other axis based on tool capabilities */
 		if (ev->tool->distance) {
@@ -349,8 +388,19 @@ handle_axis(struct wl_listener *listener, void *data)
 				wlr_tablet_v2_tablet_tool_notify_proximity_out(
 					tool->tool_v2);
 			}
-			cursor_emulate_move_absolute(tablet->seat, &ev->tablet->base,
-				x, y, ev->time_msec);
+
+			switch (tablet->motion_mode) {
+			case LAB_TABLET_MOTION_ABSOLUTE:
+				cursor_emulate_move_absolute(tablet->seat,
+					&ev->tablet->base,
+					x, y, ev->time_msec);
+				break;
+			case LAB_TABLET_MOTION_RELATIVE:
+				cursor_emulate_move(tablet->seat,
+					&ev->tablet->base,
+					dx, dy, ev->time_msec);
+				break;
+			}
 		}
 	}
 }
@@ -407,8 +457,8 @@ handle_tip(struct wl_listener *listener, void *data)
 	struct drawing_tablet *tablet = ev->tablet->data;
 	struct drawing_tablet_tool *tool = ev->tool->data;
 
-	double x, y;
-	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y);
+	double x, y, dx, dy;
+	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);
 
 	uint32_t button = tablet_get_mapped_button(BTN_TOOL_PEN);
 
@@ -482,8 +532,8 @@ handle_button(struct wl_listener *listener, void *data)
 	struct drawing_tablet *tablet = ev->tablet->data;
 	struct drawing_tablet_tool *tool = ev->tool->data;
 
-	double x, y;
-	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y);
+	double x, y, dx, dy;
+	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);
 
 	uint32_t button = tablet_get_mapped_button(ev->button);
 

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -111,6 +111,13 @@ adjust_for_rotation_relative(enum rotation rotation, double *dx, double *dy)
 	}
 }
 
+static void
+adjust_for_motion_sensitivity(double motion_sensitivity, double *dx, double *dy)
+{
+	*dx = *dx * motion_sensitivity;
+	*dy = *dy * motion_sensitivity;
+}
+
 static struct wlr_surface*
 tablet_get_coords(struct drawing_tablet *tablet, double *x, double *y, double *dx, double *dy)
 {
@@ -122,6 +129,7 @@ tablet_get_coords(struct drawing_tablet *tablet, double *x, double *y, double *d
 		rc.tablet.box, x, y);
 	adjust_for_rotation(rc.tablet.rotation, x, y);
 	adjust_for_rotation_relative(rc.tablet.rotation, dx, dy);
+	adjust_for_motion_sensitivity(rc.tablet_tool.relative_motion_sensitivity, dx, dy);
 
 	if (rc.tablet.force_mouse_emulation
 			|| !tablet->tablet_v2) {

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -83,6 +83,30 @@ adjust_for_rotation(enum rotation rotation, double *x, double *y)
 	}
 }
 
+static void
+adjust_for_rotation_relative(enum rotation rotation, double *dx, double *dy)
+{
+	double tmp;
+	switch (rotation) {
+	case LAB_ROTATE_NONE:
+		break;
+	case LAB_ROTATE_90:
+		tmp = *dx;
+		*dx = -*dy;
+		*dy = tmp;
+		break;
+	case LAB_ROTATE_180:
+		*dx = -*dx;
+		*dy = -*dy;
+		break;
+	case LAB_ROTATE_270:
+		tmp = *dx;
+		*dx = *dy;
+		*dy = -tmp;
+		break;
+	}
+}
+
 static struct wlr_surface*
 tablet_get_coords(struct drawing_tablet *tablet, double *x, double *y)
 {
@@ -228,6 +252,9 @@ handle_axis(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	tablet->tilt_x = 0;
+	tablet->tilt_y = 0;
+
 	if (ev->updated_axes & WLR_TABLET_TOOL_AXIS_X) {
 		tablet->x = ev->x;
 	}
@@ -299,7 +326,7 @@ handle_axis(struct wl_listener *listener, void *data)
 			 */
 			double tilt_x = tablet->tilt_x;
 			double tilt_y = tablet->tilt_y;
-			adjust_for_rotation(rc.tablet.rotation, &tilt_x, &tilt_y);
+			adjust_for_rotation_relative(rc.tablet.rotation, &tilt_x, &tilt_y);
 
 			wlr_tablet_v2_tablet_tool_notify_tilt(tool->tool_v2,
 				tilt_x, tilt_y);


### PR DESCRIPTION
Still draft since early days and there is already a big flaw:  the motion configuration overwrites all tools (Stylus, Pen, Tablet Mouse etc), but actually this should be on a per-tool base. Since we have `tool->hardware_serial` and/or `tool->hardware_wacom`, this should be doable. 

TODO:
- [x] ~configuration per tool~
- [x] add/improve code comments
- [x] documentation

PS: Multiple tool configurations could also be a separate PR, or may be even wait until someone hits this to have a real life demand.

Closes https://github.com/labwc/labwc/issues/1957