### PR TITLE
action: add ToggleSnapToEdge/Region and UnSnap

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -108,6 +108,10 @@ Actions are used in menus and keyboard/mouse bindings.
 
 	See labwc-config(5) for further information on how to define regions.
 
+*<action name="UnSnap" />*
+	Resize and move active window back to its untiled position if
+	it had been tiled to a direction or region.
+
 *<action name="NextWindow" />*++
 *<action name="PreviousWindow" />*
 	Cycle focus to next/previous window respectively.++

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -109,8 +109,8 @@ Actions are used in menus and keyboard/mouse bindings.
 	See labwc-config(5) for further information on how to define regions.
 
 *<action name="UnSnap" />*
-	Resize and move active window back to its untiled position if
-	it had been tiled to a direction or region.
+	Resize and move the active window back to its untiled or unmaximized
+	position if it had been maximized or tiled to a direction or region.
 
 *<action name="NextWindow" />*++
 *<action name="PreviousWindow" />*

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -91,12 +91,21 @@ Actions are used in menus and keyboard/mouse bindings.
 	Move window relative to its current position. Positive value of x moves
 	it right, negative left. Positive value of y moves it down, negative up.
 
+*<action name="ToggleSnapToEdge" direction="value" />*++
 *<action name="SnapToEdge" direction="value" />*
 	Resize window to fill half the output in the given direction. Supports
 	directions "left", "up", "right", "down" and "center".
 
+	ToggleSnapToEdge additionally toggles the active window between
+	tiled to the given direction and its untiled position.
+
+*<action name="ToggleSnapToRegion" region="value" />*++
 *<action name="SnapToRegion" region="value" />*
 	Resize and move active window according to the given region.
+
+	ToggleSnapToRegion additionally toggles the active window between
+	tiled to the given region and its untiled position.
+
 	See labwc-config(5) for further information on how to define regions.
 
 *<action name="NextWindow" />*++

--- a/include/view.h
+++ b/include/view.h
@@ -463,6 +463,12 @@ void view_set_fallback_natural_geometry(struct view *view);
 void view_store_natural_geometry(struct view *view);
 
 /**
+ * view_apply_natural_geometry - adjust view->natural_geometry if it doesn't
+ * intersect with view->output and then apply it
+ */
+void view_apply_natural_geometry(struct view *view);
+
+/**
  * view_effective_height - effective height of view, with respect to shaded state
  * @view: view for which effective height is desired
  * @use_pending: if false, report current height; otherwise, report pending height

--- a/src/action.c
+++ b/src/action.c
@@ -1172,8 +1172,9 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_UNSNAP:
-			if (view && view->maximized == VIEW_AXIS_NONE && !view->fullscreen
-					&& view_is_tiled(view)) {
+			if (view && !view->fullscreen && !view_is_floating(view)) {
+				view_maximize(view, VIEW_AXIS_NONE,
+					/* store_natural_geometry */ false);
 				view_set_untiled(view);
 				view_apply_natural_geometry(view);
 			}

--- a/src/action.c
+++ b/src/action.c
@@ -102,6 +102,7 @@ enum action_type {
 	ACTION_TYPE_GO_TO_DESKTOP,
 	ACTION_TYPE_TOGGLE_SNAP_TO_REGION,
 	ACTION_TYPE_SNAP_TO_REGION,
+	ACTION_TYPE_UNSNAP,
 	ACTION_TYPE_TOGGLE_KEYBINDS,
 	ACTION_TYPE_FOCUS_OUTPUT,
 	ACTION_TYPE_MOVE_TO_OUTPUT,
@@ -165,6 +166,7 @@ const char *action_names[] = {
 	"GoToDesktop",
 	"ToggleSnapToRegion",
 	"SnapToRegion",
+	"UnSnap",
 	"ToggleKeybinds",
 	"FocusOutput",
 	"MoveToOutput",
@@ -1167,6 +1169,13 @@ actions_run(struct view *activator, struct server *server,
 					/*store_natural_geometry*/ true);
 			} else {
 				wlr_log(WLR_ERROR, "Invalid SnapToRegion id: '%s'", region_name);
+			}
+			break;
+		case ACTION_TYPE_UNSNAP:
+			if (view && view->maximized == VIEW_AXIS_NONE && !view->fullscreen
+					&& view_is_tiled(view)) {
+				view_set_untiled(view);
+				view_apply_natural_geometry(view);
 			}
 			break;
 		case ACTION_TYPE_TOGGLE_KEYBINDS:

--- a/src/view.c
+++ b/src/view.c
@@ -1036,7 +1036,7 @@ view_constrain_size_to_that_of_usable_area(struct view *view)
 	view_move_resize(view, box);
 }
 
-static void
+void
 view_apply_natural_geometry(struct view *view)
 {
 	assert(view);


### PR DESCRIPTION
Behaves identical like SnapToEdge and SnapToRegion, but untiles the window when already being tiled to the given region or direction.

I somehow missed this since there is already `ToggleMaximize` ;). `ToggleSnapToEdge` is also identical with the behavior I'm seeing on Gnome Mutter w.r.t. tiling.