### PR TITLE
theme: add circle hover effect for window buttons

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -47,12 +47,18 @@ labwc-config(5).
 # THEME ELEMENTS
 
 *border.width*
-	Line width (integer) of border border drawn around window frames.
+	Line width (integer) of border drawn around window frames.
 	Default is 1.
 
+*padding.width*
+	Horizontal padding size, in pixels, between border and first
+	button on the left/right.
+	Default is 0.
+
 *padding.height*
-	Vertical padding size, used for spacing out elements in the window
-	decorations. Default is 3.
+	Vertical padding size, in pixels, used for spacing out elements
+	in the window decorations.
+	Default is 3.
 
 *titlebar.height*
 	Window title bar height.
@@ -121,6 +127,10 @@ labwc-config(5).
 *window.button.width*
 	Width of a titlebar button, in pixels.
 	Default is 26.
+
+*window.button.spacing*
+	Space between titlebar buttons, in pixels.
+	Default is 0.
 
 *window.active.button.unpressed.image.color*
 	Color of the images in titlebar buttons in their default, unpressed,

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -132,6 +132,10 @@ labwc-config(5).
 	Space between titlebar buttons, in pixels.
 	Default is 0.
 
+*window.button.hover.bg.shape*
+	The shape of the hover effect of a titlebar button: "rectangle" or "circle".
+	Default is "rectangle".
+
 *window.active.button.unpressed.image.color*
 	Color of the images in titlebar buttons in their default, unpressed,
 	state. This element is for the focused window.

--- a/docs/themerc
+++ b/docs/themerc
@@ -7,6 +7,7 @@
 
 # general
 border.width: 1
+padding.width: 0
 padding.height: 3
 
 # The following options has no default, but fallbacks back to
@@ -29,8 +30,9 @@ window.active.label.text.color: #000000
 window.inactive.label.text.color: #000000
 window.label.text.justify: center
 
-# window button width
+# window button width and spacing
 window.button.width: 26
+window.button.spacing: 0
 
 # window buttons
 window.active.button.unpressed.image.color: #000000

--- a/docs/themerc
+++ b/docs/themerc
@@ -34,6 +34,9 @@ window.label.text.justify: center
 window.button.width: 26
 window.button.spacing: 0
 
+# window button hover effect
+window.button.hover.bg.shape: rectangle
+
 # window buttons
 window.active.button.unpressed.image.color: #000000
 window.inactive.button.unpressed.image.color: #000000

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -79,6 +79,7 @@ struct wlr_scene_node;
  */
 struct ssd *ssd_create(struct view *view, bool active);
 struct border ssd_get_margin(const struct ssd *ssd);
+int ssd_get_corner_width(void);
 void ssd_update_margin(struct ssd *ssd);
 void ssd_set_active(struct ssd *ssd, bool active);
 void ssd_update_title(struct ssd *ssd);

--- a/include/theme.h
+++ b/include/theme.h
@@ -17,6 +17,11 @@ enum lab_justification {
 	LAB_JUSTIFY_RIGHT,
 };
 
+enum lab_shape {
+	LAB_RECTANGLE,
+	LAB_CIRCLE,
+};
+
 struct theme_snapping_overlay {
 	bool bg_enabled;
 	bool border_enabled;
@@ -57,6 +62,8 @@ struct theme {
 	int window_button_width;
 	/* the space between buttons */
 	int window_button_spacing;
+	/* the shape of the hover effect */
+	enum lab_shape window_button_hover_bg_shape;
 
 	/* button colors */
 	float window_active_button_menu_unpressed_image_color[4];

--- a/include/theme.h
+++ b/include/theme.h
@@ -27,7 +27,14 @@ struct theme_snapping_overlay {
 
 struct theme {
 	int border_width;
+
+	/*
+	 * the space between title bar border and
+	 * buttons on the left/right/top
+	 */
+	int padding_width;
 	int padding_height;
+
 	int title_height;
 	int menu_overlap_x;
 	int menu_overlap_y;
@@ -48,6 +55,8 @@ struct theme {
 
 	/* button width */
 	int window_button_width;
+	/* the space between buttons */
+	int window_button_spacing;
 
 	/* button colors */
 	float window_active_button_menu_unpressed_image_color[4];

--- a/include/view.h
+++ b/include/view.h
@@ -538,6 +538,7 @@ const char *view_get_string_prop(struct view *view, const char *prop);
 void view_update_title(struct view *view);
 void view_update_app_id(struct view *view);
 void view_reload_ssd(struct view *view);
+int view_get_min_width(void);
 
 void view_set_shade(struct view *view, bool shaded);
 

--- a/src/snap.c
+++ b/src/snap.c
@@ -220,8 +220,7 @@ snap_shrink_to_next_edge(struct view *view,
 
 	*geo = view->pending;
 	uint32_t resize_edges;
-	int min_view_width = rc.theme->window_button_width * (
-		wl_list_length(&rc.title_buttons_left) + wl_list_length(&rc.title_buttons_right));
+	int min_width = view_get_min_width();
 
 	/*
 	 * First shrink the view along the relevant edge. The maximum shrink
@@ -230,12 +229,12 @@ snap_shrink_to_next_edge(struct view *view,
 	 */
 	switch (direction) {
 	case VIEW_EDGE_RIGHT:
-		geo->width = MAX(geo->width / 2, min_view_width);
+		geo->width = MAX(geo->width / 2, min_width);
 		geo->x = view->pending.x + view->pending.width - geo->width;
 		resize_edges = WLR_EDGE_LEFT;
 		break;
 	case VIEW_EDGE_LEFT:
-		geo->width = MAX(geo->width / 2, min_view_width);
+		geo->width = MAX(geo->width / 2, min_width);
 		resize_edges = WLR_EDGE_RIGHT;
 		break;
 	case VIEW_EDGE_DOWN:

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -22,6 +22,7 @@ ssd_border_create(struct ssd *ssd)
 	int width = view->current.width;
 	int height = view_effective_height(view, /* use_pending */ false);
 	int full_width = width + 2 * theme->border_width;
+	int corner_width = ssd_get_corner_width();
 
 	float *color;
 	struct wlr_scene_tree *parent;
@@ -48,8 +49,8 @@ ssd_border_create(struct ssd *ssd)
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_BOTTOM, parent,
 			full_width, theme->border_width, 0, height, color);
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_TOP, parent,
-			width - 2 * theme->window_button_width, theme->border_width,
-			theme->border_width + theme->window_button_width,
+			width - 2 * corner_width, theme->border_width,
+			theme->border_width + corner_width,
 			-(ssd->titlebar.height + theme->border_width), color);
 	} FOR_EACH_END
 
@@ -93,6 +94,7 @@ ssd_border_update(struct ssd *ssd)
 	int width = view->current.width;
 	int height = view_effective_height(view, /* use_pending */ false);
 	int full_width = width + 2 * theme->border_width;
+	int corner_width = ssd_get_corner_width();
 
 	/*
 	 * From here on we have to cover the following border scenarios:
@@ -121,10 +123,10 @@ ssd_border_update(struct ssd *ssd)
 		: 0;
 	int top_width = ssd->titlebar.height <= 0 || ssd->state.was_squared
 		? full_width
-		: width - 2 * theme->window_button_width;
+		: width - 2 * corner_width;
 	int top_x = ssd->titlebar.height <= 0 || ssd->state.was_squared
 		? 0
-		: theme->border_width + theme->window_button_width;
+		: theme->border_width + corner_width;
 
 	struct ssd_part *part;
 	struct wlr_scene_rect *rect;

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -76,8 +76,9 @@ ssd_extents_update(struct ssd *ssd)
 	int full_height = height + theme->border_width * 2 + ssd->titlebar.height;
 	int full_width = width + 2 * theme->border_width;
 	int extended_area = SSD_EXTENDED_AREA;
+	int corner_width = ssd_get_corner_width();
 	int corner_size = extended_area + theme->border_width +
-		MIN(theme->window_button_width, width) / 2;
+		MIN(corner_width, width) / 2;
 	int side_width = full_width + extended_area * 2 - corner_size * 2;
 	int side_height = full_height + extended_area * 2 - corner_size * 2;
 

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -205,6 +205,13 @@ ssd_get_margin(const struct ssd *ssd)
 	return ssd ? ssd->margin : (struct border){ 0 };
 }
 
+int
+ssd_get_corner_width(void)
+{
+	/* ensure a minimum corner width */
+	return MAX(rc.corner_radius, 5);
+}
+
 void
 ssd_update_margin(struct ssd *ssd)
 {

--- a/src/theme.c
+++ b/src/theme.c
@@ -566,7 +566,9 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->window_label_text_justify = parse_justification("Center");
 	theme->menu_title_text_justify = parse_justification("Center");
 
+	theme->padding_width = 0;
 	theme->window_button_width = 26;
+	theme->window_button_spacing = 0;
 
 	parse_hexstr("#000000",
 		theme->window_active_button_menu_unpressed_image_color);
@@ -682,6 +684,9 @@ entry(struct theme *theme, const char *key, const char *value)
 	if (match_glob(key, "border.width")) {
 		theme->border_width = atoi(value);
 	}
+	if (match_glob(key, "padding.width")) {
+		theme->padding_width = atoi(value);
+	}
 	if (match_glob(key, "padding.height")) {
 		theme->padding_height = atoi(value);
 	}
@@ -744,6 +749,9 @@ entry(struct theme *theme, const char *key, const char *value)
 				"be less than 1, clamping it to 1.");
 			theme->window_button_width = 1;
 		}
+	}
+	if (match_glob(key, "window.button.spacing")) {
+		theme->window_button_spacing = atoi(value);
 	}
 
 	/* universal button */
@@ -1198,10 +1206,12 @@ out:
 static void
 create_corners(struct theme *theme)
 {
+	int corner_width = ssd_get_corner_width();
+
 	struct wlr_box box = {
 		.x = 0,
 		.y = 0,
-		.width = theme->window_button_width + theme->border_width,
+		.width = corner_width + theme->border_width,
 		.height = theme->title_height + theme->border_width,
 	};
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -670,6 +670,18 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->mag_border_width = 1;
 }
 
+static int
+get_int_if_positive(const char *content, const char *field)
+{
+	int value = atoi(content);
+	if (value < 0) {
+		wlr_log(WLR_ERROR,
+			"%s cannot be negative, clamping it to 0.", field);
+		value = 0;
+	}
+	return value;
+}
+
 static void
 entry(struct theme *theme, const char *key, const char *value)
 {
@@ -682,31 +694,39 @@ entry(struct theme *theme, const char *key, const char *value)
 	 * the first instance, "else if" cannot be used throughout this function
 	 */
 	if (match_glob(key, "border.width")) {
-		theme->border_width = atoi(value);
+		theme->border_width = get_int_if_positive(
+			value, "border.width");
 	}
 	if (match_glob(key, "padding.width")) {
-		theme->padding_width = atoi(value);
+		theme->padding_width = get_int_if_positive(
+			value, "padding.width");
 	}
 	if (match_glob(key, "padding.height")) {
-		theme->padding_height = atoi(value);
+		theme->padding_height = get_int_if_positive(
+			value, "padding.height");
 	}
 	if (match_glob(key, "titlebar.height")) {
-		theme->title_height = atoi(value);
+		theme->title_height = get_int_if_positive(
+			value, "titlebar.height");
 	}
 	if (match_glob(key, "menu.items.padding.x")) {
-		theme->menu_item_padding_x = atoi(value);
+		theme->menu_item_padding_x = get_int_if_positive(
+			value, "menu.items.padding.x");
 	}
 	if (match_glob(key, "menu.items.padding.y")) {
-		theme->menu_item_padding_y = atoi(value);
+		theme->menu_item_padding_y = get_int_if_positive(
+			value, "menu.items.padding.y");
 	}
 	if (match_glob(key, "menu.title.text.justify")) {
 		theme->menu_title_text_justify = parse_justification(value);
 	}
 	if (match_glob(key, "menu.overlap.x")) {
-		theme->menu_overlap_x = atoi(value);
+		theme->menu_overlap_x = get_int_if_positive(
+			value, "menu.overlap.x");
 	}
 	if (match_glob(key, "menu.overlap.y")) {
-		theme->menu_overlap_y = atoi(value);
+		theme->menu_overlap_y = get_int_if_positive(
+			value, "menu.overlap.y");
 	}
 
 	if (match_glob(key, "window.active.border.color")) {
@@ -751,7 +771,8 @@ entry(struct theme *theme, const char *key, const char *value)
 		}
 	}
 	if (match_glob(key, "window.button.spacing")) {
-		theme->window_button_spacing = atoi(value);
+		theme->window_button_spacing = get_int_if_positive(
+			value, "window.button.spacing");
 	}
 
 	/* universal button */
@@ -836,20 +857,12 @@ entry(struct theme *theme, const char *key, const char *value)
 
 	/* window drop-shadows */
 	if (match_glob(key, "window.active.shadow.size")) {
-		theme->window_active_shadow_size = atoi(value);
-		if (theme->window_active_shadow_size < 0) {
-			wlr_log(WLR_ERROR, "window.active.shadow.size cannot "
-				"be negative, clamping it to 0.");
-			theme->window_active_shadow_size = 0;
-		}
+		theme->window_active_shadow_size = get_int_if_positive(
+			value, "window.active.shadow.size");
 	}
 	if (match_glob(key, "window.inactive.shadow.size")) {
-		theme->window_inactive_shadow_size = atoi(value);
-		if (theme->window_inactive_shadow_size < 0) {
-			wlr_log(WLR_ERROR, "window.inactive.shadow.size cannot "
-				"be negative, clamping it to 0.");
-			theme->window_inactive_shadow_size = 0;
-		}
+		theme->window_inactive_shadow_size = get_int_if_positive(
+			value, "window.inactive.shadow.size");
 	}
 	if (match_glob(key, "window.active.shadow.color")) {
 		parse_hexstr(value, theme->window_active_shadow_color);
@@ -859,10 +872,12 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 
 	if (match_glob(key, "menu.width.min")) {
-		theme->menu_min_width = atoi(value);
+		theme->menu_min_width = get_int_if_positive(
+			value, "menu.width.min");
 	}
 	if (match_glob(key, "menu.width.max")) {
-		theme->menu_max_width = atoi(value);
+		theme->menu_max_width = get_int_if_positive(
+			value, "menu.width.max");
 	}
 
 	if (match_glob(key, "menu.items.bg.color")) {
@@ -879,13 +894,16 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 
 	if (match_glob(key, "menu.separator.width")) {
-		theme->menu_separator_line_thickness = atoi(value);
+		theme->menu_separator_line_thickness = get_int_if_positive(
+			value, "menu.separator.width");
 	}
 	if (match_glob(key, "menu.separator.padding.width")) {
-		theme->menu_separator_padding_width = atoi(value);
+		theme->menu_separator_padding_width = get_int_if_positive(
+			value, "menu.separator.padding.width");
 	}
 	if (match_glob(key, "menu.separator.padding.height")) {
-		theme->menu_separator_padding_height = atoi(value);
+		theme->menu_separator_padding_height = get_int_if_positive(
+			value, "menu.separator.padding.height");
 	}
 	if (match_glob(key, "menu.separator.color")) {
 		parse_hexstr(value, theme->menu_separator_color);
@@ -903,7 +921,8 @@ entry(struct theme *theme, const char *key, const char *value)
 		parse_hexstr(value, theme->osd_bg_color);
 	}
 	if (match_glob(key, "osd.border.width")) {
-		theme->osd_border_width = atoi(value);
+		theme->osd_border_width = get_int_if_positive(
+			value, "osd.border.width");
 	}
 	if (match_glob(key, "osd.border.color")) {
 		parse_hexstr(value, theme->osd_border_color);
@@ -914,31 +933,45 @@ entry(struct theme *theme, const char *key, const char *value)
 		} else {
 			theme->osd_window_switcher_width_is_percent = false;
 		}
-		theme->osd_window_switcher_width = MAX(atoi(value), 0);
+		theme->osd_window_switcher_width = get_int_if_positive(
+			value, "osd.window-switcher.width");
 	}
 	if (match_glob(key, "osd.window-switcher.padding")) {
-		theme->osd_window_switcher_padding = atoi(value);
+		theme->osd_window_switcher_padding = get_int_if_positive(
+			value, "osd.window-switcher.padding");
 	}
 	if (match_glob(key, "osd.window-switcher.item.padding.x")) {
-		theme->osd_window_switcher_item_padding_x = atoi(value);
+		theme->osd_window_switcher_item_padding_x =
+			get_int_if_positive(
+				value, "osd.window-switcher.item.padding.x");
 	}
 	if (match_glob(key, "osd.window-switcher.item.padding.y")) {
-		theme->osd_window_switcher_item_padding_y = atoi(value);
+		theme->osd_window_switcher_item_padding_y =
+			get_int_if_positive(
+				value, "osd.window-switcher.item.padding.y");
 	}
 	if (match_glob(key, "osd.window-switcher.item.active.border.width")) {
-		theme->osd_window_switcher_item_active_border_width = atoi(value);
+		theme->osd_window_switcher_item_active_border_width =
+			get_int_if_positive(
+				value, "osd.window-switcher.item.active.border.width");
 	}
 	if (match_glob(key, "osd.window-switcher.preview.border.width")) {
-		theme->osd_window_switcher_preview_border_width = atoi(value);
+		theme->osd_window_switcher_preview_border_width =
+			get_int_if_positive(
+				value, "osd.window-switcher.preview.border.width");
 	}
 	if (match_glob(key, "osd.window-switcher.preview.border.color")) {
 		parse_hexstrs(value, theme->osd_window_switcher_preview_border_color);
 	}
 	if (match_glob(key, "osd.workspace-switcher.boxes.width")) {
-		theme->osd_workspace_switcher_boxes_width = atoi(value);
+		theme->osd_workspace_switcher_boxes_width =
+			get_int_if_positive(
+				value, "osd.workspace-switcher.boxes.width");
 	}
 	if (match_glob(key, "osd.workspace-switcher.boxes.height")) {
-		theme->osd_workspace_switcher_boxes_height = atoi(value);
+		theme->osd_workspace_switcher_boxes_height =
+			get_int_if_positive(
+				value, "osd.workspace-switcher.boxes.height");
 	}
 	if (match_glob(key, "osd.label.text.color")) {
 		parse_hexstr(value, theme->osd_label_text_color);
@@ -962,10 +995,12 @@ entry(struct theme *theme, const char *key, const char *value)
 		parse_hexstr(value, theme->snapping_overlay_edge.bg_color);
 	}
 	if (match_glob(key, "snapping.overlay.region.border.width")) {
-		theme->snapping_overlay_region.border_width = atoi(value);
+		theme->snapping_overlay_region.border_width = get_int_if_positive(
+			value, "snapping.overlay.region.border.width");
 	}
 	if (match_glob(key, "snapping.overlay.edge.border.width")) {
-		theme->snapping_overlay_edge.border_width = atoi(value);
+		theme->snapping_overlay_edge.border_width = get_int_if_positive(
+			value, "snapping.overlay.edge.border.width");
 	}
 	if (match_glob(key, "snapping.overlay.region.border.color")) {
 		parse_hexstrs(value, theme->snapping_overlay_region.border_color);
@@ -975,7 +1010,8 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 
 	if (match_glob(key, "magnifier.border.width")) {
-		theme->mag_border_width = atoi(value);
+		theme->mag_border_width = get_int_if_positive(
+			value, "magnifier.border.width");
 	}
 	if (match_glob(key, "magnifier.border.color")) {
 		parse_hexstr(value, theme->mag_border_color);

--- a/src/view.c
+++ b/src/view.c
@@ -617,8 +617,7 @@ view_adjust_size(struct view *view, int *w, int *h)
 {
 	assert(view);
 	struct view_size_hints hints = view_get_size_hints(view);
-	int min_view_width = rc.theme->window_button_width * (
-		wl_list_length(&rc.title_buttons_left) + wl_list_length(&rc.title_buttons_right));
+	int min_width = view_get_min_width();
 
 	/*
 	 * "If a base size is not provided, the minimum size is to be
@@ -641,7 +640,7 @@ view_adjust_size(struct view *view, int *w, int *h)
 	 * This is currently always the case for xdg-shell views.
 	 */
 	if (hints.min_width < 1) {
-		hints.min_width = min_view_width;
+		hints.min_width = min_width;
 	}
 	if (hints.min_height < 1) {
 		hints.min_height = LAB_MIN_VIEW_HEIGHT;
@@ -2277,6 +2276,17 @@ view_reload_ssd(struct view *view)
 		undecorate(view);
 		decorate(view);
 	}
+}
+
+int
+view_get_min_width(void)
+{
+	int button_count_left = wl_list_length(&rc.title_buttons_left);
+	int button_count_right =  wl_list_length(&rc.title_buttons_right);
+	return (rc.theme->window_button_width * (button_count_left + button_count_right)) +
+		(rc.theme->window_button_spacing * MAX((button_count_right - 1), 0)) +
+		(rc.theme->window_button_spacing * MAX((button_count_left - 1), 0)) +
+		(2 * rc.theme->padding_width);
 }
 
 void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -606,15 +606,15 @@ handle_map_request(struct wl_listener *listener, void *data)
 static void
 check_natural_geometry(struct view *view)
 {
+	int min_width = view_get_min_width();
+
 	/*
 	 * Some applications (example: Thonny) don't set a reasonable
 	 * un-maximized size when started maximized. Try to detect this
 	 * and set a fallback size.
 	 */
-	int min_view_width = rc.theme->window_button_width * (
-		wl_list_length(&rc.title_buttons_left) + wl_list_length(&rc.title_buttons_right));
 	if (!view_is_floating(view)
-			&& (view->natural_geometry.width < min_view_width
+			&& (view->natural_geometry.width < min_width
 			|| view->natural_geometry.height < LAB_MIN_VIEW_HEIGHT)) {
 		view_set_fallback_natural_geometry(view);
 	}


### PR DESCRIPTION
I've played a bit with the hover effects and came up with this simple version that is nicely consistent with GTK CSD applications I’m using and also plays nicely with squared corners ( win-win ;) ).

![ssd](https://github.com/user-attachments/assets/c600535e-56f4-429a-97d0-813d08bd9bb8)

I would love to get this ready for review/merge. Obviously I should put this behind an option to not break existing setups. Furthermore I guess, but not sure if it is needed, the radius of the hover circle should also be a theme option. Any thoughts on where to put and how to name those options (`rc.xml` or `theme`)?

My suggestions:
Since we already have `<theme><cornerRadius>` may be `<theme><hoverRadius>` could work, whereas  `hoverRadius == 0` would be no rounded hover effects (thus keeping the current hover effect) and any value `> 1` would be applied as is (if it fits the max possible radius).

Alternatively `<theme><roundedHover>` could be a `true/false` switch and we hard code the radius to 70% like I did now.

PS: What about disabling the CI run on Debian until Debian is ready to produce builds again? Getting the failed CI notifications is, well, misleading.  