### PR TITLE
docs: some fixes about `<action name="ShowMenu" atCursor="no">`

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -121,8 +121,8 @@ Actions are used in menus and keyboard/mouse bindings.
 
 	*atCursor* [yes|no] When opening a menu, open the menu at the location
 	of the mouse cursor. When set to no, the menu will appear at the
-	upper-left corner of the window associated with the action. Default is
-	yes.
+	upper-left corner of the window associated with the action or underneath
+	the window button that opened the menu. Default is yes.
 
 	*position* Show the menu in the specified position on the monitor
 	that has cursor focus, see below.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -269,7 +269,7 @@
       <action name="SnapToEdge" direction="down" />
     </keybind>
     <keybind key="A-Space">
-      <action name="ShowMenu" menu="client-menu" />
+      <action name="ShowMenu" menu="client-menu" atCursor="no" />
     </keybind>
     <keybind key="XF86_AudioLowerVolume">
       <action name="Execute" command="amixer sset Master 5%-" />
@@ -447,10 +447,10 @@
 
     <context name="WindowMenu">
       <mousebind button="Left" action="Click">
-        <action name="ShowMenu" menu="client-menu" />
+        <action name="ShowMenu" menu="client-menu" atCursor="no" />
       </mousebind>
       <mousebind button="Right" action="Click">
-        <action name="ShowMenu" menu="client-menu" />
+        <action name="ShowMenu" menu="client-menu" atCursor="no" />
       </mousebind>
     </context>
 


### PR DESCRIPTION
- Add some missing `atCursor="no"` in `rc.xml.all`
- Describe the behavior updated in #2146
  - The added sentence is currently a bit inaccurate as we just search for the window menu button rather than the actual button that opened the menu. #2165 will fix this.

I won't self-merge just in case because I'm bad at writing English.