### PR TITLE
src/output-state.c: add a FPS debug option

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -371,6 +371,7 @@ struct output {
 	struct server *server;
 	struct wlr_output *wlr_output;
 	struct wlr_output_state pending;
+	struct wl_event_source *fps_timer;
 	struct wlr_scene_output *scene_output;
 	struct wlr_scene_tree *layer_tree[LAB_NR_LAYERS];
 	struct wlr_scene_tree *layer_popup_tree;
@@ -389,6 +390,7 @@ struct output {
 
 	bool leased;
 	bool gamma_lut_changed;
+	uint32_t frames;
 };
 
 #undef LAB_NR_LAYERS

--- a/src/output.c
+++ b/src/output.c
@@ -168,6 +168,11 @@ output_destroy_notify(struct wl_listener *listener, void *data)
 	 */
 	output->wlr_output->data = NULL;
 
+	if (output->fps_timer) {
+		wl_event_source_remove(output->fps_timer);
+		output->fps_timer = NULL;
+	}
+
 	/*
 	 * output->scene_output (if still around at this point) is
 	 * destroyed automatically when the wlr_output is destroyed


### PR DESCRIPTION
Logs the FPS per output every $timeout ms via wlr_log() if enabled.

By default this patch does nothing unless the FPS_TIMEOUT define has been set, for example via `meson configure build -DFPS_TIMEOUT=5000`.

---

That was added for the chase 0.18 PR, I don't know if its actually useful or not. Feel free to close if not.