### PR TITLE
input: add hold gestures, notify idle-manager and ensure visible cursor on gestures

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -179,6 +179,8 @@ struct seat {
 	struct wl_listener swipe_begin;
 	struct wl_listener swipe_update;
 	struct wl_listener swipe_end;
+	struct wl_listener hold_begin;
+	struct wl_listener hold_end;
 
 	struct wl_listener request_cursor;
 	struct wl_listener request_set_shape;

--- a/src/input/gestures.c
+++ b/src/input/gestures.c
@@ -84,6 +84,32 @@ handle_swipe_end(struct wl_listener *listener, void *data)
 		seat->seat, event->time_msec, event->cancelled);
 }
 
+static void
+handle_hold_begin(struct wl_listener *listener, void *data)
+{
+	struct seat *seat = wl_container_of(listener, seat, hold_begin);
+	struct wlr_pointer_hold_begin_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
+	cursor_set_visible(seat, /* visible */ true);
+
+	wlr_pointer_gestures_v1_send_hold_begin(seat->pointer_gestures,
+		seat->seat, event->time_msec, event->fingers);
+}
+
+static void
+handle_hold_end(struct wl_listener *listener, void *data)
+{
+	struct seat *seat = wl_container_of(listener, seat, hold_end);
+	struct wlr_pointer_hold_end_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
+	cursor_set_visible(seat, /* visible */ true);
+
+	wlr_pointer_gestures_v1_send_hold_end(seat->pointer_gestures,
+		seat->seat, event->time_msec, event->cancelled);
+}
+
 void
 gestures_init(struct seat *seat)
 {
@@ -95,6 +121,8 @@ gestures_init(struct seat *seat)
 	CONNECT_SIGNAL(seat->cursor, seat, swipe_begin);
 	CONNECT_SIGNAL(seat->cursor, seat, swipe_update);
 	CONNECT_SIGNAL(seat->cursor, seat, swipe_end);
+	CONNECT_SIGNAL(seat->cursor, seat, hold_begin);
+	CONNECT_SIGNAL(seat->cursor, seat, hold_end);
 }
 
 void
@@ -106,4 +134,6 @@ gestures_finish(struct seat *seat)
 	wl_list_remove(&seat->swipe_begin.link);
 	wl_list_remove(&seat->swipe_update.link);
 	wl_list_remove(&seat->swipe_end.link);
+	wl_list_remove(&seat->hold_begin.link);
+	wl_list_remove(&seat->hold_end.link);
 }

--- a/src/input/gestures.c
+++ b/src/input/gestures.c
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <wlr/types/wlr_pointer_gestures_v1.h>
+#include "common/macros.h"
 #include "input/gestures.h"
 #include "labwc.h"
 
 static void
-handle_pointer_pinch_begin(struct wl_listener *listener, void *data)
+handle_pinch_begin(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, pinch_begin);
 	struct wlr_pointer_pinch_begin_event *event = data;
@@ -13,7 +14,7 @@ handle_pointer_pinch_begin(struct wl_listener *listener, void *data)
 }
 
 static void
-handle_pointer_pinch_update(struct wl_listener *listener, void *data)
+handle_pinch_update(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, pinch_update);
 	struct wlr_pointer_pinch_update_event *event = data;
@@ -23,7 +24,7 @@ handle_pointer_pinch_update(struct wl_listener *listener, void *data)
 }
 
 static void
-handle_pointer_pinch_end(struct wl_listener *listener, void *data)
+handle_pinch_end(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, pinch_end);
 	struct wlr_pointer_pinch_end_event *event = data;
@@ -32,7 +33,7 @@ handle_pointer_pinch_end(struct wl_listener *listener, void *data)
 }
 
 static void
-handle_pointer_swipe_begin(struct wl_listener *listener, void *data)
+handle_swipe_begin(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, swipe_begin);
 	struct wlr_pointer_swipe_begin_event *event = data;
@@ -41,7 +42,7 @@ handle_pointer_swipe_begin(struct wl_listener *listener, void *data)
 }
 
 static void
-handle_pointer_swipe_update(struct wl_listener *listener, void *data)
+handle_swipe_update(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, swipe_update);
 	struct wlr_pointer_swipe_update_event *event = data;
@@ -50,7 +51,7 @@ handle_pointer_swipe_update(struct wl_listener *listener, void *data)
 }
 
 static void
-handle_pointer_swipe_end(struct wl_listener *listener, void *data)
+handle_swipe_end(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, swipe_end);
 	struct wlr_pointer_swipe_end_event *event = data;
@@ -63,23 +64,12 @@ gestures_init(struct seat *seat)
 {
 	seat->pointer_gestures = wlr_pointer_gestures_v1_create(seat->server->wl_display);
 
-	seat->pinch_begin.notify = handle_pointer_pinch_begin;
-	wl_signal_add(&seat->cursor->events.pinch_begin, &seat->pinch_begin);
-
-	seat->pinch_update.notify = handle_pointer_pinch_update;
-	wl_signal_add(&seat->cursor->events.pinch_update, &seat->pinch_update);
-
-	seat->pinch_end.notify = handle_pointer_pinch_end;
-	wl_signal_add(&seat->cursor->events.pinch_end, &seat->pinch_end);
-
-	seat->swipe_begin.notify = handle_pointer_swipe_begin;
-	wl_signal_add(&seat->cursor->events.swipe_begin, &seat->swipe_begin);
-
-	seat->swipe_update.notify = handle_pointer_swipe_update;
-	wl_signal_add(&seat->cursor->events.swipe_update, &seat->swipe_update);
-
-	seat->swipe_end.notify = handle_pointer_swipe_end;
-	wl_signal_add(&seat->cursor->events.swipe_end, &seat->swipe_end);
+	CONNECT_SIGNAL(seat->cursor, seat, pinch_begin);
+	CONNECT_SIGNAL(seat->cursor, seat, pinch_update);
+	CONNECT_SIGNAL(seat->cursor, seat, pinch_end);
+	CONNECT_SIGNAL(seat->cursor, seat, swipe_begin);
+	CONNECT_SIGNAL(seat->cursor, seat, swipe_update);
+	CONNECT_SIGNAL(seat->cursor, seat, swipe_end);
 }
 
 void

--- a/src/input/gestures.c
+++ b/src/input/gestures.c
@@ -3,12 +3,16 @@
 #include "common/macros.h"
 #include "input/gestures.h"
 #include "labwc.h"
+#include "idle.h"
 
 static void
 handle_pinch_begin(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, pinch_begin);
 	struct wlr_pointer_pinch_begin_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
+
 	wlr_pointer_gestures_v1_send_pinch_begin(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->fingers);
 }
@@ -18,6 +22,9 @@ handle_pinch_update(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, pinch_update);
 	struct wlr_pointer_pinch_update_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
+
 	wlr_pointer_gestures_v1_send_pinch_update(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->dx, event->dy,
 		event->scale, event->rotation);
@@ -28,6 +35,9 @@ handle_pinch_end(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, pinch_end);
 	struct wlr_pointer_pinch_end_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
+
 	wlr_pointer_gestures_v1_send_pinch_end(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->cancelled);
 }
@@ -37,6 +47,9 @@ handle_swipe_begin(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, swipe_begin);
 	struct wlr_pointer_swipe_begin_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
+
 	wlr_pointer_gestures_v1_send_swipe_begin(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->fingers);
 }
@@ -46,6 +59,9 @@ handle_swipe_update(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, swipe_update);
 	struct wlr_pointer_swipe_update_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
+
 	wlr_pointer_gestures_v1_send_swipe_update(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->dx, event->dy);
 }
@@ -55,6 +71,9 @@ handle_swipe_end(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, swipe_end);
 	struct wlr_pointer_swipe_end_event *event = data;
+
+	idle_manager_notify_activity(seat->seat);
+
 	wlr_pointer_gestures_v1_send_swipe_end(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->cancelled);
 }

--- a/src/input/gestures.c
+++ b/src/input/gestures.c
@@ -12,6 +12,7 @@ handle_pinch_begin(struct wl_listener *listener, void *data)
 	struct wlr_pointer_pinch_begin_event *event = data;
 
 	idle_manager_notify_activity(seat->seat);
+	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_pinch_begin(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->fingers);
@@ -24,6 +25,7 @@ handle_pinch_update(struct wl_listener *listener, void *data)
 	struct wlr_pointer_pinch_update_event *event = data;
 
 	idle_manager_notify_activity(seat->seat);
+	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_pinch_update(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->dx, event->dy,
@@ -37,6 +39,7 @@ handle_pinch_end(struct wl_listener *listener, void *data)
 	struct wlr_pointer_pinch_end_event *event = data;
 
 	idle_manager_notify_activity(seat->seat);
+	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_pinch_end(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->cancelled);
@@ -49,6 +52,7 @@ handle_swipe_begin(struct wl_listener *listener, void *data)
 	struct wlr_pointer_swipe_begin_event *event = data;
 
 	idle_manager_notify_activity(seat->seat);
+	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_swipe_begin(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->fingers);
@@ -61,6 +65,7 @@ handle_swipe_update(struct wl_listener *listener, void *data)
 	struct wlr_pointer_swipe_update_event *event = data;
 
 	idle_manager_notify_activity(seat->seat);
+	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_swipe_update(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->dx, event->dy);
@@ -73,6 +78,7 @@ handle_swipe_end(struct wl_listener *listener, void *data)
 	struct wlr_pointer_swipe_end_event *event = data;
 
 	idle_manager_notify_activity(seat->seat);
+	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_swipe_end(seat->pointer_gestures,
 		seat->seat, event->time_msec, event->cancelled);


### PR DESCRIPTION
Adds hold gestures (added in `wlroots` with https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/20d9448257f4871d3a57deab2f105d7335a64fb2) and also add the usual ceremony for the gesture handlers.

Not tested because no touch pad on my development machine. That said, i don't expect any side effects (famous last words ..). Keeping this draft until confirmation that there are indeed no side effects.