### PR TITLE
theme: allow negative values for menu overlap

### DIFF
--- a/src/theme.c
+++ b/src/theme.c
@@ -851,12 +851,10 @@ entry(struct theme *theme, const char *key, const char *value)
 	}
 
 	if (match_glob(key, "menu.overlap.x")) {
-		theme->menu_overlap_x = get_int_if_positive(
-			value, "menu.overlap.x");
+		theme->menu_overlap_x = atoi(value);
 	}
 	if (match_glob(key, "menu.overlap.y")) {
-		theme->menu_overlap_y = get_int_if_positive(
-			value, "menu.overlap.y");
+		theme->menu_overlap_y = atoi(value);
 	}
 	if (match_glob(key, "menu.width.min")) {
 		theme->menu_min_width = get_int_if_positive(


### PR DESCRIPTION
This fixes a regression introduced with:
https://github.com/labwc/labwc/commit/dcd9b47e5b584a2559d41cd255bb043f11970d12

A weak moment, missed that those can be negative while adding the checks ;)

Fixes #2294