### PR TITLE
treewide: fix memory leaks on reconfigure

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -671,7 +671,7 @@ parse_xml(const char *filename, struct server *server)
 		struct path *path = wl_container_of(elm, path, link);
 		FILE *stream = fopen(path->string, "r");
 		if (!stream) {
-			return;
+			continue;
 		}
 		wlr_log(WLR_INFO, "read menu file %s", path->string);
 		parse_stream(server, stream);

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -938,6 +938,8 @@ menu_free(struct menu *menu)
 	 */
 	wlr_scene_node_destroy(&menu->scene_tree->node);
 	wl_list_remove(&menu->link);
+	zfree(menu->id);
+	zfree(menu->label);
 	zfree(menu);
 }
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -1397,10 +1397,35 @@ theme_init(struct theme *theme, struct server *server, const char *theme_name)
 void
 theme_finish(struct theme *theme)
 {
+	zdrop(&theme->button_close_active_unpressed);
+	zdrop(&theme->button_maximize_active_unpressed);
+	zdrop(&theme->button_restore_active_unpressed);
+	zdrop(&theme->button_iconify_active_unpressed);
+	zdrop(&theme->button_menu_active_unpressed);
+
+	zdrop(&theme->button_close_inactive_unpressed);
+	zdrop(&theme->button_maximize_inactive_unpressed);
+	zdrop(&theme->button_restore_inactive_unpressed);
+	zdrop(&theme->button_iconify_inactive_unpressed);
+	zdrop(&theme->button_menu_inactive_unpressed);
+
+	zdrop(&theme->button_close_active_hover);
+	zdrop(&theme->button_maximize_active_hover);
+	zdrop(&theme->button_restore_active_hover);
+	zdrop(&theme->button_iconify_active_hover);
+	zdrop(&theme->button_menu_active_hover);
+
+	zdrop(&theme->button_close_inactive_hover);
+	zdrop(&theme->button_maximize_inactive_hover);
+	zdrop(&theme->button_restore_inactive_hover);
+	zdrop(&theme->button_iconify_inactive_hover);
+	zdrop(&theme->button_menu_inactive_hover);
+
 	zdrop(&theme->corner_top_left_active_normal);
 	zdrop(&theme->corner_top_left_inactive_normal);
 	zdrop(&theme->corner_top_right_active_normal);
 	zdrop(&theme->corner_top_right_inactive_normal);
+
 	zdrop(&theme->shadow_corner_top_active);
 	zdrop(&theme->shadow_corner_bottom_active);
 	zdrop(&theme->shadow_edge_active);


### PR DESCRIPTION
- Add missing `zfree/zdrop()` calls in menu.c and theme.c
- Change an early `return` to a `continue` when trying multiple config paths -- this appears to be what was intended, and fixes a memory leak