### PR TITLE
action: rename "omnipresent" button options for Openbox compatibility

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -439,10 +439,10 @@ extending outward from the snapped edge.
 	- |: empty space (can be used instead of a title)
 	- W: window menu
 	- I: iconify
-	- M: maximize
+	- M: maximize toggle
 	- C: close
-	- S: shade
-	- D: omnipresent
+	- S: shade toggle
+	- D: all-desktops toggle
 
 	Example: WLIMC
 
@@ -618,7 +618,7 @@ extending outward from the snapped edge.
 	- Iconify: A button that, by default, iconifies a window.
 	- Maximize: A button that, by default, toggles maximization of a window.
 	- Shade: A button that, by default, toggles window shading.
-	- Omnipresent: A button that, by default, toggles omnipresence of a window.
+	- AllDesktops: A button that, by default, toggles omnipresence of a window.
 	- Close: A button that, by default, closses a window.
 	- Top: The top edge of the window's border.
 	- Bottom: The bottom edge of the window's border.

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -130,13 +130,19 @@ labwc-config(5).
 	Color of the images in titlebar buttons in their default, unpressed,
 	state. This element is for non-focused windows.
 
-Note: The button elements (i.e. window.[in]active.button.\*) support defining
-different types of buttons individually by inserting the type ("menu",
-"iconify", "max" and "close") after the button node. For example:
-window.active.button.iconify.unpressed.image.color
-This syntax is not documented on the openbox.org wiki, but is supported by
-openbox and is used by many popular themes. For the sake of brevity, these
-elements are not listed here, but are supported.
+Note: Button elements (i.e. window.[in]active.button.\*) may be defined uniquely
+for each type of button ("menu", "iconify", "max", "shade", "desk" or "close")
+by appending the type after the "button" node. For example:
+
+- window.active.button.iconify.unpressed.image.color indicates the color of the
+iconify button for active windows; while
+
+- window.inactive.button.close.unpressed.image.color indicates the color of the
+close button for inactive windows.
+
+This syntax is not documented by Openbox, but is supported and is used by many
+popular themes. For the sake of brevity, these elements are not listed here, but
+all are supported.
 
 *window.active.shadow.size*
 	Size of the drop-shadow for the focused window, in pixels.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -447,7 +447,7 @@
       </mousebind>
     </context>
 
-    <context name="Omnipresent">
+    <context name="AllDesktops">
       <mousebind button="Left" action="Click">
         <action name="ToggleOmnipresent" />
       </mousebind>

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -328,7 +328,7 @@ static struct mouse_combos {
 		.event = "Click",
 		.action = "ToggleShade",
 	}, {
-		.context = "Omnipresent",
+		.context = "AllDesktops",
 		.button = "Left",
 		.event = "Click",
 		.action = "ToggleOmnipresent",

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -116,7 +116,7 @@ context_from_str(const char *str)
 		return LAB_SSD_BUTTON_WINDOW_MENU;
 	} else if (!strcasecmp(str, "Shade")) {
 		return LAB_SSD_BUTTON_SHADE;
-	} else if (!strcasecmp(str, "Omnipresent")) {
+	} else if (!strcasecmp(str, "AllDesktops")) {
 		return LAB_SSD_BUTTON_OMNIPRESENT;
 	} else if (!strcasecmp(str, "Titlebar")) {
 		return LAB_SSD_PART_TITLEBAR;

--- a/src/theme.c
+++ b/src/theme.c
@@ -793,7 +793,7 @@ entry(struct theme *theme, const char *key, const char *value)
 		parse_hexstr(value,
 			theme->window_active_button_shade_unpressed_image_color);
 	}
-	if (match_glob(key, "window.active.button.omnipresent.unpressed.image.color")) {
+	if (match_glob(key, "window.active.button.desk.unpressed.image.color")) {
 		parse_hexstr(value,
 			theme->window_active_button_omnipresent_unpressed_image_color);
 	}
@@ -817,7 +817,7 @@ entry(struct theme *theme, const char *key, const char *value)
 		parse_hexstr(value,
 			theme->window_inactive_button_shade_unpressed_image_color);
 	}
-	if (match_glob(key, "window.inactive.button.omnipresent.unpressed.image.color")) {
+	if (match_glob(key, "window.inactive.button.desk.unpressed.image.color")) {
 		parse_hexstr(value,
 			theme->window_inactive_button_omnipresent_unpressed_image_color);
 	}


### PR DESCRIPTION
- Mouse context `Omnipresent` -> `AllDesktops`
- Theme elements `window.*.button.omnipresent` -> `window.*.button.desk`
- Update documentation accordingly

This implements the first, and simplest, alternative discussed in #2112.