### PR TITLE
Add openbox style decoration actions

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -134,6 +134,18 @@ Actions are used in menus and keyboard/mouse bindings.
 	windows that have client side decorations if it would increase the
 	amount of decoration. Default is no.
 
+*<action name="Decorate" />*
+	Similar to ToggleDecorations below but a single state
+	- Titlebar and borders
+
+*<action name="Undecorate" />*
+	Similar to ToggleDecorations below but a single state
+	- No titlebar or borders
+
+*<action name="Border" />*
+	Similar to ToggleDecorations below but a single state
+	- Borders only
+
 *<action name="ToggleDecorations" />*
 	Toggle decorations of focused window.
 

--- a/src/action.c
+++ b/src/action.c
@@ -118,7 +118,10 @@ enum action_type {
 	ACTION_TYPE_TOGGLE_TABLET_MOUSE_EMULATION,
 	ACTION_TYPE_TOGGLE_MAGNIFY,
 	ACTION_TYPE_ZOOM_IN,
-	ACTION_TYPE_ZOOM_OUT
+	ACTION_TYPE_ZOOM_OUT,
+	ACTION_TYPE_DECORATE,
+	ACTION_TYPE_UNDECORATE,
+	ACTION_TYPE_BORDER
 };
 
 const char *action_names[] = {
@@ -180,6 +183,9 @@ const char *action_names[] = {
 	"ToggleMagnify",
 	"ZoomIn",
 	"ZoomOut",
+	"Decorate",
+	"Undecorate",
+	"Border",
 	NULL
 };
 
@@ -1166,6 +1172,21 @@ actions_run(struct view *activator, struct server *server,
 			break;
 		case ACTION_TYPE_ZOOM_OUT:
 			magnify_set_scale(server, MAGNIFY_DECREASE);
+			break;
+		case ACTION_TYPE_DECORATE:
+			if (view) {
+				view_set_ssd_mode(view, LAB_SSD_MODE_FULL);
+			}
+			break;
+		case ACTION_TYPE_UNDECORATE:
+			if (view) {
+				view_set_ssd_mode(view, LAB_SSD_MODE_NONE);
+			}
+			break;
+		case ACTION_TYPE_BORDER:
+			if (view) {
+				view_set_ssd_mode(view, LAB_SSD_MODE_BORDER);
+			}
 			break;
 		case ACTION_TYPE_INVALID:
 			wlr_log(WLR_ERROR, "Not executing unknown action");


### PR DESCRIPTION
- Decorate, set full decorations, ie titlebar and border
- Undecorate, turn off all decorations
- Border, border only decoration, unaffected by keepBorder setting

Brought about by discussions in  #2070

Edit to add: this does not undo the 3-way toggle decorations, though IMO, we should go back to OB behavior
ie, two states and use the border action if a border is wanted.
keepBorder yes - toggle between full and border
keepBorder no  - toggle between full and none (current behavior)

ETA2: On my home system, I changed the 3 way action back to 2 way (matching openbox)
and it seems to work well, toggles as mentioned in previous ETA, and the direct actions of
Decorate, Undecorate and Border handle just those states. Works well on my end.
Let me know if you want to change the 3 state toggle back to 2 states.
Also not sure about the action name "Border" maybe change to "BorderOnly"?