### PR TITLE
config/rcxml.c: fix parsing of three-state query parameters

### DIFF
--- a/include/common/parse-bool.h
+++ b/include/common/parse-bool.h
@@ -2,6 +2,16 @@
 #ifndef LABWC_PARSE_BOOL_H
 #define LABWC_PARSE_BOOL_H
 #include <stdbool.h>
+#include "view.h"
+
+/**
+ * parse_three_state() - Parse boolean value of string as a three-state enum.
+ * @string: String to interpret. This check is case-insensitive.
+ *
+ * Return: LAB_STATE_DISABLED for false; LAB_STATE_ENABLED for true;
+ * LAB_STATE_UNSPECIFIED for non-boolean
+ */
+enum three_state parse_three_state(const char *str);
 
 /**
  * parse_bool() - Parse boolean value of string.

--- a/src/common/parse-bool.c
+++ b/src/common/parse-bool.c
@@ -3,31 +3,41 @@
 #include <wlr/util/log.h>
 #include "common/parse-bool.h"
 
-int
-parse_bool(const char *str, int default_value)
+enum three_state
+parse_three_state(const char *str)
 {
 	if (!str) {
 		goto error_not_a_boolean;
 	} else if (!strcasecmp(str, "yes")) {
-		return true;
+		return LAB_STATE_ENABLED;
 	} else if (!strcasecmp(str, "true")) {
-		return true;
+		return LAB_STATE_ENABLED;
 	} else if (!strcasecmp(str, "on")) {
-		return true;
+		return LAB_STATE_ENABLED;
 	} else if (!strcmp(str, "1")) {
-		return true;
+		return LAB_STATE_ENABLED;
 	} else if (!strcasecmp(str, "no")) {
-		return false;
+		return LAB_STATE_DISABLED;
 	} else if (!strcasecmp(str, "false")) {
-		return false;
+		return LAB_STATE_DISABLED;
 	} else if (!strcasecmp(str, "off")) {
-		return false;
+		return LAB_STATE_DISABLED;
 	} else if (!strcmp(str, "0")) {
-		return false;
+		return LAB_STATE_DISABLED;
 	}
 error_not_a_boolean:
 	wlr_log(WLR_ERROR, "(%s) is not a boolean value", str);
-	return default_value;
+	return LAB_STATE_UNSPECIFIED;
+}
+
+int
+parse_bool(const char *str, int default_value)
+{
+	enum three_state val = parse_three_state(str);
+	if (val == LAB_STATE_UNSPECIFIED) {
+		return default_value;
+	}
+	return (val == LAB_STATE_ENABLED) ? 1 : 0;
 }
 
 void

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -474,15 +474,15 @@ fill_action_query(char *nodename, char *content, struct action *action)
 	} else if (!strcasecmp(nodename, "sandboxAppId")) {
 		current_view_query->sandbox_app_id = xstrdup(content);
 	} else if (!strcasecmp(nodename, "shaded")) {
-		current_view_query->shaded = parse_bool(content, -1);
+		current_view_query->shaded = parse_three_state(content);
 	} else if (!strcasecmp(nodename, "maximized")) {
 		current_view_query->maximized = view_axis_parse(content);
 	} else if (!strcasecmp(nodename, "iconified")) {
-		current_view_query->iconified = parse_bool(content, -1);
+		current_view_query->iconified = parse_three_state(content);
 	} else if (!strcasecmp(nodename, "focused")) {
-		current_view_query->focused = parse_bool(content, -1);
+		current_view_query->focused = parse_three_state(content);
 	} else if (!strcasecmp(nodename, "omnipresent")) {
-		current_view_query->omnipresent = parse_bool(content, -1);
+		current_view_query->omnipresent = parse_three_state(content);
 	} else if (!strcasecmp(nodename, "tiled")) {
 		current_view_query->tiled = view_edge_parse(content);
 	} else if (!strcasecmp(nodename, "tiled_region")) {


### PR DESCRIPTION
Parsing directly as a bool was setting incorrect values in the query struct.

Reported on IRC by @Consolatis 