### PR TITLE
Don't detect edge-resizes in configure timeout

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -244,8 +244,18 @@ handle_configure_timeout(void *data)
 	view->pending_configure_serial = 0;
 	view->pending_configure_timeout = NULL;
 
-	view_impl_apply_geometry(view,
-		view->current.width, view->current.height);
+	/*
+	 * We do not use view_impl_apply_geometry() here since in the timeout
+	 * case we prefer to always put the top-left corner of the view at the
+	 * desired position rather than anchoring some other edge or corner
+	 */
+	bool moved = view->current.x != view->pending.x
+		|| view->current.y != view->pending.y;
+	view->current.x = view->pending.x;
+	view->current.y = view->pending.y;
+	if (moved) {
+		view_moved(view);
+	}
 
 	/* Re-sync pending view with current state */
 	snap_constraints_update(view);


### PR DESCRIPTION
If a client times out responding to a configure request then the handle_configure_timeout() callback is run.  This cleans up the pending state and moves the view to the pending location, but keeps the current size. The idea is to stop slow applications causing too much lag when the user manipulates the window.  This callback used view_impl_apply_geometry() to actually apply the changes.

view_impl_apply_geometry() contains some heuristics to detect if we're resizing a window from the top, left, or top-left, and if so to do the expected behaviour of keeping the window's bottom/right corner in the same place.  However, that code was erroneously triggering in the case when the user requests to change a window from maximized to fullscreen but the client times out on the configure request. handle_configure_timeout() decides to enact the movement of the window but keep its size at the old size and tells view_impl_apply_geometry() to do that.

The current view position and size is 0,64 1920x1016, the pending position/size is 0,0 1920x1080, and the last committed size is 1920x1016.  Looking at the current and pending position and size, the height changes while the bottom edge stays in the same place so this looks like a top-edge-resize and view_impl_apply_geometry() decides to keep the window's bottom edge in the same place while setting the position according to the last-committed size.  This results in the window staying at position 0,64 size 1920x1016 despite being marked as fullscreen.

My solution to this is just to change handle_configure_timeout() to directly change the view's position and call view_moved() if necessary. The idea of handle_configure_timeout() is to action the window movement now while discarding the size change, and let the size change take place later on when the client catches up.  The logic of view_impl_apply_geometry() doesn't make sense in this case so just avoid it entirely.

Fixes #1922