### PR TITLE
Add final check for matching partial strings when looking for icons

### DIFF
--- a/src/icon-loader.c
+++ b/src/icon-loader.c
@@ -245,7 +245,7 @@ get_db_entry_by_id_fuzzy(struct sfdo_desktop_db *db, const char *app_id)
 		int alen = strlen(app_id);
 		int dlen = strlen(desktop_id_base);
 
-		if (!strncmp(app_id, desktop_id, alen > dlen ? dlen : alen)) {
+		if (!strncasecmp(app_id, desktop_id, alen > dlen ? dlen : alen)) {
 			return entry;
 		}
 	}

--- a/src/icon-loader.c
+++ b/src/icon-loader.c
@@ -236,6 +236,20 @@ get_db_entry_by_id_fuzzy(struct sfdo_desktop_db *db, const char *app_id)
 		}
 	}
 
+	/* Try matching partial strings - catches GIMP, among others */
+	for (size_t i = 0; i < n_entries; i++) {
+		struct sfdo_desktop_entry *entry = entries[i];
+		const char *desktop_id = sfdo_desktop_entry_get_id(entry, NULL);
+		const char *dot = strrchr(desktop_id, '.');
+		const char *desktop_id_base = dot ? (dot + 1) : desktop_id;
+		int alen = strlen(app_id);
+		int dlen = strlen(desktop_id_base);
+
+		if (!strncmp(app_id, desktop_id, alen > dlen ? dlen : alen)) {
+			return entry;
+		}
+	}
+
 	return NULL;
 }
 


### PR DESCRIPTION
This adds a final check to the fuzzy matching for application icons, whereby the number of characters in whichever is shorter of the desktop file name and the app id is compared.

I have already implemented heuristics similar to this in my desktop panel application to get icons for the task switcher - https://github.com/raspberrypi-ui/wf-panel-pi/blob/efafe5800adbf76869c8b7f1e03b6cf6dd4d4622/src/widgets/window-list/toplevel.cpp#L701 - and this final test matches a few common applications which are otherwise missed, such as GIMP.