### PR TITLE
xdg: fix error when launching windowed Chromium

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -149,7 +149,7 @@ handle_commit(struct wl_listener *listener, void *data)
 	 * the pending x/y is also unset and we still need to position
 	 * the window.
 	 */
-	if (wlr_box_empty(&view->pending)) {
+	if (wlr_box_empty(&view->pending) && !wlr_box_empty(&size)) {
 		view->pending.width = size.width;
 		view->pending.height = size.height;
 		do_late_positioning(view);


### PR DESCRIPTION
This PR fixes an error message when launching a windowed Chromium: `00:00:01.778 [../src/view.c:720] view has empty geometry, not centering`.
That occurred because Chromium sends 2 commits before the mapping commit.