### PR TITLE
[v0.7 backport] view: ensure output is usable before setting adaptive sync

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -372,6 +372,11 @@ set_adaptive_sync_fullscreen(struct view *view)
 	if (rc.adaptive_sync != LAB_ADAPTIVE_SYNC_FULLSCREEN) {
 		return;
 	}
+
+	if (!output_is_usable(view->output)) {
+		return;
+	}
+
 	/* Enable adaptive sync if view is fullscreen */
 	output_enable_adaptive_sync(view->output->wlr_output, view->fullscreen);
 	wlr_output_commit(view->output->wlr_output);


### PR DESCRIPTION
Fixes
- #2337

Backported from 36e099fc93b3caf87e7f390a732fcec69373de8c

Slightly modified to handle the changed `struct output` rather than `struct wlr_output` argument for `output_enable_adaptive_sync()` in 7912665b0f3a541e5d766c7942446716df5e839d.

Edit:
Removed the `assert()` completely to keep the code churn to a minimum. Even with the [earlier changes](https://github.com/labwc/labwc/compare/f0212400f0e0fc2f6901fa658301fe2a2497b83b..12a1ae4c92560c4c984444d1f82f7248b5154478) due to the changed argument we still run into a `unused var` warning due to `struct output` only being used within the assert which would require a further workaround.

CC @spl237 (another backport for 0.7)