### PR TITLE
ssd: scale titlebar buttons to fit for very small views

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -65,6 +65,7 @@ struct ssd {
 	/* The top of the view, containing buttons, title, .. */
 	struct {
 		int height;
+		int button_width;
 		struct wlr_scene_tree *tree;
 		struct ssd_sub_tree active;
 		struct ssd_sub_tree inactive;
@@ -129,15 +130,15 @@ struct ssd_part *add_scene_button(
 	struct wl_list *part_list, enum ssd_part_type type,
 	struct wlr_scene_tree *parent, float *bg_color,
 	struct wlr_buffer *icon_buffer, struct wlr_buffer *hover_buffer,
-	int x, struct view *view);
+	int x, int width, struct view *view);
 void add_toggled_icon(struct ssd_button *button, struct wl_list *part_list,
 	enum ssd_part_type type, struct wlr_buffer *icon_buffer,
-	struct wlr_buffer *hover_buffer);
+	struct wlr_buffer *hover_buffer, int width);
 struct ssd_part *add_scene_button_corner(
 	struct wl_list *part_list, enum ssd_part_type type,
 	enum ssd_part_type corner_type, struct wlr_scene_tree *parent,
 	struct wlr_buffer *corner_buffer, struct wlr_buffer *icon_buffer,
-	struct wlr_buffer *hover_buffer, int x, struct view *view);
+	struct wlr_buffer *hover_buffer, int x, int width, struct view *view);
 
 /* SSD internal helpers */
 struct ssd_part *ssd_get_part(

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -22,6 +22,7 @@ ssd_border_create(struct ssd *ssd)
 	int width = view->current.width;
 	int height = view_effective_height(view, /* use_pending */ false);
 	int full_width = width + 2 * theme->border_width;
+	int button_width = ssd->titlebar.button_width;
 
 	float *color;
 	struct wlr_scene_tree *parent;
@@ -48,8 +49,8 @@ ssd_border_create(struct ssd *ssd)
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_BOTTOM, parent,
 			full_width, theme->border_width, 0, height, color);
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_TOP, parent,
-			width - 2 * theme->window_button_width, theme->border_width,
-			theme->border_width + theme->window_button_width,
+			width - 2 * button_width, theme->border_width,
+			theme->border_width + button_width,
 			-(ssd->titlebar.height + theme->border_width), color);
 	} FOR_EACH_END
 
@@ -93,6 +94,7 @@ ssd_border_update(struct ssd *ssd)
 	int width = view->current.width;
 	int height = view_effective_height(view, /* use_pending */ false);
 	int full_width = width + 2 * theme->border_width;
+	int button_width = ssd->titlebar.button_width;
 
 	/*
 	 * From here on we have to cover the following border scenarios:
@@ -121,10 +123,10 @@ ssd_border_update(struct ssd *ssd)
 		: 0;
 	int top_width = ssd->titlebar.height <= 0 || ssd->state.was_tiled_not_maximized
 		? full_width
-		: width - 2 * theme->window_button_width;
+		: width - 2 * button_width;
 	int top_x = ssd->titlebar.height <= 0 || ssd->state.was_tiled_not_maximized
 		? 0
-		: theme->border_width + theme->window_button_width;
+		: theme->border_width + button_width;
 
 	struct ssd_part *part;
 	struct wlr_scene_rect *rect;

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -32,8 +32,8 @@ ssd_extents_create(struct ssd *ssd)
 	struct theme *theme = view->server->theme;
 	struct wl_list *part_list = &ssd->extents.parts;
 	int extended_area = SSD_EXTENDED_AREA;
-	int corner_size = extended_area + theme->border_width +
-		theme->window_button_width / 2;
+	int corner_size = extended_area + theme->border_width
+		+ ssd->titlebar.button_width / 2;
 
 	ssd->extents.tree = wlr_scene_tree_create(ssd->tree);
 	struct wlr_scene_tree *parent = ssd->extents.tree;
@@ -110,8 +110,8 @@ ssd_extents_update(struct ssd *ssd)
 	int full_height = height + theme->border_width * 2 + ssd->titlebar.height;
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = SSD_EXTENDED_AREA;
-	int corner_size = extended_area + theme->border_width +
-		theme->window_button_width / 2;
+	int corner_size = extended_area + theme->border_width
+		+ ssd->titlebar.button_width / 2;
 	int side_width = full_width + extended_area * 2 - corner_size * 2;
 	int side_height = full_height + extended_area * 2 - corner_size * 2;
 


### PR DESCRIPTION
Alternative to:
- https://github.com/labwc/labwc/pull/1959

The rendering is not pixel-perfect since we still use some shared/pre-rendered buffers from the theme, but IMHO it looks fairly decent given the tricky geometry.

xterm at 1x4, 3x4, 5x4, 7x4, and 9x4:

![xterm-1x4](https://github.com/labwc/labwc/assets/1244737/bc7e124d-5901-478c-93e4-94c40bf4f8ec)
![xterm-3x4](https://github.com/labwc/labwc/assets/1244737/89c5f75e-ed92-48ed-a38d-d86eb3f9ae4e)
![xterm-5x4](https://github.com/labwc/labwc/assets/1244737/7dd77438-4084-44d9-97cd-e69a133c5782)
![xterm-7x4](https://github.com/labwc/labwc/assets/1244737/1beb141d-6b50-495d-9ea9-ed6e3ca21aad)
![xterm-9x4](https://github.com/labwc/labwc/assets/1244737/44f2c76c-1650-4fbb-b983-3ed4b402c654)
