### PR TITLE
wayland-wrap: add wayland-1.23

### DIFF
--- a/subprojects/wayland.wrap
+++ b/subprojects/wayland.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://gitlab.freedesktop.org/wayland/wayland.git
+revision = 1.23.0
+
+[provide]
+dependency_names = wayland-1.23.0
+wayland-1.23=wayland


### PR DESCRIPTION
Stable Fedora and Debian distributions are still on 1.22.