### PR TITLE
Revert "src/interactive.c: don't unshade when view is un-tiled by dragging"

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -253,6 +253,8 @@ process_cursor_move(struct server *server, uint32_t time)
 			.height = view->natural_geometry.height,
 		};
 		interactive_anchor_to_cursor(server, &new_geo);
+		/* Shaded clients will not process resize events until unshaded */
+		view_set_shade(view, false);
 		view_set_untiled(view);
 		view_restore_to(view, new_geo);
 		x = new_geo.x;

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -85,6 +85,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 			 */
 			return;
 		}
+
 		if (view_is_floating(view)) {
 			/* Store natural geometry at start of move */
 			view_store_natural_geometry(view);
@@ -146,6 +147,8 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 			&& rc.unsnap_threshold <= 0) {
 		struct wlr_box natural_geo = view->natural_geometry;
 		interactive_anchor_to_cursor(server, &natural_geo);
+		/* Shaded clients will not process resize events until unshaded */
+		view_set_shade(view, false);
 		view_set_untiled(view);
 		view_restore_to(view, natural_geo);
 	}


### PR DESCRIPTION
When labwc un-tiles views, it generally changes their size, which sends a configure request to the client. However, because the view has been disabled in the wlroots scene, it will not receive and process the configure when labwc expects. Instead, the handling will be deferred until the user unshades the view at some arbitrary time in the future, resulting in labwc registering complains like

    [../src/xdg.c:239] client did not respond to configure request in 100 ms

Furthermore, the reconfigure will still generally produce flicker (as the view opens in its tiled size and then jumps to its natural geometry). Because skipping the unshade might cause client problems and doesn't eliminate the problem it sought to resolve, let's revert this.

This reverts commit 2e19bd4d5b3c67c27d13be24d41a0ea9ba2f1626.

cc: @tokyo4j 