### PR TITLE
Fix some small config related memory leaks

### DIFF
--- a/include/common/mem.h
+++ b/include/common/mem.h
@@ -45,6 +45,14 @@ void *xrealloc(void *ptr, size_t size);
 char *xstrdup(const char *str);
 
 /*
+ * Same as ptr = xstrdup(str) but free
+ * <ptr> before assigning the result.
+ */
+#define xstrdup_replace(ptr, str) do { \
+	free(ptr); (ptr) = xstrdup(str); \
+} while (0)
+
+/*
  * Frees memory pointed to by <ptr> and sets <ptr> to NULL.
  * Does nothing if <ptr> is already NULL.
  */

--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -30,6 +30,8 @@ struct keybind {
  */
 struct keybind *keybind_create(const char *keybind);
 
+void keybind_destroy(struct keybind *keybind);
+
 /**
  * parse_modifier - parse a string containing a single modifier name (e.g. "S")
  * into the represented modifier value. returns 0 for invalid modifier names.

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -188,3 +188,12 @@ keybind_create(const char *keybind)
 	wl_list_init(&k->actions);
 	return k;
 }
+
+void
+keybind_destroy(struct keybind *keybind)
+{
+	assert(wl_list_empty(&keybind->actions));
+
+	zfree(keybind->keysyms);
+	zfree(keybind);
+}

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -270,8 +270,7 @@ fill_usable_area_override(char *nodename, char *content)
 	} else if (!current_usable_area_override) {
 		wlr_log(WLR_ERROR, "no usable-area-override object");
 	} else if (!strcmp(nodename, "output")) {
-		free(current_usable_area_override->output);
-		current_usable_area_override->output = xstrdup(content);
+		xstrdup_replace(current_usable_area_override->output, content);
 	} else if (!strcmp(nodename, "left")) {
 		current_usable_area_override->margin.left = atoi(content);
 	} else if (!strcmp(nodename, "right")) {
@@ -320,21 +319,17 @@ fill_window_rule(char *nodename, char *content)
 
 	/* Criteria */
 	} else if (!strcmp(nodename, "identifier")) {
-		free(current_window_rule->identifier);
-		current_window_rule->identifier = xstrdup(content);
+		xstrdup_replace(current_window_rule->identifier, content);
 	} else if (!strcmp(nodename, "title")) {
-		free(current_window_rule->title);
-		current_window_rule->title = xstrdup(content);
+		xstrdup_replace(current_window_rule->title, content);
 	} else if (!strcmp(nodename, "type")) {
 		current_window_rule->window_type = parse_window_type(content);
 	} else if (!strcasecmp(nodename, "matchOnce")) {
 		set_bool(content, &current_window_rule->match_once);
 	} else if (!strcasecmp(nodename, "sandboxEngine")) {
-		free(current_window_rule->sandbox_engine);
-		current_window_rule->sandbox_engine = xstrdup(content);
+		xstrdup_replace(current_window_rule->sandbox_engine, content);
 	} else if (!strcasecmp(nodename, "sandboxAppId")) {
-		free(current_window_rule->sandbox_app_id);
-		current_window_rule->sandbox_app_id = xstrdup(content);
+		xstrdup_replace(current_window_rule->sandbox_app_id, content);
 
 	/* Event */
 	} else if (!strcmp(nodename, "event")) {
@@ -464,15 +459,15 @@ fill_action_query(char *nodename, char *content, struct action *action)
 	}
 
 	if (!strcasecmp(nodename, "identifier")) {
-		current_view_query->identifier = xstrdup(content);
+		xstrdup_replace(current_view_query->identifier, content);
 	} else if (!strcasecmp(nodename, "title")) {
-		current_view_query->title = xstrdup(content);
+		xstrdup_replace(current_view_query->title, content);
 	} else if (!strcmp(nodename, "type")) {
 		current_view_query->window_type = parse_window_type(content);
 	} else if (!strcasecmp(nodename, "sandboxEngine")) {
-		current_view_query->sandbox_engine = xstrdup(content);
+		xstrdup_replace(current_view_query->sandbox_engine, content);
 	} else if (!strcasecmp(nodename, "sandboxAppId")) {
-		current_view_query->sandbox_app_id = xstrdup(content);
+		xstrdup_replace(current_view_query->sandbox_app_id, content);
 	} else if (!strcasecmp(nodename, "shaded")) {
 		current_view_query->shaded = parse_three_state(content);
 	} else if (!strcasecmp(nodename, "maximized")) {
@@ -486,13 +481,13 @@ fill_action_query(char *nodename, char *content, struct action *action)
 	} else if (!strcasecmp(nodename, "tiled")) {
 		current_view_query->tiled = view_edge_parse(content);
 	} else if (!strcasecmp(nodename, "tiled_region")) {
-		current_view_query->tiled_region = xstrdup(content);
+		xstrdup_replace(current_view_query->tiled_region, content);
 	} else if (!strcasecmp(nodename, "desktop")) {
-		current_view_query->desktop = xstrdup(content);
+		xstrdup_replace(current_view_query->desktop, content);
 	} else if (!strcasecmp(nodename, "decoration")) {
 		current_view_query->decoration = ssd_mode_parse(content);
 	} else if (!strcasecmp(nodename, "monitor")) {
-		current_view_query->monitor = xstrdup(content);
+		xstrdup_replace(current_view_query->monitor, content);
 	}
 }
 
@@ -650,9 +645,9 @@ fill_touch(char *nodename, char *content)
 		current_touch = znew(*current_touch);
 		wl_list_append(&rc.touch_configs, &current_touch->link);
 	} else if (!strcasecmp(nodename, "deviceName.touch")) {
-		current_touch->device_name = xstrdup(content);
+		xstrdup_replace(current_touch->device_name, content);
 	} else if (!strcasecmp(nodename, "mapToOutput.touch")) {
-		current_touch->output_name = xstrdup(content);
+		xstrdup_replace(current_touch->output_name, content);
 	} else if (!strcasecmp(nodename, "mouseEmulation.touch")) {
 		set_bool(content, &current_touch->force_mouse_emulation);
 	} else {
@@ -735,7 +730,7 @@ fill_libinput_category(char *nodename, char *content)
 		 * should be applicable to.
 		 */
 		if (current_libinput_category->type == LAB_LIBINPUT_DEVICE_NONE) {
-			current_libinput_category->name = xstrdup(content);
+			xstrdup_replace(current_libinput_category->name, content);
 		}
 	} else if (!strcasecmp(nodename, "naturalScroll")) {
 		set_bool_as_int(content, &current_libinput_category->natural_scroll);
@@ -850,8 +845,7 @@ static void
 set_font_attr(struct font *font, const char *nodename, const char *content)
 {
 	if (!strcmp(nodename, "name")) {
-		zfree(font->name);
-		font->name = xstrdup(content);
+		xstrdup_replace(font->name, content);
 	} else if (!strcmp(nodename, "size")) {
 		font->size = atoi(content);
 	} else if (!strcmp(nodename, "slant")) {
@@ -1090,9 +1084,9 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "y.cascadeOffset.placement")) {
 		rc.placement_cascade_offset_y = atoi(content);
 	} else if (!strcmp(nodename, "name.theme")) {
-		rc.theme_name = xstrdup(content);
+		xstrdup_replace(rc.theme_name, content);
 	} else if (!strcmp(nodename, "icon.theme")) {
-		rc.icon_theme_name = xstrdup(content);
+		xstrdup_replace(rc.icon_theme_name, content);
 	} else if (!strcasecmp(nodename, "layout.titlebar.theme")) {
 		fill_title_layout(content);
 	} else if (!strcasecmp(nodename, "showTitle.titlebar.theme")) {
@@ -1222,7 +1216,7 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "number.desktops")) {
 		rc.workspace_config.min_nr_workspaces = MAX(1, atoi(content));
 	} else if (!strcasecmp(nodename, "prefix.desktops")) {
-		rc.workspace_config.prefix = xstrdup(content);
+		xstrdup_replace(rc.workspace_config.prefix, content);
 	} else if (!strcasecmp(nodename, "popupShow.resize")) {
 		if (!strcasecmp(content, "Always")) {
 			rc.resize_indicator = LAB_RESIZE_INDICATOR_ALWAYS;
@@ -1238,7 +1232,7 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "mouseEmulation.tablet")) {
 		set_bool(content, &rc.tablet.force_mouse_emulation);
 	} else if (!strcasecmp(nodename, "mapToOutput.tablet")) {
-		rc.tablet.output_name = xstrdup(content);
+		xstrdup_replace(rc.tablet.output_name, content);
 	} else if (!strcasecmp(nodename, "rotate.tablet")) {
 		rc.tablet.rotation = tablet_parse_rotation(atoi(content));
 	} else if (!strcasecmp(nodename, "left.area.tablet")) {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1920,6 +1920,7 @@ rcxml_finish(void)
 	zfree(rc.theme_name);
 	zfree(rc.icon_theme_name);
 	zfree(rc.workspace_config.prefix);
+	zfree(rc.tablet.output_name);
 
 	struct title_button *p, *p_tmp;
 	wl_list_for_each_safe(p, p_tmp, &rc.title_buttons_left, link) {
@@ -1959,8 +1960,6 @@ rcxml_finish(void)
 		zfree(touch_config->output_name);
 		zfree(touch_config);
 	}
-
-	zfree(rc.tablet.output_name);
 
 	struct libinput_category *l, *l_tmp;
 	wl_list_for_each_safe(l, l_tmp, &rc.libinput_categories, link) {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1626,7 +1626,7 @@ deduplicate_key_bindings(void)
 			if (keybind_the_same(existing, current)) {
 				wl_list_remove(&existing->link);
 				action_list_free(&existing->actions);
-				free(existing);
+				keybind_destroy(existing);
 				replaced++;
 				break;
 			}
@@ -1635,7 +1635,7 @@ deduplicate_key_bindings(void)
 	wl_list_for_each_safe(current, tmp, &rc.keybinds, link) {
 		if (wl_list_empty(&current->actions)) {
 			wl_list_remove(&current->link);
-			free(current);
+			keybind_destroy(current);
 			cleared++;
 		}
 	}
@@ -1948,8 +1948,7 @@ rcxml_finish(void)
 	wl_list_for_each_safe(k, k_tmp, &rc.keybinds, link) {
 		wl_list_remove(&k->link);
 		action_list_free(&k->actions);
-		zfree(k->keysyms);
-		zfree(k);
+		keybind_destroy(k);
 	}
 
 	struct mousebind *m, *m_tmp;

--- a/src/config/touch.c
+++ b/src/config/touch.c
@@ -21,11 +21,11 @@ find_default_config(void)
 struct touch_config_entry *
 touch_find_config_for_device(char *device_name)
 {
-	wlr_log(WLR_INFO, "find touch configuration for %s\n", device_name);
+	wlr_log(WLR_INFO, "find touch configuration for %s", device_name);
 	struct touch_config_entry *entry;
 	wl_list_for_each(entry, &rc.touch_configs, link) {
 		if (entry->device_name && !strcasecmp(entry->device_name, device_name)) {
-			wlr_log(WLR_INFO, "found touch configuration for %s\n", device_name);
+			wlr_log(WLR_INFO, "found touch configuration for %s", device_name);
 			return entry;
 		}
 	}

--- a/src/img/img-svg.c
+++ b/src/img/img-svg.c
@@ -45,7 +45,7 @@ img_svg_load(const char *filename, struct lab_data_buffer **buffer, int size,
 
 	rsvg_handle_render_document(svg, cr, &viewport, &err);
 	if (err) {
-		wlr_log(WLR_ERROR, "error rendering svg %s-%s\n", filename, err->message);
+		wlr_log(WLR_ERROR, "error rendering svg %s-%s", filename, err->message);
 		g_error_free(err);
 		goto error;
 	}

--- a/src/seat.c
+++ b/src/seat.c
@@ -284,7 +284,7 @@ static void
 map_pointer_to_output(struct seat *seat, struct wlr_input_device *dev)
 {
 	struct wlr_pointer *pointer = wlr_pointer_from_input_device(dev);
-	wlr_log(WLR_INFO, "map pointer to output %s\n", pointer->output_name);
+	wlr_log(WLR_INFO, "map pointer to output %s", pointer->output_name);
 	map_input_to_output(seat, dev, pointer->output_name);
 }
 
@@ -353,7 +353,7 @@ map_touch_to_output(struct seat *seat, struct wlr_input_device *dev)
 	}
 
 	char *output_name = touch->output_name ? touch->output_name : touch_config_output_name;
-	wlr_log(WLR_INFO, "map touch to output %s\n", output_name ? output_name : "unknown");
+	wlr_log(WLR_INFO, "map touch to output %s", output_name ? output_name : "unknown");
 	map_input_to_output(seat, dev, output_name);
 }
 
@@ -378,7 +378,7 @@ new_tablet(struct seat *seat, struct wlr_input_device *dev)
 	input->wlr_input_device = dev;
 	tablet_create(seat, dev);
 	wlr_cursor_attach_input_device(seat->cursor, dev);
-	wlr_log(WLR_INFO, "map tablet to output %s\n", rc.tablet.output_name);
+	wlr_log(WLR_INFO, "map tablet to output %s", rc.tablet.output_name);
 	map_input_to_output(seat, dev, rc.tablet.output_name);
 
 	return input;

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -54,7 +54,7 @@ view_impl_map(struct view *view)
 	 */
 	desktop_update_top_layer_visiblity(view->server);
 
-	wlr_log(WLR_DEBUG, "[map] identifier=%s, title=%s\n",
+	wlr_log(WLR_DEBUG, "[map] identifier=%s, title=%s",
 		view_get_string_prop(view, "app_id"),
 		view_get_string_prop(view, "title"));
 }


### PR DESCRIPTION
We didn't free `keybind->keysyms` on
- keybind de-duplication
- keybind removal due to empty action list

This PR adds a `keybind_destroy()` function which takes care of properly freeing the keybind.

---
For some `char *` vars in `struct rc` we were using `= xstrdup()` without freeing the previous value. This caused a mem leak with a config like
```xml
<theme>
  <name>Numix</name>
</theme>
<theme name="Numix" />
```

This PR adds a new `xstrdup_replace(char *ptr, const char *val)` helper which does a `free(ptr); ptr = xstrdup(val)`.

---
Also thrown in a  small fix to remove line terminators from some log messages.