### PR TITLE
xdg: don't always adjust the window size before configure

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -397,15 +397,6 @@ xdg_toplevel_view_configure(struct view *view, struct wlr_box geo)
 	uint32_t serial = 0;
 
 	/*
-	 * Leave a size of 0x0 unchanged; this has special meaning in
-	 * an xdg-toplevel configure event and requests the application
-	 * to choose its own preferred size.
-	 */
-	if (!wlr_box_empty(&geo)) {
-		view_adjust_size(view, &geo.width, &geo.height);
-	}
-
-	/*
 	 * We do not need to send a configure request unless the size
 	 * changed (wayland has no notion of a global position). If the
 	 * size is the same (and there is no pending configure request)


### PR DESCRIPTION
Fixes #2142 by just removing `view_adjust_size()` from `xdg_toplevel_view_configure()`.

Maybe we should still adjust the window size before when resizing windows via actions (https://github.com/labwc/labwc/pull/83#issuecomment-945166313), but I wonder if we really need to do it.

At least we currently have a strange behavior with `<keybind key="" name.action="ResizeRelative" left="-10" />` like the video below and we should fix it when we decide to adjust the window size before resizing windows via actions.

https://github.com/user-attachments/assets/bb1e9ab6-757c-4705-b19f-41ad74001959

