### PR TITLE
Implement resistance for tiled windows

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -347,6 +347,10 @@ extending outward from the snapped edge.
 	SnapToEdge action for that edge. A *range* of 0 disables snapping via
 	interactive moves. Default is 1.
 
+*<snapping><dragResistance>*
+	Sets the movement of cursor in pixel required for a tiled or maximized
+	window to be moved with an interactive move. Default is 20.
+
 *<snapping><overlay><enabled>* [yes|no]
 	Show an overlay when snapping to a window to an edge. Default is yes.
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -125,6 +125,7 @@
   <snapping>
     <!-- Set range to 0 to disable window snapping completely -->
     <range>1</range>
+    <dragResistance>20</dragResistance>
     <overlay enabled="yes">
       <delay inner="500" outer="500" />
     </overlay>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -125,6 +125,7 @@ struct rcxml {
 	int snap_overlay_delay_outer;
 	bool snap_top_maximize;
 	enum tiling_events_mode snap_tiling_events_mode;
+	int snap_drag_resistance;
 
 	enum resize_indicator_mode resize_indicator;
 	bool resize_draw_contents;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -256,7 +256,16 @@ struct server {
 	/* cursor interactive */
 	enum input_mode input_mode;
 	struct view *grabbed_view;
+	/*
+	 * When an interactive move is requested for tiled/maximized views by CSD
+	 * clients or by Drag actions, the actual motion and untiling of the view
+	 * can be delayed to prevent the view from being unintentionally untiled.
+	 * During this delay, move_pending is set.
+	 */
+	bool move_pending;
+	/* Cursor position when interactive move/resize is requested */
 	double grab_x, grab_y;
+	/* View geometry when interactive move/resize is requested */
 	struct wlr_box grab_box;
 	uint32_t resize_edges;
 
@@ -496,6 +505,15 @@ void seat_output_layout_changed(struct seat *seat);
  * geometry->{x,y} are computed by this function.
  */
 void interactive_anchor_to_cursor(struct view *view, struct wlr_box *geometry);
+
+/**
+ * interactive_move_tiled_view_to() - Un-tile the tiled/maximized view at the
+ * start of an interactive move or when an interactive move is pending.
+ * Returns true if the distance of cursor motion exceeds the value of
+ * <snapping><dragResistance> and the view is un-tiled.
+ */
+bool interactive_move_tiled_view_to(struct server *server, struct view *view,
+	struct wlr_box *geometry);
 
 void interactive_begin(struct view *view, enum input_mode mode, uint32_t edges);
 void interactive_finish(struct view *view);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -971,6 +971,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "ignoring invalid value for notifyClient");
 		}
+	} else if (!strcasecmp(nodename, "dragResistance.snapping")) {
+		rc.snap_drag_resistance = atoi(content);
 
 	/* <windowSwitcher show="" preview="" outlines="" /> */
 	} else if (!strcasecmp(nodename, "show.windowSwitcher")) {
@@ -1278,6 +1280,7 @@ rcxml_init(void)
 	rc.snap_overlay_delay_outer = 500;
 	rc.snap_top_maximize = true;
 	rc.snap_tiling_events_mode = LAB_TILING_EVENTS_ALWAYS;
+	rc.snap_drag_resistance = 20;
 
 	rc.window_switcher.show = true;
 	rc.window_switcher.preview = true;

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -232,9 +232,19 @@ request_set_primary_selection_notify(struct wl_listener *listener, void *data)
 static void
 process_cursor_move(struct server *server, uint32_t time)
 {
+	struct view *view = server->grabbed_view;
+
+	/*
+	 * Un-tile the view when interactive move is delayed and the distance
+	 * of cursor movement exceeds <snapping><dragResistance>.
+	 */
+	if (server->move_pending && !interactive_move_tiled_view_to(
+			server, server->grabbed_view, &server->grab_box)) {
+		return;
+	}
+
 	double dx = server->seat.cursor->x - server->grab_x;
 	double dy = server->seat.cursor->y - server->grab_y;
-	struct view *view = server->grabbed_view;
 
 	/* Move the grabbed view to the new position. */
 	dx += server->grab_box.x;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -94,6 +94,7 @@ do_late_positioning(struct view *view)
 	if (server->input_mode == LAB_INPUT_STATE_MOVE
 			&& view == server->grabbed_view) {
 		/* Keep view underneath cursor */
+		/* TODO: resistance is not considered */
 		interactive_anchor_to_cursor(view, &view->pending);
 		/* Update grab offsets */
 		server->grab_x = server->seat.cursor->x;


### PR DESCRIPTION
Closes #1968.

This PR adds `<snapping><dragResistance>` which configures the distance of cursor movement for dragging a tiled/maximized window.

I found dragging an initially maximized window places the window at a bit incorrect position. Not sure I can fix it in this PR.

~This PR also temporarily includes the commit from #2010.~