### PR TITLE
ssd: fix crash on app_id updates while the app is in fullscreen

### DIFF
--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -638,6 +638,10 @@ void
 ssd_update_window_icon(struct ssd *ssd)
 {
 #if HAVE_LIBSFDO
+	if (!ssd) {
+		return;
+	}
+
 	const char *app_id = view_get_string_prop(ssd->view, "app_id");
 	if (string_null_or_empty(app_id)) {
 		return;


### PR DESCRIPTION
`view->ssd_enabled && view->ssd == NULL` is possible during the client is in fullscreen. So we need to check if `view->ssd` is NULL first in `ssd_update_window_icon()`.