### PR TITLE
tearing: add 'always' which by default enables tearing for all windows

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -190,10 +190,12 @@ this is for compatibility with Openbox.
 	*fullscreen* enables adaptive sync whenever a window is in fullscreen
 	mode.
 
-*<core><allowTearing>* [yes|no|fullscreen|fullscreenForced]
+*<core><allowTearing>* [yes|no|fullscreen|fullscreenForced|always]
 	Allow tearing to reduce input lag. Default is no.
 
 	*yes* allows tearing if requested by the active window.
+
+	*no* tearing is disabled completely.
 
 	*fullscreen* allows tearing if requested by the active window, but
 	only when the window is in fullscreen mode.
@@ -201,7 +203,11 @@ this is for compatibility with Openbox.
 	*fullscreenForced* enables tearing whenever the active window is in
 	fullscreen mode, whether or not the application has requested tearing.
 
-	Use the *ToggleTearing* action for forcefully enable tearing.
+	*always* enable tearing for all windows by default, ignoring application
+	requests. The ToggleTearing action may be used to disable tearing.
+
+	Use the *ToggleTearing* action to forcefully enable / disable tearing
+	for the active window. Has no effect when allowTearing is set to no.
 
 	Note: Enabling this option with atomic mode setting is experimental. If
 	you experience undesirable side effects when tearing is allowed,

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -36,6 +36,7 @@ enum tearing_mode {
 	LAB_TEARING_ENABLED,
 	LAB_TEARING_FULLSCREEN,
 	LAB_TEARING_FULLSCREEN_FORCED,
+	LAB_TEARING_ALWAYS,
 };
 
 enum tiling_events_mode {

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -108,9 +108,14 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 	}
 
 	if (state->tearing_page_flip) {
+		wlr_log(WLR_ERROR, "tearing enabled");
 		if (!wlr_output_test_state(wlr_output, state)) {
+			wlr_log(WLR_ERROR,
+				"tearing output test failed, reverting for current frame");
 			state->tearing_page_flip = false;
 		}
+	} else {
+		wlr_log(WLR_ERROR, "tearing disabled");
 	}
 
 	struct wlr_box additional_damage = {0};
@@ -124,6 +129,7 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 	 * but actual commit failed. Retry wihout tearing.
 	 */
 	if (!committed && state->tearing_page_flip) {
+		wlr_log(WLR_ERROR, "tearing output commit failed, trying again without");
 		state->tearing_page_flip = false;
 		committed = wlr_output_commit_state(wlr_output, state);
 	}

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -954,6 +954,8 @@ set_tearing_mode(const char *str, enum tearing_mode *variable)
 		*variable = LAB_TEARING_FULLSCREEN;
 	} else if (!strcasecmp(str, "fullscreenForced")) {
 		*variable = LAB_TEARING_FULLSCREEN_FORCED;
+	} else if (!strcasecmp(str, "always")) {
+		*variable = LAB_TEARING_ALWAYS;
 	} else if (parse_bool(str, -1) == 1) {
 		*variable = LAB_TEARING_ENABLED;
 	} else {
@@ -1447,7 +1449,7 @@ rcxml_init(void)
 
 	rc.gap = 0;
 	rc.adaptive_sync = LAB_ADAPTIVE_SYNC_DISABLED;
-	rc.allow_tearing = false;
+	rc.allow_tearing = LAB_TEARING_DISABLED;
 	rc.reuse_output_mode = false;
 	rc.xwayland_persistence = false;
 

--- a/src/output.c
+++ b/src/output.c
@@ -50,7 +50,7 @@ output_get_tearing_allowance(struct output *output)
 	}
 
 	/* allow tearing for any window when requested or forced */
-	if (rc.allow_tearing == LAB_TEARING_ENABLED) {
+	if (rc.allow_tearing == LAB_TEARING_ENABLED || rc.allow_tearing == LAB_TEARING_ALWAYS) {
 		if (view->force_tearing == LAB_STATE_UNSPECIFIED) {
 			return view->tearing_hint;
 		} else {

--- a/src/view.c
+++ b/src/view.c
@@ -2474,10 +2474,6 @@ view_init(struct view *view)
 	wl_signal_init(&view->events.minimized);
 	wl_signal_init(&view->events.fullscreened);
 	wl_signal_init(&view->events.activated);
-
-	if (rc.allow_tearing == LAB_TEARING_ALWAYS) {
-		view->force_tearing = LAB_STATE_ENABLED;
-	}
 }
 
 void

--- a/src/view.c
+++ b/src/view.c
@@ -2474,6 +2474,10 @@ view_init(struct view *view)
 	wl_signal_init(&view->events.minimized);
 	wl_signal_init(&view->events.fullscreened);
 	wl_signal_init(&view->events.activated);
+
+	if (rc.allow_tearing == LAB_TEARING_ALWAYS) {
+		view->force_tearing = LAB_STATE_ENABLED;
+	}
 }
 
 void


### PR DESCRIPTION
Closes
- #2272