### PR TITLE
docs: add a note on padding.height

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -57,8 +57,9 @@ labwc-config(5).
 
 *padding.height*
 	Vertical padding size, in pixels, used for spacing out elements
-	in the window decorations.
-	Default is 3.
+	in the window decorations. Unlike *padding.width*, this padding is
+	not applied for window buttons in PNG/XBM format, or the builtin
+	hover effects. Default is 3.
 
 *titlebar.height*
 	Window title bar height.


### PR DESCRIPTION
Currently, unlike `padding.width`, `padding.height` is not applied for the button images in PNG/XBM format, or builtin hover effects. I personally don't like this inconsistency, but I have no idea how to fix this without breaking compatibility. At least we should document this behavior to avoid confusion, which I'm doing in this PR.

CC @johanmalm @jp7677