### PR TITLE
fix: move cursor event listeners from tablet to seat 

### DIFF
--- a/include/input/tablet-pad.h
+++ b/include/input/tablet-pad.h
@@ -36,7 +36,7 @@ struct drawing_tablet_pad {
 	struct wl_list link; /* seat.tablet_pads */
 };
 
-void tablet_pad_init(struct seat *seat, struct wlr_input_device *wlr_input_device);
+void tablet_pad_create(struct seat *seat, struct wlr_input_device *wlr_input_device);
 void tablet_pad_attach_tablet(struct seat *seat);
 void tablet_pad_enter_surface(struct seat *seat, struct wlr_surface *wlr_surface);
 

--- a/include/input/tablet-tool.h
+++ b/include/input/tablet-tool.h
@@ -17,7 +17,7 @@ struct drawing_tablet_tool {
 	struct wl_list link; /* seat.tablet_tools */
 };
 
-void tablet_tool_init(struct seat *seat,
+void tablet_tool_create(struct seat *seat,
 	struct wlr_tablet_tool *wlr_tablet_tool);
 bool tablet_tool_has_focused_surface(struct seat *seat);
 

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -23,15 +23,13 @@ struct drawing_tablet {
 	double slider;
 	double wheel_delta;
 	struct {
-		struct wl_listener tablet_tool_proximity;
-		struct wl_listener tablet_tool_axis;
-		struct wl_listener tablet_tool_tip;
-		struct wl_listener tablet_tool_button;
 		struct wl_listener destroy;
 	} handlers;
 	struct wl_list link; /* seat.tablets */
 };
 
-void tablet_init(struct seat *seat, struct wlr_input_device *wlr_input_device);
+void tablet_init(struct seat *seat);
+void tablet_finish(struct seat *seat);
+void tablet_create(struct seat *seat, struct wlr_input_device *wlr_input_device);
 
 #endif /* LABWC_TABLET_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -192,6 +192,11 @@ struct seat {
 	struct wl_listener touch_motion;
 	struct wl_listener touch_frame;
 
+	struct wl_listener tablet_tool_proximity;
+	struct wl_listener tablet_tool_axis;
+	struct wl_listener tablet_tool_tip;
+	struct wl_listener tablet_tool_button;
+
 	struct wl_list tablets;
 	struct wl_list tablet_tools;
 	struct wl_list tablet_pads;

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -13,12 +13,13 @@
 #include "common/scene-helpers.h"
 #include "common/surface-helpers.h"
 #include "config/mousebind.h"
+#include "config/tablet-tool.h"
 #include "dnd.h"
 #include "idle.h"
 #include "input/gestures.h"
 #include "input/touch.h"
+#include "input/tablet.h"
 #include "input/tablet-tool.h"
-#include "input/tablet-pad.h"
 #include "labwc.h"
 #include "layers.h"
 #include "menu/menu.h"
@@ -1450,6 +1451,8 @@ cursor_init(struct seat *seat)
 	gestures_init(seat);
 	touch_init(seat);
 
+	tablet_init(seat);
+
 	seat->request_cursor.notify = request_cursor_notify;
 	wl_signal_add(&seat->seat->events.request_set_cursor,
 		&seat->request_cursor);
@@ -1487,6 +1490,8 @@ void cursor_finish(struct seat *seat)
 
 	gestures_finish(seat);
 	touch_finish(seat);
+
+	tablet_finish(seat);
 
 	wl_list_remove(&seat->request_cursor.link);
 	wl_list_remove(&seat->request_set_shape.link);

--- a/src/input/tablet-pad.c
+++ b/src/input/tablet-pad.c
@@ -175,7 +175,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 }
 
 void
-tablet_pad_init(struct seat *seat, struct wlr_input_device *wlr_device)
+tablet_pad_create(struct seat *seat, struct wlr_input_device *wlr_device)
 {
 	wlr_log(WLR_DEBUG, "setting up tablet pad");
 	struct drawing_tablet_pad *pad = znew(*pad);

--- a/src/input/tablet-tool.c
+++ b/src/input/tablet-tool.c
@@ -60,7 +60,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 }
 
 void
-tablet_tool_init(struct seat *seat,
+tablet_tool_create(struct seat *seat,
 		struct wlr_tablet_tool *wlr_tablet_tool)
 {
 	wlr_log(WLR_DEBUG, "setting up tablet tool");

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -241,6 +241,10 @@ handle_tablet_tool_proximity(struct wl_listener *listener, void *data)
 	struct wlr_tablet_tool_proximity_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
 	struct drawing_tablet_tool *tool = ev->tool->data;
+	if (!tablet) {
+		wlr_log(WLR_DEBUG, "tool proximity event before tablet create");
+		return;
+	}
 
 	if (ev->state == WLR_TABLET_TOOL_PROXIMITY_IN) {
 		tablet->motion_mode =
@@ -291,6 +295,10 @@ handle_tablet_tool_axis(struct wl_listener *listener, void *data)
 	struct wlr_tablet_tool_axis_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
 	struct drawing_tablet_tool *tool = ev->tool->data;
+	if (!tablet) {
+		wlr_log(WLR_DEBUG, "tool axis event before tablet create");
+		return;
+	}
 
 	/*
 	 * Reset relative coordinates. If those axes aren't updated,
@@ -465,6 +473,10 @@ handle_tablet_tool_tip(struct wl_listener *listener, void *data)
 	struct wlr_tablet_tool_tip_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
 	struct drawing_tablet_tool *tool = ev->tool->data;
+	if (!tablet) {
+		wlr_log(WLR_DEBUG, "tool tip event before tablet create");
+		return;
+	}
 
 	double x, y, dx, dy;
 	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);
@@ -540,6 +552,10 @@ handle_tablet_tool_button(struct wl_listener *listener, void *data)
 	struct wlr_tablet_tool_button_event *ev = data;
 	struct drawing_tablet *tablet = ev->tablet->data;
 	struct drawing_tablet_tool *tool = ev->tool->data;
+	if (!tablet) {
+		wlr_log(WLR_DEBUG, "tool button event before tablet create");
+		return;
+	}
 
 	double x, y, dx, dy;
 	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -2,6 +2,7 @@
 #include <wayland-util.h>
 #include <wlr/types/wlr_touch.h>
 #include <linux/input-event-codes.h>
+#include "common/macros.h"
 #include "common/mem.h"
 #include "common/scene-helpers.h"
 #include "idle.h"
@@ -9,7 +10,6 @@
 #include "labwc.h"
 #include "config/mousebind.h"
 #include "action.h"
-#include "view.h"
 
 /* Holds layout -> surface offsets to report motion events in relative coords */
 struct touch_point {
@@ -46,7 +46,7 @@ touch_get_coords(struct seat *seat, struct wlr_touch *touch, double x, double y,
 }
 
 static void
-touch_motion(struct wl_listener *listener, void *data)
+handle_touch_motion(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, touch_motion);
 	struct wlr_touch_motion_event *event = data;
@@ -78,7 +78,7 @@ touch_motion(struct wl_listener *listener, void *data)
 }
 
 static void
-touch_frame(struct wl_listener *listener, void *data)
+handle_touch_frame(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, touch_frame);
 
@@ -86,7 +86,7 @@ touch_frame(struct wl_listener *listener, void *data)
 }
 
 static void
-touch_down(struct wl_listener *listener, void *data)
+handle_touch_down(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, touch_down);
 	struct wlr_touch_down_event *event = data;
@@ -133,7 +133,7 @@ touch_down(struct wl_listener *listener, void *data)
 }
 
 static void
-touch_up(struct wl_listener *listener, void *data)
+handle_touch_up(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, touch_up);
 	struct wlr_touch_up_event *event = data;
@@ -159,14 +159,10 @@ touch_up(struct wl_listener *listener, void *data)
 void
 touch_init(struct seat *seat)
 {
-	seat->touch_down.notify = touch_down;
-	wl_signal_add(&seat->cursor->events.touch_down, &seat->touch_down);
-	seat->touch_up.notify = touch_up;
-	wl_signal_add(&seat->cursor->events.touch_up, &seat->touch_up);
-	seat->touch_motion.notify = touch_motion;
-	wl_signal_add(&seat->cursor->events.touch_motion, &seat->touch_motion);
-	seat->touch_frame.notify = touch_frame;
-	wl_signal_add(&seat->cursor->events.touch_frame, &seat->touch_frame);
+	CONNECT_SIGNAL(seat->cursor, seat, touch_down);
+	CONNECT_SIGNAL(seat->cursor, seat, touch_up);
+	CONNECT_SIGNAL(seat->cursor, seat, touch_motion);
+	CONNECT_SIGNAL(seat->cursor, seat, touch_frame);
 }
 
 void

--- a/src/seat.c
+++ b/src/seat.c
@@ -367,7 +367,7 @@ new_tablet(struct seat *seat, struct wlr_input_device *dev)
 {
 	struct input *input = znew(*input);
 	input->wlr_input_device = dev;
-	tablet_init(seat, dev);
+	tablet_create(seat, dev);
 	wlr_cursor_attach_input_device(seat->cursor, dev);
 	wlr_log(WLR_INFO, "map tablet to output %s\n", rc.tablet.output_name);
 	map_input_to_output(seat, dev, rc.tablet.output_name);
@@ -380,7 +380,7 @@ new_tablet_pad(struct seat *seat, struct wlr_input_device *dev)
 {
 	struct input *input = znew(*input);
 	input->wlr_input_device = dev;
-	tablet_pad_init(seat, dev);
+	tablet_pad_create(seat, dev);
 
 	return input;
 }


### PR DESCRIPTION
Otherwise we would subscribe multiple times to the same event when having multiple tablets.

Follow up from https://github.com/labwc/labwc/pull/2060 after sleeping a night and looking again how the eventing is setup for `touch` (which also subscribes to cursor events).