### PR TITLE
data: disable file-chooser in xdg-portals configuration

### DIFF
--- a/data/labwc-portals.conf
+++ b/data/labwc-portals.conf
@@ -1,3 +1,4 @@
 [preferred]
 default=wlr;*
 org.freedesktop.impl.portal.Inhibit=none
+org.freedesktop.impl.portal.FileChooser=none


### PR DESCRIPTION
Similar like the Inhibit interface, the FileChooser does not work on labwc and thus preventing a file dialog from appearing in applications/toolkits using this interface (e.g. GTK 4.16).

Disabling this interfaces makes those GTK4 application fallback to an alternative file open/safe dialog which works again normally on labwc.

Observed and tested with Gnomes Simple-Scan and Clapper i.c.w. GTK 4.16.