### PR TITLE
Fix memory leaks detected by ASAN

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -399,8 +399,6 @@ struct output {
 
 	struct wl_list regions;  /* struct region.link */
 
-	struct lab_data_buffer *osd_buffer;
-
 	struct wl_listener destroy;
 	struct wl_listener frame;
 	struct wl_listener request_state;

--- a/src/icon-loader.c
+++ b/src/icon-loader.c
@@ -117,6 +117,7 @@ icon_loader_finish(struct server *server)
 		return;
 	}
 
+	sfdo_icon_theme_destroy(loader->icon_theme);
 	sfdo_desktop_db_destroy(loader->desktop_db);
 	sfdo_icon_ctx_destroy(loader->icon_ctx);
 	sfdo_desktop_ctx_destroy(loader->desktop_ctx);

--- a/src/main.c
+++ b/src/main.c
@@ -228,11 +228,12 @@ main(int argc, char *argv[])
 
 	session_shutdown(&server);
 
-	server_finish(&server);
-
 	menu_finish(&server);
 	theme_finish(&theme);
 	rcxml_finish();
 	font_finish();
+
+	server_finish(&server);
+
 	return 0;
 }

--- a/src/osd.c
+++ b/src/osd.c
@@ -347,22 +347,19 @@ display_osd(struct output *output, struct wl_array *views)
 		h += theme->osd_window_switcher_item_height;
 	}
 
-	/* Reset buffer */
-	if (output->osd_buffer) {
-		wlr_buffer_drop(&output->osd_buffer->base);
-	}
-	output->osd_buffer = buffer_create_cairo(w, h, scale);
-	if (!output->osd_buffer) {
+	struct lab_data_buffer *buffer = buffer_create_cairo(w, h, scale);
+	if (!buffer) {
 		wlr_log(WLR_ERROR, "Failed to allocate cairo buffer for the window switcher");
 		return;
 	}
 
 	/* Render OSD image */
-	cairo_t *cairo = output->osd_buffer->cairo;
+	cairo_t *cairo = buffer->cairo;
 	render_osd(server, cairo, w, h, show_workspace, workspace_name, views);
 
 	struct wlr_scene_buffer *scene_buffer = wlr_scene_buffer_create(
-		output->osd_tree, &output->osd_buffer->base);
+		output->osd_tree, &buffer->base);
+	wlr_buffer_drop(&buffer->base);
 	wlr_scene_buffer_set_dest_size(scene_buffer, w, h);
 
 	/* Center OSD */

--- a/src/protocols/cosmic_workspaces/cosmic-workspaces.c
+++ b/src/protocols/cosmic_workspaces/cosmic-workspaces.c
@@ -395,8 +395,18 @@ manager_handle_display_destroy(struct wl_listener *listener, void *data)
 	struct lab_cosmic_workspace_manager *manager =
 		wl_container_of(listener, manager, on.display_destroy);
 
+	struct lab_cosmic_workspace_group *group, *tmp;
+	wl_list_for_each_safe(group, tmp, &manager->groups, link) {
+		lab_cosmic_workspace_group_destroy(group);
+	}
+
+	if (manager->idle_source) {
+		wl_event_source_remove(manager->idle_source);
+	}
+
 	wl_list_remove(&manager->on.display_destroy.link);
-	manager->event_loop = NULL;
+	wl_global_destroy(manager->global);
+	free(manager);
 }
 
 /* Manager internal helpers */

--- a/src/seat.c
+++ b/src/seat.c
@@ -583,6 +583,11 @@ seat_finish(struct server *server)
 		input_device_destroy(&input->destroy, NULL);
 	}
 
+	if (seat->workspace_osd_timer) {
+		wl_event_source_remove(seat->workspace_osd_timer);
+		seat->workspace_osd_timer = NULL;
+	}
+
 	input_handlers_finish(seat);
 	input_method_relay_finish(seat->input_method_relay);
 }

--- a/src/server.c
+++ b/src/server.c
@@ -639,6 +639,8 @@ server_finish(struct server *server)
 	/* TODO: clean up various scene_tree nodes */
 	workspaces_destroy(server);
 
+	free(server->ssd_hover_state);
+
 #if HAVE_LIBSFDO
 	icon_loader_finish(server);
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -628,20 +628,19 @@ server_finish(struct server *server)
 #if HAVE_XWAYLAND
 	xwayland_server_finish(server);
 #endif
+#if HAVE_LIBSFDO
+	icon_loader_finish(server);
+#endif
 	if (sighup_source) {
 		wl_event_source_remove(sighup_source);
 	}
 	wl_display_destroy_clients(server->wl_display);
-
+	wlr_allocator_destroy(server->allocator);
+	wlr_renderer_destroy(server->renderer);
+	wlr_backend_destroy(server->backend);
 	seat_finish(server);
-	wl_display_destroy(server->wl_display);
-
-	/* TODO: clean up various scene_tree nodes */
 	workspaces_destroy(server);
-
+	wlr_scene_node_destroy(&server->scene->tree.node);
+	wl_display_destroy(server->wl_display);
 	free(server->ssd_hover_state);
-
-#if HAVE_LIBSFDO
-	icon_loader_finish(server);
-#endif
 }


### PR DESCRIPTION
This PR fixes some memory leaks (including ones for singletons) detected by ASAN.
The first 5 commits fixes memory leaks for `output->osd_buffer`, `icon_loader->icon_theme`, `seat->workspace_osd_timer`, `cosmic_manager` and `server->ssd_hover_state` respectively, and the last commit finally releases all the resources like `wlr_allocator`, `wlr_renderer`, `wlr_backend` and `wlr_scene`.

To suppress all the errors from ASAN with EGL renderer, https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/ce615a44c06ed10ab51b9c5a630acb43ef014efb needs to be reverted.