### PR TITLE
 interactive: allow moving horizontally/vertically maximized window

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -330,6 +330,11 @@ this is for compatibility with Openbox.
 	Sets the movement of cursor in pixel required for a tiled or maximized
 	window to be moved with an interactive move. Default is 20.
 
+*<resistance><unMaximizeThreshold>*
+	Sets the one-dimentional movement of cursor in pixel required for a
+	*vertically or horizontally* maximized window to be moved with an
+	interactive move. Default is 150.
+
 ## FOCUS
 
 *<focus><followMouse>* [yes|no]

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -107,7 +107,10 @@
   <resistance>
     <screenEdgeStrength>20</screenEdgeStrength>
     <windowEdgeStrength>20</windowEdgeStrength>
+    <!-- resistance for maximized/tiled windows -->
     <unSnapThreshold>20</unSnapThreshold>
+    <!-- resistance for vertically/horizontally maximized windows -->
+    <unMaximizeThreshold>150</unMaximizeThreshold>
   </resistance>
 
   <resize>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -125,6 +125,7 @@ struct rcxml {
 	int screen_edge_strength;
 	int window_edge_strength;
 	int unsnap_threshold;
+	int unmaximize_threshold;
 
 	/* window snapping */
 	int snap_edge_range;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -261,13 +261,6 @@ struct server {
 	/* cursor interactive */
 	enum input_mode input_mode;
 	struct view *grabbed_view;
-	/*
-	 * When an interactive move is requested for tiled/maximized views by CSD
-	 * clients or by Drag actions, the actual motion and untiling of the view
-	 * can be delayed to prevent the view from being unintentionally untiled.
-	 * During this delay, move_pending is set.
-	 */
-	bool move_pending;
 	/* Cursor position when interactive move/resize is requested */
 	double grab_x, grab_y;
 	/* View geometry when interactive move/resize is requested */
@@ -503,26 +496,15 @@ void seat_reset_pressed(struct seat *seat);
 void seat_output_layout_changed(struct seat *seat);
 
 /**
- * interactive_anchor_to_cursor() - repositions the view to remain
+ * interactive_anchor_to_cursor() - repositions the geometry to remain
  * underneath the cursor when its size changes during interactive move.
+ * This function also resizes server->grab_box and repositions it to remain
+ * underneath server->grab_{x,y}.
  *
- * geometry->{width,height} are provided by the caller.
- * geometry->{x,y} are computed by this function.
- *
- * @note When <unSnapThreshold> is non-zero, cursor_x/y should be the original
- *       cursor position when the button was pressed.
+ * geo->{width,height} are provided by the caller.
+ * geo->{x,y} are computed by this function.
  */
-void interactive_anchor_to_cursor(struct view *view, struct wlr_box *geometry,
-	int cursor_x, int cursor_y);
-
-/**
- * interactive_move_tiled_view_to() - Un-tile the tiled/maximized view at the
- * start of an interactive move or when an interactive move is pending.
- * Returns true if the distance of cursor motion exceeds the value of
- * <resistance><unSnapThreshold> and the view is un-tiled.
- */
-bool interactive_move_tiled_view_to(struct server *server, struct view *view,
-	struct wlr_box *geometry);
+void interactive_anchor_to_cursor(struct server *server, struct wlr_box *geo);
 
 void interactive_begin(struct view *view, enum input_mode mode, uint32_t edges);
 void interactive_finish(struct view *view);

--- a/include/resistance.h
+++ b/include/resistance.h
@@ -3,7 +3,12 @@
 #define LABWC_RESISTANCE_H
 #include "labwc.h"
 
-void resistance_move_apply(struct view *view, double *x, double *y);
+/**
+ * resistance_unsnap_apply() - Apply resistance when dragging a
+ * maximized/tiled window. Returns true when the view needs to be un-tiled.
+ */
+bool resistance_unsnap_apply(struct view *view, int *x, int *y);
+void resistance_move_apply(struct view *view, int *x, int *y);
 void resistance_resize_apply(struct view *view, struct wlr_box *new_view_geo);
 
 #endif /* LABWC_RESISTANCE_H */

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -967,6 +967,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.window_edge_strength = atoi(content);
 	} else if (!strcasecmp(nodename, "unSnapThreshold.resistance")) {
 		rc.unsnap_threshold = atoi(content);
+	} else if (!strcasecmp(nodename, "unMaximizeThreshold.resistance")) {
+		rc.unmaximize_threshold = atoi(content);
 	} else if (!strcasecmp(nodename, "range.snapping")) {
 		rc.snap_edge_range = atoi(content);
 	} else if (!strcasecmp(nodename, "enabled.overlay.snapping")) {
@@ -1290,6 +1292,7 @@ rcxml_init(void)
 	rc.screen_edge_strength = 20;
 	rc.window_edge_strength = 20;
 	rc.unsnap_threshold = 20;
+	rc.unmaximize_threshold = 150;
 
 	rc.snap_edge_range = 1;
 	rc.snap_overlay_enabled = true;

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -56,7 +56,6 @@ interactive_move_tiled_view_to(struct server *server, struct view *view,
 		}
 	}
 
-	view_set_shade(view, false);
 	view_set_untiled(view);
 	view_restore_to(view, *geometry);
 	server->move_pending = false;
@@ -100,11 +99,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 		}
 		if (!view_is_floating(view)) {
 			/*
-			 * Un-maximize, unshade and restore natural
-			 * width/height.
-			 * Don't reset tiled state yet since we may want
-			 * to keep it (in the snap-to-maximize case).
-			 *
+			 * Un-maximize and restore natural width/height.
 			 * If the natural geometry is unknown (possible
 			 * with xdg-shell views), then we set a size of
 			 * 0x0 here and determine the correct geometry

--- a/src/regions.c
+++ b/src/regions.c
@@ -20,7 +20,8 @@ regions_should_snap(struct server *server)
 {
 	if (server->input_mode != LAB_INPUT_STATE_MOVE
 			|| wl_list_empty(&rc.regions)
-			|| server->seat.region_prevent_snap) {
+			|| server->seat.region_prevent_snap
+			|| !view_is_floating(server->grabbed_view)) {
 		return false;
 	}
 

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -91,8 +91,38 @@ check_edge_window(int *next, struct edge current, struct edge target,
 		oppose, align, rc.window_edge_strength, lesser);
 }
 
+bool
+resistance_unsnap_apply(struct view *view, int *x, int *y)
+{
+	if (view_is_floating(view)) {
+		return false;
+	}
+
+	int dx = *x - view->current.x;
+	int dy = *y - view->current.y;
+	if (view->maximized == VIEW_AXIS_HORIZONTAL) {
+		if (abs(dx) < rc.unmaximize_threshold) {
+			*x = view->current.x;
+			return false;
+		}
+	} else if (view->maximized == VIEW_AXIS_VERTICAL) {
+		if (abs(dy) < rc.unmaximize_threshold) {
+			*y = view->current.y;
+			return false;
+		}
+	} else {
+		if (dx * dx + dy * dy < rc.unsnap_threshold * rc.unsnap_threshold) {
+			*x = view->current.x;
+			*y = view->current.y;
+			return false;
+		}
+	}
+
+	return true;
+}
+
 void
-resistance_move_apply(struct view *view, double *x, double *y)
+resistance_move_apply(struct view *view, int *x, int *y)
 {
 	assert(view);
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -93,14 +93,8 @@ do_late_positioning(struct view *view)
 	struct server *server = view->server;
 	if (server->input_mode == LAB_INPUT_STATE_MOVE
 			&& view == server->grabbed_view) {
-		/* Anchor view to original grab position */
-		interactive_anchor_to_cursor(view, &view->pending,
-			server->grab_x, server->grab_y);
-		/* Next update grab offsets */
-		server->grab_box = view->pending;
-		/* Finally, move by same distance cursor has moved */
-		view->pending.x += server->seat.cursor->x - server->grab_x;
-		view->pending.y += server->seat.cursor->y - server->grab_y;
+		/* Reposition the view while anchoring it to cursor */
+		interactive_anchor_to_cursor(server, &view->pending);
 	} else {
 		/* TODO: smart placement? */
 		view_compute_centered_position(view, NULL,


### PR DESCRIPTION
Fixes #1521

Applies drag resistance unidirectionally for horizontally/vertically maximized windows, allowing them to be dragged without being untiled immediately.

While dragging a horizontally/vertically maximized window, edge/region snapping is disabled to prevent unintentional snapping and overlays.

The first commit stops unshading maximized/tiled views at the start of interactive move as it did't seem to be useful and caused flicker.

This PR also includes some refactoring to simplify the logic.

I'm totally fine delaying this PR after the next release. But I want to move forward the discussion below:

## Discussion

As I said in IRC yesterday, I'm thinking of changing `<snapping><dragResistance>` to something like `<resistance><snapOffThreshold>` (or maybe `<resistance><unSnapThreshold>`) as `<resistance>` feels more suitable place for this setting. But while testing this PR, I started to think that it may be also useful to have another setting to configure the resistance for horizontally/vertically maximized windows as it requires more carefulness to drag them in one direction without un-tiling them.

What I came up with are:
- `<resistance><snapOffThreshold>` - for normally maximized or tiled windows
- `<resistance><snapOffThresholdHVMaximized>` - for horizontally/vertically maximized windows

Any ideas?