### PR TITLE
menu: fix UAFs in menu_destroy() and item_destroy()

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -437,7 +437,9 @@ item_destroy(struct menuitem *item)
 	}
 	wl_list_remove(&item->link);
 	action_list_free(&item->actions);
-	wlr_scene_node_destroy(&item->tree->node);
+	if (item->tree) {
+		wlr_scene_node_destroy(&item->tree->node);
+	}
 	free(item->execute);
 	free(item->id);
 	free(item->text);
@@ -1166,7 +1168,9 @@ menu_free(struct menu *menu)
 	 * Destroying the root node will destroy everything,
 	 * including node descriptors and scaled_font_buffers.
 	 */
-	wlr_scene_node_destroy(&menu->scene_tree->node);
+	if (menu->scene_tree) {
+		wlr_scene_node_destroy(&menu->scene_tree->node);
+	}
 	wl_list_remove(&menu->link);
 	zfree(menu->id);
 	zfree(menu->label);


### PR DESCRIPTION
This fixes use-after-free when there's only 1 desktop and `menu_hide_submenu()` is called to delete "Workspaces" submenu in client-menu before menu scenes are initialized.

As `menu_create()` and `item_create()` no longer initialize scenes after 76515316, `menu->scene_tree` and `item->tree` should be null-checked.

Sorry for another regression!