### PR TITLE
xwayland: remove dissociate work-around

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -279,19 +279,8 @@ handle_dissociate(struct wl_listener *listener, void *data)
 	struct xwayland_view *xwayland_view =
 		wl_container_of(listener, xwayland_view, dissociate);
 
-	if (!xwayland_view->base.mappable.connected) {
-		/*
-		 * In some cases wlroots fails to emit the associate event
-		 * due to an early return in xwayland_surface_associate().
-		 * This is arguably a wlroots bug, but nevertheless it
-		 * should not bring down labwc.
-		 *
-		 * TODO: Potentially remove when starting to track
-		 *       wlroots 0.18 and it got fixed upstream.
-		 */
-		wlr_log(WLR_ERROR, "dissociate received before associate");
-		return;
-	}
+	/* https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4524 */
+	assert(xwayland_view->base.mappable.connected);
 	mappable_disconnect(&xwayland_view->base.mappable);
 }
 


### PR DESCRIPTION
...to cope with pre-wlroots-0.18.0 behaviour resulting in dissociate events being emitted without a prior associate one.

As discussed via IRC with @vyivel and @Consolatis 

Suggest merging after `0.8.0`