### PR TITLE
menu: support titles defined by `<separator label="">`

### DIFF
--- a/docs/labwc-menu.5.scd
+++ b/docs/labwc-menu.5.scd
@@ -25,13 +25,16 @@ The menu file must be entirely enclosed within <openbox_menu> and
   <!-- A submenu defined elsewhere -->
   <menu id="" />
 
-  <!-- Horizontal line >
+  <!-- Horizontal line -->
   <separator />
 
   <!-- An inline submenu -->
   <menu id="" label="">
     ...some content...
   </menu>
+
+  <!-- Title -->
+  <separator label=""/>
 
   <!-- Pipemenu -->
   <menu id="" label="" execute="COMMAND"/>
@@ -62,6 +65,11 @@ The menu file must be entirely enclosed within <openbox_menu> and
 
 *menu.separator*
 	Horizontal line.
+
+*menu.separator.label*
+	In a "separator" element, the label attribute transforms the separator
+	from a horizontal line to a menu title (heading) with the text specified
+	by label in it.
 
 *menu.execute*
 	Command to execute for pipe menu. See details below.

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -174,6 +174,10 @@ elements are not listed here, but are supported.
 *menu.separator.color*
 	Menu separator color. Default #888888.
 
+*menu.title.bg.color*
+	Menu title color. Default #589bda.
+	Note: A menu title is a separator with a label.
+
 *osd.bg.color*
 	Background color of on-screen-display. Inherits
 	*window.active.title.bg.color* if not set.

--- a/docs/themerc
+++ b/docs/themerc
@@ -62,6 +62,7 @@ menu.separator.width: 1
 menu.separator.padding.width: 6
 menu.separator.padding.height: 3
 menu.separator.color: #888888
+menu.title.bg.color: #589bda
 
 # on screen display (window-cycle dialog)
 osd.bg.color: #e1dedb

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -27,6 +27,12 @@ struct menu_scene {
 	struct scaled_font_buffer *buffer;
 };
 
+enum menuitem_type {
+	LAB_MENU_ITEM = 0,
+	LAB_MENU_SEPARATOR_LINE,
+	LAB_MENU_TITLE,
+};
+
 struct menuitem {
 	struct wl_list actions;
 	char *execute;
@@ -34,6 +40,7 @@ struct menuitem {
 	struct menu *parent;
 	struct menu *submenu;
 	bool selectable;
+	enum menuitem_type type;
 	int height;
 	int native_width;
 	struct wlr_scene_tree *tree;

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -53,7 +53,6 @@ struct menuitem {
 struct menu {
 	char *id;
 	char *label;
-	int item_height;
 	struct menu *parent;
 
 	struct {

--- a/include/theme.h
+++ b/include/theme.h
@@ -61,6 +61,7 @@ struct theme {
 
 	int menu_item_padding_x;
 	int menu_item_padding_y;
+	int menu_item_height;
 
 	float menu_items_bg_color[4];
 	float menu_items_text_color[4];

--- a/include/theme.h
+++ b/include/theme.h
@@ -75,6 +75,8 @@ struct theme {
 	int menu_separator_padding_height;
 	float menu_separator_color[4];
 
+	float menu_title_bg_color[4];
+
 	int osd_border_width;
 
 	float osd_bg_color[4];

--- a/src/common/scaled-font-buffer.c
+++ b/src/common/scaled-font-buffer.c
@@ -14,12 +14,16 @@
 static struct lab_data_buffer *
 _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
 {
-	struct lab_data_buffer *buffer;
+	struct lab_data_buffer *buffer = NULL;
 	struct scaled_font_buffer *self = scaled_buffer->data;
 
 	/* Buffer gets free'd automatically along the backing wlr_buffer */
 	font_buffer_create(&buffer, self->max_width, self->text,
 		&self->font, self->color, self->bg_color, self->arrow, scale);
+
+	if (!buffer) {
+		wlr_log(WLR_ERROR, "font_buffer_create() failed");
+	}
 
 	self->width = buffer ? buffer->unscaled_width : 0;
 	self->height = buffer ? buffer->unscaled_height : 0;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -200,12 +200,7 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 
 	const char *arrow = show_arrow ? "›" : NULL;
 
-	/* TODO: Consider setting this somewhere else */
-	if (!menu->item_height) {
-		menu->item_height = font_height(&rc.font_menuitem)
-			+ 2 * theme->menu_item_padding_y;
-	}
-	menuitem->height = menu->item_height;
+	menuitem->height = theme->menu_item_height;
 
 	int x, y;
 	menuitem->native_width = font_width(&rc.font_menuitem, text);
@@ -225,11 +220,11 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 	/* Item background nodes */
 	menuitem->normal.background = &wlr_scene_rect_create(
 		menuitem->normal.tree,
-		menu->size.width, menu->item_height,
+		menu->size.width, theme->menu_item_height,
 		theme->menu_items_bg_color)->node;
 	menuitem->selected.background = &wlr_scene_rect_create(
 		menuitem->selected.tree,
-		menu->size.width, menu->item_height,
+		menu->size.width, theme->menu_item_height,
 		theme->menu_items_active_bg_color)->node;
 
 	/* Font nodes */
@@ -258,9 +253,9 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 
 	/* Center font nodes */
 	x = theme->menu_item_padding_x;
-	y = (menu->item_height - menuitem->normal.buffer->height) / 2;
+	y = (theme->menu_item_height - menuitem->normal.buffer->height) / 2;
 	wlr_scene_node_set_position(menuitem->normal.text, x, y);
-	y = (menu->item_height - menuitem->selected.buffer->height) / 2;
+	y = (theme->menu_item_height - menuitem->selected.buffer->height) / 2;
 	wlr_scene_node_set_position(menuitem->selected.text, x, y);
 
 	/* Position the item in relation to its menu */
@@ -289,7 +284,7 @@ separator_create(struct menu *menu, const char *label)
 	struct theme *theme = server->theme;
 
 	if (menuitem->type == LAB_MENU_TITLE) {
-		menuitem->height = menu->item_height;
+		menuitem->height = theme->menu_item_height;
 		menuitem->native_width = font_width(&rc.font_menuitem, label);
 	} else if (menuitem->type == LAB_MENU_SEPARATOR_LINE) {
 		menuitem->height = theme->menu_separator_line_thickness +
@@ -328,7 +323,7 @@ separator_create(struct menu *menu, const char *label)
 		/* Center font nodes */
 		int x, y;
 		x = theme->menu_item_padding_x;
-		y = (menu->item_height - menuitem->normal.buffer->height) / 2;
+		y = (theme->menu_item_height - menuitem->normal.buffer->height) / 2;
 		wlr_scene_node_set_position(menuitem->normal.text, x, y);
 	} else {
 		int nominal_width = theme->menu_min_width;
@@ -836,7 +831,7 @@ menu_configure(struct menu *menu, int lx, int ly, enum menu_align align)
 		ly -= menu->size.height;
 		if (menu->parent) {
 			/* For submenus adjust y to bottom left corner */
-			ly += menu->item_height;
+			ly += theme->menu_item_height;
 		}
 	}
 	wlr_scene_node_set_position(&menu->scene_tree->node, lx, ly);

--- a/src/theme.c
+++ b/src/theme.c
@@ -1305,6 +1305,9 @@ post_processing(struct theme *theme)
 		theme->title_height = h + 2 * theme->padding_height;
 	}
 
+	theme->menu_item_height = font_height(&rc.font_menuitem)
+		+ 2 * theme->menu_item_padding_y;
+
 	theme->osd_window_switcher_item_height = font_height(&rc.font_osd)
 		+ 2 * theme->osd_window_switcher_item_padding_y
 		+ 2 * theme->osd_window_switcher_item_active_border_width;

--- a/src/theme.c
+++ b/src/theme.c
@@ -528,6 +528,8 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->menu_separator_padding_height = 3;
 	parse_hexstr("#888888", theme->menu_separator_color);
 
+	parse_hexstr("#589bda", theme->menu_title_bg_color);
+
 	theme->osd_window_switcher_width = 600;
 	theme->osd_window_switcher_width_is_percent = false;
 	theme->osd_window_switcher_padding = 4;
@@ -764,6 +766,10 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match_glob(key, "menu.separator.color")) {
 		parse_hexstr(value, theme->menu_separator_color);
+	}
+
+	if (match_glob(key, "menu.title.bg.color")) {
+		parse_hexstr(value, theme->menu_title_bg_color);
 	}
 
 	if (match_glob(key, "osd.bg.color")) {


### PR DESCRIPTION
For visibility only so nobody else duplicates effort.

Cc: @heroin-moose  (as you mentioned this some time ago).

Have implemented `menu.title.bg.color: #589bda`

TODO:

- [x] Documentation
- [x] Handle title before first item

![foo](https://github.com/user-attachments/assets/44135383-b64f-4103-bc71-77fe9c23e30b)