### PR TITLE
backend/drm: Fix up tearing for atomic modesetting

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -186,10 +186,13 @@ this is for compatibility with Openbox.
 	mode.
 
 *<core><allowTearing>* [yes|no]
-	Allow tearing to reduce input lag. Default is no.
-	This option requires setting the environment variable
-	WLR_DRM_NO_ATOMIC=1.
-	*yes* allow tearing if requested by the active window.
+	Allow tearing, if requested by the active window, to reduce input lag.
+	Default is no.
+
+	Note: Enabling this option with atomic mode setting is experimental. If
+	you experience undesirable side effects when tearing is allowed,
+	consider setting the environment variable WLR_DRM_NO_ATOMIC=1 when
+	launching labwc.
 
 *<core><reuseOutputMode>* [yes|no]
 	Try to re-use the existing output mode (resolution / refresh rate).

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -389,6 +389,8 @@ struct output {
 
 	bool leased;
 	bool gamma_lut_changed;
+
+	uint32_t nr_tearing_failures;
 };
 
 #undef LAB_NR_LAYERS

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -885,13 +885,6 @@ entry(xmlNode *node, char *nodename, char *content)
 		set_adaptive_sync_mode(content, &rc.adaptive_sync);
 	} else if (!strcasecmp(nodename, "allowTearing.core")) {
 		set_bool(content, &rc.allow_tearing);
-		if (rc.allow_tearing) {
-			char *no_atomic_env = getenv("WLR_DRM_NO_ATOMIC");
-			if (!no_atomic_env || strcmp(no_atomic_env, "1") != 0) {
-				rc.allow_tearing = false;
-				wlr_log(WLR_ERROR, "tearing requires WLR_DRM_NO_ATOMIC=1");
-			}
-		}
 	} else if (!strcasecmp(nodename, "reuseOutputMode.core")) {
 		set_bool(content, &rc.reuse_output_mode);
 	} else if (!strcmp(nodename, "policy.placement")) {


### PR DESCRIPTION
Remove the NO_ATOMIC check, and add a conditional fallback for errors, which usually result from properties being applied during a flip, such as hardware cursor image changes. Falling back is limited so that persistent errors do not keep immediate flips running forever, but instead disable them until an output is reset. Verified working at least on AMD Radeon 6700 XT.