### PR TITLE
server: add dmabuf feedback

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -225,6 +225,7 @@ struct server {
 		struct wlr_backend *backend;
 	} headless;
 	struct wlr_session *session;
+	struct wlr_linux_dmabuf_v1 *linux_dmabuf;
 
 	struct wlr_xdg_shell *xdg_shell;
 	struct wlr_layer_shell_v1 *layer_shell;


### PR DESCRIPTION
I spend this weekend setting up labwc `master` with wlroots `0.18` on a Raspberry Pi with a touch screen and an hdmi display. This is essentially a multi GPU setup.

It turns out that dmabuf feedback is needed to let labwc/wlroots find the correct EGL-Wayland driver. Without this PR `eglinfo -B` showed me the mesa `swrast` driver for EGL wayland platform, with this PR applied it shows the Raspberry Pi driver `drm-rp1-dsi`.

Using `mpv --vo=gpu --gpu-context=wayland` confirmed that with this PR I was no longer using a software renderer.

Note that this patch is only needed with labwc `0.8`. Labwc `0.7.4` with wlroots `0.17` did not needed this for seeing the hardware driver.

This PR mirrors #1278  as-is but with adjusted logging and a in wlroots `0.18` changed function call (https://github.com/labwc/labwc/pull/1278#issuecomment-2228293665)

The commit is co-authored with @Consolatis 

Supersedes #1278 