### PR TITLE
theme: replace `window.button.hover.bg.shape` with `window.button.hover.bg.corner-radius`

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -126,9 +126,13 @@ labwc-config(5).
 	Space between titlebar buttons, in pixels.
 	Default is 0.
 
-*window.button.hover.bg.shape*
-	The shape of the hover effect of a titlebar button: "rectangle" or "circle".
-	Default is "rectangle".
+*window.button.hover.bg.corner-radius*
+	Radius of the hover effect of a titlebar button, in pixels.
+	Default is 0.
+
+	Note: for a circular hover effect, set *window.button.width* and
+	*window.button.height* equal and *window.button.hover.bg.corner-radius* half
+	of them.
 
 *window.active.button.unpressed.image.color*
 	Color of the images in titlebar buttons in their default, unpressed,

--- a/docs/themerc
+++ b/docs/themerc
@@ -36,7 +36,7 @@ window.button.width: 26
 window.button.spacing: 0
 
 # window button hover effect
-window.button.hover.bg.shape: rectangle
+window.button.hover.bg.corner-radius: 0
 
 # window buttons
 window.active.button.unpressed.image.color: #000000

--- a/include/theme.h
+++ b/include/theme.h
@@ -18,11 +18,6 @@ enum lab_justification {
 	LAB_JUSTIFY_RIGHT,
 };
 
-enum lab_shape {
-	LAB_RECTANGLE,
-	LAB_CIRCLE,
-};
-
 struct theme_snapping_overlay {
 	bool bg_enabled;
 	bool border_enabled;
@@ -72,8 +67,8 @@ struct theme {
 	int window_button_height;
 	int window_button_spacing;
 
-	/* the shape of the hover effect */
-	enum lab_shape window_button_hover_bg_shape;
+	/* the corner radius of the hover effect */
+	int window_button_hover_bg_corner_radius;
 
 	int menu_item_padding_x;
 	int menu_item_padding_y;


### PR DESCRIPTION
My GTK theme (Arc-Dark) has a hover effect with rounded corners, so I think it's worth supporting it rather than only supporting `rectangle` and `circle`. The existing `circle` hover effect can be reproduced if you set `window.button.hover.bg.corner-radius` more than half the button size and `window.button.{width,height}` equal.

![20241012_15h18m11s_grim](https://github.com/user-attachments/assets/8dc162ac-ff70-40f6-904f-897c0a2f3c7c)

I will not stick with this change, however, as I'll keep using the default theme anyway. I just wanted to confirm the right approach for the customization of the hover effect before the next release.

CC @johanmalm @jp7677