### PR TITLE
src/xdg.c: verify source surface for xdg_activation request

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -248,6 +248,7 @@ struct server {
 
 	struct wlr_xdg_activation_v1 *xdg_activation;
 	struct wl_listener xdg_activation_request;
+	struct wl_listener xdg_activation_new_token;
 
 	struct wl_list views;
 	struct wl_list unmanaged_surfaces;


### PR DESCRIPTION
wlroots < 0.17 didn't allow to reliably check the source surface of an xdg activation request as it reset the surface to NULL when it was destroyed before the token was used. This happens regularly for notifications for example. Thus we treated the token as valid even without checking for the source surface.

wlroots 0.17 added a new_token signal where we can attach information to the existing token which we can then use when evaluating activation requests. This patch implements that check.