### PR TITLE
CI: Install libwlroots-0.18-dev for the Debian runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
           apt-get upgrade -y
           apt-get install -y git gcc clang gdb xwayland
           apt-get build-dep -y labwc
+          apt-get install libwlroots-0.18-dev
 
       - name: Install FreeBSD dependencies
         if: matrix.name == 'FreeBSD'


### PR DESCRIPTION
Its not available yet but once its available in the Testing repo the CI should start working again for Debian.