### PR TITLE
Improve icon display especially at larger output scales

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -62,6 +62,18 @@ struct lab_data_buffer *buffer_create_cairo(uint32_t logical_width,
 	uint32_t logical_height, float scale);
 
 /*
+ * Create a buffer from an image surface, for display as an icon.
+ *
+ * The surface is either adopted by the buffer (which takes ownership),
+ * or copied and then destroyed.
+ *
+ * This function allows non-ARGB32 source images and converts to
+ * CAIRO_FORMAT_ARGB32 if needed.
+ */
+struct lab_data_buffer *buffer_convert_cairo_surface_for_icon(
+	cairo_surface_t *surface, uint32_t icon_size, float scale);
+
+/*
  * Create a buffer which holds (and takes ownership of) raw pixel data
  * in pre-multiplied ARGB32 format.
  *

--- a/include/common/box.h
+++ b/include/common/box.h
@@ -4,14 +4,23 @@
 
 #include <wlr/util/box.h>
 
-bool
-box_contains(struct wlr_box *box_super, struct wlr_box *box_sub);
+bool box_contains(struct wlr_box *box_super, struct wlr_box *box_sub);
 
-bool
-box_intersects(struct wlr_box *box_a, struct wlr_box *box_b);
+bool box_intersects(struct wlr_box *box_a, struct wlr_box *box_b);
 
 /* Returns the bounding box of 2 boxes */
-void
-box_union(struct wlr_box *box_dest, struct wlr_box *box_a, struct wlr_box *box_b);
+void box_union(struct wlr_box *box_dest, struct wlr_box *box_a,
+	struct wlr_box *box_b);
+
+/*
+ * Fits and centers a content box (width & height) within a bounding box
+ * (max_width & max_height). The content box is downscaled if necessary
+ * (preserving aspect ratio) but not upscaled.
+ *
+ * The returned x & y coordinates are the centered content position
+ * relative to the top-left corner of the bounding box.
+ */
+struct wlr_box box_fit_within(int width, int height, int max_width,
+	int max_height);
 
 #endif /* LABWC_BOX_H */

--- a/include/icon-loader.h
+++ b/include/icon-loader.h
@@ -7,6 +7,6 @@ struct server;
 void icon_loader_init(struct server *server);
 void icon_loader_finish(struct server *server);
 struct lab_data_buffer *icon_loader_lookup(struct server *server,
-	const char *app_id, int size, int scale);
+	const char *app_id, int size, float scale);
 
 #endif /* LABWC_ICON_LOADER_H */

--- a/include/img/img-png.h
+++ b/include/img/img-png.h
@@ -4,6 +4,7 @@
 
 struct lab_data_buffer;
 
-void img_png_load(const char *filename, struct lab_data_buffer **buffer);
+void img_png_load(const char *filename, struct lab_data_buffer **buffer,
+	int size, float scale);
 
 #endif /* LABWC_IMG_PNG_H */

--- a/include/img/img-svg.h
+++ b/include/img/img-svg.h
@@ -5,6 +5,6 @@
 struct lab_data_buffer;
 
 void img_svg_load(const char *filename, struct lab_data_buffer **buffer,
-	int size);
+	int size, float scale);
 
 #endif /* LABWC_IMG_SVG_H */

--- a/include/img/img-xpm.h
+++ b/include/img/img-xpm.h
@@ -4,6 +4,7 @@
 
 struct lab_data_buffer;
 
-void img_xpm_load(const char *filename, struct lab_data_buffer **buffer);
+void img_xpm_load(const char *filename, struct lab_data_buffer **buffer,
+	int size, float scale);
 
 #endif /* LABWC_IMG_XPM_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -546,6 +546,14 @@ struct wlr_box output_usable_area_scaled(struct output *output);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
 void output_enable_adaptive_sync(struct wlr_output *output, bool enabled);
+
+/**
+ * output_max_scale() - get maximum scale factor of all usable outputs.
+ * Used when loading/rendering resources (e.g. icons) that may be
+ * displayed on any output.
+ */
+float output_max_scale(struct server *server);
+
 void new_tearing_hint(struct wl_listener *listener, void *data);
 
 void server_init(struct server *server);

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -149,7 +149,7 @@ struct ssd_part *add_scene_button(struct wl_list *part_list,
 	struct lab_data_buffer *buffers[LAB_BS_ALL + 1], int x,
 	struct view *view);
 void update_window_icon_buffer(struct wlr_scene_node *button_node,
-	struct wlr_buffer *buffer);
+	struct lab_data_buffer *buffer);
 
 /* SSD internal helpers */
 struct ssd_part *ssd_get_part(

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -29,6 +29,7 @@
 #include <drm_fourcc.h>
 #include <wlr/interfaces/wlr_buffer.h>
 #include "buffer.h"
+#include "common/box.h"
 #include "common/mem.h"
 
 static const struct wlr_buffer_impl data_buffer_impl;
@@ -130,6 +131,58 @@ buffer_create_cairo(uint32_t logical_width, uint32_t logical_height, float scale
 	buffer->logical_width = logical_width;
 	buffer->logical_height = logical_height;
 	buffer->cairo = cairo_create(surface);
+
+	return buffer;
+}
+
+struct lab_data_buffer *
+buffer_convert_cairo_surface_for_icon(cairo_surface_t *surface,
+		uint32_t icon_size, float scale)
+{
+	assert(cairo_surface_get_type(surface) == CAIRO_SURFACE_TYPE_IMAGE);
+
+	/*
+	 * Compute logical size for display and decide whether we can
+	 * use the image data directly (fast path). Requirements are:
+	 *
+	 *  - The pixel format must be ARGB32.
+	 *  - The image must not be so large as to need downsampling by
+	 *    more than 2x when displayed at the target scale. wlr_scene
+	 *    uses linear interpolation without pixel averaging, which
+	 *    starts to skip samples if downsampling more than 2x,
+	 *    resulting in a grainy look.
+	 */
+	int width = cairo_image_surface_get_width(surface);
+	int height = cairo_image_surface_get_height(surface);
+	struct wlr_box logical =
+		box_fit_within(width, height, icon_size, icon_size);
+	struct lab_data_buffer *buffer;
+
+	if (cairo_image_surface_get_format(surface) == CAIRO_FORMAT_ARGB32
+			&& width <= 2 * logical.width * scale
+			&& height <= 2 * logical.height * scale) {
+		buffer = buffer_adopt_cairo_surface(surface);
+		/* set logical size for display */
+		buffer->logical_width = logical.width;
+		buffer->logical_height = logical.height;
+	} else {
+		/* convert to ARGB32 and scale for display (slow path) */
+		buffer = buffer_create_cairo(logical.width,
+			logical.height, scale);
+
+		cairo_t *cairo = buffer->cairo;
+		cairo_scale(cairo, (double)logical.width / width,
+			(double)logical.height / height);
+		cairo_set_source_surface(cairo, surface, 0, 0);
+		cairo_pattern_set_filter(cairo_get_source(cairo),
+			CAIRO_FILTER_GOOD);
+		cairo_paint(cairo);
+
+		/* ensure pixel data is updated */
+		cairo_surface_flush(buffer->surface);
+		/* destroy original surface */
+		cairo_surface_destroy(surface);
+	}
 
 	return buffer;
 }

--- a/src/common/box.c
+++ b/src/common/box.c
@@ -47,3 +47,29 @@ box_union(struct wlr_box *box_dest, struct wlr_box *box_a, struct wlr_box *box_b
 	box_dest->width = x2 - x1;
 	box_dest->height = y2 - y1;
 }
+
+struct wlr_box
+box_fit_within(int width, int height, int max_width, int max_height)
+{
+	struct wlr_box box;
+
+	if (width <= max_width && height <= max_height) {
+		/* No downscaling needed */
+		box.width = width;
+		box.height = height;
+	} else if (width * max_height > height * max_width) {
+		/* Wider content, fit width */
+		box.width = max_width;
+		box.height = (height * max_width + (width / 2)) / width;
+	} else {
+		/* Taller content, fit height */
+		box.width = (width * max_height + (height / 2)) / height;
+		box.height = max_height;
+	}
+
+	/* Compute centered position */
+	box.x = (max_width - box.width) / 2;
+	box.y = (max_height - box.height) / 2;
+
+	return box;
+}

--- a/src/icon-loader.c
+++ b/src/icon-loader.c
@@ -266,7 +266,7 @@ icon_loader_lookup(struct server *server, const char *app_id, int size,
 
 	switch (ctx.format) {
 	case SFDO_ICON_FILE_FORMAT_PNG:
-		img_png_load(ctx.path, &icon_buffer);
+		img_png_load(ctx.path, &icon_buffer, size, scale);
 		break;
 	case SFDO_ICON_FILE_FORMAT_SVG:
 #if HAVE_RSVG
@@ -274,7 +274,7 @@ icon_loader_lookup(struct server *server, const char *app_id, int size,
 #endif
 		break;
 	case SFDO_ICON_FILE_FORMAT_XPM:
-		img_xpm_load(ctx.path, &icon_buffer);
+		img_xpm_load(ctx.path, &icon_buffer, size, scale);
 		break;
 	}
 

--- a/src/img/img-png.c
+++ b/src/img/img-png.c
@@ -43,7 +43,8 @@ ispng(const char *filename)
 #undef PNG_BYTES_TO_CHECK
 
 void
-img_png_load(const char *filename, struct lab_data_buffer **buffer)
+img_png_load(const char *filename, struct lab_data_buffer **buffer, int size,
+		float scale)
 {
 	if (*buffer) {
 		wlr_buffer_drop(&(*buffer)->base);
@@ -62,22 +63,6 @@ img_png_load(const char *filename, struct lab_data_buffer **buffer)
 		cairo_surface_destroy(image);
 		return;
 	}
-	cairo_surface_flush(image);
 
-	if (cairo_image_surface_get_format(image) == CAIRO_FORMAT_ARGB32) {
-		/* we can wrap ARGB32 image surfaces directly */
-		*buffer = buffer_adopt_cairo_surface(image);
-		return;
-	}
-
-	/* convert to ARGB32 by painting to a new surface */
-	uint32_t w = cairo_image_surface_get_width(image);
-	uint32_t h = cairo_image_surface_get_height(image);
-	*buffer = buffer_create_cairo(w, h, 1);
-	cairo_t *cairo = (*buffer)->cairo;
-	cairo_set_source_surface(cairo, image, 0, 0);
-	cairo_paint(cairo);
-	cairo_surface_flush((*buffer)->surface);
-	/* destroy original surface */
-	cairo_surface_destroy(image);
+	*buffer = buffer_convert_cairo_surface_for_icon(image, size, scale);
 }

--- a/src/img/img-svg.c
+++ b/src/img/img-svg.c
@@ -15,8 +15,8 @@
 #include "labwc.h"
 
 void
-img_svg_load(const char *filename, struct lab_data_buffer **buffer,
-		int size)
+img_svg_load(const char *filename, struct lab_data_buffer **buffer, int size,
+		float scale)
 {
 	if (*buffer) {
 		wlr_buffer_drop(&(*buffer)->base);
@@ -39,7 +39,7 @@ img_svg_load(const char *filename, struct lab_data_buffer **buffer,
 		return;
 	}
 
-	*buffer = buffer_create_cairo(size, size, 1.0);
+	*buffer = buffer_create_cairo(size, size, scale);
 	cairo_surface_t *image = (*buffer)->surface;
 	cairo_t *cr = (*buffer)->cairo;
 

--- a/src/output.c
+++ b/src/output.c
@@ -1067,3 +1067,17 @@ output_enable_adaptive_sync(struct wlr_output *output, bool enabled)
 			enabled ? "en" : "dis", output->name);
 	}
 }
+
+float
+output_max_scale(struct server *server)
+{
+	/* Never return less than 1, in case outputs are disabled */
+	float scale = 1;
+	struct output *output;
+	wl_list_for_each(output, &server->outputs, link) {
+		if (output_is_usable(output)) {
+			scale = MAX(scale, output->wlr_output->scale);
+		}
+	}
+	return scale;
+}

--- a/src/ssd/ssd-part.c
+++ b/src/ssd/ssd-part.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include "buffer.h"
+#include "common/box.h"
 #include "common/list.h"
 #include "common/mem.h"
 #include "labwc.h"
@@ -80,29 +81,11 @@ add_scene_buffer(struct wl_list *list, enum ssd_part_type type,
 }
 
 static struct wlr_box
-get_scale_box(struct lab_data_buffer *buffer, double container_width,
-		double container_height)
+get_scale_box(struct lab_data_buffer *buffer, int container_width,
+		int container_height)
 {
-	struct wlr_box icon_geo = {
-		.width = buffer->logical_width,
-		.height = buffer->logical_height
-	};
-
-	/* Scale down buffer if required */
-	if (icon_geo.width && icon_geo.height) {
-		double scale = MIN(container_width / icon_geo.width,
-			container_height / icon_geo.height);
-		if (scale < 1.0f) {
-			icon_geo.width = (double)icon_geo.width * scale;
-			icon_geo.height = (double)icon_geo.height * scale;
-		}
-	}
-
-	/* Center buffer on both axis */
-	icon_geo.x = (container_width - icon_geo.width) / 2;
-	icon_geo.y = (container_height - icon_geo.height) / 2;
-
-	return icon_geo;
+	return box_fit_within(buffer->logical_width, buffer->logical_height,
+		container_width, container_height);
 }
 
 void

--- a/src/ssd/ssd-part.c
+++ b/src/ssd/ssd-part.c
@@ -80,12 +80,12 @@ add_scene_buffer(struct wl_list *list, enum ssd_part_type type,
 }
 
 static struct wlr_box
-get_scale_box(struct wlr_buffer *buffer, double container_width,
+get_scale_box(struct lab_data_buffer *buffer, double container_width,
 		double container_height)
 {
 	struct wlr_box icon_geo = {
-		.width = buffer->width,
-		.height = buffer->height
+		.width = buffer->logical_width,
+		.height = buffer->logical_height
 	};
 
 	/* Scale down buffer if required */
@@ -107,7 +107,7 @@ get_scale_box(struct wlr_buffer *buffer, double container_width,
 
 void
 update_window_icon_buffer(struct wlr_scene_node *button_node,
-		struct wlr_buffer *buffer)
+		struct lab_data_buffer *buffer)
 {
 	struct wlr_scene_buffer *scene_buffer =
 		wlr_scene_buffer_from_node(button_node);
@@ -116,7 +116,7 @@ update_window_icon_buffer(struct wlr_scene_node *button_node,
 		rc.theme->window_button_width,
 		rc.theme->title_height);
 
-	wlr_scene_buffer_set_buffer(scene_buffer, buffer);
+	wlr_scene_buffer_set_buffer(scene_buffer, &buffer->base);
 	wlr_scene_buffer_set_dest_size(scene_buffer,
 		icon_geo.width, icon_geo.height);
 	wlr_scene_node_set_position(button_node, icon_geo.x, icon_geo.y);
@@ -145,11 +145,11 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 		if (!buffers[state_set]) {
 			continue;
 		}
-		struct wlr_buffer *icon_buffer = &buffers[state_set]->base;
+		struct lab_data_buffer *icon_buffer = buffers[state_set];
 		struct wlr_box icon_geo = get_scale_box(icon_buffer,
 			rc.theme->window_button_width, rc.theme->title_height);
 		struct ssd_part *icon_part = add_scene_buffer(part_list, type,
-			parent, icon_buffer, icon_geo.x, icon_geo.y);
+			parent, &icon_buffer->base, icon_geo.x, icon_geo.y);
 		/* Make sure big icons are scaled down if necessary */
 		wlr_scene_buffer_set_dest_size(
 			wlr_scene_buffer_from_node(icon_part->node),

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -635,7 +635,7 @@ ssd_update_window_icon(struct ssd *ssd)
 		for (uint8_t state_set = 0; state_set <= LAB_BS_ALL; state_set++) {
 			if (button->nodes[state_set]) {
 				update_window_icon_buffer(button->nodes[state_set],
-					&icon_buffer->base);
+					icon_buffer);
 			}
 		}
 	} FOR_EACH_END

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -604,8 +604,16 @@ ssd_update_window_icon(struct ssd *ssd)
 	int hpad = theme->window_button_width / 10;
 	int icon_size = MIN(theme->window_button_width - 2 * hpad,
 		theme->title_height - 2 * theme->padding_height);
-	/* TODO: take into account output scales */
-	int icon_scale = 1;
+
+	/*
+	 * Load/render icons at the max scale of any usable output (at
+	 * this point in time). We don't want to be constantly reloading
+	 * icons as views are moved between outputs.
+	 *
+	 * TODO: currently there's no signal to reload/render icons if
+	 * outputs are reconfigured and the max scale changes.
+	 */
+	float icon_scale = output_max_scale(ssd->view->server);
 
 	struct lab_data_buffer *icon_buffer = icon_loader_lookup(
 		ssd->view->server, app_id, icon_size, icon_scale);

--- a/src/theme.c
+++ b/src/theme.c
@@ -246,19 +246,20 @@ load_button(struct theme *theme, struct button *b, int active)
 
 	zdrop(buffer);
 
+	int size = theme->title_height - 2 * theme->padding_height;
+	float scale = 1; /* TODO: account for output scale */
+
 	/* PNG */
 	get_button_filename(filename, sizeof(filename), b->name,
 		active ? "-active.png" : "-inactive.png");
-	img_png_load(filename, buffer);
+	img_png_load(filename, buffer, size, scale);
 
 #if HAVE_RSVG
 	/* SVG */
 	if (!*buffer) {
-		int size = theme->title_height - 2 * theme->padding_height;
 		get_button_filename(filename, sizeof(filename), b->name,
 			active ? "-active.svg" : "-inactive.svg");
-		/* TODO: account for output scale */
-		img_svg_load(filename, buffer, size, 1);
+		img_svg_load(filename, buffer, size, scale);
 	}
 #endif
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -257,7 +257,8 @@ load_button(struct theme *theme, struct button *b, int active)
 		int size = theme->title_height - 2 * theme->padding_height;
 		get_button_filename(filename, sizeof(filename), b->name,
 			active ? "-active.svg" : "-inactive.svg");
-		img_svg_load(filename, buffer, size);
+		/* TODO: account for output scale */
+		img_svg_load(filename, buffer, size, 1);
 	}
 #endif
 


### PR DESCRIPTION
Very short summary: make icon-loader and ssd agree on what size icons
will be displayed at, and then load icons at the best available quality
for that size.

Before/after comparison, logical icon size 16px, various scales:
![icons2](https://github.com/user-attachments/assets/637b03f5-d096-411f-89a3-f9d62e7a1795)

Before/after comparison, logical icon size 22px, various scales:
![icons1](https://github.com/user-attachments/assets/de85390e-1ce7-4347-a724-cc8c24ae2795)

(Left-to-right: Xfce4 Terminal, XTerm, Spotify. Xfce4 Terminal has PNGs
at various sizes (but notably not 22px) plus an SVG. XTerm has a single
48px XPM. Spotify has a single huge 512px PNG, which as you can see is
downscaled badly in master.)

Changes in detail (just copied from commit messages):

### icon-loader: load SVG icons at max scale of any usable output

- Add a new function to get the maximum scale of all usable outputs
- Pass the maximum output scale through to img_svg_load(), which
  ultimately calls cairo_surface_set_device_scale() before rendering

### ssd: respect logical size when displaying window icon

get_scale_box() was using the raw pixel size of the icon buffer for
layout, which caused the icon to be incorrectly scaled up if the buffer
scale was >1.

### common/box: add box_fit_within()

Factor out common math from ssd's get_scale_box() for use elsewhere.

### buffer: add buffer_convert_cairo_surface_for_icon()

Which handles:
 - conversion from other pixel formats to ARGB32
 - setting the logical size to the desired display size
 - downscaling very large images using CAIRO_FILTER_GOOD

### icon-loader: update PNG and XPM loaders to use new buffer helper ###
