### PR TITLE
menu: invalidate nested duplicated menus

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -656,6 +656,17 @@ handle_menu_element(xmlNode *n, struct server *server)
 		}
 
 		struct menu *menu = menu_get_by_id(server, id);
+
+		struct menu *iter = current_menu;
+		while (iter) {
+			if (iter == menu) {
+				wlr_log(WLR_ERROR, "menus with the same id '%s' "
+					"cannot be nested", id);
+				goto error;
+			}
+			iter = iter->parent;
+		}
+
 		if (menu) {
 			current_item = item_create(current_menu, menu->label, true);
 			if (current_item) {


### PR DESCRIPTION
Prior to this PR, nesting the same menus (e.g. `<menu id="foo"><menu id="foo" /></menu>`) caused stack overflow at `close_all_submenus()` when trying to open it.