### PR TITLE
feat: hide cursor for touch and prevent pointer cursor interference

### DIFF
--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -72,6 +72,8 @@ struct cursor_context get_cursor_context(struct server *server);
  */
 void cursor_set(struct seat *seat, enum lab_cursors cursor);
 
+void cursor_set_visible(struct seat *seat, bool visible);
+
 /**
  * cursor_get_resize_edges - calculate resize edge based on cursor position
  * @cursor - the current cursor (usually server->seat.cursor)

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -489,6 +489,8 @@ void seat_finish(struct server *server);
 void seat_reconfigure(struct server *server);
 void seat_focus_surface(struct seat *seat, struct wlr_surface *surface);
 
+void seat_pointer_end_grab(struct seat *seat, struct wlr_surface *surface);
+
 /**
  * seat_focus_lock_surface() - ONLY to be called from session-lock.c to
  * focus lock screen surfaces. Use seat_focus_surface() otherwise.

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -109,6 +109,7 @@ struct seat {
 	 * (in that case the client is expected to set its own cursor image).
 	 */
 	enum lab_cursors server_cursor;
+	bool cursor_visible;
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;
 	struct {

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1194,8 +1194,6 @@ void
 cursor_emulate_move_absolute(struct seat *seat, struct wlr_input_device *device,
 		double x, double y, uint32_t time_msec)
 {
-	idle_manager_notify_activity(seat->seat);
-
 	double lx, ly;
 	wlr_cursor_absolute_to_layout_coords(seat->cursor,
 		device, x, y, &lx, &ly);
@@ -1210,8 +1208,6 @@ void
 cursor_emulate_button(struct seat *seat, uint32_t button,
 		enum wl_pointer_button_state state, uint32_t time_msec)
 {
-	idle_manager_notify_activity(seat->seat);
-
 	bool notify;
 	switch (state) {
 	case WL_POINTER_BUTTON_STATE_PRESSED:

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -180,8 +180,6 @@ notify_motion(struct drawing_tablet *tablet, struct drawing_tablet_tool *tool,
 		struct wlr_surface *surface, double x, double y, double dx, double dy,
 		uint32_t time)
 {
-	idle_manager_notify_activity(tool->seat->seat);
-
 	bool enter_surface = false;
 	/* Postpone proximity-in on a new surface when the tip is down */
 	if (surface != tool->tool_v2->focused_surface && !tool->tool_v2->is_down) {
@@ -252,6 +250,8 @@ handle_tablet_tool_proximity(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	idle_manager_notify_activity(tablet->seat->seat);
+
 	if (ev->state == WLR_TABLET_TOOL_PROXIMITY_IN) {
 		tablet->motion_mode =
 			tool_motion_mode(rc.tablet_tool.motion, ev->tool);
@@ -311,6 +311,8 @@ handle_tablet_tool_axis(struct wl_listener *listener, void *data)
 		wlr_log(WLR_DEBUG, "tool axis event before tablet create");
 		return;
 	}
+
+	idle_manager_notify_activity(tablet->seat->seat);
 
 	/*
 	 * Reset relative coordinates. If those axes aren't updated,
@@ -490,6 +492,8 @@ handle_tablet_tool_tip(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	idle_manager_notify_activity(tablet->seat->seat);
+
 	double x, y, dx, dy;
 	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);
 
@@ -506,8 +510,6 @@ handle_tablet_tool_tip(struct wl_listener *listener, void *data)
 	 */
 	if (tool && !is_down_mouse_emulation && (surface
 			|| wlr_tablet_tool_v2_has_implicit_grab(tool->tool_v2))) {
-		idle_manager_notify_activity(tool->seat->seat);
-
 		uint32_t stylus_button = to_stylus_button(button);
 		if (stylus_button != BTN_TOOL_PEN) {
 			wlr_log(WLR_INFO, "ignoring stylus tool pen mapping for tablet mode");
@@ -569,6 +571,8 @@ handle_tablet_tool_button(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	idle_manager_notify_activity(tablet->seat->seat);
+
 	double x, y, dx, dy;
 	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);
 
@@ -583,8 +587,6 @@ handle_tablet_tool_button(struct wl_listener *listener, void *data)
 	 * - the surface below the tip understands the tablet protocol.
 	 */
 	if (tool && !is_down_mouse_emulation && surface) {
-		idle_manager_notify_activity(tool->seat->seat);
-
 		if (button && ev->state == WLR_BUTTON_PRESSED) {
 			struct view *view = view_from_wlr_surface(surface);
 			struct mousebind *mousebind;

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -251,6 +251,7 @@ handle_tablet_tool_proximity(struct wl_listener *listener, void *data)
 	}
 
 	idle_manager_notify_activity(tablet->seat->seat);
+	cursor_set_visible(tablet->seat, /* visible */ true);
 
 	if (ev->state == WLR_TABLET_TOOL_PROXIMITY_IN) {
 		tablet->motion_mode =
@@ -313,6 +314,7 @@ handle_tablet_tool_axis(struct wl_listener *listener, void *data)
 	}
 
 	idle_manager_notify_activity(tablet->seat->seat);
+	cursor_set_visible(tablet->seat, /* visible */ true);
 
 	/*
 	 * Reset relative coordinates. If those axes aren't updated,
@@ -470,6 +472,7 @@ handle_tablet_tool_tip(struct wl_listener *listener, void *data)
 	}
 
 	idle_manager_notify_activity(tablet->seat->seat);
+	cursor_set_visible(tablet->seat, /* visible */ true);
 
 	double x, y, dx, dy;
 	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);
@@ -549,6 +552,7 @@ handle_tablet_tool_button(struct wl_listener *listener, void *data)
 	}
 
 	idle_manager_notify_activity(tablet->seat->seat);
+	cursor_set_visible(tablet->seat, /* visible */ true);
 
 	double x, y, dx, dy;
 	struct wlr_surface *surface = tablet_get_coords(tablet, &x, &y, &dx, &dy);

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -61,6 +61,7 @@ handle_touch_motion(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, touch_motion);
 	struct wlr_touch_motion_event *event = data;
+
 	idle_manager_notify_activity(seat->seat);
 
 	int touch_point_count = wl_list_length(&seat->touch_points);
@@ -109,6 +110,8 @@ handle_touch_down(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, touch_down);
 	struct wlr_touch_down_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
 
 	/* Compute layout => surface offset and save for this touch point */
 	struct touch_point *touch_point = znew(*touch_point);
@@ -166,6 +169,8 @@ handle_touch_up(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, touch_up);
 	struct wlr_touch_up_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
 
 	/* Remove the touch point from the seat */
 	struct touch_point *touch_point, *tmp;

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -125,6 +125,9 @@ handle_touch_down(struct wl_listener *listener, void *data)
 	wl_list_insert(&seat->touch_points, &touch_point->link);
 	int touch_point_count = wl_list_length(&seat->touch_points);
 
+	/* hide the cursor when starting touch input */
+	cursor_set_visible(seat, /* visible */ false);
+
 	if (touch_point->surface) {
 		seat_pointer_end_grab(seat, touch_point->surface);
 		/* Clear focus to not interfere with touch input */

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -126,6 +126,7 @@ handle_touch_down(struct wl_listener *listener, void *data)
 	int touch_point_count = wl_list_length(&seat->touch_points);
 
 	if (touch_point->surface) {
+		seat_pointer_end_grab(seat, touch_point->surface);
 		/* Clear focus to not interfere with touch input */
 		wlr_seat_pointer_notify_clear_focus(seat->seat);
 

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -123,6 +123,9 @@ handle_touch_down(struct wl_listener *listener, void *data)
 	int touch_point_count = wl_list_length(&seat->touch_points);
 
 	if (touch_point->surface) {
+		/* Clear focus to not interfere with touch input */
+		wlr_seat_pointer_notify_clear_focus(seat->seat);
+
 		/* Convert coordinates: first [0, 1] => layout */
 		double lx, ly;
 		wlr_cursor_absolute_to_layout_coords(seat->cursor,

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -77,6 +77,8 @@ handle_touch_motion(struct wl_listener *listener, void *data)
 				double sx = lx - touch_point->x_offset;
 				double sy = ly - touch_point->y_offset;
 
+				wlr_cursor_warp_absolute(seat->cursor,
+					&event->touch->base, event->x, event->y);
 				wlr_seat_touch_notify_motion(seat->seat, event->time_msec,
 					event->touch_id, sx, sy);
 			} else {
@@ -133,6 +135,8 @@ handle_touch_down(struct wl_listener *listener, void *data)
 			}
 		}
 
+		wlr_cursor_warp_absolute(seat->cursor,
+			&event->touch->base, event->x, event->y);
 		wlr_seat_touch_notify_down(seat->seat, touch_point->surface,
 			event->time_msec, event->touch_id, sx, sy);
 	} else {

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -63,6 +63,8 @@ handle_touch_motion(struct wl_listener *listener, void *data)
 	struct wlr_touch_motion_event *event = data;
 	idle_manager_notify_activity(seat->seat);
 
+	int touch_point_count = wl_list_length(&seat->touch_points);
+
 	/* Find existing touch point to determine initial offsets to subtract */
 	struct touch_point *touch_point;
 	wl_list_for_each(touch_point, &seat->touch_points, link) {
@@ -77,13 +79,17 @@ handle_touch_motion(struct wl_listener *listener, void *data)
 				double sx = lx - touch_point->x_offset;
 				double sy = ly - touch_point->y_offset;
 
-				wlr_cursor_warp_absolute(seat->cursor,
-					&event->touch->base, event->x, event->y);
+				if (touch_point_count == 1) {
+					wlr_cursor_warp_absolute(seat->cursor, &event->touch->base,
+						event->x, event->y);
+				}
 				wlr_seat_touch_notify_motion(seat->seat, event->time_msec,
 					event->touch_id, sx, sy);
 			} else {
-				cursor_emulate_move_absolute(seat, &event->touch->base,
-					event->x, event->y, event->time_msec);
+				if (touch_point_count == 1) {
+					cursor_emulate_move_absolute(seat, &event->touch->base,
+						event->x, event->y, event->time_msec);
+				}
 			}
 			return;
 		}
@@ -114,6 +120,7 @@ handle_touch_down(struct wl_listener *listener, void *data)
 	touch_point->y_offset = y_offset;
 
 	wl_list_insert(&seat->touch_points, &touch_point->link);
+	int touch_point_count = wl_list_length(&seat->touch_points);
 
 	if (touch_point->surface) {
 		/* Convert coordinates: first [0, 1] => layout */
@@ -135,13 +142,17 @@ handle_touch_down(struct wl_listener *listener, void *data)
 			}
 		}
 
-		wlr_cursor_warp_absolute(seat->cursor,
-			&event->touch->base, event->x, event->y);
+		if (touch_point_count == 1) {
+			wlr_cursor_warp_absolute(seat->cursor, &event->touch->base,
+				event->x, event->y);
+		}
 		wlr_seat_touch_notify_down(seat->seat, touch_point->surface,
 			event->time_msec, event->touch_id, sx, sy);
 	} else {
-		cursor_emulate_move_absolute(seat, &event->touch->base,
-			event->x, event->y, event->time_msec);
+		if (touch_point_count == 1) {
+			cursor_emulate_move_absolute(seat, &event->touch->base,
+				event->x, event->y, event->time_msec);
+		}
 		cursor_emulate_button(seat, BTN_LEFT, WL_POINTER_BUTTON_STATE_PRESSED,
 			event->time_msec);
 	}

--- a/src/seat.c
+++ b/src/seat.c
@@ -596,6 +596,28 @@ configure_keyboard(struct seat *seat, struct input *input)
 	keyboard_configure(seat, kb, keyboard->is_virtual);
 }
 
+void
+seat_pointer_end_grab(struct seat *seat, struct wlr_surface *surface)
+{
+	if (!surface || !wlr_seat_pointer_has_grab(seat->seat)) {
+		return;
+	}
+
+	struct wlr_xdg_surface *xdg_surface =
+		wlr_xdg_surface_try_from_wlr_surface(surface);
+	if (!xdg_surface || xdg_surface->role != WLR_XDG_SURFACE_ROLE_POPUP) {
+		/*
+		 * If we have an active popup grab (an open popup) and we are
+		 * not on the popup itself, end that grab to close the popup.
+		 * Contrary to pointer button notifications, a tablet/touch
+		 * button notification sometimes doesn't end grabs automatically
+		 * on button notifications in another client (observed in GTK4),
+		 * so end the grab manually.
+		 */
+		wlr_seat_pointer_end_grab(seat->seat);
+	}
+}
+
 /* This is called on SIGHUP (generally in response to labwc --reconfigure */
 void
 seat_reconfigure(struct server *server)

--- a/src/seat.c
+++ b/src/seat.c
@@ -556,6 +556,7 @@ seat_init(struct server *server)
 	seat->input_method_relay = input_method_relay_create(seat);
 
 	seat->xcursor_manager = NULL;
+	seat->cursor_visible = true;
 	seat->cursor = wlr_cursor_create();
 	if (!seat->cursor) {
 		wlr_log(WLR_ERROR, "unable to create cursor");


### PR DESCRIPTION
The last commit is work in progress, I'm Just opening this for visibility and early feedback.

This needs to be based on https://github.com/labwc/labwc/pull/2253 . Once that one is in, I'll probably open a separate PR with only the first two commits, which are a follow up from https://github.com/labwc/labwc/issues/2242#issuecomment-2417932320. Well, after some testing…

About the WIP commit, hiding the cursor for touch feels very natural for me (Sway does that as well, see https://github.com/swaywm/sway/blob/master/sway/input/cursor.c#L408), but unfortunately it is slightly more work to keep the cursor hidden and affects other input handlers.
Not sure though if the cursor should still be hidden when cursor emulation for touch is enabled, I tend to keep the cursor visible in that case. Any thoughts on this direction?

cc @spl237 