### PR TITLE
Remove link to archlabslinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ For themes, search the internet for "openbox themes" and place them in
 
 - https://github.com/addy-dclxvi/openbox-theme-collections
 - https://github.com/the-zero885/Lubuntu-Arc-Round-Openbox-Theme
-- https://bitbucket.org/archlabslinux/themes/
 - https://github.com/BunsenLabs/bunsen-themes
 
 ## 5. Translations


### PR DESCRIPTION
Project is no longer available.

https://archlabs.github.io/