### PR TITLE
menu: fix UAF in client-list-combined-menu after window destruction

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2473,5 +2473,6 @@ view_destroy(struct view *view)
 	wl_list_remove(&view->link);
 	free(view);
 
+	update_client_list_combined_menu(server);
 	cursor_update_focus(server);
 }


### PR DESCRIPTION
client-list-combined-menu should be updated when a window is destroyed, otherwise we get SEGFAULT when selecting an old window entry in it (https://github.com/labwc/labwc/pull/2101#discussion_r1727053580).

In my opinion, we should merge fix this before the next release as we should always try not to introduce bugs that trigger SEGFAULT.