### PR TITLE
backend/drm: Implement support for renderer loss recovery

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -318,6 +318,8 @@ struct server {
 	 */
 	int pending_output_layout_change;
 
+	struct wl_listener renderer_lost;
+
 	struct wlr_gamma_control_manager_v1 *gamma_control_manager_v1;
 	struct wl_listener gamma_control_set_gamma;
 

--- a/include/magnifier.h
+++ b/include/magnifier.h
@@ -20,5 +20,6 @@ bool output_wants_magnification(struct output *output);
 void magnify(struct output *output, struct wlr_buffer *output_buffer,
 	struct wlr_box *damage);
 bool is_magnify_on(void);
+void magnify_reset(void);
 
 #endif /* LABWC_MAGNIFIER_H */


### PR DESCRIPTION
This implementation is nearly identical to Sway's, except that it also reloads the configuration, to spur on reloading the server-side decorations.