### PR TITLE
placement: set default placement policy to `cascade`

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -232,7 +232,7 @@ this is for compatibility with Openbox.
 	center new windows under the cursor. The "cascade" policy will try to
 	place new windows at the center of the active output, but possibly
 	shifts its position to bottom-right not to cover existing windows.
-	Default is "center".
+	Default is "cascade".
 
 *<placement><cascadeOffset><x>*++
 *<placement><cascadeOffset><y>*

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -17,7 +17,7 @@
   </core>
 
   <placement>
-    <policy>center</policy>
+    <policy>cascade</policy>
     <!--
       When <placement><policy> is "cascade", the offset for cascading new
       windows can be overwritten like this:

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1079,9 +1079,9 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "reuseOutputMode.core")) {
 		set_bool(content, &rc.reuse_output_mode);
 	} else if (!strcmp(nodename, "policy.placement")) {
-		rc.placement_policy = view_placement_parse(content);
-		if (rc.placement_policy == LAB_PLACE_INVALID) {
-			rc.placement_policy = LAB_PLACE_CENTER;
+		enum view_placement_policy policy = view_placement_parse(content);
+		if (policy != LAB_PLACE_INVALID) {
+			rc.placement_policy = policy;
 		}
 	} else if (!strcasecmp(nodename, "xwaylandPersistence.core")) {
 		set_bool(content, &rc.xwayland_persistence);
@@ -1434,7 +1434,7 @@ rcxml_init(void)
 	}
 	has_run = true;
 
-	rc.placement_policy = LAB_PLACE_CENTER;
+	rc.placement_policy = LAB_PLACE_CASCADE;
 	rc.placement_cascade_offset_x = 0;
 	rc.placement_cascade_offset_y = 0;
 


### PR DESCRIPTION
I've been using `cascade` placement policy for several months and it's been working very well. It avoids the perfect overlap with `center` policy when user opens multiple windows consecutively, but its behavior is more predictable than `automatic` policy in my opinion.

I think we can provide better out-of-the-box experience to users by setting this policy to the default value.