### PR TITLE
ssd: unround hover effects when the window is tiled

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -18,12 +18,18 @@
 struct ssd_button {
 	struct view *view;
 	enum ssd_part_type type;
+
 	struct wlr_scene_node *normal;
-	struct wlr_scene_node *hover;
 	struct wlr_scene_node *toggled;
+	/*
+	 * Hover icons provided by user or builtin translucent hover overlay.
+	 * Hover overlays are rendered on top of normal/toggled nodes.
+	 */
+	struct wlr_scene_node *hover;
 	struct wlr_scene_node *toggled_hover;
-	struct wlr_scene_tree *icon_tree;
-	struct wlr_scene_tree *hover_tree;
+
+	struct wlr_scene_tree *untoggled_tree;
+	struct wlr_scene_tree *toggled_tree;
 
 	struct wl_listener destroy;
 };

--- a/include/theme.h
+++ b/include/theme.h
@@ -22,6 +22,12 @@ enum lab_shape {
 	LAB_CIRCLE,
 };
 
+enum ssd_corner {
+	LAB_CORNER_UNKNOWN = 0,
+	LAB_CORNER_TOP_LEFT,
+	LAB_CORNER_TOP_RIGHT,
+};
+
 struct theme_snapping_overlay {
 	bool bg_enabled;
 	bool border_enabled;
@@ -169,6 +175,10 @@ struct theme {
 	struct lab_data_buffer *button_unshade_inactive_hover;
 	struct lab_data_buffer *button_omnipresent_inactive_hover;
 	struct lab_data_buffer *button_exclusive_inactive_hover;
+
+	struct lab_data_buffer *button_hover_overlay_left;
+	struct lab_data_buffer *button_hover_overlay_right;
+	struct lab_data_buffer *button_hover_overlay_middle;
 
 	struct lab_data_buffer *corner_top_left_active_normal;
 	struct lab_data_buffer *corner_top_right_active_normal;


### PR DESCRIPTION
Fixes #1682.

This also  fixes another problem that the window menu button as the fallback of the window icon is not rounded correctly:

![20241002_16h43m45s_grim](https://github.com/user-attachments/assets/619f48d8-d286-4681-98a7-ce64958a805b)

Now the translucent hover effect is stored separately from the non-hover icons and rendered on top of them. This might incur some overhead on pixman renderer, but it's not obvious in my testing.