### PR TITLE
theme: scale corner radius in hover effect rendering

### DIFF
--- a/src/theme.c
+++ b/src/theme.c
@@ -198,19 +198,15 @@ create_hover_fallback(struct theme *theme, const char *icon_name,
 			};
 			struct lab_data_buffer *mask_buffer =
 				rounded_rect(&rounded_ctx);
-			cairo_pattern_t *mask_pattern =
-				cairo_pattern_create_for_surface(
-					cairo_get_target(mask_buffer->cairo));
 			int mask_offset;
 			if (corner == LAB_CORNER_TOP_LEFT) {
 				mask_offset = -theme->padding_width;
 			} else {
 				mask_offset = 0;
 			}
-			cairo_save(cairo);
-			cairo_translate(cairo, mask_offset, 0);
-			cairo_mask(cairo, mask_pattern);
-			cairo_restore(cairo);
+			cairo_mask_surface(cairo,
+				cairo_get_target(mask_buffer->cairo),
+				mask_offset, 0);
 			wlr_buffer_drop(&mask_buffer->base);
 		}
 		break;


### PR DESCRIPTION
The current `create_hover_fallback()` doesn't scale up the corner radius (and `padding.width`) correctly when the fallback hover effect is drawn on top of a non-hover icon buffer that's larger than the window button size.

So for example, when `close-active.png` with the size of 800x200 is provided, the hover effect looks as if it's not rounded at all:

![20241003_09h39m37s_grim](https://github.com/user-attachments/assets/e9eecb52-e02d-4fc3-b125-44595a4d8869) 

This PR fixes it by switching the scale of the cairo context with `cairo_scale()`.

This also includes a minor refactor of #2145.