### PR TITLE
menu: support pipemenu with the toplevel `<menu>` element

### DIFF
--- a/docs/labwc-menu.5.scd
+++ b/docs/labwc-menu.5.scd
@@ -112,6 +112,16 @@ ID attributes are unique. Duplicates are ignored.
 When writing pipe menu scripts, make sure to escape XML special characters such
 as "&" ("&amp;"), "<" ("&lt;"), and ">" ("&gt;").
 
+A pipemenu can also be used to define the toplevel *<menu>* element. In this
+case the entire menu.xml file would be reduced to something like this (replacing
+obmenu-generator with the menu generator of your choice):
+
+```
+<?xml version="1.0"?>
+<openbox_menu>
+  <menu id="root-menu" label="" execute="obmenu-generator"/>
+</openbox_menu>
+```
 
 # LOCALISATION
 

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -42,6 +42,7 @@ struct menu {
 	char *id;
 	char *label;
 	struct menu *parent;
+	struct menu_pipe_context *pipe_ctx;
 
 	struct {
 		int width;


### PR DESCRIPTION
For example:

```xml
<?xml version="1.0"?>
<openbox_menu>
  <menu id="root-menu" label="" execute="obmenu-generator"/>
</openbox_menu>
```

Fixes: #2238

Intended for after `0.8.1`