### PR TITLE
output: don't auto-configure new outputs during powersave

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -330,6 +330,7 @@ struct server {
 	 * do_output_layout_change() must be called explicitly.
 	 */
 	int pending_output_layout_change;
+	bool all_outputs_off;
 
 	struct wl_listener renderer_lost;
 
@@ -406,6 +407,7 @@ struct output {
 
 	bool leased;
 	bool gamma_lut_changed;
+	bool powered_off;
 };
 
 #undef LAB_NR_LAYERS


### PR DESCRIPTION
After e.g. `wlopm --off`, some external outputs will appear to labwc to
disconnect and reconnect. (I have one HDMI monitor which does this
repeatedly every 10 seconds as it cycles through inputs.) Currently,
these outputs are immediately reconfigured and enabled when they
reconnect, after which point they remain on all night.

For a screensaver/powersave mode that actually works, we need to prevent
this. This change adds logic to not auto-configure new outputs once all
existing outputs are turned off.

Downsides as currently implemented are:

- once reconnected, outputs are logically "disabled", not just "off",
  and `wlopm --on` cannot re-enable them (wlr-randr or kanshi works).

- this doesn't prevent external clients like kanshi from re-enabling
  outputs immediately when they reconnect, so it's necessary to stop
  kanshi during powersave and restart it afterward.

Additionally, I've included a change (1st commit) to auto-select the
mode when an output is enabled via e.g. kanshi after leaving powersave,
in which case the output may not have been previously modeset.

In this case, if kanshi does not specify a mode, the requested width +
height + refresh rate will all be zero, and we should select the best
mode just as we would when auto-configuring a new output.

We need to do the mode auto-selection in both the test & commit stages
for consistency, so factor out a new `output_test_auto()` function to help
with this.

Finally, remove a guard against a refresh rate of zero, which was a
workaround for wlroots 0.17 and is no longer needed. It is incompatible
with mode auto-selection since the refresh rate is zero in that case.

I've been running with these changes for a couple weeks with good
results, but I'm setting this to draft in case there's a better way to
solve the issue that I haven't thought of.