### PR TITLE
xdg: fix crash on actions from menu opened by show_window_menu requests

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -734,7 +734,6 @@ show_menu(struct server *server, struct view *view, struct cursor_context *ctx,
 
 	/* Replaced by next show_menu() or cleaned on view_destroy() */
 	menu->triggered_by_view = view;
-	menu->server->menu_current = menu;
 	menu_open_root(menu, x, y);
 }
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -418,8 +418,11 @@ handle_request_show_window_menu(struct wl_listener *listener, void *data)
 	struct xdg_toplevel_view *xdg_toplevel_view = wl_container_of(
 		listener, xdg_toplevel_view, request_show_window_menu);
 	struct server *server = xdg_toplevel_view->base.server;
+
 	struct menu *menu = menu_get_by_id(server, "client-menu");
 	assert(menu);
+	menu->triggered_by_view = &xdg_toplevel_view->base;
+
 	struct wlr_cursor *cursor = server->seat.cursor;
 	menu_open_root(menu, cursor->x, cursor->y);
 }


### PR DESCRIPTION
Fix crash when executing view-related actions like `Maximize` from a menu opened by `show_window_menu` requests (https://github.com/labwc/labwc/pull/2167#issuecomment-2393015264).

Note that I don't know internals of `menu.c`. I just copied the lines from `show_menu()` in `action.c`.