### PR TITLE
theme: tidy up codebase and documentation

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -59,38 +59,6 @@ labwc-config(5).
 	Vertical titlebar padding size, in pixels.
 	Default is 0.
 
-*menu.items.padding.x*
-	Horizontal padding of menu text entries in pixels.
-	Default is 7.
-
-*menu.items.padding.y*
-	Vertical padding of menu text entries in pixels.
-	Default is 4.
-
-*menu.title.text.justify*
-	Specifies how menu titles are aligned in the titlebar.
-	Type justification. Default Center.
-
-*menu.overlap.x*
-	Horizontal overlap in pixels between submenus and their parents. A
-	positive value move submenus over the top of their parents, whereas a
-	negative value creates a gap between submenus and their parents.
-	Default is 0.
-
-*menu.overlap.y*
-	Vertical offset in pixels between submenus and their parents. Positive
-	values for downwards and negative for upwards. Default is 0.
-
-*menu.width.min*
-	Minimal width for menus. Default is 20.
-	A fixed width can be achieved by setting .min and .max to the same
-	value.
-
-*menu.width.max*
-	Maximal width for menus. Default is 200.
-	A fixed width can be achieved by setting .min and .max to the same
-	value.
-
 *window.active.border.color*
 	Border color of active window.
 
@@ -176,6 +144,34 @@ all are supported.
 	Color of drop-shadows for non-focused windows, including opacity.
 	Default is #00000040 (black with 25% opacity).
 
+*menu.overlap.x*
+	Horizontal overlap in pixels between submenus and their parents. A
+	positive value move submenus over the top of their parents, whereas a
+	negative value creates a gap between submenus and their parents.
+	Default is 0.
+
+*menu.overlap.y*
+	Vertical offset in pixels between submenus and their parents. Positive
+	values for downwards and negative for upwards. Default is 0.
+
+*menu.width.min*
+	Minimal width for menus. Default is 20.
+	A fixed width can be achieved by setting .min and .max to the same
+	value.
+
+*menu.width.max*
+	Maximal width for menus. Default is 200.
+	A fixed width can be achieved by setting .min and .max to the same
+	value.
+
+*menu.items.padding.x*
+	Horizontal padding of menu text entries in pixels.
+	Default is 7.
+
+*menu.items.padding.y*
+	Vertical padding of menu text entries in pixels.
+	Default is 4.
+
 *menu.items.bg.color*
 	Background color of inactive menu items.
 
@@ -203,6 +199,10 @@ all are supported.
 *menu.title.bg.color*
 	Menu title color. Default #589bda.
 	Note: A menu title is a separator with a label.
+
+*menu.title.text.justify*
+	Specifies how menu titles are aligned in the titlebar.
+	Type justification. Default Center.
 
 *menu.title.text.color*
 	Text color of separator label.  Default #ffffff.

--- a/include/theme.h
+++ b/include/theme.h
@@ -45,8 +45,6 @@ struct theme {
 	int window_titlebar_padding_height;
 
 	int title_height;
-	int menu_overlap_x;
-	int menu_overlap_y;
 
 	/* colors */
 	float window_active_border_color[4];
@@ -60,7 +58,6 @@ struct theme {
 	float window_active_label_text_color[4];
 	float window_inactive_label_text_color[4];
 	enum lab_justification window_label_text_justify;
-	enum lab_justification menu_title_text_justify;
 
 	/* buttons */
 	int window_button_width;
@@ -69,50 +66,6 @@ struct theme {
 
 	/* the corner radius of the hover effect */
 	int window_button_hover_bg_corner_radius;
-
-	int menu_item_padding_x;
-	int menu_item_padding_y;
-	int menu_item_height;
-
-	int menu_header_height;
-
-	float menu_items_bg_color[4];
-	float menu_items_text_color[4];
-	float menu_items_active_bg_color[4];
-	float menu_items_active_text_color[4];
-
-	int menu_min_width;
-	int menu_max_width;
-
-	int menu_separator_line_thickness;
-	int menu_separator_padding_width;
-	int menu_separator_padding_height;
-	float menu_separator_color[4];
-
-	float menu_title_bg_color[4];
-
-	float menu_title_text_color[4];
-
-	int osd_border_width;
-
-	float osd_bg_color[4];
-	float osd_border_color[4];
-	float osd_label_text_color[4];
-
-	int osd_window_switcher_width;
-	int osd_window_switcher_padding;
-	int osd_window_switcher_item_padding_x;
-	int osd_window_switcher_item_padding_y;
-	int osd_window_switcher_item_active_border_width;
-	bool osd_window_switcher_width_is_percent;
-	int osd_window_switcher_preview_border_width;
-	float osd_window_switcher_preview_border_color[3][4];
-
-	int osd_workspace_switcher_boxes_width;
-	int osd_workspace_switcher_boxes_height;
-
-	struct theme_snapping_overlay
-		snapping_overlay_region, snapping_overlay_edge;
 
 	/* window drop-shadows */
 	int window_active_shadow_size;
@@ -139,8 +92,52 @@ struct theme {
 
 	} window[2]; /* indexed by THEME_INACTIVE and THEME_ACTIVE */
 
-	/* textures */
+	int menu_item_height;
+	int menu_header_height;
 
+	int menu_overlap_x;
+	int menu_overlap_y;
+	int menu_min_width;
+	int menu_max_width;
+
+	int menu_item_padding_x;
+	int menu_item_padding_y;
+	float menu_items_bg_color[4];
+	float menu_items_text_color[4];
+	float menu_items_active_bg_color[4];
+	float menu_items_active_text_color[4];
+
+	int menu_separator_line_thickness;
+	int menu_separator_padding_width;
+	int menu_separator_padding_height;
+	float menu_separator_color[4];
+
+	float menu_title_bg_color[4];
+	enum lab_justification menu_title_text_justify;
+	float menu_title_text_color[4];
+
+	int osd_border_width;
+
+	float osd_bg_color[4];
+	float osd_border_color[4];
+	float osd_label_text_color[4];
+
+	int osd_window_switcher_width;
+	int osd_window_switcher_padding;
+	int osd_window_switcher_item_padding_x;
+	int osd_window_switcher_item_padding_y;
+	int osd_window_switcher_item_active_border_width;
+	bool osd_window_switcher_width_is_percent;
+	int osd_window_switcher_preview_border_width;
+	float osd_window_switcher_preview_border_color[3][4];
+
+	int osd_workspace_switcher_boxes_width;
+	int osd_workspace_switcher_boxes_height;
+
+	struct theme_snapping_overlay
+		snapping_overlay_region, snapping_overlay_edge;
+
+	/* textures */
 	struct lab_data_buffer *corner_top_left_active_normal;
 	struct lab_data_buffer *corner_top_right_active_normal;
 	struct lab_data_buffer *corner_top_left_inactive_normal;

--- a/include/theme.h
+++ b/include/theme.h
@@ -46,17 +46,7 @@ struct theme {
 
 	int title_height;
 
-	/* colors */
-	float window_active_border_color[4];
-	float window_inactive_border_color[4];
-
 	float window_toggled_keybinds_color[4];
-
-	float window_active_title_bg_color[4];
-	float window_inactive_title_bg_color[4];
-
-	float window_active_label_text_color[4];
-	float window_inactive_label_text_color[4];
 	enum lab_justification window_label_text_justify;
 
 	/* buttons */
@@ -67,13 +57,23 @@ struct theme {
 	/* the corner radius of the hover effect */
 	int window_button_hover_bg_corner_radius;
 
-	/* window drop-shadows */
-	int window_active_shadow_size;
-	int window_inactive_shadow_size;
-	float window_active_shadow_color[4];
-	float window_inactive_shadow_color[4];
-
+	/*
+	 * Themes/textures for each active/inactive window. Indexed by
+	 * THEME_INACTIVE and THEME_ACTIVE.
+	 */
 	struct {
+		/* TODO: add toggled/hover/pressed/disabled colors for buttons */
+		float button_colors[LAB_SSD_BUTTON_LAST + 1][4];
+
+		float border_color[4];
+		float toggled_keybinds_color[4];
+		float title_bg_color[4];
+		float label_text_color[4];
+
+		/* window drop-shadows */
+		int shadow_size;
+		float shadow_color[4];
+
 		/*
 		 * The texture of a window buttons for each hover/toggled/rounded
 		 * state. This can be accessed like:
@@ -85,13 +85,15 @@ struct theme {
 		struct lab_data_buffer *buttons
 			[LAB_SSD_BUTTON_LAST + 1][LAB_BS_ALL + 1];
 
-		/* TODO: add toggled/hover/pressed/disabled colors for buttons */
-		float button_colors[LAB_SSD_BUTTON_LAST + 1][4];
+		struct lab_data_buffer *corner_top_left_normal;
+		struct lab_data_buffer *corner_top_right_normal;
 
-		/* TODO: move other window.(in)active.* entries to here */
+		struct lab_data_buffer *shadow_corner_top;
+		struct lab_data_buffer *shadow_corner_bottom;
+		struct lab_data_buffer *shadow_edge;
+	} window[2];
 
-	} window[2]; /* indexed by THEME_INACTIVE and THEME_ACTIVE */
-
+	/* Derived from font sizes */
 	int menu_item_height;
 	int menu_header_height;
 
@@ -136,19 +138,6 @@ struct theme {
 
 	struct theme_snapping_overlay
 		snapping_overlay_region, snapping_overlay_edge;
-
-	/* textures */
-	struct lab_data_buffer *corner_top_left_active_normal;
-	struct lab_data_buffer *corner_top_right_active_normal;
-	struct lab_data_buffer *corner_top_left_inactive_normal;
-	struct lab_data_buffer *corner_top_right_inactive_normal;
-
-	struct lab_data_buffer *shadow_corner_top_active;
-	struct lab_data_buffer *shadow_corner_bottom_active;
-	struct lab_data_buffer *shadow_edge_active;
-	struct lab_data_buffer *shadow_corner_top_inactive;
-	struct lab_data_buffer *shadow_corner_bottom_inactive;
-	struct lab_data_buffer *shadow_edge_inactive;
 
 	/*
 	 * Not set in rc.xml/themerc, but derived from the tallest titlebar

--- a/include/theme.h
+++ b/include/theme.h
@@ -44,7 +44,7 @@ struct theme {
 	int window_titlebar_padding_width;
 	int window_titlebar_padding_height;
 
-	int title_height;
+	int titlebar_height;
 
 	float window_toggled_keybinds_color[4];
 	enum lab_justification window_label_text_justify;

--- a/include/theme.h
+++ b/include/theme.h
@@ -102,8 +102,8 @@ struct theme {
 	int menu_min_width;
 	int menu_max_width;
 
-	int menu_item_padding_x;
-	int menu_item_padding_y;
+	int menu_items_padding_x;
+	int menu_items_padding_y;
 	float menu_items_bg_color[4];
 	float menu_items_text_color[4];
 	float menu_items_active_bg_color[4];

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -118,7 +118,7 @@ menu_update_width(struct menu *menu)
 				? item->native_width : theme->menu_max_width;
 		}
 	}
-	menu->size.width = max_width + 2 * theme->menu_item_padding_x;
+	menu->size.width = max_width + 2 * theme->menu_items_padding_x;
 
 	/*
 	 * TODO: This function is getting a bit unwieldy. Consider calculating
@@ -275,7 +275,7 @@ item_create(struct menu *menu, const char *text, bool show_arrow)
 		theme->menu_items_active_bg_color, arrow);
 
 	/* Center font nodes */
-	x = theme->menu_item_padding_x;
+	x = theme->menu_items_padding_x;
 	y = (theme->menu_item_height - menuitem->normal.buffer->height) / 2;
 	wlr_scene_node_set_position(menuitem->normal.text, x, y);
 	y = (theme->menu_item_height - menuitem->selected.buffer->height) / 2;
@@ -347,7 +347,7 @@ separator_create(struct menu *menu, const char *label)
 			text_color, bg_color, /* arrow */ NULL);
 		/* Center font nodes */
 		int x, y;
-		x = theme->menu_item_padding_x;
+		x = theme->menu_items_padding_x;
 		y = (theme->menu_header_height - menuitem->normal.buffer->height) / 2;
 		wlr_scene_node_set_position(menuitem->normal.text, x, y);
 	} else {

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -27,6 +27,7 @@ ssd_border_create(struct ssd *ssd)
 	float *color;
 	struct wlr_scene_tree *parent;
 	struct ssd_sub_tree *subtree;
+	int active;
 
 	ssd->border.tree = wlr_scene_tree_create(ssd->tree);
 	wlr_scene_node_set_position(&ssd->border.tree->node, -theme->border_width, 0);
@@ -34,12 +35,11 @@ ssd_border_create(struct ssd *ssd)
 	FOR_EACH_STATE(ssd, subtree) {
 		subtree->tree = wlr_scene_tree_create(ssd->border.tree);
 		parent = subtree->tree;
-		if (subtree == &ssd->border.active) {
-			color = theme->window_active_border_color;
-		} else {
-			color = theme->window_inactive_border_color;
-			wlr_scene_node_set_enabled(&parent->node, false);
-		}
+		active = (subtree == &ssd->border.active) ?
+			THEME_ACTIVE : THEME_INACTIVE;
+		wlr_scene_node_set_enabled(&parent->node, active);
+		color = theme->window[active].border_color;
+
 		wl_list_init(&subtree->parts);
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_LEFT, parent,
 			theme->border_width, height, 0, 0, color);

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -52,12 +52,12 @@ ssd_titlebar_create(struct ssd *ssd)
 		corner_top_left = &theme->window[active].corner_top_left_normal->base;
 		corner_top_right = &theme->window[active].corner_top_right_normal->base;
 		wlr_scene_node_set_enabled(&parent->node, active);
-		wlr_scene_node_set_position(&parent->node, 0, -theme->title_height);
+		wlr_scene_node_set_position(&parent->node, 0, -theme->titlebar_height);
 		wl_list_init(&subtree->parts);
 
 		/* Background */
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_TITLEBAR, parent,
-			width - corner_width * 2, theme->title_height,
+			width - corner_width * 2, theme->titlebar_height,
 			corner_width, 0, color);
 		add_scene_buffer(&subtree->parts, LAB_SSD_PART_TITLEBAR_CORNER_LEFT, parent,
 			corner_top_left, -rc.theme->border_width, -rc.theme->border_width);
@@ -70,7 +70,7 @@ ssd_titlebar_create(struct ssd *ssd)
 		int x = theme->window_titlebar_padding_width;
 
 		/* Center vertically within titlebar */
-		int y = (theme->title_height - theme->window_button_height) / 2;
+		int y = (theme->titlebar_height - theme->window_button_height) / 2;
 
 		wl_list_for_each(b, &rc.title_buttons_left, link) {
 			struct lab_data_buffer **buffers =
@@ -152,8 +152,8 @@ set_squared_corners(struct ssd *ssd, bool enable)
 	FOR_EACH_STATE(ssd, subtree) {
 		part = ssd_get_part(&subtree->parts, LAB_SSD_PART_TITLEBAR);
 		wlr_scene_node_set_position(part->node, x, 0);
-		wlr_scene_rect_set_size(
-			wlr_scene_rect_from_node(part->node), width - 2 * x, theme->title_height);
+		wlr_scene_rect_set_size(wlr_scene_rect_from_node(part->node),
+			width - 2 * x, theme->titlebar_height);
 
 		part = ssd_get_part(&subtree->parts, LAB_SSD_PART_TITLEBAR_CORNER_LEFT);
 		wlr_scene_node_set_enabled(part->node, !enable);
@@ -291,7 +291,7 @@ ssd_titlebar_update(struct ssd *ssd)
 	update_visible_buttons(ssd);
 
 	/* Center buttons vertically within titlebar */
-	int y = (theme->title_height - theme->window_button_height) / 2;
+	int y = (theme->titlebar_height - theme->window_button_height) / 2;
 	int x;
 	struct ssd_part *part;
 	struct ssd_sub_tree *subtree;
@@ -301,7 +301,7 @@ ssd_titlebar_update(struct ssd *ssd)
 		part = ssd_get_part(&subtree->parts, LAB_SSD_PART_TITLEBAR);
 		wlr_scene_rect_set_size(
 			wlr_scene_rect_from_node(part->node),
-			width - bg_offset * 2, theme->title_height);
+			width - bg_offset * 2, theme->titlebar_height);
 
 		x = theme->window_titlebar_padding_width;
 		wl_list_for_each(b, &rc.title_buttons_left, link) {
@@ -386,7 +386,7 @@ ssd_update_title_positions(struct ssd *ssd, int offset_left, int offset_right)
 		buffer_width = part->buffer ? part->buffer->width : 0;
 		buffer_height = part->buffer ? part->buffer->height : 0;
 		x = offset_left;
-		y = (theme->title_height - buffer_height) / 2;
+		y = (theme->titlebar_height - buffer_height) / 2;
 
 		if (title_bg_width <= 0) {
 			wlr_scene_node_set_enabled(part->node, false);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -404,7 +404,7 @@ ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable)
 
 	float *color = enable
 		? rc.theme->window_toggled_keybinds_color
-		: rc.theme->window_active_border_color;
+		: rc.theme->window[THEME_ACTIVE].border_color;
 
 	struct ssd_part *part = ssd_get_part(&ssd->border.active.parts, LAB_SSD_PART_TOP);
 	struct wlr_scene_rect *rect = wlr_scene_rect_from_node(part->node);

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -39,20 +39,20 @@ ssd_thickness(struct view *view)
 	if (view->maximized == VIEW_AXIS_BOTH) {
 		struct border thickness = { 0 };
 		if (!view->ssd_titlebar_hidden) {
-			thickness.top += theme->title_height;
+			thickness.top += theme->titlebar_height;
 		}
 		return thickness;
 	}
 
 	struct border thickness = {
-		.top = theme->title_height + theme->border_width,
+		.top = theme->titlebar_height + theme->border_width,
 		.bottom = theme->border_width,
 		.left = theme->border_width,
 		.right = theme->border_width,
 	};
 
 	if (view->ssd_titlebar_hidden) {
-		thickness.top -= theme->title_height;
+		thickness.top -= theme->titlebar_height;
 	}
 	return thickness;
 }
@@ -176,7 +176,7 @@ ssd_create(struct view *view, bool active)
 	ssd->view = view;
 	ssd->tree = wlr_scene_tree_create(view->scene_tree);
 	wlr_scene_node_lower_to_bottom(&ssd->tree->node);
-	ssd->titlebar.height = view->server->theme->title_height;
+	ssd->titlebar.height = view->server->theme->titlebar_height;
 	ssd_shadow_create(ssd);
 	ssd_extents_create(ssd);
 	/*
@@ -271,7 +271,7 @@ ssd_set_titlebar(struct ssd *ssd, bool enabled)
 		return;
 	}
 	wlr_scene_node_set_enabled(&ssd->titlebar.tree->node, enabled);
-	ssd->titlebar.height = enabled ? ssd->view->server->theme->title_height : 0;
+	ssd->titlebar.height = enabled ? ssd->view->server->theme->titlebar_height : 0;
 	ssd_border_update(ssd);
 	ssd_extents_update(ssd);
 	ssd_shadow_update(ssd);

--- a/src/theme.c
+++ b/src/theme.c
@@ -563,8 +563,6 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->window_titlebar_padding_height = 0;
 	theme->window_titlebar_padding_width = 0;
 	theme->title_height = INT_MIN;
-	theme->menu_overlap_x = 0;
-	theme->menu_overlap_y = 0;
 
 	parse_hexstr("#e1dedb", theme->window_active_border_color);
 	parse_hexstr("#f6f5f4", theme->window_inactive_border_color);
@@ -577,7 +575,6 @@ theme_builtin(struct theme *theme, struct server *server)
 	parse_hexstr("#000000", theme->window_active_label_text_color);
 	parse_hexstr("#000000", theme->window_inactive_label_text_color);
 	theme->window_label_text_justify = parse_justification("Center");
-	theme->menu_title_text_justify = parse_justification("Center");
 
 	theme->window_button_width = 26;
 	theme->window_button_height = 26;
@@ -597,16 +594,17 @@ theme_builtin(struct theme *theme, struct server *server)
 	parse_hexstr("#00000060", theme->window_active_shadow_color);
 	parse_hexstr("#00000040", theme->window_inactive_shadow_color);
 
+	theme->menu_overlap_x = 0;
+	theme->menu_overlap_y = 0;
+	theme->menu_min_width = 20;
+	theme->menu_max_width = 200;
+
+	theme->menu_item_padding_x = 7;
+	theme->menu_item_padding_y = 4;
 	parse_hexstr("#fcfbfa", theme->menu_items_bg_color);
 	parse_hexstr("#000000", theme->menu_items_text_color);
 	parse_hexstr("#e1dedb", theme->menu_items_active_bg_color);
 	parse_hexstr("#000000", theme->menu_items_active_text_color);
-
-	theme->menu_item_padding_x = 7;
-	theme->menu_item_padding_y = 4;
-
-	theme->menu_min_width = 20;
-	theme->menu_max_width = 200;
 
 	theme->menu_separator_line_thickness = 1;
 	theme->menu_separator_padding_width = 6;
@@ -614,7 +612,7 @@ theme_builtin(struct theme *theme, struct server *server)
 	parse_hexstr("#888888", theme->menu_separator_color);
 
 	parse_hexstr("#589bda", theme->menu_title_bg_color);
-
+	theme->menu_title_text_justify = parse_justification("Center");
 	parse_hexstr("#ffffff", theme->menu_title_text_color);
 
 	theme->osd_window_switcher_width = 600;
@@ -707,25 +705,6 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 	if (match_glob(key, "padding.height")) {
 		wlr_log(WLR_ERROR, "padding.height is no longer supported");
-	}
-	if (match_glob(key, "menu.items.padding.x")) {
-		theme->menu_item_padding_x = get_int_if_positive(
-			value, "menu.items.padding.x");
-	}
-	if (match_glob(key, "menu.items.padding.y")) {
-		theme->menu_item_padding_y = get_int_if_positive(
-			value, "menu.items.padding.y");
-	}
-	if (match_glob(key, "menu.title.text.justify")) {
-		theme->menu_title_text_justify = parse_justification(value);
-	}
-	if (match_glob(key, "menu.overlap.x")) {
-		theme->menu_overlap_x = get_int_if_positive(
-			value, "menu.overlap.x");
-	}
-	if (match_glob(key, "menu.overlap.y")) {
-		theme->menu_overlap_y = get_int_if_positive(
-			value, "menu.overlap.y");
 	}
 
 	if (match_glob(key, "window.active.border.color")) {
@@ -872,6 +851,14 @@ entry(struct theme *theme, const char *key, const char *value)
 		parse_hexstr(value, theme->window_inactive_shadow_color);
 	}
 
+	if (match_glob(key, "menu.overlap.x")) {
+		theme->menu_overlap_x = get_int_if_positive(
+			value, "menu.overlap.x");
+	}
+	if (match_glob(key, "menu.overlap.y")) {
+		theme->menu_overlap_y = get_int_if_positive(
+			value, "menu.overlap.y");
+	}
 	if (match_glob(key, "menu.width.min")) {
 		theme->menu_min_width = get_int_if_positive(
 			value, "menu.width.min");
@@ -881,6 +868,14 @@ entry(struct theme *theme, const char *key, const char *value)
 			value, "menu.width.max");
 	}
 
+	if (match_glob(key, "menu.items.padding.x")) {
+		theme->menu_item_padding_x = get_int_if_positive(
+			value, "menu.items.padding.x");
+	}
+	if (match_glob(key, "menu.items.padding.y")) {
+		theme->menu_item_padding_y = get_int_if_positive(
+			value, "menu.items.padding.y");
+	}
 	if (match_glob(key, "menu.items.bg.color")) {
 		parse_hexstr(value, theme->menu_items_bg_color);
 	}
@@ -913,7 +908,9 @@ entry(struct theme *theme, const char *key, const char *value)
 	if (match_glob(key, "menu.title.bg.color")) {
 		parse_hexstr(value, theme->menu_title_bg_color);
 	}
-
+	if (match_glob(key, "menu.title.text.justify")) {
+		theme->menu_title_text_justify = parse_justification(value);
+	}
 	if (match_glob(key, "menu.title.text.color")) {
 		parse_hexstr(value, theme->menu_title_text_color);
 	}

--- a/src/theme.c
+++ b/src/theme.c
@@ -179,7 +179,7 @@ create_rounded_buffer(struct theme *theme, enum corner corner,
 	 * border. See the picture in #2189 for reference.
 	 */
 	int margin_x = theme->window_titlebar_padding_width;
-	int margin_y = (theme->title_height - theme->window_button_height) / 2;
+	int margin_y = (theme->titlebar_height - theme->window_button_height) / 2;
 	float white[4] = {1, 1, 1, 1};
 	struct rounded_corner_ctx rounded_ctx = {
 		.box = &(struct wlr_box){
@@ -562,7 +562,6 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->border_width = 1;
 	theme->window_titlebar_padding_height = 0;
 	theme->window_titlebar_padding_width = 0;
-	theme->title_height = INT_MIN;
 
 	parse_hexstr("#e1dedb", theme->window[THEME_ACTIVE].border_color);
 	parse_hexstr("#f6f5f4", theme->window[THEME_INACTIVE].border_color);
@@ -1243,7 +1242,7 @@ create_corners(struct theme *theme)
 		.x = 0,
 		.y = 0,
 		.width = corner_width + theme->border_width,
-		.height = theme->title_height + theme->border_width,
+		.height = theme->titlebar_height + theme->border_width,
 	};
 
 	for (int active = THEME_INACTIVE; active <= THEME_ACTIVE; active++) {
@@ -1409,7 +1408,7 @@ create_shadow(struct theme *theme, int active)
 		total_size, theme->window[active].shadow_color);
 	shadow_corner_gradient(theme->window[active].shadow_corner_top,
 		visible_size, total_size,
-		theme->title_height, theme->window[active].shadow_color);
+		theme->titlebar_height, theme->window[active].shadow_color);
 	shadow_corner_gradient(theme->window[active].shadow_corner_bottom,
 		visible_size, total_size, 0,
 		theme->window[active].shadow_color);
@@ -1445,7 +1444,7 @@ get_titlebar_height(struct theme *theme)
 static void
 post_processing(struct theme *theme)
 {
-	theme->title_height = get_titlebar_height(theme);
+	theme->titlebar_height = get_titlebar_height(theme);
 
 	theme->menu_item_height = font_height(&rc.font_menuitem)
 		+ 2 * theme->menu_items_padding_y;
@@ -1457,8 +1456,8 @@ post_processing(struct theme *theme)
 		+ 2 * theme->osd_window_switcher_item_padding_y
 		+ 2 * theme->osd_window_switcher_item_active_border_width;
 
-	if (rc.corner_radius >= theme->title_height) {
-		rc.corner_radius = theme->title_height - 1;
+	if (rc.corner_radius >= theme->titlebar_height) {
+		rc.corner_radius = theme->titlebar_height - 1;
 	}
 
 	int min_button_hover_radius =

--- a/src/theme.c
+++ b/src/theme.c
@@ -599,8 +599,8 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->menu_min_width = 20;
 	theme->menu_max_width = 200;
 
-	theme->menu_item_padding_x = 7;
-	theme->menu_item_padding_y = 4;
+	theme->menu_items_padding_x = 7;
+	theme->menu_items_padding_y = 4;
 	parse_hexstr("#fcfbfa", theme->menu_items_bg_color);
 	parse_hexstr("#000000", theme->menu_items_text_color);
 	parse_hexstr("#e1dedb", theme->menu_items_active_bg_color);
@@ -869,11 +869,11 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 
 	if (match_glob(key, "menu.items.padding.x")) {
-		theme->menu_item_padding_x = get_int_if_positive(
+		theme->menu_items_padding_x = get_int_if_positive(
 			value, "menu.items.padding.x");
 	}
 	if (match_glob(key, "menu.items.padding.y")) {
-		theme->menu_item_padding_y = get_int_if_positive(
+		theme->menu_items_padding_y = get_int_if_positive(
 			value, "menu.items.padding.y");
 	}
 	if (match_glob(key, "menu.items.bg.color")) {
@@ -1448,10 +1448,10 @@ post_processing(struct theme *theme)
 	theme->title_height = get_titlebar_height(theme);
 
 	theme->menu_item_height = font_height(&rc.font_menuitem)
-		+ 2 * theme->menu_item_padding_y;
+		+ 2 * theme->menu_items_padding_y;
 
 	theme->menu_header_height = font_height(&rc.font_menuheader)
-		+ 2 * theme->menu_item_padding_y;
+		+ 2 * theme->menu_items_padding_y;
 
 	theme->osd_window_switcher_item_height = font_height(&rc.font_osd)
 		+ 2 * theme->osd_window_switcher_item_padding_y

--- a/src/theme.c
+++ b/src/theme.c
@@ -564,16 +564,16 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->window_titlebar_padding_width = 0;
 	theme->title_height = INT_MIN;
 
-	parse_hexstr("#e1dedb", theme->window_active_border_color);
-	parse_hexstr("#f6f5f4", theme->window_inactive_border_color);
+	parse_hexstr("#e1dedb", theme->window[THEME_ACTIVE].border_color);
+	parse_hexstr("#f6f5f4", theme->window[THEME_INACTIVE].border_color);
 
 	parse_hexstr("#ff0000", theme->window_toggled_keybinds_color);
 
-	parse_hexstr("#e1dedb", theme->window_active_title_bg_color);
-	parse_hexstr("#f6f5f4", theme->window_inactive_title_bg_color);
+	parse_hexstr("#e1dedb", theme->window[THEME_ACTIVE].title_bg_color);
+	parse_hexstr("#f6f5f4", theme->window[THEME_INACTIVE].title_bg_color);
 
-	parse_hexstr("#000000", theme->window_active_label_text_color);
-	parse_hexstr("#000000", theme->window_inactive_label_text_color);
+	parse_hexstr("#000000", theme->window[THEME_ACTIVE].label_text_color);
+	parse_hexstr("#000000", theme->window[THEME_INACTIVE].label_text_color);
 	theme->window_label_text_justify = parse_justification("Center");
 
 	theme->window_button_width = 26;
@@ -589,10 +589,10 @@ theme_builtin(struct theme *theme, struct server *server)
 			theme->window[THEME_ACTIVE].button_colors[type]);
 	}
 
-	theme->window_active_shadow_size = 60;
-	theme->window_inactive_shadow_size = 40;
-	parse_hexstr("#00000060", theme->window_active_shadow_color);
-	parse_hexstr("#00000040", theme->window_inactive_shadow_color);
+	theme->window[THEME_ACTIVE].shadow_size = 60;
+	theme->window[THEME_INACTIVE].shadow_size = 40;
+	parse_hexstr("#00000060", theme->window[THEME_ACTIVE].shadow_color);
+	parse_hexstr("#00000040", theme->window[THEME_INACTIVE].shadow_color);
 
 	theme->menu_overlap_x = 0;
 	theme->menu_overlap_y = 0;
@@ -708,15 +708,15 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 
 	if (match_glob(key, "window.active.border.color")) {
-		parse_hexstr(value, theme->window_active_border_color);
+		parse_hexstr(value, theme->window[THEME_ACTIVE].border_color);
 	}
 	if (match_glob(key, "window.inactive.border.color")) {
-		parse_hexstr(value, theme->window_inactive_border_color);
+		parse_hexstr(value, theme->window[THEME_INACTIVE].border_color);
 	}
 	/* border.color is obsolete, but handled for backward compatibility */
 	if (match_glob(key, "border.color")) {
-		parse_hexstr(value, theme->window_active_border_color);
-		parse_hexstr(value, theme->window_inactive_border_color);
+		parse_hexstr(value, theme->window[THEME_ACTIVE].border_color);
+		parse_hexstr(value, theme->window[THEME_INACTIVE].border_color);
 	}
 
 	if (match_glob(key, "window.active.indicator.toggled-keybind.color")) {
@@ -724,17 +724,17 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 
 	if (match_glob(key, "window.active.title.bg.color")) {
-		parse_hexstr(value, theme->window_active_title_bg_color);
+		parse_hexstr(value, theme->window[THEME_ACTIVE].title_bg_color);
 	}
 	if (match_glob(key, "window.inactive.title.bg.color")) {
-		parse_hexstr(value, theme->window_inactive_title_bg_color);
+		parse_hexstr(value, theme->window[THEME_INACTIVE].title_bg_color);
 	}
 
 	if (match_glob(key, "window.active.label.text.color")) {
-		parse_hexstr(value, theme->window_active_label_text_color);
+		parse_hexstr(value, theme->window[THEME_ACTIVE].label_text_color);
 	}
 	if (match_glob(key, "window.inactive.label.text.color")) {
-		parse_hexstr(value, theme->window_inactive_label_text_color);
+		parse_hexstr(value, theme->window[THEME_INACTIVE].label_text_color);
 	}
 	if (match_glob(key, "window.label.text.justify")) {
 		theme->window_label_text_justify = parse_justification(value);
@@ -837,18 +837,18 @@ entry(struct theme *theme, const char *key, const char *value)
 
 	/* window drop-shadows */
 	if (match_glob(key, "window.active.shadow.size")) {
-		theme->window_active_shadow_size = get_int_if_positive(
+		theme->window[THEME_ACTIVE].shadow_size = get_int_if_positive(
 			value, "window.active.shadow.size");
 	}
 	if (match_glob(key, "window.inactive.shadow.size")) {
-		theme->window_inactive_shadow_size = get_int_if_positive(
+		theme->window[THEME_INACTIVE].shadow_size = get_int_if_positive(
 			value, "window.inactive.shadow.size");
 	}
 	if (match_glob(key, "window.active.shadow.color")) {
-		parse_hexstr(value, theme->window_active_shadow_color);
+		parse_hexstr(value, theme->window[THEME_ACTIVE].shadow_color);
 	}
 	if (match_glob(key, "window.inactive.shadow.color")) {
-		parse_hexstr(value, theme->window_inactive_shadow_color);
+		parse_hexstr(value, theme->window[THEME_INACTIVE].shadow_color);
 	}
 
 	if (match_glob(key, "menu.overlap.x")) {
@@ -1246,28 +1246,19 @@ create_corners(struct theme *theme)
 		.height = theme->title_height + theme->border_width,
 	};
 
-	struct rounded_corner_ctx ctx = {
-		.box = &box,
-		.radius = rc.corner_radius,
-		.line_width = theme->border_width,
-		.fill_color = theme->window_active_title_bg_color,
-		.border_color = theme->window_active_border_color,
-		.corner = LAB_CORNER_TOP_LEFT,
-	};
-	theme->corner_top_left_active_normal = rounded_rect(&ctx);
-
-	ctx.fill_color = theme->window_inactive_title_bg_color,
-	ctx.border_color = theme->window_inactive_border_color,
-	theme->corner_top_left_inactive_normal = rounded_rect(&ctx);
-
-	ctx.corner = LAB_CORNER_TOP_RIGHT;
-	ctx.fill_color = theme->window_active_title_bg_color,
-	ctx.border_color = theme->window_active_border_color,
-	theme->corner_top_right_active_normal = rounded_rect(&ctx);
-
-	ctx.fill_color = theme->window_inactive_title_bg_color,
-	ctx.border_color = theme->window_inactive_border_color,
-	theme->corner_top_right_inactive_normal = rounded_rect(&ctx);
+	for (int active = THEME_INACTIVE; active <= THEME_ACTIVE; active++) {
+		struct rounded_corner_ctx ctx = {
+			.box = &box,
+			.radius = rc.corner_radius,
+			.line_width = theme->border_width,
+			.fill_color = theme->window[active].title_bg_color,
+			.border_color = theme->window[active].border_color,
+			.corner = LAB_CORNER_TOP_LEFT,
+		};
+		theme->window[active].corner_top_left_normal = rounded_rect(&ctx);
+		ctx.corner = LAB_CORNER_TOP_RIGHT;
+		theme->window[active].corner_top_right_normal = rounded_rect(&ctx);
+	}
 }
 
 /*
@@ -1385,68 +1376,50 @@ shadow_corner_gradient(struct lab_data_buffer *buffer, int visible_size,
 }
 
 static void
-create_shadows(struct theme *theme)
+create_shadow(struct theme *theme, int active)
 {
 	/* Size of shadow visible extending beyond the window */
-	int visible_active_size = theme->window_active_shadow_size;
-	int visible_inactive_size = theme->window_inactive_shadow_size;
+	int visible_size = theme->window[active].shadow_size;
 	/* How far inside the window the shadow inset begins */
-	int inset_active = (double)visible_active_size * SSD_SHADOW_INSET;
-	int inset_inactive = (double)visible_inactive_size * SSD_SHADOW_INSET;
+	int inset = (double)visible_size * SSD_SHADOW_INSET;
 	/* Total width including visible and obscured portion */
-	int total_active_size = visible_active_size + inset_active;
-	int total_inactive_size = visible_inactive_size + inset_inactive;
+	int total_size = visible_size + inset;
 
 	/*
 	 * Edge shadows don't need to be inset so the buffers are sized just for
 	 * the visible width.  Corners are inset so the buffers are larger for
 	 * this.
 	 */
-	if (visible_active_size > 0) {
-		theme->shadow_edge_active = buffer_create_cairo(
-			visible_active_size, 1, 1.0);
-		theme->shadow_corner_top_active = buffer_create_cairo(
-			total_active_size, total_active_size, 1.0);
-		theme->shadow_corner_bottom_active = buffer_create_cairo(
-			total_active_size, total_active_size, 1.0);
-		if (!theme->shadow_corner_top_active
-				|| !theme->shadow_corner_bottom_active
-				|| !theme->shadow_edge_active) {
-			wlr_log(WLR_ERROR, "Failed to allocate shadow buffer");
-			return;
-		}
-	}
-	if (visible_inactive_size > 0) {
-		theme->shadow_edge_inactive = buffer_create_cairo(
-			visible_inactive_size, 1, 1.0);
-		theme->shadow_corner_top_inactive = buffer_create_cairo(
-			total_inactive_size, total_inactive_size, 1.0);
-		theme->shadow_corner_bottom_inactive = buffer_create_cairo(
-			total_inactive_size, total_inactive_size, 1.0);
-		if (!theme->shadow_corner_top_inactive
-				|| !theme->shadow_corner_bottom_inactive
-				|| !theme->shadow_edge_inactive) {
+	if (visible_size > 0) {
+		theme->window[active].shadow_edge = buffer_create_cairo(
+			visible_size, 1, 1.0);
+		theme->window[active].shadow_corner_top = buffer_create_cairo(
+			total_size, total_size, 1.0);
+		theme->window[active].shadow_corner_bottom = buffer_create_cairo(
+			total_size, total_size, 1.0);
+		if (!theme->window[active].shadow_corner_top
+				|| !theme->window[active].shadow_corner_bottom
+				|| !theme->window[active].shadow_edge) {
 			wlr_log(WLR_ERROR, "Failed to allocate shadow buffer");
 			return;
 		}
 	}
 
-	shadow_edge_gradient(theme->shadow_edge_active, visible_active_size,
-		total_active_size, theme->window_active_shadow_color);
-	shadow_edge_gradient(theme->shadow_edge_inactive, visible_inactive_size,
-		total_inactive_size, theme->window_inactive_shadow_color);
-	shadow_corner_gradient(theme->shadow_corner_top_active,
-		visible_active_size, total_active_size,
-		theme->title_height, theme->window_active_shadow_color);
-	shadow_corner_gradient(theme->shadow_corner_bottom_active,
-		visible_active_size, total_active_size, 0,
-		theme->window_active_shadow_color);
-	shadow_corner_gradient(theme->shadow_corner_top_inactive,
-		visible_inactive_size, total_inactive_size,
-		theme->title_height, theme->window_inactive_shadow_color);
-	shadow_corner_gradient(theme->shadow_corner_bottom_inactive,
-		visible_inactive_size, total_inactive_size, 0,
-		theme->window_inactive_shadow_color);
+	shadow_edge_gradient(theme->window[active].shadow_edge, visible_size,
+		total_size, theme->window[active].shadow_color);
+	shadow_corner_gradient(theme->window[active].shadow_corner_top,
+		visible_size, total_size,
+		theme->title_height, theme->window[active].shadow_color);
+	shadow_corner_gradient(theme->window[active].shadow_corner_bottom,
+		visible_size, total_size, 0,
+		theme->window[active].shadow_color);
+}
+
+static void
+create_shadows(struct theme *theme)
+{
+	create_shadow(theme, THEME_INACTIVE);
+	create_shadow(theme, THEME_ACTIVE);
 }
 
 static void
@@ -1504,7 +1477,7 @@ post_processing(struct theme *theme)
 	/* Inherit OSD settings if not set */
 	if (theme->osd_bg_color[0] == FLT_MIN) {
 		memcpy(theme->osd_bg_color,
-			theme->window_active_title_bg_color,
+			theme->window[THEME_ACTIVE].title_bg_color,
 			sizeof(theme->osd_bg_color));
 	}
 	if (theme->osd_border_width == INT_MIN) {
@@ -1512,19 +1485,19 @@ post_processing(struct theme *theme)
 	}
 	if (theme->osd_label_text_color[0] == FLT_MIN) {
 		memcpy(theme->osd_label_text_color,
-			theme->window_active_label_text_color,
+			theme->window[THEME_ACTIVE].label_text_color,
 			sizeof(theme->osd_label_text_color));
 	}
 	if (theme->osd_border_color[0] == FLT_MIN) {
 		/*
 		 * As per https://openbox.org/help/Themes#osd.border.color
-		 * we should fall back to window_active_border_color but
-		 * that is usually the same as window_active_title_bg_color
-		 * and thus the fallback for osd_bg_color. Which would mean
+		 * we should fall back to window.active.border.color but
+		 * that is usually the same as window.active.title.bg.color
+		 * and thus the fallback for osd.bg.color. Which would mean
 		 * they are both the same color and thus the border is invisible.
 		 *
-		 * Instead, we fall back to osd_label_text_color which in turn
-		 * falls back to window_active_label_text_color.
+		 * Instead, we fall back to osd.label.text.color which in turn
+		 * falls back to window.active.label.text.color.
 		 */
 		memcpy(theme->osd_border_color, theme->osd_label_text_color,
 			sizeof(theme->osd_border_color));
@@ -1606,15 +1579,11 @@ theme_finish(struct theme *theme)
 		}
 	}
 
-	zdrop(&theme->corner_top_left_active_normal);
-	zdrop(&theme->corner_top_left_inactive_normal);
-	zdrop(&theme->corner_top_right_active_normal);
-	zdrop(&theme->corner_top_right_inactive_normal);
-
-	zdrop(&theme->shadow_corner_top_active);
-	zdrop(&theme->shadow_corner_bottom_active);
-	zdrop(&theme->shadow_edge_active);
-	zdrop(&theme->shadow_corner_top_inactive);
-	zdrop(&theme->shadow_corner_bottom_inactive);
-	zdrop(&theme->shadow_edge_inactive);
+	for (int active = THEME_INACTIVE; active <= THEME_ACTIVE; active++) {
+		zdrop(&theme->window[active].corner_top_left_normal);
+		zdrop(&theme->window[active].corner_top_right_normal);
+		zdrop(&theme->window[active].shadow_corner_top);
+		zdrop(&theme->window[active].shadow_corner_bottom);
+		zdrop(&theme->window[active].shadow_edge);
+	}
 }

--- a/src/view.c
+++ b/src/view.c
@@ -980,7 +980,7 @@ view_cascade(struct view *view)
 	int offset_x = rc.placement_cascade_offset_x;
 	int offset_y = rc.placement_cascade_offset_y;
 	struct theme *theme = view->server->theme;
-	int default_offset = theme->title_height + theme->border_width + 5;
+	int default_offset = theme->titlebar_height + theme->border_width + 5;
 	if (offset_x <= 0) {
 		offset_x = default_offset;
 	}


### PR DESCRIPTION
- Reorder `menu.*` theme entries (in documentation and codebase) that are currently scattered around. This is my primary motivation of this PR so that we can smoothly add theme entries for richer menu design (borders, rounded corners and padding).
- Move `theme->*_inactive_*` and `theme->*_active_*` into `theme->window`. This is a fixup for #2213.
- Rename `theme->menu_item_padding_*` to `theme->menu_items_padding_*`
- Rename `theme->title_height` to `theme->titlebar_height` (ref. https://github.com/labwc/labwc/pull/2189#issue-2555113495)
