### PR TITLE
cursor: prevent Drag mousebinds from running without button press

### DIFF
--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -142,7 +142,7 @@ bool cursor_process_button_release(struct seat *seat, uint32_t button, uint32_t 
  * Finishes cursor button release. The return value indicates if an interactive
  * move/resize had been finished. Should be called after notifying a client.
  */
-bool cursor_finish_button_release(struct seat *seat);
+bool cursor_finish_button_release(struct seat *seat, uint32_t button);
 
 void cursor_init(struct seat *seat);
 void cursor_reload(struct seat *seat);

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -516,7 +516,7 @@ handle_tablet_tool_tip(struct wl_listener *listener, void *data)
 				wlr_tablet_v2_tablet_tool_notify_up(tool->tool_v2);
 			}
 
-			bool exit_interactive = cursor_finish_button_release(tool->seat);
+			bool exit_interactive = cursor_finish_button_release(tool->seat, BTN_LEFT);
 			if (exit_interactive && surface && tool->tool_v2->focused_surface) {
 				/*
 				 * Re-enter the surface after a resize/move to ensure


### PR DESCRIPTION
Fixes #2175.

For `Drag` mousebinds, `mousebind->pressed_in_context` is set on button press and cleared on cursor motion, which executes actions bounded to the mousebind. However, when interactive move/resize has been already started on cursor motion by other keybinds/mousebinds, `mousebind->pressed_in_context` is not cleared, so the mousebind could be unexpectedly executed after the button is released and the interactive move/resize is finished.

So this PR fixes it by always clearing `pressed_in_context` on button releases.