### PR TITLE
xwayland: support xinitrc scripts to configure server on launch

### DIFF
--- a/docs/README
+++ b/docs/README
@@ -5,6 +5,7 @@ Config layout for ~/.config/labwc/
 - rc.xml
 - shutdown
 - themerc-override
+- xinitrc
 
 See `man labwc-config and `man labwc-theme` for further details.
 

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -8,7 +8,7 @@ labwc - configuration files
 
 Labwc uses openbox-3.6 specification for configuration and theming, but does not
 support all options. The following files form the basis of the labwc
-configuration: rc.xml, menu.xml, autostart, shutdown and environment.
+configuration: rc.xml, menu.xml, autostart, shutdown, environment and xinitrc.
 
 No configuration files are needed to start and run labwc.
 
@@ -77,6 +77,10 @@ in labwc-theme(5).
 
 *rc.xml* is the main configuration file and all its options are described in
 detail below.
+
+The *xinitrc* file is executed as a shell script whenever labwc launches the
+Xwayland X11 server. This may happen multiple times throughout the session if
+Xwayland is not configured to persist when no X11 clients are connected.
 
 # CONFIGURATION
 

--- a/docs/xinitrc
+++ b/docs/xinitrc
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+## This file is run every time labwc launches Xwayland.
+##
+## In the default configuration, Xwayland will be launched lazily, and will
+## terminate after several seconds when no X11 clients are connected. Thus,
+## this script may run repeatedly throughout a single labwc session.
+
+# Configure the X resource database if a file is provided
+#
+# NOTE: when Xwayland is launched lazily, an X11 client that triggers its
+# launch may attempt to read the resource database before this command can be
+# run. In that case, it is recommended to make a symlink to .Xdefaults:
+#
+#     ln -s .Xresources "${HOME}/.Xdefaults"
+#
+# With this link in place, X11 applications will fall back to reading
+# the .Xdefaults file directly when no resource database can be read from the
+# server's root window properties.
+#
+# Invoking xrdb is still useful to pre-load the resource database for
+# subsequent clients, because any additional clients launched while the X
+# server remains alive will be able to query the database without resorting to
+# filesystem access.
+
+if [ -r "${HOME}/.Xresources" ] && command -v xrdb >/dev/null 2>&1; then
+	xrdb -merge "${HOME}/.Xresources"
+fi

--- a/include/config/session.h
+++ b/include/config/session.h
@@ -5,6 +5,12 @@
 struct server;
 
 /**
+ * session_run_script - run a named session script (or, in merge-config mode,
+ * all named session scripts) from the XDG path.
+ */
+void session_run_script(const char *script);
+
+/**
  * session_environment_init - set environment variables based on <key>=<value>
  * pairs in `${XDG_CONFIG_DIRS:-/etc/xdg}/labwc/environment` with user override
  * in `${XDG_CONFIG_HOME:-$HOME/.config}`

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -261,8 +261,8 @@ session_environment_init(void)
 	paths_destroy(&paths);
 }
 
-static void
-run_session_script(const char *script)
+void
+session_run_script(const char *script)
 {
 	struct wl_list paths;
 	paths_config_create(&paths, script);
@@ -293,13 +293,13 @@ session_autostart_init(struct server *server)
 {
 	/* Update dbus and systemd user environment, each may fail gracefully */
 	update_activation_env(server, /* initialize */ true);
-	run_session_script("autostart");
+	session_run_script("autostart");
 }
 
 void
 session_shutdown(struct server *server)
 {
-	run_session_script("shutdown");
+	session_run_script("shutdown");
 
 	/* Clear the dbus and systemd user environment, each may fail gracefully */
 	update_activation_env(server, /* initialize */ false);

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -7,6 +7,7 @@
 #include "common/macros.h"
 #include "common/mem.h"
 #include "config/rcxml.h"
+#include "config/session.h"
 #include "labwc.h"
 #include "node.h"
 #include "ssd.h"
@@ -1023,6 +1024,9 @@ sync_atoms(xcb_connection_t *xcb_conn)
 static void
 handle_server_ready(struct wl_listener *listener, void *data)
 {
+	/* Fire an Xwayland startup script if one (or many) can be found */
+	session_run_script("xinitrc");
+
 	xcb_connection_t *xcb_conn = xcb_connect(NULL, NULL);
 	if (xcb_connection_has_error(xcb_conn)) {
 		wlr_log(WLR_ERROR, "Failed to create xcb connection");


### PR DESCRIPTION
Cf. #1961. This splits the xinitrc support for separate consideration.

Even though this change doesn't address the issue in #1958 because of a [race that we can't control](https://github.com/labwc/labwc/pull/1961#issuecomment-2207000149), I think it still warrants inclusion for four reasons:
1. It seems to partially address the issue, especially for remote clients where symlinking `.Xdefaults -> .Xresources` server-side is insufficient to trigger Xlib behavior that will cause clients to read resource configuration on disk.
2. It allows users of even local clients to force things like an `xrdb` load every time Xwayland is lazily restarted. This means that, even if the intitial client triggering its launch must fall back on `.Xdefaults` behavior for proper configuration, subsequent clients that connect during the lifetime of a particular Xwayland session can avoid disk access by reading the resource database from the properties of the root window.
3. Users may wish adopt other workflows that opportunistically launch X11 clients every time that Xwayland is started, without regard for sequencing with other clients triggering an auto-launch.
4. The `xinitrc` script permits a logical separation between "Xwayland configuration" and "labwc client configuration" as done in the `autostart` script.