### PR TITLE
ssd: limit icon size to ~85% of window_button_width

### DIFF
--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -654,7 +654,16 @@ ssd_update_window_icon(struct ssd *ssd)
 
 	struct theme *theme = ssd->view->server->theme;
 
-	int icon_size = MIN(theme->window_button_width,
+	/*
+	 * Ensure a small amount of horizontal padding within the button
+	 * area (2px on each side with the default 26px button width).
+	 * A new theme setting could be added to configure this. Using
+	 * an existing setting (padding.width or window.button.spacing)
+	 * was considered, but these settings have distinct purposes
+	 * already and are zero by default.
+	 */
+	int hpad = theme->window_button_width / 10;
+	int icon_size = MIN(theme->window_button_width - 2 * hpad,
 		theme->title_height - 2 * theme->padding_height);
 	/* TODO: take into account output scales */
 	int icon_scale = 1;


### PR DESCRIPTION
This ensures that the icon doesn't push right up to the window edge (or left-aligned title) when using a large font or narrow button width. In the default config (with 10pt font), it makes no difference since the limiting factor on the icon size is the titlebar height anyway.

I spent way too much time over-thinking how to compute the padding. I think 2px on each side is reasonable (and it should be equal on each side), so window_button_width/10 (rounded down) should be fine. Eventually the padding should probably be configurable anyway.

Previously:
- #2189 (broader discussion covering various options, including this)
- #2194 (works only if themes to set a non-zero `window.button.spacing`)

Before/after, default theme except for left-aligned title, with 10pt font:
![Screenshot 2024-10-03 07:40:10](https://github.com/user-attachments/assets/71e5f143-8c2e-4350-818c-73a754dfb6a9)
![Screenshot 2024-10-03 08:23:51](https://github.com/user-attachments/assets/a5f8ef06-f381-423b-8865-6b8783286bb2)

Before/after, default theme except for left-aligned title, with 16pt font:
![Screenshot 2024-10-03 07:41:03](https://github.com/user-attachments/assets/ccfc74e5-1e43-4e89-bcad-a307767936f6)
![Screenshot 2024-10-03 08:25:38](https://github.com/user-attachments/assets/6ede71ef-d9b9-4abc-b920-ca9544438836)