### PR TITLE
Titlebar related breaking changes

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -58,7 +58,7 @@ labwc-config(5).
 *padding.height*
 	Vertical padding size, in pixels, used for spacing out elements
 	in the window decorations.
-	Default is 3.
+	Default is 0.
 
 *menu.items.padding.x*
 	Horizontal padding of menu text entries in pixels.

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -50,14 +50,13 @@ labwc-config(5).
 	Line width (integer) of border drawn around window frames.
 	Default is 1.
 
-*padding.width*
-	Horizontal padding size, in pixels, between border and first
+*window.titlebar.padding.width*
+	Horizontal titlebar padding size, in pixels, between border and first
 	button on the left/right.
 	Default is 0.
 
-*padding.height*
-	Vertical padding size, in pixels, used for spacing out elements
-	in the window decorations.
+*window.titlebar.padding.height*
+	Vertical titlebar padding size, in pixels.
 	Default is 0.
 
 *menu.items.padding.x*

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -60,11 +60,6 @@ labwc-config(5).
 	in the window decorations.
 	Default is 3.
 
-*titlebar.height*
-	Window title bar height.
-	Default equals the vertical font extents of the title plus 2x
-	padding.height.
-
 *menu.items.padding.x*
 	Horizontal padding of menu text entries in pixels.
 	Default is 7.

--- a/docs/themerc
+++ b/docs/themerc
@@ -8,7 +8,7 @@
 # general
 border.width: 1
 padding.width: 0
-padding.height: 3
+padding.height: 0
 
 # window border
 window.active.border.color: #e1dedb

--- a/docs/themerc
+++ b/docs/themerc
@@ -7,8 +7,13 @@
 
 # general
 border.width: 1
-padding.width: 0
-padding.height: 0
+
+#
+# We do not support the global padding.{width,height} of openbox because
+# the default labwc button geometry has deviates from that of openbox
+#
+window.titlebar.padding.width: 0
+window.titlebar.padding.height: 0
 
 # window border
 window.active.border.color: #e1dedb

--- a/docs/themerc
+++ b/docs/themerc
@@ -10,10 +10,6 @@ border.width: 1
 padding.width: 0
 padding.height: 3
 
-# The following options has no default, but fallbacks back to
-# font-height + 2x padding.height if not set.
-# titlebar.height:
-
 # window border
 window.active.border.color: #e1dedb
 window.inactive.border.color: #f6f5f4

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -146,7 +146,7 @@ struct ssd_part *add_scene_buffer(
 	struct wlr_scene_tree *parent, struct wlr_buffer *buffer, int x, int y);
 struct ssd_part *add_scene_button(struct wl_list *part_list,
 	enum ssd_part_type type, struct wlr_scene_tree *parent,
-	struct lab_data_buffer *buffers[LAB_BS_ALL + 1], int x,
+	struct lab_data_buffer *buffers[LAB_BS_ALL + 1], int x, int y,
 	struct view *view);
 void update_window_icon_buffer(struct wlr_scene_node *button_node,
 	struct lab_data_buffer *buffer);

--- a/include/theme.h
+++ b/include/theme.h
@@ -46,8 +46,8 @@ struct theme {
 	 * the space between title bar border and
 	 * buttons on the left/right/top
 	 */
-	int padding_width;
-	int padding_height;
+	int window_titlebar_padding_width;
+	int window_titlebar_padding_height;
 
 	int title_height;
 	int menu_overlap_x;
@@ -156,7 +156,10 @@ struct theme {
 	struct lab_data_buffer *shadow_corner_bottom_inactive;
 	struct lab_data_buffer *shadow_edge_inactive;
 
-	/* not set in rc.xml/themerc, but derived from font & padding_height */
+	/*
+	 * Not set in rc.xml/themerc, but derived from the tallest titlebar
+	 * object plus 2 * window_titlebar_padding_height
+	 */
 	int osd_window_switcher_item_height;
 
 	/* magnifier */

--- a/include/theme.h
+++ b/include/theme.h
@@ -67,10 +67,11 @@ struct theme {
 	enum lab_justification window_label_text_justify;
 	enum lab_justification menu_title_text_justify;
 
-	/* button width */
+	/* buttons */
 	int window_button_width;
-	/* the space between buttons */
+	int window_button_height;
 	int window_button_spacing;
+
 	/* the shape of the hover effect */
 	enum lab_shape window_button_hover_bg_shape;
 

--- a/src/ssd/ssd-part.c
+++ b/src/ssd/ssd-part.c
@@ -97,7 +97,7 @@ update_window_icon_buffer(struct wlr_scene_node *button_node,
 
 	struct wlr_box icon_geo = get_scale_box(buffer,
 		rc.theme->window_button_width,
-		rc.theme->title_height);
+		rc.theme->window_button_height);
 
 	wlr_scene_buffer_set_buffer(scene_buffer, &buffer->base);
 	wlr_scene_buffer_set_dest_size(scene_buffer,
@@ -109,17 +109,17 @@ struct ssd_part *
 add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 		struct wlr_scene_tree *parent,
 		struct lab_data_buffer *buffers[LAB_BS_ALL + 1],
-		int x, struct view *view)
+		int x, int y, struct view *view)
 {
 	struct ssd_part *button_root = add_scene_part(part_list, type);
 	parent = wlr_scene_tree_create(parent);
 	button_root->node = &parent->node;
-	wlr_scene_node_set_position(button_root->node, x, 0);
+	wlr_scene_node_set_position(button_root->node, x, y);
 
 	/* Hitbox */
 	float invisible[4] = { 0, 0, 0, 0 };
 	add_scene_rect(part_list, type, parent,
-		rc.theme->window_button_width, rc.theme->title_height, 0, 0,
+		rc.theme->window_button_width, rc.theme->window_button_height, 0, 0,
 		invisible);
 
 	/* Icons */
@@ -130,7 +130,7 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 		}
 		struct lab_data_buffer *icon_buffer = buffers[state_set];
 		struct wlr_box icon_geo = get_scale_box(icon_buffer,
-			rc.theme->window_button_width, rc.theme->title_height);
+			rc.theme->window_button_width, rc.theme->window_button_height);
 		struct ssd_part *icon_part = add_scene_buffer(part_list, type,
 			parent, &icon_buffer->base, icon_geo.x, icon_geo.y);
 		/* Make sure big icons are scaled down if necessary */

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -75,11 +75,15 @@ ssd_titlebar_create(struct ssd *ssd)
 		/* Buttons */
 		struct title_button *b;
 		int x = theme->padding_width;
+
+		/* Center vertically within titlebar */
+		int y = (theme->title_height - theme->window_button_height) / 2;
+
 		wl_list_for_each(b, &rc.title_buttons_left, link) {
 			struct lab_data_buffer **buffers =
 				theme->window[active].buttons[b->type];
 			add_scene_button(&subtree->parts, b->type, parent,
-				buffers, x, view);
+				buffers, x, y, view);
 			x += theme->window_button_width + theme->window_button_spacing;
 		}
 
@@ -89,7 +93,7 @@ ssd_titlebar_create(struct ssd *ssd)
 			struct lab_data_buffer **buffers =
 				theme->window[active].buttons[b->type];
 			add_scene_button(&subtree->parts, b->type, parent,
-				buffers, x, view);
+				buffers, x, y, view);
 		}
 	} FOR_EACH_END
 
@@ -293,6 +297,8 @@ ssd_titlebar_update(struct ssd *ssd)
 
 	update_visible_buttons(ssd);
 
+	/* Center buttons vertically within titlebar */
+	int y = (theme->title_height - theme->window_button_height) / 2;
 	int x;
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
@@ -307,7 +313,7 @@ ssd_titlebar_update(struct ssd *ssd)
 		x = theme->padding_width;
 		wl_list_for_each(b, &rc.title_buttons_left, link) {
 			part = ssd_get_part(&subtree->parts, b->type);
-			wlr_scene_node_set_position(part->node, x, 0);
+			wlr_scene_node_set_position(part->node, x, y);
 			x += theme->window_button_width + theme->window_button_spacing;
 		}
 
@@ -319,7 +325,7 @@ ssd_titlebar_update(struct ssd *ssd)
 		wl_list_for_each_reverse(b, &rc.title_buttons_right, link) {
 			part = ssd_get_part(&subtree->parts, b->type);
 			x -= theme->window_button_width + theme->window_button_spacing;
-			wlr_scene_node_set_position(part->node, x, 0);
+			wlr_scene_node_set_position(part->node, x, y);
 		}
 	} FOR_EACH_END
 

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -609,7 +609,7 @@ ssd_update_window_icon(struct ssd *ssd)
 	 */
 	int hpad = theme->window_button_width / 10;
 	int icon_size = MIN(theme->window_button_width - 2 * hpad,
-		theme->title_height - 2 * theme->window_titlebar_padding_height);
+		theme->window_button_height);
 
 	/*
 	 * Load/render icons at the max scale of any usable output (at

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -74,7 +74,7 @@ ssd_titlebar_create(struct ssd *ssd)
 
 		/* Buttons */
 		struct title_button *b;
-		int x = theme->padding_width;
+		int x = theme->window_titlebar_padding_width;
 
 		/* Center vertically within titlebar */
 		int y = (theme->title_height - theme->window_button_height) / 2;
@@ -87,7 +87,7 @@ ssd_titlebar_create(struct ssd *ssd)
 			x += theme->window_button_width + theme->window_button_spacing;
 		}
 
-		x = width - theme->padding_width + theme->window_button_spacing;
+		x = width - theme->window_titlebar_padding_width + theme->window_button_spacing;
 		wl_list_for_each_reverse(b, &rc.title_buttons_right, link) {
 			x -= theme->window_button_width + theme->window_button_spacing;
 			struct lab_data_buffer **buffers =
@@ -211,7 +211,7 @@ static void
 update_visible_buttons(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
-	int width = view->current.width - (2 * view->server->theme->padding_width);
+	int width = view->current.width - (2 * view->server->theme->window_titlebar_padding_width);
 	int button_width = view->server->theme->window_button_width;
 	int button_spacing = view->server->theme->window_button_spacing;
 	int button_count_left = wl_list_length(&rc.title_buttons_left);
@@ -310,7 +310,7 @@ ssd_titlebar_update(struct ssd *ssd)
 			wlr_scene_rect_from_node(part->node),
 			width - bg_offset * 2, theme->title_height);
 
-		x = theme->padding_width;
+		x = theme->window_titlebar_padding_width;
 		wl_list_for_each(b, &rc.title_buttons_left, link) {
 			part = ssd_get_part(&subtree->parts, b->type);
 			wlr_scene_node_set_position(part->node, x, y);
@@ -321,7 +321,7 @@ ssd_titlebar_update(struct ssd *ssd)
 		part = ssd_get_part(&subtree->parts, LAB_SSD_PART_TITLEBAR_CORNER_RIGHT);
 		wlr_scene_node_set_position(part->node, x, -rc.theme->border_width);
 
-		x = width - theme->padding_width + theme->window_button_spacing;
+		x = width - theme->window_titlebar_padding_width + theme->window_button_spacing;
 		wl_list_for_each_reverse(b, &rc.title_buttons_right, link) {
 			part = ssd_get_part(&subtree->parts, b->type);
 			x -= theme->window_button_width + theme->window_button_spacing;
@@ -432,7 +432,7 @@ get_title_offsets(struct ssd *ssd, int *offset_left, int *offset_right)
 	struct ssd_sub_tree *subtree = &ssd->titlebar.active;
 	int button_width = ssd->view->server->theme->window_button_width;
 	int button_spacing = ssd->view->server->theme->window_button_spacing;
-	int padding_width = ssd->view->server->theme->padding_width;
+	int padding_width = ssd->view->server->theme->window_titlebar_padding_width;
 	*offset_left = padding_width;
 	*offset_right = padding_width;
 
@@ -609,7 +609,7 @@ ssd_update_window_icon(struct ssd *ssd)
 	 */
 	int hpad = theme->window_button_width / 10;
 	int icon_size = MIN(theme->window_button_width - 2 * hpad,
-		theme->title_height - 2 * theme->padding_height);
+		theme->title_height - 2 * theme->window_titlebar_padding_height);
 
 	/*
 	 * Load/render icons at the max scale of any usable output (at

--- a/src/theme.c
+++ b/src/theme.c
@@ -180,7 +180,7 @@ create_rounded_buffer(struct theme *theme, enum corner corner,
 	float white[4] = {1, 1, 1, 1};
 	struct rounded_corner_ctx rounded_ctx = {
 		.box = &(struct wlr_box){
-			.width = theme->padding_width + width,
+			.width = theme->window_titlebar_padding_width + width,
 			.height = height,
 		},
 		.radius = rc.corner_radius,
@@ -191,7 +191,7 @@ create_rounded_buffer(struct theme *theme, enum corner corner,
 	};
 	int mask_offset;
 	if (corner == LAB_CORNER_TOP_LEFT) {
-		mask_offset = -theme->padding_width;
+		mask_offset = -theme->window_titlebar_padding_width;
 	} else {
 		mask_offset = 0;
 	}
@@ -573,7 +573,8 @@ static void
 theme_builtin(struct theme *theme, struct server *server)
 {
 	theme->border_width = 1;
-	theme->padding_height = 0;
+	theme->window_titlebar_padding_height = 0;
+	theme->window_titlebar_padding_width = 0;
 	theme->title_height = INT_MIN;
 	theme->menu_overlap_x = 0;
 	theme->menu_overlap_y = 0;
@@ -591,7 +592,6 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->window_label_text_justify = parse_justification("Center");
 	theme->menu_title_text_justify = parse_justification("Center");
 
-	theme->padding_width = 0;
 	theme->window_button_width = 26;
 	theme->window_button_height = 26;
 	theme->window_button_spacing = 0;
@@ -707,13 +707,13 @@ entry(struct theme *theme, const char *key, const char *value)
 		theme->border_width = get_int_if_positive(
 			value, "border.width");
 	}
-	if (match_glob(key, "padding.width")) {
-		theme->padding_width = get_int_if_positive(
-			value, "padding.width");
+	if (match_glob(key, "window.titlebar.padding.width")) {
+		theme->window_titlebar_padding_width = get_int_if_positive(
+			value, "window.titlebar.padding.width");
 	}
-	if (match_glob(key, "padding.height")) {
-		theme->padding_height = get_int_if_positive(
-			value, "padding.height");
+	if (match_glob(key, "window.titlebar.padding.height")) {
+		theme->window_titlebar_padding_height = get_int_if_positive(
+			value, "window.titlebar.padding.height");
 	}
 	if (match_glob(key, "menu.items.padding.x")) {
 		theme->menu_item_padding_x = get_int_if_positive(
@@ -1474,7 +1474,7 @@ get_titlebar_height(struct theme *theme)
 	if (h < theme->window_button_height) {
 		h = theme->window_button_height;
 	}
-	h += 2 * theme->padding_height;
+	h += 2 * theme->window_titlebar_padding_height;
 	return h;
 }
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -573,7 +573,7 @@ static void
 theme_builtin(struct theme *theme, struct server *server)
 {
 	theme->border_width = 1;
-	theme->padding_height = 3;
+	theme->padding_height = 0;
 	theme->title_height = INT_MIN;
 	theme->menu_overlap_x = 0;
 	theme->menu_overlap_y = 0;

--- a/src/theme.c
+++ b/src/theme.c
@@ -91,7 +91,7 @@ copy_icon_buffer(struct theme *theme, struct lab_data_buffer *icon_buffer)
 	int icon_height = cairo_image_surface_get_height(icon.surface);
 
 	int width = theme->window_button_width;
-	int height = theme->title_height;
+	int height = theme->window_button_height;
 
 	/*
 	 * Proportionately increase size of hover_buffer if the non-hover
@@ -139,7 +139,7 @@ create_hover_fallback(struct theme *theme,
 	assert(!*hover_buffer);
 
 	int width = theme->window_button_width;
-	int height = theme->title_height;
+	int height = theme->window_button_height;
 
 	*hover_buffer = copy_icon_buffer(theme, icon_buffer);
 	cairo_t *cairo = (*hover_buffer)->cairo;
@@ -171,7 +171,7 @@ create_rounded_buffer(struct theme *theme, enum corner corner,
 	cairo_t *cairo = (*rounded_buffer)->cairo;
 
 	int width = theme->window_button_width;
-	int height = theme->title_height;
+	int height = theme->window_button_height;
 
 	/*
 	 * Round the hover overlay of corner buttons by
@@ -246,7 +246,7 @@ load_button(struct theme *theme, struct button *b, int active)
 
 	zdrop(buffer);
 
-	int size = theme->title_height - 2 * theme->padding_height;
+	int size = theme->window_button_height;
 	float scale = 1; /* TODO: account for output scale */
 
 	/* PNG */
@@ -593,6 +593,7 @@ theme_builtin(struct theme *theme, struct server *server)
 
 	theme->padding_width = 0;
 	theme->window_button_width = 26;
+	theme->window_button_height = 26;
 	theme->window_button_spacing = 0;
 	theme->window_button_hover_bg_shape = LAB_RECTANGLE;
 
@@ -777,6 +778,14 @@ entry(struct theme *theme, const char *key, const char *value)
 			wlr_log(WLR_ERROR, "window.button.width cannot "
 				"be less than 1, clamping it to 1.");
 			theme->window_button_width = 1;
+		}
+	}
+	if (match_glob(key, "window.button.height")) {
+		theme->window_button_height = atoi(value);
+		if (theme->window_button_height < 1) {
+			wlr_log(WLR_ERROR, "window.button.height cannot "
+				"be less than 1, clamping it to 1.");
+			theme->window_button_height = 1;
 		}
 	}
 	if (match_glob(key, "window.button.spacing")) {

--- a/src/theme.c
+++ b/src/theme.c
@@ -174,14 +174,16 @@ create_rounded_buffer(struct theme *theme, enum corner corner,
 	int height = theme->window_button_height;
 
 	/*
-	 * Round the hover overlay of corner buttons by
-	 * cropping the region within the window border.
+	 * Round the corner button by cropping the region within the window
+	 * border. See the picture in #2189 for reference.
 	 */
+	int margin_x = theme->window_titlebar_padding_width;
+	int margin_y = (theme->title_height - theme->window_button_height) / 2;
 	float white[4] = {1, 1, 1, 1};
 	struct rounded_corner_ctx rounded_ctx = {
 		.box = &(struct wlr_box){
-			.width = theme->window_titlebar_padding_width + width,
-			.height = height,
+			.width = margin_x + width,
+			.height = margin_y + height,
 		},
 		.radius = rc.corner_radius,
 		.line_width = theme->border_width,
@@ -189,16 +191,11 @@ create_rounded_buffer(struct theme *theme, enum corner corner,
 		.border_color = white,
 		.corner = corner,
 	};
-	int mask_offset;
-	if (corner == LAB_CORNER_TOP_LEFT) {
-		mask_offset = -theme->window_titlebar_padding_width;
-	} else {
-		mask_offset = 0;
-	}
 	struct lab_data_buffer *mask_buffer = rounded_rect(&rounded_ctx);
 	cairo_set_operator(cairo, CAIRO_OPERATOR_DEST_IN);
-	cairo_set_source_surface(cairo,
-		cairo_get_target(mask_buffer->cairo), mask_offset, 0);
+	cairo_set_source_surface(cairo, cairo_get_target(mask_buffer->cairo),
+		(corner == LAB_CORNER_TOP_LEFT) ? -margin_x : 0,
+		-margin_y);
 	cairo_paint(cairo);
 
 	cairo_surface_flush(cairo_get_target(cairo));

--- a/src/theme.c
+++ b/src/theme.c
@@ -715,10 +715,6 @@ entry(struct theme *theme, const char *key, const char *value)
 		theme->padding_height = get_int_if_positive(
 			value, "padding.height");
 	}
-	if (match_glob(key, "titlebar.height")) {
-		theme->title_height = get_int_if_positive(
-			value, "titlebar.height");
-	}
 	if (match_glob(key, "menu.items.padding.x")) {
 		theme->menu_item_padding_x = get_int_if_positive(
 			value, "menu.items.padding.x");
@@ -1474,9 +1470,7 @@ static void
 post_processing(struct theme *theme)
 {
 	int h = MAX(font_height(&rc.font_activewindow), font_height(&rc.font_inactivewindow));
-	if (theme->title_height < h) {
-		theme->title_height = h + 2 * theme->padding_height;
-	}
+	theme->title_height = h + 2 * theme->padding_height;
 
 	theme->menu_item_height = font_height(&rc.font_menuitem)
 		+ 2 * theme->menu_item_padding_y;

--- a/src/theme.c
+++ b/src/theme.c
@@ -1466,11 +1466,22 @@ fill_colors_with_osd_theme(struct theme *theme, float colors[3][4])
 	memcpy(colors[2], theme->osd_bg_color, sizeof(colors[2]));
 }
 
+static int
+get_titlebar_height(struct theme *theme)
+{
+	int h = MAX(font_height(&rc.font_activewindow),
+		font_height(&rc.font_inactivewindow));
+	if (h < theme->window_button_height) {
+		h = theme->window_button_height;
+	}
+	h += 2 * theme->padding_height;
+	return h;
+}
+
 static void
 post_processing(struct theme *theme)
 {
-	int h = MAX(font_height(&rc.font_activewindow), font_height(&rc.font_inactivewindow));
-	theme->title_height = h + 2 * theme->padding_height;
+	theme->title_height = get_titlebar_height(theme);
 
 	theme->menu_item_height = font_height(&rc.font_menuitem)
 		+ 2 * theme->menu_item_padding_y;

--- a/src/view.c
+++ b/src/view.c
@@ -2284,7 +2284,7 @@ view_get_min_width(void)
 	return (rc.theme->window_button_width * (button_count_left + button_count_right)) +
 		(rc.theme->window_button_spacing * MAX((button_count_right - 1), 0)) +
 		(rc.theme->window_button_spacing * MAX((button_count_left - 1), 0)) +
-		(2 * rc.theme->padding_width);
+		(2 * rc.theme->window_titlebar_padding_width);
 }
 
 void


### PR DESCRIPTION
As we are approach the cool-down for the next release I am pondering the
titlebar settings. We have added some slightly conflicting theme options and it
is important that we strike a balance between sane default value and avoiding
some visible breaking changes.

Firstly we have added support for icons which are enabled by default.

Secondly - and over slightly longer than this release cycle - we have moved
from a very simple BUTTON_WIDTH constant which originated in early labwc
commits, to a few more knobs namely:

```
window.button.hover.bg.shape: circle|rectangle (default rectangle)
padding.width: 0
window.button.spacing: 0
window.button.width: 26
```

Whilst these have been given _default_ values to maintain the current look,
themes containing for example `padding.width` will result in a different look.

So, where am I going with this?

1. Our theme-spec is crying out for a `window.button.height`, unless of course
   we just accept that button height will always be the same as button width.
   If you have followed the commits in this release cycle, these dimentions
   relate to the allocated space for each button. Buttons can be smaller (and
   will then center-align) but cannot be any bigger. Also, this allocated space
   is what determines the size of the button hover effect.
2. It feels like the titlebar height should be derived from now only the
   font-height but now also this new `window.button.height` plus of course
   `2 * padding.height` which has always been the case.
3. Following (2) we need `window.button.height` to be 23 for the same 'look'
   based on the fact that on my system font_height() is 17 (using default font)
   so 17 + 2 * 3 (`padding.height`) = 23
4. So now have an odd situation whereby window.button.{width,height} is 26x23,
   which is unlikely to be particularly helpful in keeping icons look crisp.
   For example if you try to use a 24x24 icon, you'll end up distorted. 
   So, I suggest just setting `window.button.height` to 26.
5. Well, now for the next inconsistency. Until the introduction of
   `window.button.height` in this PR, buttons have actually used the whole
   titlebar height. That works fine for rectangular hover-effects spanning
   the full height, but if you want a circular/rectangular hover-effect that's
   a bit smaller you'll be very grateful for `window.button.height`. BUT as a
   result, buttons now respect `padding.height` which is really nice, except
   that the default `padding.height` of 3 changes the default look.
   I suggest therefore that we set the `padding.height` to 0 (as in this PR).
6. Follwoing (3) I'm suggesting that we actually get rid of the theme setting
   `titlebar.height`. It doesn't exist in Openbox spec and was one of those
   "additional" levers that someone wanted (and I had a weak moment and said
   yes :smile:) but it just offers an alternative way (more direct) of setting
   the titlebar height but creates logic that's harder for users to follow.
   I think it's important with UI design that primary objects (buttons in our
   case) decide the geometry and that secondary objects (the titlebar) follow.
   So giving users the `titlebar.height` setting just creates more code for us
   and a false sense of how it works for the users.

What I haven't added in the PR - but we really ought to consider at this time
is that if `padding.{height,width}` is set to zero (and assuming that
`window.button.height` is greater than `font_height()`) then there is no
padding around the window-icon which looks a bit "tight".  So we ought to
consider either/both a setting for the icon-size and icon-margin. For example,
we could change `<theme><icon>` before the next release (beyond which point it
becomes less appealing) to enable something like:

```xml
<theme>
  <iconTheme></iconTheme>
  <iconSize><iconSize>
</theme>
```

--EDIT-- We may also want to consider icon-margin because the icon is a bit special.

Also on the TODO list is 

- [ ] Draw svg icons to the size specified by the icon rather than the
      space allocated by window.button.{width,height}
      Ref: https://github.com/labwc/labwc/pull/2144#issuecomment-2359397672

- [ ] Change `theme->title_height` to `theme->titlebar_height`. Just seems a
      better variable name.

![20240929_20h18m48s_grim](https://github.com/user-attachments/assets/101450f0-4fca-45f6-baf0-c9edcbcd75f2)
