### PR TITLE
cursor: send a frame event after emulated button events

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1225,6 +1225,7 @@ cursor_emulate_button(struct seat *seat, uint32_t button,
 		cursor_finish_button_release(seat, button);
 		break;
 	}
+	wlr_seat_pointer_notify_frame(seat->seat);
 }
 
 static int


### PR DESCRIPTION
This fixes the issues reported in #2242 that emulated tablet/touchscreen button events sometimes don't take effect on applications immediately.