### PR TITLE
icon-loader: fix a few more missing icons

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -489,9 +489,17 @@ xwayland_view_get_string_prop(struct view *view, const char *prop)
 	if (!strcmp(prop, "class")) {
 		return xwayland_surface->class;
 	}
-	/* We give 'class' for wlr_foreign_toplevel_handle_v1_set_app_id() */
+	/*
+	 * Use the WM_CLASS 'instance' (1st string) for the app_id. Per
+	 * ICCCM, this is usually "the trailing part of the name used to
+	 * invoke the program (argv[0] stripped of any directory names)".
+	 *
+	 * In most cases, the 'class' (2nd string) is the same as the
+	 * 'instance' except for being capitalized. We want lowercase
+	 * here since we use the app_id for icon lookups.
+	 */
 	if (!strcmp(prop, "app_id")) {
-		return xwayland_surface->class;
+		return xwayland_surface->instance;
 	}
 	return "";
 }


### PR DESCRIPTION
By:
- stripping extensions from relative icon filenames (for example, gdmap.desktop has "Icon=gdmap_icon.png")
- ~lowercasing the app_id before the fallback lookup since WM_CLASS is often capitalized ("Scid" now matches /usr/share/pixmaps/scid.png)~
- using the WM_CLASS "instance" rather than "class" string, which is usually the same but lowercase

~Change strcasecmp() to locale-independent g_ascii_strcasecmp() throughout the file, for consistency with g_ascii_strdown().~