### PR TITLE
Rename <snapping><dragResistance> to <resistance><unSnapThreshold>

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -326,6 +326,10 @@ this is for compatibility with Openbox.
 
 	The default value for both parameters is 20 pixels.
 
+*<resistance><unSnapThreshold>*
+	Sets the movement of cursor in pixel required for a tiled or maximized
+	window to be moved with an interactive move. Default is 20.
+
 ## FOCUS
 
 *<focus><followMouse>* [yes|no]
@@ -355,10 +359,6 @@ extending outward from the snapped edge.
 	(in pixels) from the edge of an output, the move will trigger a
 	SnapToEdge action for that edge. A *range* of 0 disables snapping via
 	interactive moves. Default is 1.
-
-*<snapping><dragResistance>*
-	Sets the movement of cursor in pixel required for a tiled or maximized
-	window to be moved with an interactive move. Default is 20.
 
 *<snapping><overlay><enabled>* [yes|no]
 	Show an overlay when snapping to a window to an edge. Default is yes.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -107,6 +107,7 @@
   <resistance>
     <screenEdgeStrength>20</screenEdgeStrength>
     <windowEdgeStrength>20</windowEdgeStrength>
+    <unSnapThreshold>20</unSnapThreshold>
   </resistance>
 
   <resize>
@@ -125,7 +126,6 @@
   <snapping>
     <!-- Set range to 0 to disable window snapping completely -->
     <range>1</range>
-    <dragResistance>20</dragResistance>
     <overlay enabled="yes">
       <delay inner="500" outer="500" />
     </overlay>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -124,6 +124,7 @@ struct rcxml {
 	/* resistance */
 	int screen_edge_strength;
 	int window_edge_strength;
+	int unsnap_threshold;
 
 	/* window snapping */
 	int snap_edge_range;
@@ -132,7 +133,6 @@ struct rcxml {
 	int snap_overlay_delay_outer;
 	bool snap_top_maximize;
 	enum tiling_events_mode snap_tiling_events_mode;
-	int snap_drag_resistance;
 
 	enum resize_indicator_mode resize_indicator;
 	bool resize_draw_contents;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -504,7 +504,7 @@ void seat_output_layout_changed(struct seat *seat);
  * geometry->{width,height} are provided by the caller.
  * geometry->{x,y} are computed by this function.
  *
- * @note When drag-resistance is used, cursor_x/y should be the original
+ * @note When <unSnapThreshold> is non-zero, cursor_x/y should be the original
  *       cursor position when the button was pressed.
  */
 void interactive_anchor_to_cursor(struct view *view, struct wlr_box *geometry,
@@ -514,7 +514,7 @@ void interactive_anchor_to_cursor(struct view *view, struct wlr_box *geometry,
  * interactive_move_tiled_view_to() - Un-tile the tiled/maximized view at the
  * start of an interactive move or when an interactive move is pending.
  * Returns true if the distance of cursor motion exceeds the value of
- * <snapping><dragResistance> and the view is un-tiled.
+ * <resistance><unSnapThreshold> and the view is un-tiled.
  */
 bool interactive_move_tiled_view_to(struct server *server, struct view *view,
 	struct wlr_box *geometry);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -965,6 +965,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.screen_edge_strength = atoi(content);
 	} else if (!strcasecmp(nodename, "windowEdgeStrength.resistance")) {
 		rc.window_edge_strength = atoi(content);
+	} else if (!strcasecmp(nodename, "unSnapThreshold.resistance")) {
+		rc.unsnap_threshold = atoi(content);
 	} else if (!strcasecmp(nodename, "range.snapping")) {
 		rc.snap_edge_range = atoi(content);
 	} else if (!strcasecmp(nodename, "enabled.overlay.snapping")) {
@@ -987,8 +989,6 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			wlr_log(WLR_ERROR, "ignoring invalid value for notifyClient");
 		}
-	} else if (!strcasecmp(nodename, "dragResistance.snapping")) {
-		rc.snap_drag_resistance = atoi(content);
 
 	/* <windowSwitcher show="" preview="" outlines="" /> */
 	} else if (!strcasecmp(nodename, "show.windowSwitcher")) {
@@ -1289,6 +1289,7 @@ rcxml_init(void)
 	rc.kb_layout_per_window = false;
 	rc.screen_edge_strength = 20;
 	rc.window_edge_strength = 20;
+	rc.unsnap_threshold = 20;
 
 	rc.snap_edge_range = 1;
 	rc.snap_overlay_enabled = true;
@@ -1296,7 +1297,6 @@ rcxml_init(void)
 	rc.snap_overlay_delay_outer = 500;
 	rc.snap_top_maximize = true;
 	rc.snap_tiling_events_mode = LAB_TILING_EVENTS_ALWAYS;
-	rc.snap_drag_resistance = 20;
 
 	rc.window_switcher.show = true;
 	rc.window_switcher.preview = true;

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -236,7 +236,7 @@ process_cursor_move(struct server *server, uint32_t time)
 
 	/*
 	 * Un-tile the view when interactive move is delayed and the distance
-	 * of cursor movement exceeds <snapping><dragResistance>.
+	 * of cursor movement exceeds <resistance><unSnapThreshold>.
 	 */
 	if (server->move_pending && !interactive_move_tiled_view_to(
 			server, server->grabbed_view, &server->grab_box)) {

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -38,7 +38,7 @@ interactive_move_tiled_view_to(struct server *server, struct view *view,
 {
 	assert(!view_is_floating(view));
 
-	int resistance = rc.snap_drag_resistance;
+	int threshold = rc.unsnap_threshold;
 
 	if (server->input_mode == LAB_INPUT_STATE_MOVE) {
 		/* When called from cursor motion handler */
@@ -46,12 +46,12 @@ interactive_move_tiled_view_to(struct server *server, struct view *view,
 
 		double dx = server->seat.cursor->x - server->grab_x;
 		double dy = server->seat.cursor->y - server->grab_y;
-		if (dx * dx + dy * dy < resistance * resistance) {
+		if (dx * dx + dy * dy < threshold * threshold) {
 			return false;
 		}
 	} else {
 		/* When called from interactive_begin() */
-		if (resistance > 0) {
+		if (threshold > 0) {
 			return false;
 		}
 	}
@@ -118,7 +118,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 			}
 
 			/*
-			 * If <snapping><dragResistance> is non-zero, the
+			 * If <resistance><unSnapThreshold> is non-zero, the
 			 * tiled/maximized view is un-tiled later in cursor
 			 * motion handler.
 			 */


### PR DESCRIPTION
As we already have `<resistance><{screen,window}EdgeStrength>`, `<resistance>` will be a better place for this setting.