### PR TITLE
xdg-activation: temporarily disable source surface verification

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -785,10 +785,17 @@ xdg_activation_handle_request(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	if (!token_data->had_valid_surface) {
-		wlr_log(WLR_INFO, "Denying focus request, source surface not set");
-		return;
-	}
+	/*
+	 * TODO: The verification of source surface is temporarily disabled to
+	 * allow activation of some clients (e.g. thunderbird). Reland this
+	 * check when we implement the configuration for activation policy or
+	 * urgency hints.
+	 *
+	 * if (!token_data->had_valid_surface) {
+	 *	wlr_log(WLR_INFO, "Denying focus request, source surface not set");
+	 *	return;
+	 * }
+	 */
 
 	if (window_rules_get_property(view, "ignoreFocusRequest") == LAB_PROP_TRUE) {
 		wlr_log(WLR_INFO, "Ignoring focus request due to window rule configuration");


### PR DESCRIPTION
I believe #1974 is the way to go, but it prevents activation of some major applications like thunderbird.

As I suggested #1974, adding option to configure policy for focus requests like `<core><focusRequestRequirement input="yes|no" focus="yes|no">` or implementing urgency hint will be the optimal way to prevent arbitrary focus-stealing without degrading UX. But as we're almost in the cool-down period, let's disable the source surface verification temporarily and move it forward later.