### PR TITLE
edges.c: fix flicker of snapped windows in nested session

### DIFF
--- a/src/edges.c
+++ b/src/edges.c
@@ -515,7 +515,7 @@ edges_adjust_move_coords(struct view *view, struct border edges,
 
 	if (view_geom->x != *x) {
 		int lshift = border.left + rc.gap;
-		int rshift = border.right + rc.gap + view->pending.width;
+		int rshift = border.right + rc.gap + view_geom->width;
 
 		adjust_move_coords_1d(x, edges.left, lshift,
 			edges.right, rshift, *x < view_geom->x);
@@ -524,7 +524,7 @@ edges_adjust_move_coords(struct view *view, struct border edges,
 	if (view_geom->y != *y) {
 		int tshift = border.top + rc.gap;
 		int bshift = border.bottom + rc.gap
-			+ view_effective_height(view, /* use_pending */ true);
+			+ view_effective_height(view, use_pending);
 
 		adjust_move_coords_1d(y, edges.top, tshift,
 			edges.bottom, bshift, *y < view_geom->y);


### PR DESCRIPTION
Fixes: #1621

I haven't made a PR for this because I don't understand how resistance works and the issue only happened when I drag a window tiled to the bottom edge in nested session, but now the issue is more apparent while testing #2009.

CC @ahesford