### PR TITLE
menu: correctly center a menu opened with <position x="center" y="center">

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -688,19 +688,9 @@ show_menu(struct server *server, struct view *view, struct cursor_context *ctx,
 	if (pos_x && pos_y) {
 		struct output *output = output_nearest_to(server,
 				server->seat.cursor->x, server->seat.cursor->y);
-		struct menuitem *item;
-		struct theme *theme = server->theme;
-		int max_width = theme->menu_min_width;
-
-		wl_list_for_each(item, &menu->menuitems, link) {
-			if (item->native_width > max_width) {
-				max_width = item->native_width < theme->menu_max_width
-					? item->native_width : theme->menu_max_width;
-			}
-		}
 
 		if (!strcasecmp(pos_x, "center")) {
-			x = (output->usable_area.width / 2) - (max_width / 2);
+			x = (output->usable_area.width - menu->size.width) / 2;
 		} else if (strchr(pos_x, '%')) {
 			x = (output->usable_area.width * atoi(pos_x)) / 100;
 		} else {

--- a/src/action.c
+++ b/src/action.c
@@ -716,9 +716,9 @@ show_menu(struct server *server, struct view *view, struct cursor_context *ctx,
 		}
 		/* keep menu from being off screen */
 		x = MAX(x, 0);
-		x = MIN(x, (output->usable_area.width -1));
+		x = MIN(x, output->usable_area.width - 1);
 		y = MAX(y, 0);
-		y = MIN(y, (output->usable_area.height -1));
+		y = MIN(y, output->usable_area.height - 1);
 		/* adjust for which monitor to appear on */
 		x += output->usable_area.x;
 		y += output->usable_area.y;


### PR DESCRIPTION
Prior to this PR, a menu opened with:
```xml
  <action name="ShowMenu">
    <position x="center" y="center" />
  </action>
```
was not correctly centered when `menu.items.padding.x` is non-zero.