### PR TITLE
input: move <scrollFactor> to <libinput> section

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -590,9 +590,6 @@ extending outward from the snapped edge.
 *<mouse><doubleClickTime>*
 	Set double click time in milliseconds. Default is 500.
 
-*<mouse><scrollFactor>*
-	Set scroll factor. Default is 1.0.
-
 *<mouse><context name=""><mousebind button="" direction="" action=""><action>*
 	Multiple *<mousebind>* can exist within one *<context>*; and multiple
 	*<action>* can exist within one *<mousebind>*.
@@ -798,6 +795,7 @@ extending outward from the snapped edge.
     <clickMethod></clickMethod>
     <sendEventsMode></sendEventsMode>
     <calibrationMatrix></calibrationMatrix>
+    <scrollFactor>1.0</scrollFactor>
   </device>
 </libinput>
 ```
@@ -922,6 +920,9 @@ The most common matrices are:
 
 	visit https://wayland.freedesktop.org/libinput/doc/latest/absolute-axes.html#calibration-of-absolute-devices
 	for more information.
+
+*<libinput><scrollFactor>*
+	Set scroll factor. Default is 1.0.
 
 ## WINDOW RULES
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -323,7 +323,6 @@
 
     <!-- time is in ms -->
     <doubleClickTime>500</doubleClickTime>
-    <scrollFactor>1.0</scrollFactor>
 
     <context name="Frame">
       <mousebind button="A-Left" action="Press">
@@ -552,6 +551,7 @@
       - clickMethod [none|buttonAreas|clickfinger]
       - sendEventsMode [yes|no|disabledOnExternalMouse]
       - calibrationMatrix [six float values split by space]
+      - scrollFactor [float]
   -->
   <libinput>
     <device category="default">
@@ -568,6 +568,7 @@
       <clickMethod></clickMethod>
       <sendEventsMode></sendEventsMode>
       <calibrationMatrix></calibrationMatrix>
+      <scrollFactor>1.0</scrollFactor>
     </device>
   </libinput>
 

--- a/include/config/libinput.h
+++ b/include/config/libinput.h
@@ -31,6 +31,7 @@ struct libinput_category {
 	int click_method;               /* -1 or libinput_config_click_method */
 	int send_events_mode;           /* -1 or libinput_config_send_events_mode */
 	bool have_calibration_matrix;
+	double scroll_factor;
 	float calibration_matrix[6];
 };
 

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -99,7 +99,6 @@ struct rcxml {
 	/* mouse */
 	long doubleclick_time;     /* in ms */
 	struct wl_list mousebinds; /* struct mousebind.link */
-	double scroll_factor;
 
 	/* touch tablet */
 	struct wl_list touch_configs;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -71,6 +71,8 @@ enum input_mode {
 struct input {
 	struct wlr_input_device *wlr_input_device;
 	struct seat *seat;
+	/* Set for pointer/touch devices */
+	double scroll_factor;
 	struct wl_listener destroy;
 	struct wl_list link; /* seat.inputs */
 };

--- a/src/config/libinput.c
+++ b/src/config/libinput.c
@@ -26,6 +26,7 @@ libinput_category_init(struct libinput_category *l)
 	l->click_method = -1;
 	l->send_events_mode = -1;
 	l->have_calibration_matrix = false;
+	l->scroll_factor = 1.0;
 }
 
 enum lab_libinput_device_type

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1334,6 +1334,13 @@ cursor_axis(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(listener, seat, cursor_axis);
 	struct wlr_pointer_axis_event *event = data;
 	struct server *server = seat->server;
+
+	/* input->scroll_factor is set for pointer/touch devices */
+	assert(event->pointer->base.type == WLR_INPUT_DEVICE_POINTER
+		|| event->pointer->base.type == WLR_INPUT_DEVICE_TOUCH);
+	struct input *input = event->pointer->base.data;
+	double scroll_factor = input->scroll_factor;
+
 	struct cursor_context ctx = get_cursor_context(server);
 	idle_manager_notify_activity(seat->seat);
 
@@ -1348,8 +1355,8 @@ cursor_axis(struct wl_listener *listener, void *data)
 
 		/* Notify the client with pointer focus of the axis event. */
 		wlr_seat_pointer_notify_axis(seat->seat, event->time_msec,
-			event->orientation, rc.scroll_factor * event->delta,
-			round(rc.scroll_factor * event->delta_discrete),
+			event->orientation, scroll_factor * event->delta,
+			round(scroll_factor * event->delta_discrete),
 			event->source, event->relative_direction);
 	}
 }

--- a/src/seat.c
+++ b/src/seat.c
@@ -114,7 +114,11 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		wlr_log(WLR_ERROR, "no wlr_input_device");
 		return;
 	}
+	struct input *input = wlr_input_device->data;
+
+	/* Set scroll factor to 1.0 for Wayland/X11 backends or virtual pointers */
 	if (!wlr_input_device_is_libinput(wlr_input_device)) {
+		input->scroll_factor = 1.0;
 		return;
 	}
 
@@ -247,6 +251,9 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		wlr_log(WLR_INFO, "calibration matrix configured");
 		libinput_device_config_calibration_set_matrix(libinput_dev, dc->calibration_matrix);
 	}
+
+	wlr_log(WLR_INFO, "scroll factor configured");
+	input->scroll_factor = dc->scroll_factor;
 }
 
 static struct wlr_output *
@@ -286,6 +293,7 @@ new_pointer(struct seat *seat, struct wlr_input_device *dev)
 {
 	struct input *input = znew(*input);
 	input->wlr_input_device = dev;
+	dev->data = input;
 	configure_libinput(dev);
 	wlr_cursor_attach_input_device(seat->cursor, dev);
 
@@ -354,6 +362,7 @@ new_touch(struct seat *seat, struct wlr_input_device *dev)
 {
 	struct input *input = znew(*input);
 	input->wlr_input_device = dev;
+	dev->data = input;
 	configure_libinput(dev);
 	wlr_cursor_attach_input_device(seat->cursor, dev);
 	/* In support of running with WLR_WL_OUTPUTS set to >=2 */


### PR DESCRIPTION
Closes #2033.

But my concern about this PR is whether we should allow users to configure per-device scroll factor also for tablet devices. Looking at `handle_axis()` in `src/input/tablet.c`, it seems that we are not applying any multiplier to `distance` or `wheel_delta`. @jp7677 Do you have any opinions on this?