### PR TITLE
src/menu: prevent delayed pipe menu response on item destroy

### DIFF
--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -39,6 +39,7 @@ struct menuitem {
 	struct wlr_scene_tree *tree;
 	struct menu_scene normal;
 	struct menu_scene selected;
+	struct menu_pipe_context *pipe_ctx;
 	struct wl_list link; /* menu.menuitems */
 };
 


### PR DESCRIPTION
Without this patch we would happily access `pipe_ctx->item` members even if the item had been destroyed in the meantime.

---
Reproducer:
```bash
#!/usr/bin/bash

if test -n "$1"; then
	sleep $1
fi

cat << EOF
<openbox_pipe_menu>
	<menu id="delay-test-$(( RANDOM ))" label="Delay 3" execute="$(readlink -f "$0") 3" />
</openbox_pipe_menu>
EOF
```
and in menu.xml:
```xml
<menu id="root-menu">
  <menu id="delay" label="Delay" execute="~/.config/labwc/pipe_delay.sh" />
</menu>
```
Open the `Delay` menu, hover over `Delay 3` and then press `ESC` before the 3 seconds have been elapsed.