### PR TITLE
ssd: allow ssd to be smaller than minimal size by removing buttons

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -53,12 +53,19 @@ struct ssd {
 		bool was_omnipresent;
 
 		/*
-		 * Corners need to be (un)rounded when toggling tiling or
-		 * maximization, and the button needs to be swapped on
+		 * Corners need to be (un)rounded and borders need be shown/hidden
+		 * when toggling maximization, and the button needs to be swapped on
 		 * maximization toggles.
 		 */
 		bool was_maximized;
-		bool was_tiled_not_maximized;
+
+		/*
+		 * Corners need to be (un)rounded but borders should be kept shown when
+		 * the window is (un)tiled and notified about it or when the window may
+		 * become so small that only a squared scene-rect can be used to render
+		 * such a small titlebar.
+		 */
+		bool was_squared;
 
 		struct wlr_box geometry;
 		struct ssd_state_title {
@@ -109,9 +116,6 @@ struct ssd_part {
 	/* This part represented in scene graph */
 	struct wlr_scene_node *node;
 
-	/* Targeted geometry. May be NULL */
-	struct wlr_box *geometry;
-
 	struct wl_list link;
 };
 
@@ -151,6 +155,7 @@ void ssd_destroy_parts(struct wl_list *list);
 void ssd_titlebar_create(struct ssd *ssd);
 void ssd_titlebar_update(struct ssd *ssd);
 void ssd_titlebar_destroy(struct ssd *ssd);
+bool ssd_should_be_squared(struct ssd *ssd);
 
 void ssd_border_create(struct ssd *ssd);
 void ssd_border_update(struct ssd *ssd);

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -113,16 +113,16 @@ ssd_border_update(struct ssd *ssd)
 	 *  |_______________|
 	 */
 
-	int side_height = ssd->state.was_tiled_not_maximized
+	int side_height = ssd->state.was_squared
 		? height + ssd->titlebar.height
 		: height;
-	int side_y = ssd->state.was_tiled_not_maximized
+	int side_y = ssd->state.was_squared
 		? -ssd->titlebar.height
 		: 0;
-	int top_width = ssd->titlebar.height <= 0 || ssd->state.was_tiled_not_maximized
+	int top_width = ssd->titlebar.height <= 0 || ssd->state.was_squared
 		? full_width
 		: width - 2 * theme->window_button_width;
-	int top_x = ssd->titlebar.height <= 0 || ssd->state.was_tiled_not_maximized
+	int top_x = ssd->titlebar.height <= 0 || ssd->state.was_squared
 		? 0
 		: theme->border_width + theme->window_button_width;
 

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <assert.h>
 #include <pixman.h>
 #include "common/mem.h"
 #include "common/scene-helpers.h"
@@ -14,14 +15,7 @@ add_extent(struct wl_list *part_list, enum ssd_part_type type,
 {
 	float invisible[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 	struct ssd_part *part = add_scene_part(part_list, type);
-	/*
-	 * Extents need additional geometry to enable dynamic
-	 * resize based on position and output->usable_area.
-	 *
-	 * part->geometry will get free'd automatically in ssd_destroy_parts().
-	 */
 	part->node = &wlr_scene_rect_create(parent, 0, 0, invisible)->node;
-	part->geometry = znew(struct wlr_box);
 	return part;
 }
 
@@ -32,8 +26,6 @@ ssd_extents_create(struct ssd *ssd)
 	struct theme *theme = view->server->theme;
 	struct wl_list *part_list = &ssd->extents.parts;
 	int extended_area = SSD_EXTENDED_AREA;
-	int corner_size = extended_area + theme->border_width +
-		theme->window_button_width / 2;
 
 	ssd->extents.tree = wlr_scene_tree_create(ssd->tree);
 	struct wlr_scene_tree *parent = ssd->extents.tree;
@@ -45,43 +37,17 @@ ssd_extents_create(struct ssd *ssd)
 		-(theme->border_width + extended_area),
 		-(ssd->titlebar.height + theme->border_width + extended_area));
 
-	/* Initialize parts and set constant values for targeted geometry */
-	struct ssd_part *p;
-
 	/* Top */
-	p = add_extent(part_list, LAB_SSD_PART_CORNER_TOP_LEFT, parent);
-	p->geometry->width = corner_size;
-	p->geometry->height = corner_size;
-
-	p = add_extent(part_list, LAB_SSD_PART_TOP, parent);
-	p->geometry->x = corner_size;
-	p->geometry->height = extended_area;
-
-	p = add_extent(part_list, LAB_SSD_PART_CORNER_TOP_RIGHT, parent);
-	p->geometry->width = corner_size;
-	p->geometry->height = corner_size;
-
+	add_extent(part_list, LAB_SSD_PART_CORNER_TOP_LEFT, parent);
+	add_extent(part_list, LAB_SSD_PART_TOP, parent);
+	add_extent(part_list, LAB_SSD_PART_CORNER_TOP_RIGHT, parent);
 	/* Sides */
-	p = add_extent(part_list, LAB_SSD_PART_LEFT, parent);
-	p->geometry->y = corner_size;
-	p->geometry->width = extended_area;
-
-	p = add_extent(part_list, LAB_SSD_PART_RIGHT, parent);
-	p->geometry->y = corner_size;
-	p->geometry->width = extended_area;
-
+	add_extent(part_list, LAB_SSD_PART_LEFT, parent);
+	add_extent(part_list, LAB_SSD_PART_RIGHT, parent);
 	/* Bottom */
-	p = add_extent(part_list, LAB_SSD_PART_CORNER_BOTTOM_LEFT, parent);
-	p->geometry->width = corner_size;
-	p->geometry->height = corner_size;
-
-	p = add_extent(part_list, LAB_SSD_PART_BOTTOM, parent);
-	p->geometry->x = corner_size;
-	p->geometry->height = extended_area;
-
-	p = add_extent(part_list, LAB_SSD_PART_CORNER_BOTTOM_RIGHT, parent);
-	p->geometry->width = corner_size;
-	p->geometry->height = corner_size;
+	add_extent(part_list, LAB_SSD_PART_CORNER_BOTTOM_LEFT, parent);
+	add_extent(part_list, LAB_SSD_PART_BOTTOM, parent);
+	add_extent(part_list, LAB_SSD_PART_CORNER_BOTTOM_RIGHT, parent);
 
 	/* Initial manual update to keep X11 applications happy */
 	ssd_extents_update(ssd);
@@ -111,7 +77,7 @@ ssd_extents_update(struct ssd *ssd)
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = SSD_EXTENDED_AREA;
 	int corner_size = extended_area + theme->border_width +
-		theme->window_button_width / 2;
+		MIN(theme->window_button_width, width) / 2;
 	int side_width = full_width + extended_area * 2 - corner_size * 2;
 	int side_height = full_height + extended_area * 2 - corner_size * 2;
 
@@ -119,6 +85,7 @@ ssd_extents_update(struct ssd *ssd)
 	struct wlr_box result_box;
 	struct ssd_part *part;
 	struct wlr_scene_rect *rect;
+	struct wlr_box target;
 
 	/* Make sure we update the y offset based on titlebar shown / hidden */
 	wlr_scene_node_set_position(&ssd->extents.tree->node,
@@ -149,44 +116,69 @@ ssd_extents_update(struct ssd *ssd)
 	int base_x, base_y;
 	wlr_scene_node_coords(&ssd->extents.tree->node, &base_x, &base_y);
 
-	struct wlr_box *target;
 	wl_list_for_each(part, &ssd->extents.parts, link) {
 		rect = wlr_scene_rect_from_node(part->node);
-		target = part->geometry;
 		switch (part->type) {
+		case LAB_SSD_PART_CORNER_TOP_LEFT:
+			target.x = 0;
+			target.y = 0;
+			target.width = corner_size;
+			target.height = corner_size;
+			break;
 		case LAB_SSD_PART_TOP:
-			target->width = side_width;
+			target.x = corner_size;
+			target.y = 0;
+			target.width = side_width;
+			target.height = extended_area;
 			break;
 		case LAB_SSD_PART_CORNER_TOP_RIGHT:
-			target->x = corner_size + side_width;
+			target.x = corner_size + side_width;
+			target.y = 0;
+			target.width = corner_size;
+			target.height = corner_size;
 			break;
 		case LAB_SSD_PART_LEFT:
-			target->height = side_height;
+			target.x = 0;
+			target.y = corner_size;
+			target.width = extended_area;
+			target.height = side_height;
 			break;
 		case LAB_SSD_PART_RIGHT:
-			target->x = extended_area + full_width;
-			target->height = side_height;
+			target.x = extended_area + full_width;
+			target.y = corner_size;
+			target.width = extended_area;
+			target.height = side_height;
 			break;
 		case LAB_SSD_PART_CORNER_BOTTOM_LEFT:
-			target->y = corner_size + side_height;
+			target.x = 0;
+			target.y = corner_size + side_height;
+			target.width = corner_size;
+			target.height = corner_size;
 			break;
 		case LAB_SSD_PART_BOTTOM:
-			target->width = side_width;
-			target->y = extended_area + full_height;
+			target.x = corner_size;
+			target.y = extended_area + full_height;
+			target.width = side_width;
+			target.height = extended_area;
 			break;
 		case LAB_SSD_PART_CORNER_BOTTOM_RIGHT:
-			target->x = corner_size + side_width;
-			target->y = corner_size + side_height;
+			target.x = corner_size + side_width;
+			target.y = corner_size + side_height;
+			target.width = corner_size;
+			target.height = corner_size;
 			break;
 		default:
-			break;
+			/* not reached */
+			assert(false);
+			/* suppress warnings with NDEBUG */
+			target = (struct wlr_box){0};
 		}
 
 		/* Get layout geometry of what the part *should* be */
-		part_box.x = base_x + target->x;
-		part_box.y = base_y + target->y;
-		part_box.width = target->width;
-		part_box.height = target->height;
+		part_box.x = base_x + target.x;
+		part_box.y = base_y + target.y;
+		part_box.width = target.width;
+		part_box.height = target.height;
 
 		/* Constrain part to output->usable_area */
 		pixman_region32_clear(&intersection);
@@ -232,18 +224,12 @@ ssd_extents_update(struct ssd *ssd)
 			wlr_scene_rect_set_size(rect, result_box.width,
 				result_box.height);
 			wlr_scene_node_set_position(part->node,
-				target->x + (result_box.x - part_box.x),
-				target->y + (result_box.y - part_box.y));
-			continue;
-		}
-
-		/* Fully visible */
-		if (target->x != part->node->x
-				|| target->y != part->node->y) {
-			wlr_scene_node_set_position(part->node, target->x, target->y);
-		}
-		if (target->width != rect->width || target->height != rect->height) {
-			wlr_scene_rect_set_size(rect, target->width, target->height);
+				target.x + (result_box.x - part_box.x),
+				target.y + (result_box.y - part_box.y));
+		} else {
+			/* Fully visible */
+			wlr_scene_node_set_position(part->node, target.x, target.y);
+			wlr_scene_rect_set_size(rect, target.width, target.height);
 		}
 	}
 	pixman_region32_fini(&intersection);

--- a/src/ssd/ssd-part.c
+++ b/src/ssd/ssd-part.c
@@ -213,10 +213,6 @@ ssd_destroy_parts(struct wl_list *list)
 		}
 		/* part->buffer will free itself along the scene_buffer node */
 		part->buffer = NULL;
-		if (part->geometry) {
-			free(part->geometry);
-			part->geometry = NULL;
-		}
 		wl_list_remove(&part->link);
 		free(part);
 	}


### PR DESCRIPTION
Another alternative for #1959 and #1964.

This fixes #1947 by removing some buttons for tiny windows. For windows smaller than (button width)*2, corners
are un-rounded so a small titlebar can be rendered with scene-rect.

Demo (extents are colored for visualization):

https://github.com/user-attachments/assets/f155c9dc-6f20-438f-8b16-74e2603d19b0
