### PR TITLE
xdg: fix de-synced SSD when shrinking Thunderbird window

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -161,8 +161,15 @@ handle_commit(struct wl_listener *listener, void *data)
 	 */
 	if (size.width != view->pending.width
 			|| size.height != view->pending.height) {
-		struct wlr_box extent;
-		wlr_surface_get_extends(xdg_surface->surface, &extent);
+		/*
+		 * Not using wlr_surface_get_extend() since Thunderbird
+		 * sometimes resizes the window geometry and the toplevel
+		 * surface size, but not the subsurface size (see #2183).
+		 */
+		struct wlr_box extent = {
+			.width = view->surface->current.width,
+			.height = view->surface->current.height,
+		};
 		if (extent.width == view->pending.width
 				&& extent.height == view->pending.height) {
 			wlr_log(WLR_DEBUG, "window geometry for client (%s) "


### PR DESCRIPTION
Fixes #2183.

This PR modifies the workaround for Qt apps introduced in #1229 by using the toplevel surface size (`surface->current.{width,height}`) instead of the whole surface extent (returned from `wlr_surface_get_extends()`), to update `view->current`.

Using toplevel surface size as the window geometry doesn't sound not right in regard to the xdg-protocol, but I think this change is OK as we're already not strictly following the protocol since #1229 and this doesn't complicate the codebase so much.

CC @jlindgren90 as I'm not 100% sure that this PR doesn't reintroduce any problems.