### PR TITLE
action: add Enable/DisableTabletMouseEmulation

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -294,8 +294,10 @@ Actions are used in menus and keyboard/mouse bindings.
 	decorations (including those for which the server-side titlebar has been
 	hidden) are not eligible for shading.
 
+*<action name="EnableTabletMouseEmulation" />*++
+*<action name="DisableTabletMouseEmulation" />*++
 *<action name="ToggleTabletMouseEmulation">*
-	Toggle mouse emulation for drawing tablets on or off.
+	Enable, disable or toggle mouse emulation for drawing tablets respectively.
 
 *<action name="ToggleMagnify">*
 	Toggle the screen magnifier on or off at the last magnification level

--- a/src/action.c
+++ b/src/action.c
@@ -114,6 +114,8 @@ enum action_type {
 	ACTION_TYPE_SHADE,
 	ACTION_TYPE_UNSHADE,
 	ACTION_TYPE_TOGGLE_SHADE,
+	ACTION_TYPE_ENABLE_TABLET_MOUSE_EMULATION,
+	ACTION_TYPE_DISABLE_TABLET_MOUSE_EMULATION,
 	ACTION_TYPE_TOGGLE_TABLET_MOUSE_EMULATION,
 	ACTION_TYPE_TOGGLE_MAGNIFY,
 	ACTION_TYPE_ZOOM_IN,
@@ -173,6 +175,8 @@ const char *action_names[] = {
 	"Shade",
 	"Unshade",
 	"ToggleShade",
+	"EnableTabletMouseEmulation",
+	"DisableTabletMouseEmulation",
 	"ToggleTabletMouseEmulation",
 	"ToggleMagnify",
 	"ZoomIn",
@@ -1141,6 +1145,12 @@ actions_run(struct view *activator, struct server *server,
 			if (view) {
 				view_set_shade(view, false);
 			}
+			break;
+		case ACTION_TYPE_ENABLE_TABLET_MOUSE_EMULATION:
+			rc.tablet.force_mouse_emulation = true;
+			break;
+		case ACTION_TYPE_DISABLE_TABLET_MOUSE_EMULATION:
+			rc.tablet.force_mouse_emulation = false;
 			break;
 		case ACTION_TYPE_TOGGLE_TABLET_MOUSE_EMULATION:
 			rc.tablet.force_mouse_emulation = !rc.tablet.force_mouse_emulation;


### PR DESCRIPTION
Useful for window rules.

This is a follow up from https://github.com/labwc/labwc/issues/1985#issuecomment-2271575221
Well, actually it is a work around for this issue, esp.  https://github.com/labwc/labwc/issues/1985#issuecomment-2271586923

@Narrat I've tested this briefly with the GTK4-Demo and Nautilus with:

```xml
  <windowRules>
    <windowRule title="*">
      <action name="EnableTabletMouseEmulation"/>
    </windowRule>
    <windowRule title="Paint">
      <action name="DisableTabletMouseEmulation"/>
    </windowRule>
  </windowRules>
```

Would be cool if you could confirm that this works for you.

PS: Not sure about the naming though like I wrote here https://github.com/labwc/labwc/discussions/2070#discussioncomment-10361475