### PR TITLE
[0.7 backport] src/menu: prevent delayed pipe menu response on item destroy

### DIFF
--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -39,6 +39,7 @@ struct menuitem {
 	struct wlr_scene_tree *tree;
 	struct menu_scene normal;
 	struct menu_scene selected;
+	struct menu_pipe_context *pipe_ctx;
 	struct wl_list link; /* menu.menuitems */
 };
 


### PR DESCRIPTION
Without this patch we would happily access `pipe_ctx->item` members even if the item had been destroyed in the meantime.