### PR TITLE
data: disable Inhibit D-BUS interface in xdg-portals configuration

### DIFF
--- a/data/labwc-portals.conf
+++ b/data/labwc-portals.conf
@@ -1,2 +1,3 @@
 [preferred]
 default=wlr;*
+org.freedesktop.impl.portal.Inhibit=none


### PR DESCRIPTION
The GTK xdg-portal implementation, which is used as the default behind the wlr xdg-portal implementation, exposes the Inhibit interface even on a non-Gnome session. Unfortunately this D-BUS interface does not work on labwc.

By explicitly disabling this interface, firefox and may be other applications are not tricked into using the xdg-portal interface but use the Wayland IdleInhibit protocol instead which labwc supports.

See https://github.com/labwc/labwc/discussions/1503 for more technical details and also how to test this. This has also been raised https://github.com/labwc/labwc/pull/1716#issuecomment-2299758917 as a comment for the PR that introduced the portal configuration. Note that the same change has been proposed for the wlr-xdg-portal implementation (https://github.com/emersion/xdg-desktop-portal-wlr/pull/315) but hasn't been merged because the actual problem is elsewhere. That said, I think disabling the Inhibit interface makes sense from a practical perspective since the effect otherwise are really annoying (the compositor suspends when watching a longer video clip in firefox) and it can be easily removed once there is a proper solution elsewhere.  