### PR TITLE
Menu changes/additions

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -498,6 +498,21 @@ extending outward from the snapped edge.
 	outlined rectangle is shown to indicate the geometry of resized window.
 	Default is yes.
 
+*<resize><popupPosition>* see rc.xml.all for example
+	Lets the menu placement be set by a fixed position or centered on
+	screen. If set then the atCursor placement is overridden.  Not enabled
+	by default. Fixed takes x,y coordinates for placement.
+
+	Note: openbox allows 'Center', 'Top', or 'Fixed' we use Center & Fixed.
+
+	Positioning is per monitor based on which monitor the cursor is in.
+
+*<resize><popupFixedPosition>*
+	set x, y coordinates for menu placement
+	- x,y accept positive offsets only.
+	- 0,0 places menu at top left corner of desktop
+	- monitor width -1, monitor height -1 places menu at bottom right.
+
 ## KEYBOARD
 
 *<keyboard><numlock>* [on|off]

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -448,6 +448,7 @@ extending outward from the snapped edge.
 	- ActiveWindow - titlebar of active window
 	- InactiveWindow - titlebar of all windows that aren't focused by the
 	  cursor
+	- MenuHeader - menu header font ie separator labels
 	- MenuItem - menu item (currently only root menu)
 	- OnScreenDisplay - items in the on screen display
 	If no place attribute is provided, the setting will be applied to all
@@ -460,7 +461,7 @@ extending outward from the snapped edge.
 	Font size in pixels. Default is 10.
 
 *<theme><font place=""><slant>*
-	Font slant (normal or italic). Default is normal.
+	Font slant (normal, oblique or italic). Default is normal.
 
 *<theme><font place=""><weight>*
 	Font weight (normal or bold). Default is normal.

--- a/docs/labwc-menu.5.scd
+++ b/docs/labwc-menu.5.scd
@@ -25,13 +25,16 @@ The menu file must be entirely enclosed within <openbox_menu> and
   <!-- A submenu defined elsewhere -->
   <menu id="" />
 
-  <!-- Horizontal line >
+  <!-- Horizontal line -->
   <separator />
 
   <!-- An inline submenu -->
   <menu id="" label="">
     ...some content...
   </menu>
+
+  <!-- Title -->
+  <separator label=""/>
 
   <!-- Pipemenu -->
   <menu id="" label="" execute="COMMAND"/>
@@ -62,6 +65,11 @@ The menu file must be entirely enclosed within <openbox_menu> and
 
 *menu.separator*
 	Horizontal line.
+
+*menu.separator.label*
+	In a "separator" element, the label attribute transforms the separator
+	from a horizontal line to a menu title (heading) with the text specified
+	by label in it.
 
 *menu.execute*
 	Command to execute for pipe menu. See details below.

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -67,6 +67,10 @@ labwc-config(5).
 	Vertical padding of menu text entries in pixels.
 	Default is 4.
 
+*menu.title.text.justify*
+	Specifies how menu titles are aligned in the titlebar.
+	Type justification. Default Left.
+
 *menu.overlap.x*
 	Horizontal overlap in pixels between submenus and their parents. A
 	positive value move submenus over the top of their parents, whereas a
@@ -177,6 +181,12 @@ elements are not listed here, but are supported.
 *menu.title.bg.color*
 	Menu title color. Default #589bda.
 	Note: A menu title is a separator with a label.
+
+*menu.title.bg.color*
+	Background color of separator label.
+
+*menu.title.text.color*
+	Text color of separator label.
 
 *osd.bg.color*
 	Background color of on-screen-display. Inherits

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -174,6 +174,10 @@ elements are not listed here, but are supported.
 *menu.separator.color*
 	Menu separator color. Default #888888.
 
+*menu.title.bg.color*
+	Menu title color. Default #589bda.
+	Note: A menu title is a separator with a label.
+
 *osd.bg.color*
 	Background color of on-screen-display. Inherits
 	*window.active.title.bg.color* if not set.

--- a/docs/menu.xml
+++ b/docs/menu.xml
@@ -61,6 +61,12 @@
 </menu>
 
 <menu id="some-custom-menu">
+  <!--
+    Creates a separator w/title that is used as a header
+    To create an empty header with no title,
+    set label=" ", not label=""
+  -->
+  <separator label="custom menu" /> 
   <item label="Reconfigure">
     <action name="Reconfigure" />
   </item>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -43,6 +43,12 @@
       <slant>normal</slant>
       <weight>normal</weight>
     </font>
+    <font place="MenuHeader">
+      <name>sans</name>
+      <size>10</size>
+      <slant>normal</slant>
+      <weight>normal</weight>
+    </font>
     <font place="MenuItem">
       <name>sans</name>
       <size>10</size>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -115,7 +115,26 @@
     <popupShow>Never</popupShow>
     <!-- Let client redraw its contents while resizing -->
     <drawContents>yes</drawContents>
-  </resize>
+
+    <!-- options for fixed menu placement
+         will override all atCursor placement -->
+
+    <!--
+    <popupPosition>Fixed</popupPosition>
+    -->
+    <!-- openbox uses 'Center', 'Top', or 'Fixed'
+         but we use Fixed & Center for now', positioning
+	 is per output. -->
+
+    <popupFixedPosition>
+     <!-- openbox allows - negative offsets but that's because of X
+          we use positive offset, 0,0 is top left corner
+          monitor width - 1, monitor height - 1
+          will put the menu at bottom right corner -->
+      <x>10</x> <!-- 10 pixel from top left corner -->
+      <y>10</y>
+    </popupFixedPosition>
+    </resize>
 
   <focus>
     <followMouse>no</followMouse>

--- a/docs/themerc
+++ b/docs/themerc
@@ -62,6 +62,7 @@ menu.separator.width: 1
 menu.separator.padding.width: 6
 menu.separator.padding.height: 3
 menu.separator.color: #888888
+menu.title.bg.color: #589bda
 
 # on screen display (window-cycle dialog)
 osd.bg.color: #e1dedb

--- a/docs/themerc
+++ b/docs/themerc
@@ -58,11 +58,13 @@ menu.items.active.bg.color: #e1dedb
 menu.items.active.text.color: #000000
 menu.items.padding.x: 7
 menu.items.padding.y: 4
+menu.title.text.justify: left
 menu.separator.width: 1
 menu.separator.padding.width: 6
 menu.separator.padding.height: 3
 menu.separator.color: #888888
 menu.title.bg.color: #589bda
+menu.title.text.color: #ffff00
 
 # on screen display (window-cycle dialog)
 osd.bg.color: #e1dedb

--- a/include/common/font.h
+++ b/include/common/font.h
@@ -6,7 +6,8 @@ struct lab_data_buffer;
 
 enum font_slant {
 	FONT_SLANT_NORMAL = 0,
-	FONT_SLANT_ITALIC
+	FONT_SLANT_ITALIC,
+	FONT_SLANT_OBLIQUE
 };
 
 enum font_weight {

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -86,6 +86,7 @@ struct rcxml {
 	bool shadows_enabled;
 	struct font font_activewindow;
 	struct font font_inactivewindow;
+	struct font font_menuheader;
 	struct font font_menuitem;
 	struct font font_osd;
 

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -45,6 +45,12 @@ enum tiling_events_mode {
 		(LAB_TILING_EVENTS_REGION | LAB_TILING_EVENTS_EDGE),
 };
 
+enum menu_placement_policy {
+	LAB_MENU_ATCURSOR = 0,
+	LAB_MENU_CENTER,
+	LAB_MENU_FIXED,
+};
+
 struct usable_area_override {
 	struct border margin;
 	char *output;
@@ -136,6 +142,13 @@ struct rcxml {
 
 	enum resize_indicator_mode resize_indicator;
 	bool resize_draw_contents;
+	/* x,y and center placement for menu */
+	enum menu_placement_policy resize_popup_position;
+
+	struct {
+		int x;
+		int y;
+	} resize_popup_fixed_position;
 
 	struct {
 		int popuptime;

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -135,4 +135,7 @@ void menu_close_root(struct server *server);
 /* menu_reconfigure - reload theme and content */
 void menu_reconfigure(struct server *server);
 
+void create_client_send_to_menu(struct server *server);
+void create_client_list_combined_menu(struct server *server);
+
 #endif /* LABWC_MENU_H */

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -46,6 +46,7 @@ struct menuitem {
 	struct wlr_scene_tree *tree;
 	struct menu_scene normal;
 	struct menu_scene selected;
+	struct view *client_list_view;  /* used by internal client-list */
 	struct wl_list link; /* menu.menuitems */
 };
 

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -27,6 +27,12 @@ struct menu_scene {
 	struct scaled_font_buffer *buffer;
 };
 
+enum menuitem_type {
+	LAB_MENU_ITEM = 0,
+	LAB_MENU_SEPARATOR_LINE,
+	LAB_MENU_TITLE,
+};
+
 struct menuitem {
 	struct wl_list actions;
 	char *execute;
@@ -34,6 +40,7 @@ struct menuitem {
 	struct menu *parent;
 	struct menu *submenu;
 	bool selectable;
+	enum menuitem_type type;
 	int height;
 	int native_width;
 	struct wlr_scene_tree *tree;
@@ -46,7 +53,6 @@ struct menuitem {
 struct menu {
 	char *id;
 	char *label;
-	int item_height;
 	struct menu *parent;
 
 	struct {

--- a/include/theme.h
+++ b/include/theme.h
@@ -61,6 +61,7 @@ struct theme {
 
 	int menu_item_padding_x;
 	int menu_item_padding_y;
+	int menu_item_height;
 
 	float menu_items_bg_color[4];
 	float menu_items_text_color[4];
@@ -74,6 +75,8 @@ struct theme {
 	int menu_separator_padding_width;
 	int menu_separator_padding_height;
 	float menu_separator_color[4];
+
+	float menu_title_bg_color[4];
 
 	int osd_border_width;
 

--- a/include/theme.h
+++ b/include/theme.h
@@ -44,6 +44,7 @@ struct theme {
 	float window_active_label_text_color[4];
 	float window_inactive_label_text_color[4];
 	enum lab_justification window_label_text_justify;
+	enum lab_justification menu_title_text_justify;
 
 	/* button width */
 	int window_button_width;
@@ -77,6 +78,7 @@ struct theme {
 	float menu_separator_color[4];
 
 	float menu_title_bg_color[4];
+	float menu_title_text_color[4];
 
 	int osd_border_width;
 

--- a/src/action.c
+++ b/src/action.c
@@ -630,6 +630,10 @@ show_menu(struct server *server, struct view *view,
 		return;
 	}
 
+	/* need to be current to be useful */
+	create_client_list_combined_menu(menu->server);
+	create_client_send_to_menu(menu->server);
+
 	int x = server->seat.cursor->x;
 	int y = server->seat.cursor->y;
 
@@ -655,11 +659,15 @@ show_menu(struct server *server, struct view *view,
 			y = rc.resize_popup_fixed_position.y + output_box.y;
 		} else { /* Center the menu */
 			struct menuitem *item;
-			int max_width = 0;
+			struct theme *theme = server->theme;
+			int max_width = theme->menu_min_width;
 
 			wl_list_for_each(item, &menu->menuitems, link) {
 				if (item->native_width > max_width) {
-					max_width = item->native_width;
+					max_width = item->native_width <
+						theme->menu_max_width ?
+						item->native_width :
+						theme->menu_max_width;
 				}
 			}
 			x = (output->usable_area.width / 2) -

--- a/src/common/font.c
+++ b/src/common/font.c
@@ -20,6 +20,9 @@ font_to_pango_desc(struct font *font)
 	if (font->slant == FONT_SLANT_ITALIC) {
 		pango_font_description_set_style(desc, PANGO_STYLE_ITALIC);
 	}
+	if (font->slant == FONT_SLANT_OBLIQUE) {
+		pango_font_description_set_style(desc, PANGO_STYLE_OBLIQUE);
+	}
 	if (font->weight == FONT_WEIGHT_BOLD) {
 		pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
 	}

--- a/src/common/scaled-font-buffer.c
+++ b/src/common/scaled-font-buffer.c
@@ -14,12 +14,16 @@
 static struct lab_data_buffer *
 _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
 {
-	struct lab_data_buffer *buffer;
+	struct lab_data_buffer *buffer = NULL;
 	struct scaled_font_buffer *self = scaled_buffer->data;
 
 	/* Buffer gets free'd automatically along the backing wlr_buffer */
 	font_buffer_create(&buffer, self->max_width, self->text,
 		&self->font, self->color, self->bg_color, self->arrow, scale);
+
+	if (!buffer) {
+		wlr_log(WLR_ERROR, "font_buffer_create() failed");
+	}
 
 	self->width = buffer ? buffer->unscaled_width : 0;
 	self->height = buffer ? buffer->unscaled_height : 0;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -69,6 +69,7 @@ enum font_place {
 	FONT_PLACE_UNKNOWN,
 	FONT_PLACE_ACTIVEWINDOW,
 	FONT_PLACE_INACTIVEWINDOW,
+	FONT_PLACE_MENUHEADER,
 	FONT_PLACE_MENUITEM,
 	FONT_PLACE_OSD,
 	/* TODO: Add all places based on Openbox's rc.xml */
@@ -691,8 +692,13 @@ set_font_attr(struct font *font, const char *nodename, const char *content)
 	} else if (!strcmp(nodename, "size")) {
 		font->size = atoi(content);
 	} else if (!strcmp(nodename, "slant")) {
-		font->slant = !strcasecmp(content, "italic") ?
-			FONT_SLANT_ITALIC : FONT_SLANT_NORMAL;
+		if (!strcasecmp(content, "italic")) {
+			font->slant = FONT_SLANT_ITALIC;
+		} else if (!strcasecmp(content, "oblique")) {
+			font->slant = FONT_SLANT_OBLIQUE;
+		} else {
+			font->slant = FONT_SLANT_NORMAL;
+		}
 	} else if (!strcmp(nodename, "weight")) {
 		font->weight = !strcasecmp(content, "bold") ?
 			FONT_WEIGHT_BOLD : FONT_WEIGHT_NORMAL;
@@ -715,6 +721,7 @@ fill_font(char *nodename, char *content, enum font_place place)
 		 */
 		set_font_attr(&rc.font_activewindow, nodename, content);
 		set_font_attr(&rc.font_inactivewindow, nodename, content);
+		set_font_attr(&rc.font_menuheader, nodename, content);
 		set_font_attr(&rc.font_menuitem, nodename, content);
 		set_font_attr(&rc.font_osd, nodename, content);
 		break;
@@ -723,6 +730,9 @@ fill_font(char *nodename, char *content, enum font_place place)
 		break;
 	case FONT_PLACE_INACTIVEWINDOW:
 		set_font_attr(&rc.font_inactivewindow, nodename, content);
+		break;
+	case FONT_PLACE_MENUHEADER:
+		set_font_attr(&rc.font_menuheader, nodename, content);
 		break;
 	case FONT_PLACE_MENUITEM:
 		set_font_attr(&rc.font_menuitem, nodename, content);
@@ -748,6 +758,8 @@ enum_font_place(const char *place)
 		return FONT_PLACE_ACTIVEWINDOW;
 	} else if (!strcasecmp(place, "InactiveWindow")) {
 		return FONT_PLACE_INACTIVEWINDOW;
+	} else if (!strcasecmp(place, "MenuHeader")) {
+		return FONT_PLACE_MENUHEADER;
 	} else if (!strcasecmp(place, "MenuItem")) {
 		return FONT_PLACE_MENUITEM;
 	} else if (!strcasecmp(place, "OnScreenDisplay")
@@ -1277,6 +1289,7 @@ rcxml_init(void)
 
 	init_font_defaults(&rc.font_activewindow);
 	init_font_defaults(&rc.font_inactivewindow);
+	init_font_defaults(&rc.font_menuheader);
 	init_font_defaults(&rc.font_menuitem);
 	init_font_defaults(&rc.font_osd);
 
@@ -1523,6 +1536,9 @@ post_processing(void)
 	if (!rc.font_inactivewindow.name) {
 		rc.font_inactivewindow.name = xstrdup("sans");
 	}
+	if (!rc.font_menuheader.name) {
+		rc.font_menuheader.name = xstrdup("sans");
+	}
 	if (!rc.font_menuitem.name) {
 		rc.font_menuitem.name = xstrdup("sans");
 	}
@@ -1728,6 +1744,7 @@ rcxml_finish(void)
 {
 	zfree(rc.font_activewindow.name);
 	zfree(rc.font_inactivewindow.name);
+	zfree(rc.font_menuheader.name);
 	zfree(rc.font_menuitem.name);
 	zfree(rc.font_osd.name);
 	zfree(rc.theme_name);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1051,6 +1051,18 @@ entry(xmlNode *node, char *nodename, char *content)
 		}
 	} else if (!strcasecmp(nodename, "drawContents.resize")) {
 		set_bool(content, &rc.resize_draw_contents);
+	} else if (!strcasecmp(nodename, "popupPosition.resize")) {
+		rc.resize_popup_position = LAB_MENU_ATCURSOR;
+		if (!strcasecmp(content, "Fixed")) {
+			rc.resize_popup_position = LAB_MENU_FIXED;
+		}
+		if (!strcasecmp(content, "Center")) {
+			rc.resize_popup_position = LAB_MENU_CENTER;
+		}
+	} else if (!strcasecmp(nodename, "x.popupFixedPosition.resize")) {
+		rc.resize_popup_fixed_position.x = atoi(content);
+	} else if (!strcasecmp(nodename, "y.popupFixedPosition.resize")) {
+		rc.resize_popup_fixed_position.y = atoi(content);
 	} else if (!strcasecmp(nodename, "mouseEmulation.tablet")) {
 		set_bool(content, &rc.tablet.force_mouse_emulation);
 	} else if (!strcasecmp(nodename, "mapToOutput.tablet")) {
@@ -1307,6 +1319,7 @@ rcxml_init(void)
 
 	rc.resize_indicator = LAB_RESIZE_INDICATOR_NEVER;
 	rc.resize_draw_contents = true;
+	rc.resize_popup_position = LAB_MENU_ATCURSOR;
 
 	rc.workspace_config.popuptime = INT_MIN;
 	rc.workspace_config.min_nr_workspaces = 1;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -138,6 +138,14 @@ menu_update_width(struct menu *menu)
 				scaled_font_buffer_set_max_width(item->normal.buffer,
 					max_width);
 			}
+			if (theme->menu_title_text_justify == LAB_JUSTIFY_CENTER) {
+				int x, y;
+				x = (max_width - theme->menu_item_padding_x -
+						item->native_width) / 2;
+				x = x < 0 ? 0 : x;
+				y = (theme->menu_item_height - item->normal.buffer->height) / 2;
+				wlr_scene_node_set_position(item->normal.text, x, y);
+			}
 		}
 
 		if (item->selectable) {
@@ -290,9 +298,16 @@ separator_create(struct menu *menu, const char *label)
 	struct server *server = menu->server;
 	struct theme *theme = server->theme;
 
+	/*
+	 * Convert empty label ie "", to a regular separator line
+	 * if one desires an empty title line then set label to " "
+	 */
+	if (label && !strlen(label)) {
+		menuitem->type = LAB_MENU_SEPARATOR_LINE;
+	}
 	if (menuitem->type == LAB_MENU_TITLE) {
 		menuitem->height = theme->menu_item_height;
-		menuitem->native_width = font_width(&rc.font_menuitem, label);
+		menuitem->native_width = font_width(&rc.font_menuheader, label);
 	} else if (menuitem->type == LAB_MENU_SEPARATOR_LINE) {
 		menuitem->height = theme->menu_separator_line_thickness +
 				2 * theme->menu_separator_padding_height;
@@ -309,6 +324,8 @@ separator_create(struct menu *menu, const char *label)
 	/* Item background nodes */
 	float *bg_color = menuitem->type == LAB_MENU_TITLE
 		? theme->menu_title_bg_color : theme->menu_items_bg_color;
+	float *text_color = menuitem->type == LAB_MENU_TITLE
+		? theme->menu_title_text_color : theme->menu_items_text_color;
 	menuitem->normal.background = &wlr_scene_rect_create(
 		menuitem->normal.tree,
 		menu->size.width, menuitem->height, bg_color)->node;
@@ -325,8 +342,8 @@ separator_create(struct menu *menu, const char *label)
 		menuitem->normal.text = &menuitem->normal.buffer->scene_buffer->node;
 		/* Font buffer */
 		scaled_font_buffer_update(menuitem->normal.buffer, label,
-			menuitem->native_width, &rc.font_menuitem,
-			theme->menu_items_text_color, bg_color, /* arrow */ NULL);
+			menuitem->native_width, &rc.font_menuheader,
+			text_color, bg_color, /* arrow */ NULL);
 		/* Center font nodes */
 		int x, y;
 		x = theme->menu_item_padding_x;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -108,26 +108,42 @@ menu_update_width(struct menu *menu)
 	}
 	menu->size.width = max_width + 2 * theme->menu_item_padding_x;
 
+	/*
+	 * TODO: This function is getting a bit unwieldy. Consider calculating
+	 * the menu-window width up-front to avoid this post_processing() and
+	 * second-bite-of-the-cherry stuff
+	 */
+
 	/* Update all items for the new size */
 	wl_list_for_each(item, &menu->menuitems, link) {
 		wlr_scene_rect_set_size(
 			wlr_scene_rect_from_node(item->normal.background),
 			menu->size.width, item->height);
 
-		if (!item->selected.background) {
-			/* This is a separator. They don't have a selected background. */
+		/*
+		 * Separator lines are special because they change width with
+		 * the menu.
+		 */
+		if (item->type == LAB_MENU_SEPARATOR_LINE) {
+			int width = menu->size.width
+				- 2 * theme->menu_separator_padding_width
+				- 2 * theme->menu_item_padding_x;
 			wlr_scene_rect_set_size(
 				wlr_scene_rect_from_node(item->normal.text),
-				menu->size.width - 2 * theme->menu_separator_padding_width,
-				theme->menu_separator_line_thickness);
-		} else {
-			/* Usual menu item */
+				width, theme->menu_separator_line_thickness);
+		}
+
+		if (item->selectable) {
+			/* Only selectable items have item->selected.background */
 			wlr_scene_rect_set_size(
 				wlr_scene_rect_from_node(item->selected.background),
 				menu->size.width, item->height);
-			if (item->native_width > max_width || item->submenu || item->execute) {
-				scaled_font_buffer_set_max_width(item->normal.buffer,
-					max_width);
+		}
+
+		if (item->native_width > max_width || item->submenu || item->execute) {
+			scaled_font_buffer_set_max_width(item->normal.buffer,
+				max_width);
+			if (item->selectable) {
 				scaled_font_buffer_set_max_width(item->selected.buffer,
 					max_width);
 			}
@@ -178,16 +194,13 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 	struct menuitem *menuitem = znew(*menuitem);
 	menuitem->parent = menu;
 	menuitem->selectable = true;
+	menuitem->type = LAB_MENU_ITEM;
 	struct server *server = menu->server;
 	struct theme *theme = server->theme;
 
 	const char *arrow = show_arrow ? "›" : NULL;
 
-	if (!menu->item_height) {
-		menu->item_height = font_height(&rc.font_menuitem)
-			+ 2 * theme->menu_item_padding_y;
-	}
-	menuitem->height = menu->item_height;
+	menuitem->height = theme->menu_item_height;
 
 	int x, y;
 	menuitem->native_width = font_width(&rc.font_menuitem, text);
@@ -207,11 +220,11 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 	/* Item background nodes */
 	menuitem->normal.background = &wlr_scene_rect_create(
 		menuitem->normal.tree,
-		menu->size.width, menu->item_height,
+		menu->size.width, theme->menu_item_height,
 		theme->menu_items_bg_color)->node;
 	menuitem->selected.background = &wlr_scene_rect_create(
 		menuitem->selected.tree,
-		menu->size.width, menu->item_height,
+		menu->size.width, theme->menu_item_height,
 		theme->menu_items_active_bg_color)->node;
 
 	/* Font nodes */
@@ -240,9 +253,9 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 
 	/* Center font nodes */
 	x = theme->menu_item_padding_x;
-	y = (menu->item_height - menuitem->normal.buffer->height) / 2;
+	y = (theme->menu_item_height - menuitem->normal.buffer->height) / 2;
 	wlr_scene_node_set_position(menuitem->normal.text, x, y);
-	y = (menu->item_height - menuitem->selected.buffer->height) / 2;
+	y = (theme->menu_item_height - menuitem->selected.buffer->height) / 2;
 	wlr_scene_node_set_position(menuitem->selected.text, x, y);
 
 	/* Position the item in relation to its menu */
@@ -265,33 +278,67 @@ separator_create(struct menu *menu, const char *label)
 	struct menuitem *menuitem = znew(*menuitem);
 	menuitem->parent = menu;
 	menuitem->selectable = false;
+	menuitem->type = string_null_or_empty(label) ? LAB_MENU_SEPARATOR_LINE
+		: LAB_MENU_TITLE;
 	struct server *server = menu->server;
 	struct theme *theme = server->theme;
-	menuitem->height = theme->menu_separator_line_thickness +
-			2 * theme->menu_separator_padding_height;
 
+	if (menuitem->type == LAB_MENU_TITLE) {
+		menuitem->height = theme->menu_item_height;
+		menuitem->native_width = font_width(&rc.font_menuitem, label);
+	} else if (menuitem->type == LAB_MENU_SEPARATOR_LINE) {
+		menuitem->height = theme->menu_separator_line_thickness +
+				2 * theme->menu_separator_padding_height;
+	}
+
+	/* Menu item root node */
 	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
 	node_descriptor_create(&menuitem->tree->node,
 		LAB_NODE_DESC_MENUITEM, menuitem);
+
+	/* Tree to hold background and text/line buffer */
 	menuitem->normal.tree = wlr_scene_tree_create(menuitem->tree);
+
+	/* Item background nodes */
+	float *bg_color = menuitem->type == LAB_MENU_TITLE
+		? theme->menu_title_bg_color : theme->menu_items_bg_color;
 	menuitem->normal.background = &wlr_scene_rect_create(
 		menuitem->normal.tree,
-		menu->size.width, menuitem->height,
-		theme->menu_items_bg_color)->node;
+		menu->size.width, menuitem->height, bg_color)->node;
 
-	int width = menu->size.width - 2 * theme->menu_separator_padding_width;
-	menuitem->normal.text = &wlr_scene_rect_create(
-		menuitem->normal.tree,
-		width > 0 ? width : 0,
-		theme->menu_separator_line_thickness,
-		theme->menu_separator_color)->node;
-
+	/* Draw separator line or title */
+	if (menuitem->type == LAB_MENU_TITLE) {
+		menuitem->normal.buffer = scaled_font_buffer_create(menuitem->normal.tree);
+		if (!menuitem->normal.buffer) {
+			wlr_log(WLR_ERROR, "Failed to create menu item '%s'", label);
+			wlr_scene_node_destroy(&menuitem->tree->node);
+			free(menuitem);
+			return NULL;
+		}
+		menuitem->normal.text = &menuitem->normal.buffer->scene_buffer->node;
+		/* Font buffer */
+		scaled_font_buffer_update(menuitem->normal.buffer, label,
+			menuitem->native_width, &rc.font_menuitem,
+			theme->menu_items_text_color, bg_color, /* arrow */ NULL);
+		/* Center font nodes */
+		int x, y;
+		x = theme->menu_item_padding_x;
+		y = (theme->menu_item_height - menuitem->normal.buffer->height) / 2;
+		wlr_scene_node_set_position(menuitem->normal.text, x, y);
+	} else {
+		int nominal_width = theme->menu_min_width;
+		menuitem->normal.text = &wlr_scene_rect_create(
+			menuitem->normal.tree, nominal_width,
+			theme->menu_separator_line_thickness,
+			theme->menu_separator_color)->node;
+		wlr_scene_node_set_position(&menuitem->tree->node, 0, menu->size.height);
+		/* Vertically center-align separator line */
+		wlr_scene_node_set_position(menuitem->normal.text,
+			theme->menu_separator_padding_width
+			+ theme->menu_item_padding_x,
+			theme->menu_separator_padding_height);
+	}
 	wlr_scene_node_set_position(&menuitem->tree->node, 0, menu->size.height);
-
-	/* Vertically center-align separator line */
-	wlr_scene_node_set_position(menuitem->normal.text,
-		theme->menu_separator_padding_width,
-		theme->menu_separator_padding_height);
 
 	menu->size.height += menuitem->height;
 	wl_list_append(&menu->menuitems, &menuitem->link);
@@ -784,7 +831,7 @@ menu_configure(struct menu *menu, int lx, int ly, enum menu_align align)
 		ly -= menu->size.height;
 		if (menu->parent) {
 			/* For submenus adjust y to bottom left corner */
-			ly += menu->item_height;
+			ly += theme->menu_item_height;
 		}
 	}
 	wlr_scene_node_set_position(&menu->scene_tree->node, lx, ly);

--- a/src/theme.c
+++ b/src/theme.c
@@ -528,6 +528,8 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->menu_separator_padding_height = 3;
 	parse_hexstr("#888888", theme->menu_separator_color);
 
+	parse_hexstr("#589bda", theme->menu_title_bg_color);
+
 	theme->osd_window_switcher_width = 600;
 	theme->osd_window_switcher_width_is_percent = false;
 	theme->osd_window_switcher_padding = 4;
@@ -764,6 +766,10 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match_glob(key, "menu.separator.color")) {
 		parse_hexstr(value, theme->menu_separator_color);
+	}
+
+	if (match_glob(key, "menu.title.bg.color")) {
+		parse_hexstr(value, theme->menu_title_bg_color);
 	}
 
 	if (match_glob(key, "osd.bg.color")) {
@@ -1298,6 +1304,9 @@ post_processing(struct theme *theme)
 	if (theme->title_height < h) {
 		theme->title_height = h + 2 * theme->padding_height;
 	}
+
+	theme->menu_item_height = font_height(&rc.font_menuitem)
+		+ 2 * theme->menu_item_padding_y;
 
 	theme->osd_window_switcher_item_height = font_height(&rc.font_osd)
 		+ 2 * theme->osd_window_switcher_item_padding_y

--- a/src/theme.c
+++ b/src/theme.c
@@ -487,6 +487,7 @@ theme_builtin(struct theme *theme, struct server *server)
 	parse_hexstr("#000000", theme->window_active_label_text_color);
 	parse_hexstr("#000000", theme->window_inactive_label_text_color);
 	theme->window_label_text_justify = parse_justification("Center");
+	theme->menu_title_text_justify = parse_justification("Left");
 
 	theme->window_button_width = 26;
 
@@ -529,6 +530,7 @@ theme_builtin(struct theme *theme, struct server *server)
 	parse_hexstr("#888888", theme->menu_separator_color);
 
 	parse_hexstr("#589bda", theme->menu_title_bg_color);
+	parse_hexstr("#000000", theme->menu_title_text_color);
 
 	theme->osd_window_switcher_width = 600;
 	theme->osd_window_switcher_width_is_percent = false;
@@ -605,6 +607,9 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match_glob(key, "menu.items.padding.y")) {
 		theme->menu_item_padding_y = atoi(value);
+	}
+	if (match_glob(key, "menu.title.text.justify")) {
+		theme->menu_title_text_justify = parse_justification(value);
 	}
 	if (match_glob(key, "menu.overlap.x")) {
 		theme->menu_overlap_x = atoi(value);
@@ -770,6 +775,10 @@ entry(struct theme *theme, const char *key, const char *value)
 
 	if (match_glob(key, "menu.title.bg.color")) {
 		parse_hexstr(value, theme->menu_title_bg_color);
+	}
+
+	if (match_glob(key, "menu.title.text.color")) {
+		parse_hexstr(value, theme->menu_title_text_color);
 	}
 
 	if (match_glob(key, "osd.bg.color")) {


### PR DESCRIPTION
This draft contains 4 commits, ETA - 6 commits
1. #1976 draft by johanmalm (only here so that the latter changes can be looked at)
2. Pipemenu - make non-parent work
3. Menu placement, x,y placement (global) except for client-menu ie window menu
4. client-list-combined-menu - internal menu based on openbox
ETA
5. client-send-to-menu - internal menu, shows all workspaces and left/right
6. separator label changes, text color, font for label and justification (center)

I'm having second thoughts about making x,y placement to be global, even though that's what openbox does
It would be more flexible to allow per menu placement. I'm open on going either way

This is a WIP, it works for me, and I drive it daily so, I'm keeping an eye out for unwanted behavior.

Anyway, comments, suggestions, etc.

Reference: #1945 and  #1976

Edit to add: I hadn't realized about using sprintf and strcat/strcpy, I'll change those before this goes to PR.

ETA2: Fixed logic flaw/oversight and added another commit, client-send-to-menu, replace the workspace
section of client-list, allows sending current window to any workspace, along with left/right,

ETA3: 07/31 
added send-to menu (shows all workspaces, along with left/right
added separator label enhancements, text color, font, justification (center) 