### PR TITLE
workspaces: use view_for_each_reverse() to move omnipresent views

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -381,10 +381,26 @@ bool view_matches_query(struct view *view, struct view_query *query);
  *		printf("%s\n", view_get_string_prop(view, "app_id"));
  *	}
  */
-#define for_each_view(view, head, criteria)		\
-	for (view = view_next(head, NULL, criteria);	\
-	     view;					\
+#define for_each_view(view, head, criteria)           \
+	for (view = view_next(head, NULL, criteria);  \
+	     view;                                    \
 	     view = view_next(head, view, criteria))
+
+/**
+ * for_each_view_reverse() - iterate over all views which match criteria
+ * @view: Iterator.
+ * @head: Head of list to iterate over.
+ * @criteria: Criteria to match against.
+ * Example:
+ *	struct view *view;
+ *	for_each_view_reverse(view, &server->views, LAB_VIEW_CRITERIA_NONE) {
+ *		printf("%s\n", view_get_string_prop(view, "app_id"));
+ *	}
+ */
+#define for_each_view_reverse(view, head, criteria)   \
+	for (view = view_prev(head, NULL, criteria);  \
+	     view;                                    \
+	     view = view_prev(head, view, criteria))
 
 /**
  * view_next() - Get next view which matches criteria.
@@ -396,6 +412,18 @@ bool view_matches_query(struct view *view, struct view_query *query);
  * Returns NULL if there are no views matching the criteria.
  */
 struct view *view_next(struct wl_list *head, struct view *view,
+	enum lab_view_criteria criteria);
+
+/**
+ * view_prev() - Get previous view which matches criteria.
+ * @head: Head of list to iterate over.
+ * @view: Current view from which to find the previous one. If NULL is provided
+ *        as the view argument, the end of the list will be used.
+ * @criteria: Criteria to match against.
+ *
+ * Returns NULL if there are no views matching the criteria.
+ */
+struct view *view_prev(struct wl_list *head, struct view *view,
 	enum lab_view_criteria criteria);
 
 /*

--- a/src/view.c
+++ b/src/view.c
@@ -270,6 +270,22 @@ view_next(struct wl_list *head, struct view *view, enum lab_view_criteria criter
 }
 
 struct view *
+view_prev(struct wl_list *head, struct view *view, enum lab_view_criteria criteria)
+{
+	assert(head);
+
+	struct wl_list *elm = view ? &view->link : head;
+
+	for (elm = elm->prev; elm != head; elm = elm->prev) {
+		view = wl_container_of(elm, view, link);
+		if (matches_criteria(view, criteria)) {
+			return view;
+		}
+	}
+	return NULL;
+}
+
+struct view *
 view_next_no_head_stop(struct wl_list *head, struct view *from,
 		enum lab_view_criteria criteria)
 {

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -323,7 +323,7 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	struct view *view;
 	enum lab_view_criteria criteria =
 		LAB_VIEW_CRITERIA_CURRENT_WORKSPACE;
-	for_each_view(view, &server->views, criteria) {
+	for_each_view_reverse(view, &server->views, criteria) {
 		if (view->visible_on_all_workspaces) {
 			view_move_to_workspace(view, target);
 		}


### PR DESCRIPTION
Follow-up from #2332 

One more related issue I noticed is the following:
- two omnipresent views and a usual one
- focus the usual one
- switch workspace
- one of the two omnipresent views gets focus
- switch back to the previous workspace
- focus the usual one
- switch workspace
- now the other omnipresent view gets focus

I think this is because we are using `view_for_each()` to move the omnipresent views to the new workspace. However, `server->views` is ordered topmost first and we only reparent the view scene tree without changing the ordering of `server->views`. `desktop_focus_topmost_view()` in contrast uses the scene node ordering (which is topmost last) to find the topmost view and then raises that one (which then in turn moves it to the front of `server->views`).

An easy 'fix' would be to implement `view_for_each_reverse()` and use that one to move the omnipresent views to the new workspace. I've tested that and it looks like it at least makes things deterministic. I feel like focus handling of omnipresent views on workspace switching needs some more thought instead of adding band aids like `view_for_each_reverse()` though. Currently omnipresent views `*always*` get focus on workspace switching because they are the topmost views in terms of the scene graph. That feels slightly wrong (and also desyncs `server->views | LAB_VIEW_CRITERIA_CURRENT_WORKSPACE` and `server->workspaces.current->tree->children`).

This PR implements the `view_for_each_reverse()` band aid.

Ideas how to proceed welcome.