### PR TITLE
tearing: avoid permanent disable due to rejected commits

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -406,8 +406,6 @@ struct output {
 
 	bool leased;
 	bool gamma_lut_changed;
-
-	uint32_t nr_tearing_failures;
 };
 
 #undef LAB_NR_LAYERS

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -107,6 +107,14 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 		return false;
 	}
 
+	if (state->tearing_page_flip) {
+		if (!wlr_output_test_state(wlr_output, state)) {
+			wlr_log(WLR_DEBUG, "Output test for tearing failed on %s, "
+				"trying page-flip without tearing", wlr_output->name);
+			state->tearing_page_flip = false;
+		}
+	}
+
 	struct wlr_box additional_damage = {0};
 	if (state->buffer && is_magnify_on()) {
 		magnify(output, state->buffer, &additional_damage);

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -109,8 +109,6 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 
 	if (state->tearing_page_flip) {
 		if (!wlr_output_test_state(wlr_output, state)) {
-			wlr_log(WLR_DEBUG, "Output test for tearing failed on %s, "
-				"trying page-flip without tearing", wlr_output->name);
 			state->tearing_page_flip = false;
 		}
 	}


### PR DESCRIPTION
Currently, the cursor plane does not allow async page flips which causes tearing page flips to be rejected if the cursor was moved.

However, in games where no cursor image is present, the async page flips can still work as expected.

Instead of permanently disabling tearing after too many failures, test the output state first before each frame to see if we can commit with tearing_page_flip set to true.

### What is the extra processing time caused by the test commit?

Snippet used:
```c
if (state->tearing_page_flip) {
  struct timespec start, end;
  clock_gettime(CLOCK_MONOTONIC, &start);

  if (!wlr_output_test_state(wlr_output, state)) {
    wlr_log(WLR_DEBUG, "Output test for tearing failed on %s, "
      "trying page-flip without tearing", wlr_output->name);
    state->tearing_page_flip = false;
  }

  clock_gettime(CLOCK_MONOTONIC, &end);

  long seconds = end.tv_sec - start.tv_sec;
  long nanoseconds = end.tv_nsec - start.tv_nsec;
  double elapsed = seconds + nanoseconds*1e-9;

  wlr_log(WLR_DEBUG, "test commit time: %.9f sec", elapsed);
}
```

Commit with `tearing_page_flip` set to true, that doesn't fail
```
00:00:16.648 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000014819 sec
00:00:16.649 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000014560 sec
00:00:16.649 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000014680 sec
00:00:16.649 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000017460 sec
00:00:16.649 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000014560 sec
00:00:16.649 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000014729 sec
00:00:16.650 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000014490 sec
```

Commit with `tearing_page_flip` set to true, that fails
```
00:00:16.658 [DEBUG] [backend/drm/atomic.c:79] connector DP-2: Atomic commit failed: Invalid argument
00:00:16.658 [DEBUG] [backend/drm/atomic.c:84] (Atomic commit flags: PAGE_FLIP_ASYNC | ATOMIC_TEST_ONLY)
00:00:16.658 [DEBUG] [../src/common/scene-helpers.c:118] Output test for tearing failed on DP-2, trying page-flip without tearing
00:00:16.658 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000028439 sec
00:00:16.664 [DEBUG] [backend/drm/atomic.c:79] connector DP-2: Atomic commit failed: Invalid argument
00:00:16.664 [DEBUG] [backend/drm/atomic.c:84] (Atomic commit flags: PAGE_FLIP_ASYNC | ATOMIC_TEST_ONLY)
00:00:16.664 [DEBUG] [../src/common/scene-helpers.c:118] Output test for tearing failed on DP-2, trying page-flip without tearing
00:00:16.664 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000035509 sec
00:00:16.670 [DEBUG] [backend/drm/atomic.c:79] connector DP-2: Atomic commit failed: Invalid argument
00:00:16.670 [DEBUG] [backend/drm/atomic.c:84] (Atomic commit flags: PAGE_FLIP_ASYNC | ATOMIC_TEST_ONLY)
00:00:16.670 [DEBUG] [../src/common/scene-helpers.c:118] Output test for tearing failed on DP-2, trying page-flip without tearing
00:00:16.670 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000028369 sec
00:00:16.676 [DEBUG] [backend/drm/atomic.c:79] connector DP-2: Atomic commit failed: Invalid argument
00:00:16.676 [DEBUG] [backend/drm/atomic.c:84] (Atomic commit flags: PAGE_FLIP_ASYNC | ATOMIC_TEST_ONLY)
00:00:16.676 [DEBUG] [../src/common/scene-helpers.c:118] Output test for tearing failed on DP-2, trying page-flip without tearing
00:00:16.676 [DEBUG] [../src/common/scene-helpers.c:130] test commit time: 0.000027770 sec
```

The change isn't really noticeable when playing a game, and this allows the tearing to keep working regardless of the failures, without having to use `WLR_DRM_NO_ATOMIC=1`. Note that Sway also currently does the test commit.

Fixes: https://github.com/labwc/labwc/issues/2229