### PR TITLE
src/output.c: (output_frame_notify): skip painting output when sessio…

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -128,6 +128,13 @@ output_frame_notify(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	/*
+	 * skip painting the session when it exists but is not active.
+	 */
+	if (output->server->session && !output->server->session->active) {
+		return;
+	}
+
 	if (!output->scene_output) {
 		/*
 		 * TODO: This is a short term fix for issue #1667,


### PR DESCRIPTION
…n is not active.

On switching to a console vt when an application is painting, labwc produces a stream of log messages of the form
```
 `00:00:52.345 [ERROR] [../src/output-state.c:45] Failed to commit frame` lines.
``

This patch tries to follow the lead from the solution to this problem
in https://github.com/WayfireWM/wayfire/pull/2484.patch

As noted in that commit message, this patch depends on unreleased
patches to seatd (master) to work reliably, and there may be a a risk
of locking up the labwc if it is used with the seatd-0.8.0.