### PR TITLE
Update meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'labwc',
   'c',
-  version: '0.7.3',
+  version: '0.7.4',
   license: 'GPL-2.0-only',
   meson_version: '>=0.59.0',
   default_options: [


### PR DESCRIPTION
This is a minor thing but when running `labwc --version` on the git version of labwc, I'm currently getting `labwc 0.7.3-52-g750d37b-dirty`.

I think that with the 0.7.4 release, changing meson.build was missed on the main branch. It seems that the 0.7.4 tag has the correct version numbering. Upon applying this commit, the output of `labwc --version` is now `labwc 0.7.4`.