### PR TITLE
menu: fix incorrect positioning of pipemenus

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -322,6 +322,7 @@ title_create_scene(struct menuitem *menuitem, int *item_y)
 	*item_y += theme->menu_header_height;
 }
 
+/* (Re)creates the scene of the menu */
 static void
 menu_update_scene(struct menu *menu)
 {
@@ -370,9 +371,16 @@ menu_update_scene(struct menu *menu)
 static void
 post_processing(struct server *server)
 {
+	/*
+	 * Create menu scene after all of its contents is determined
+	 * (e.g. when finished reading menu.xml or received output from
+	 * pipemenu program).
+	 */
 	struct menu *menu;
 	wl_list_for_each(menu, &server->menus, link) {
-		menu_update_scene(menu);
+		if (!menu->scene_tree) {
+			menu_update_scene(menu);
+		}
 	}
 }
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -918,9 +918,6 @@ menu_hide_submenu(struct server *server, const char *id)
 			}
 		}
 	}
-	if (hide_menu->scene_tree) {
-		menu_update_scene(hide_menu);
-	}
 }
 
 static void


### PR DESCRIPTION
7651531 introduced a regression: `menu_update_scene()` which re-creates a menu scene was called for all the menus when a pipemenu is created, so the menus (parent of the pipemenu) were always moved to (0,0) and hidden, and the pipemenu was incorrectly positioned.

This PR fixes it by calling `menu_update_scene()` only for the pipemenu when it's created.

The second commit just eliminates dead code in `menu_hide_submenu()` I added in the prior PR by mistake.