### PR TITLE
[v0.7] multirect: remove destroy listener before freeing

### DIFF
--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -14,6 +14,7 @@ static void
 multi_rect_destroy_notify(struct wl_listener *listener, void *data)
 {
 	struct multi_rect *rect = wl_container_of(listener, rect, destroy);
+	wl_list_remove(&rect->destroy.link);
 	free(rect);
 }
 


### PR DESCRIPTION
Detected by `-Db_sanitize=address,undefined` for libwayland