### PR TITLE
[v0.7] ssd: make borders respect snapped state on Reconfigure

### DIFF
--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -56,6 +56,14 @@ ssd_border_create(struct ssd *ssd)
 	if (view->maximized == VIEW_AXIS_BOTH) {
 		wlr_scene_node_set_enabled(&ssd->border.tree->node, false);
 	}
+
+	if (view->current.width > 0 && view->current.height > 0) {
+		/*
+		 * The SSD is recreated by a Reconfigure request
+		 * thus we may need to handle squared corners.
+		 */
+		ssd_border_update(ssd);
+	}
 }
 
 void

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -188,8 +188,14 @@ ssd_create(struct view *view, bool active)
 	ssd->titlebar.height = view->server->theme->title_height;
 	ssd_shadow_create(ssd);
 	ssd_extents_create(ssd);
-	ssd_border_create(ssd);
+	/*
+	 * We need to create the borders after the titlebar because it sets
+	 * ssd->state.was_tiled_not_maximized which ssd_border_create()
+	 * reacts to. TODO: Set the state here instead so the order does
+	 * not matter anymore.
+	 */
 	ssd_titlebar_create(ssd);
+	ssd_border_create(ssd);
 	if (view->ssd_titlebar_hidden) {
 		/* Ensure we keep the old state on Reconfigure or when exiting fullscreen */
 		ssd_set_titlebar(ssd, false);


### PR DESCRIPTION
Fixes: #1862