### PR TITLE
xdg: try to handle slow un-maximize with empty natural geometry better

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -14,6 +14,16 @@
 #define LAB_MIN_VIEW_HEIGHT 60
 
 /*
+ * Fallback view geometry used in some cases where a better position
+ * and/or size can't be determined. Try to avoid using these except as
+ * a last resort.
+ */
+#define VIEW_FALLBACK_X 100
+#define VIEW_FALLBACK_Y 100
+#define VIEW_FALLBACK_WIDTH  640
+#define VIEW_FALLBACK_HEIGHT 480
+
+/*
  * In labwc, a view is a container for surfaces which can be moved around by
  * the user. In practice this means XDG toplevel and XWayland windows.
  */

--- a/src/view.c
+++ b/src/view.c
@@ -29,9 +29,6 @@
 #include <wlr/xwayland.h>
 #endif
 
-#define LAB_FALLBACK_WIDTH  640
-#define LAB_FALLBACK_HEIGHT 480
-
 struct view *
 view_from_wlr_surface(struct wlr_surface *surface)
 {
@@ -827,17 +824,14 @@ adjust_floating_geometry(struct view *view, struct wlr_box *geometry,
 void
 view_set_fallback_natural_geometry(struct view *view)
 {
-	view->natural_geometry.width = LAB_FALLBACK_WIDTH;
-	view->natural_geometry.height = LAB_FALLBACK_HEIGHT;
+	view->natural_geometry.width = VIEW_FALLBACK_WIDTH;
+	view->natural_geometry.height = VIEW_FALLBACK_HEIGHT;
 	view_compute_centered_position(view, NULL,
 		view->natural_geometry.width,
 		view->natural_geometry.height,
 		&view->natural_geometry.x,
 		&view->natural_geometry.y);
 }
-
-#undef LAB_FALLBACK_WIDTH
-#undef LAB_FALLBACK_HEIGHT
 
 void
 view_store_natural_geometry(struct view *view)


### PR DESCRIPTION
In the case of an initially-maximized view which is taking a long time to un-maximize (seen for example with Thunderbird on slow machines), we may end up in handle_configure_timeout() with an empty pending geometry. In that case we have no great options (we can't center the view since we don't know the un-maximized size yet), so set a fallback position.

Fixes: #2191

Video running nested (slowed down to 50%):
https://github.com/user-attachments/assets/dfb35d39-e023-4733-a8c3-26f5b8184e34