### PR TITLE
layer-shell: stop sending configure events on surface creation

### DIFF
--- a/src/layers.c
+++ b/src/layers.c
@@ -579,15 +579,6 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 	surface->node_destroy.notify = handle_node_destroy;
 	wl_signal_add(&surface->scene_layer_surface->tree->node.events.destroy,
 		&surface->node_destroy);
-
-	/*
-	 * Temporarily set the layer's current state to pending so that
-	 * it can easily be arranged.
-	 */
-	struct wlr_layer_surface_v1_state old_state = layer_surface->current;
-	layer_surface->current = layer_surface->pending;
-	output_update_usable_area(output);
-	layer_surface->current = old_state;
 }
 
 void


### PR DESCRIPTION
With wlroots 0.18, layer-shell's `new_surface` event is emitted on `zwlr_layer_shell_v1.get_layer_surface` request rather than the first commit. This change layer-shell clients like `fuzzel` to flicker on launch because labwc was sending a configure event with fullscreen geometry due to the absence of geometry hints on `get_layer_surface` requests.

This PR removes the code that updates the usable area from `new_surface` handler, preventing unintended configure events with fullscreen geometry.

Suggested by https://github.com/labwc/labwc/pull/1995#issuecomment-2240718847