### PR TITLE
ci: use -Wno-expansion-to-defined to avoid Arch CI error

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ add_project_arguments(cc.get_supported_arguments([
   '-Wunused-macros',
 
   '-Wno-unused-parameter',
+  '-Wno-expansion-to-defined',
 ]), language: 'c')
 
 version='"@0@"'.format(meson.project_version())


### PR DESCRIPTION
...with this warning message:

```
[100/161] Compiling C object labwc.p/src_button_button-svg.c.o FAILED: labwc.p/src_button_button-svg.c.o
gcc -Ilabwc.p -I. -I.. -Iinclude -I../include -I/usr/include/wlroots-0.18 -I/usr/include/pixman-1 -I/usr/include/libdrm -I/usr/include/libxml2 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/include/cairo -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/lib/pkgconfig/../../include/librsvg-2.0 -I/usr/include/gdk-pixbuf-2.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -DWLR_USE_UNSTABLE -Wundef -Wlogical-op -Wmissing-include-dirs -Wold-style-definition -Wpointer-arith -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough=2 -Wendif-labels -Wstrict-aliasing=2 -Woverflow -Wmissing-prototypes -Walloca -Wunused-macros -Wno-unused-parameter '-DLABWC_VERSION="0.8.0"' '-DGETTEXT_PACKAGE="labwc"' '-DLOCALEDIR="/usr/local/share/locale"' -pthread -MD -MQ labwc.p/src_button_button-svg.c.o -MF labwc.p/src_button_button-svg.c.o.d -o labwc.p/src_button_button-svg.c.o -c ../src/button/button-svg.c In file included from ../src/button/button-svg.c:7: /usr/lib/pkgconfig/../../include/librsvg-2.0/librsvg/rsvg.h:1331:1: error: this use of "defined" may not be portable [-Werror=expansion-to-defined]
 1331 | #if LIBRSVG_CHECK_FEATURE(PIXBUF)
      | ^~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
