### PR TITLE
input: subscribe to tablet tool events from cursor

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -696,7 +696,7 @@ extending outward from the snapped edge.
 
 *<tablet rotate="" />* [0|90|180|270]
 	The tablet orientation can be changed in 90 degree steps. Default is
-	no rotation (0). Rotation will be applied after applying tablet area
+	no rotation (0). Rotation will be applied before applying tablet area
 	transformation.
 
 	See also *calibrationMatrix* in libinput section below for advanced

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -691,6 +691,9 @@ extending outward from the snapped edge.
 	If the output name is left empty or the output does not exists, the
 	tablet will span all outputs.
 
+	The tablet cursor automatically applies the orientation/rotation of
+	a mapped output for absolute motion.
+
 *<tablet rotate="" />* [0|90|180|270]
 	The tablet orientation can be changed in 90 degree steps. Default is
 	no rotation (0). Rotation will be applied after applying tablet area

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -23,10 +23,10 @@ struct drawing_tablet {
 	double slider;
 	double wheel_delta;
 	struct {
-		struct wl_listener proximity;
-		struct wl_listener axis;
-		struct wl_listener tip;
-		struct wl_listener button;
+		struct wl_listener tablet_tool_proximity;
+		struct wl_listener tablet_tool_axis;
+		struct wl_listener tablet_tool_tip;
+		struct wl_listener tablet_tool_button;
 		struct wl_listener destroy;
 	} handlers;
 	struct wl_list link; /* seat.tablets */

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -125,9 +125,9 @@ tablet_get_coords(struct drawing_tablet *tablet, double *x, double *y, double *d
 	*y = tablet->y;
 	*dx = tablet->dx;
 	*dy = tablet->dy;
+	adjust_for_rotation(rc.tablet.rotation, x, y);
 	adjust_for_tablet_area(tablet->tablet->width_mm, tablet->tablet->height_mm,
 		rc.tablet.box, x, y);
-	adjust_for_rotation(rc.tablet.rotation, x, y);
 	adjust_for_rotation_relative(rc.tablet.rotation, dx, dy);
 	adjust_for_motion_sensitivity(rc.tablet_tool.relative_motion_sensitivity, dx, dy);
 

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -236,7 +236,7 @@ notify_motion(struct drawing_tablet *tablet, struct drawing_tablet_tool *tool,
 }
 
 static void
-handle_proximity(struct wl_listener *listener, void *data)
+handle_tablet_tool_proximity(struct wl_listener *listener, void *data)
 {
 	struct wlr_tablet_tool_proximity_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
@@ -286,7 +286,7 @@ handle_proximity(struct wl_listener *listener, void *data)
 static bool is_down_mouse_emulation = false;
 
 static void
-handle_axis(struct wl_listener *listener, void *data)
+handle_tablet_tool_axis(struct wl_listener *listener, void *data)
 {
 	struct wlr_tablet_tool_axis_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
@@ -460,7 +460,7 @@ seat_pointer_end_grab(struct drawing_tablet_tool *tool,
 }
 
 static void
-handle_tip(struct wl_listener *listener, void *data)
+handle_tablet_tool_tip(struct wl_listener *listener, void *data)
 {
 	struct wlr_tablet_tool_tip_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
@@ -535,7 +535,7 @@ handle_tip(struct wl_listener *listener, void *data)
 }
 
 static void
-handle_button(struct wl_listener *listener, void *data)
+handle_tablet_tool_button(struct wl_listener *listener, void *data)
 {
 	struct wlr_tablet_tool_button_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
@@ -604,10 +604,10 @@ handle_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&tablet->link);
 	tablet_pad_attach_tablet(tablet->seat);
 
-	wl_list_remove(&tablet->handlers.tip.link);
-	wl_list_remove(&tablet->handlers.button.link);
-	wl_list_remove(&tablet->handlers.proximity.link);
-	wl_list_remove(&tablet->handlers.axis.link);
+	wl_list_remove(&tablet->handlers.tablet_tool_tip.link);
+	wl_list_remove(&tablet->handlers.tablet_tool_button.link);
+	wl_list_remove(&tablet->handlers.tablet_tool_proximity.link);
+	wl_list_remove(&tablet->handlers.tablet_tool_axis.link);
 	wl_list_remove(&tablet->handlers.destroy.link);
 	free(tablet);
 }
@@ -636,10 +636,10 @@ tablet_init(struct seat *seat, struct wlr_input_device *wlr_device)
 	tablet->wheel_delta = 0.0;
 	wlr_log(WLR_INFO, "tablet dimensions: %.2fmm x %.2fmm",
 		tablet->tablet->width_mm, tablet->tablet->height_mm);
-	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, axis);
-	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, proximity);
-	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, tip);
-	CONNECT_SIGNAL(tablet->tablet, &tablet->handlers, button);
+	CONNECT_SIGNAL(seat->cursor, &tablet->handlers, tablet_tool_axis);
+	CONNECT_SIGNAL(seat->cursor, &tablet->handlers, tablet_tool_proximity);
+	CONNECT_SIGNAL(seat->cursor, &tablet->handlers, tablet_tool_tip);
+	CONNECT_SIGNAL(seat->cursor, &tablet->handlers, tablet_tool_button);
 	CONNECT_SIGNAL(wlr_device, &tablet->handlers, destroy);
 
 	wl_list_insert(&seat->tablets, &tablet->link);


### PR DESCRIPTION
Contrary to the raw tablet events, the cursor events transform the coordinates based on a mapped output orientation. Otherwise those events are the same. See https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/types/wlr_cursor.c#L897

Note that this only applies to absolute coordinates, the relative ones (`dx`, `dy`) are not transformed, in that case a user still has to manually set rotation in our tablet config.

~Additionally our own rotation is applied after area transformation, but the auto rotation is applied before. No real issue, just a slightly inconsistent behavior. We could turn around our behavior though to make this fully consistent, which is a minimal change.~

TODO:
- [x]  More testing
- [x] Clarify auto rotation in the docs (tablet -> mapToOutput)
- [x] Apply rotation before (instead after) area transformation for consistent rotation behavior

Closes #1990 

cc: @dashavoo