### PR TITLE
docs: replace two 'we's with passive forms

### DIFF
--- a/docs/environment
+++ b/docs/environment
@@ -24,7 +24,7 @@
 
 ##
 ## Force Mozilla software like Firefox and Thunderbird to use wayland backend.
-## Firefox (>= v121) enables Wayland by default, but we include this note here
+## Firefox (>= v121) enables Wayland by default, but this note is included here
 ## for those on non-rolling distributions.
 ##
 

--- a/docs/themerc
+++ b/docs/themerc
@@ -9,8 +9,8 @@
 border.width: 1
 
 #
-# We do not support the global padding.{width,height} of openbox because
-# the default labwc button geometry has deviates from that of openbox
+# The global padding.{width,height} of openbox are not supported because
+# the default labwc button geometry deviates from that of openbox
 #
 window.titlebar.padding.width: 0
 window.titlebar.padding.height: 0


### PR DESCRIPTION
To match the common style in docs/