### PR TITLE
"WarpCursor" action

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -340,6 +340,19 @@ Actions are used in menus and keyboard/mouse bindings.
 	decorations (including those for which the server-side titlebar has been
 	hidden) are not eligible for shading.
 
+*<action name="WarpCursor" to="output" x="center" y="center" />*
+	Warp the cursor to a position relative to the active output or window.
+
+	*to* [output|window] Specifies the target area of the warp.
+	Default is "output"
+	*x* [center|value] Specifies the horizontal warp position within the target area.
+	"center": Moves the cursor to the horizontal center of the target area.
+	Positive or negative integers warp the cursor to a position offset by the specified
+	number of pixels from the left or right edge of the target area respectively.
+	Default is "center"
+	*y* [center|value] Equivalent for the vertical warp position within the target area.
+	Default is "center"
+
 *<action name="EnableTabletMouseEmulation" />*++
 *<action name="DisableTabletMouseEmulation" />*++
 *<action name="ToggleTabletMouseEmulation">*

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -456,7 +456,6 @@ void desktop_focus_view_or_surface(struct seat *seat, struct view *view,
 
 void desktop_arrange_all_views(struct server *server);
 void desktop_focus_output(struct output *output);
-void warp_cursor(struct view *view);
 struct view *desktop_topmost_focusable_view(struct server *server);
 
 /**


### PR DESCRIPTION
This is a simple action that warps the cursor to the middle of the currently focused view. Useful when moving windows or changing focus using keyboard shortcuts.