### PR TITLE
query: fix default values in query, fix match logic

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -419,7 +419,7 @@ Actions that execute other actions. Used in keyboard/mouse bindings.
 
 		*tiled_region*
 			Whether the client is tiled (snapped) to the indicated
-			region.
+			region. The indicated region may be a glob.
 
 		*decoration* [full|border|none]
 			Whether the client has full server-side decorations,

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -30,16 +30,19 @@ other_instances_exist(struct view *self, struct view_query *query)
 static bool
 view_matches_criteria(struct window_rule *rule, struct view *view)
 {
-	struct view_query query = {0};
-	query.identifier = rule->identifier;
-	query.title = rule->title;
-	query.window_type = rule->window_type;
-	query.sandbox_engine = rule->sandbox_engine;
-	query.sandbox_app_id = rule->sandbox_app_id;
+	struct view_query query = {
+		.identifier = rule->identifier,
+		.title = rule->title,
+		.window_type = rule->window_type,
+		.sandbox_engine = rule->sandbox_engine,
+		.sandbox_app_id = rule->sandbox_app_id,
+		.maximized = VIEW_AXIS_INVALID,
+	};
 
 	if (rule->match_once && other_instances_exist(view, &query)) {
 		return false;
 	}
+
 	return view_matches_query(view, &query);
 }
 


### PR DESCRIPTION
The `view_query.maximized` field should be initialized to the non-zero `VIEW_AXIS_INVALID` where used, rather than assuming the default zero value of `VIEW_AXIS_NONE`. Also, all of the early (pre-existing) tests in `view_matches_query` were not effectively distinguishing between "not tested" and "tested but passed" with the refactored match structure.

Fixes: #2288.