### PR TITLE
menu: fix UAF of server->menu_current

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1140,6 +1140,10 @@ menu_free(struct menu *menu)
 	/* Keep items clean on pipemenu destruction */
 	nullify_item_pointing_to_this_menu(menu);
 
+	if (menu->server->menu_current == menu) {
+		menu_close_root(menu->server);
+	}
+
 	struct menuitem *item, *next;
 	wl_list_for_each_safe(item, next, &menu->menuitems, link) {
 		item_destroy(item);


### PR DESCRIPTION
This fixes segfault when exiting with a menu opened, which is a regression from eaf11fac.