### PR TITLE
menu: fix the calculation for centered titles

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -150,8 +150,7 @@ menu_update_width(struct menu *menu)
 			}
 			if (theme->menu_title_text_justify == LAB_JUSTIFY_CENTER) {
 				int x, y;
-				x = (max_width - theme->menu_item_padding_x -
-						item->native_width) / 2;
+				x = (menu->size.width - item->native_width) / 2;
 				x = x < 0 ? 0 : x;
 				y = (theme->menu_item_height - item->normal.buffer->height) / 2;
 				wlr_scene_node_set_position(item->normal.text, x, y);


### PR DESCRIPTION
Before:

![20241020_15h22m41s_grim](https://github.com/user-attachments/assets/fecc6a1a-920b-4bd9-acff-3489667046f4)

After:

![20241020_15h22m32s_grim](https://github.com/user-attachments/assets/f5656eba-a03c-4e41-821f-f409c6add81e)
