### PR TITLE
xdg: account for drag resistance in do_late_positioning()

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -503,8 +503,12 @@ void seat_output_layout_changed(struct seat *seat);
  *
  * geometry->{width,height} are provided by the caller.
  * geometry->{x,y} are computed by this function.
+ *
+ * @note When drag-resistance is used, cursor_x/y should be the original
+ *       cursor position when the button was pressed.
  */
-void interactive_anchor_to_cursor(struct view *view, struct wlr_box *geometry);
+void interactive_anchor_to_cursor(struct view *view, struct wlr_box *geometry,
+	int cursor_x, int cursor_y);
 
 /**
  * interactive_move_tiled_view_to() - Un-tile the tiled/maximized view at the

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -23,12 +23,12 @@ max_move_scale(double pos_cursor, double pos_current,
 }
 
 void
-interactive_anchor_to_cursor(struct view *view, struct wlr_box *geometry)
+interactive_anchor_to_cursor(struct view *view, struct wlr_box *geometry,
+		int cursor_x, int cursor_y)
 {
-	struct wlr_cursor *cursor = view->server->seat.cursor;
-	geometry->x = max_move_scale(cursor->x, view->current.x,
+	geometry->x = max_move_scale(cursor_x, view->current.x,
 		view->current.width, geometry->width);
-	geometry->y = max_move_scale(cursor->y, view->current.y,
+	geometry->y = max_move_scale(cursor_y, view->current.y,
 		view->current.height, geometry->height);
 }
 
@@ -113,7 +113,8 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 			geometry.width = view->natural_geometry.width;
 			geometry.height = view->natural_geometry.height;
 			if (!wlr_box_empty(&geometry)) {
-				interactive_anchor_to_cursor(view, &geometry);
+				interactive_anchor_to_cursor(view, &geometry,
+					seat->cursor->x, seat->cursor->y);
 			}
 
 			/*

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -93,13 +93,14 @@ do_late_positioning(struct view *view)
 	struct server *server = view->server;
 	if (server->input_mode == LAB_INPUT_STATE_MOVE
 			&& view == server->grabbed_view) {
-		/* Keep view underneath cursor */
-		/* TODO: resistance is not considered */
-		interactive_anchor_to_cursor(view, &view->pending);
-		/* Update grab offsets */
-		server->grab_x = server->seat.cursor->x;
-		server->grab_y = server->seat.cursor->y;
+		/* Anchor view to original grab position */
+		interactive_anchor_to_cursor(view, &view->pending,
+			server->grab_x, server->grab_y);
+		/* Next update grab offsets */
 		server->grab_box = view->pending;
+		/* Finally, move by same distance cursor has moved */
+		view->pending.x += server->seat.cursor->x - server->grab_x;
+		view->pending.y += server->seat.cursor->y - server->grab_y;
 	} else {
 		/* TODO: smart placement? */
 		view_compute_centered_position(view, NULL,


### PR DESCRIPTION
The position where the view should be anchored can now be slightly different from the current cursor position.

Addresses a TODO from #2009.