### PR TITLE
menu: refactor in preparation for richer menu design (+ minor fixes)

### DIFF
--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -37,11 +37,12 @@ struct menuitem {
 	struct wl_list actions;
 	char *execute;
 	char *id; /* needed for pipemenus */
+	char *text;
+	const char *arrow;
 	struct menu *parent;
 	struct menu *submenu;
 	bool selectable;
 	enum menuitem_type type;
-	int height;
 	int native_width;
 	struct wlr_scene_tree *tree;
 	struct menu_scene normal;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -339,15 +339,14 @@ menu_update_scene(struct menu *menu)
 	menu->scene_tree = wlr_scene_tree_create(menu->server->menu_tree);
 	wlr_scene_node_set_enabled(&menu->scene_tree->node, false);
 
-	/* Get widest menu item, clamped by menu_max_width */
-	int max_width = theme->menu_min_width;
+	/* Menu width is the maximum item width, capped by menu.width.{min,max} */
+	menu->size.width = 0;
 	wl_list_for_each(item, &menu->menuitems, link) {
-		if (item->native_width > max_width) {
-			max_width = item->native_width < theme->menu_max_width
-				? item->native_width : theme->menu_max_width;
-		}
+		menu->size.width = MAX(menu->size.width,
+			item->native_width + 2 * theme->menu_items_padding_x);
 	}
-	menu->size.width = max_width + 2 * theme->menu_items_padding_x;
+	menu->size.width = MAX(menu->size.width, theme->menu_min_width);
+	menu->size.width = MIN(menu->size.width, theme->menu_max_width);
 
 	/* Update all items for the new size */
 	int item_y = 0;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -302,11 +302,18 @@ title_create_scene(struct menuitem *menuitem, int *item_y)
 		menu->size.width - 2 * theme->menu_items_padding_x);
 
 	int title_x = 0;
-	if (theme->menu_title_text_justify == LAB_JUSTIFY_CENTER) {
+	switch (theme->menu_title_text_justify) {
+	case LAB_JUSTIFY_CENTER:
 		title_x = (menu->size.width - menuitem->native_width) / 2;
 		title_x = MAX(title_x, 0);
-	} else {
+		break;
+	case LAB_JUSTIFY_LEFT:
 		title_x = theme->menu_items_padding_x;
+		break;
+	case LAB_JUSTIFY_RIGHT:
+		title_x = menu->size.width - menuitem->native_width
+				- theme->menu_items_padding_x;
+		break;
 	}
 	int title_y = (theme->menu_header_height - menuitem->normal.buffer->height) / 2;
 	wlr_scene_node_set_position(menuitem->normal.text, title_x, title_y);


### PR DESCRIPTION
This PR is a preparation for richer menu design including borders, rounded corners and padding around items (ref: https://github.com/tokyo4j/labwc/tree/rounded-menu, https://github.com/labwc/labwc/pull/2240#issuecomment-2422437018).

The first & second commits split the initialization of menu items into `item_create()`/`separator_create()` and `item_create_scene()`/`separator_create_scene()`/`title_create_scene()` so that we can create all the scene nodes in items after knowing the final menu width. This will allow us to smoothly add support for rounded corners without bloating `menu_update_width()` (renamed to `menu_update_scene()` in this PR) as we cannot resize cairo surfaces unlike scene-rects.

The third commit fixes that `menu.title.text.justify: right` worked like `menu.title.text.justify: left`.

The forth commit fixes that `menu.width.{min,max}` was applied to the width of menu item content rather than the menu width including `menu.items.padding.x`. (cc @Consolatis as I don't fully understand the current calculation)