### PR TITLE
scaled-scene-buffer: implement buffer sharing mechanism

### DIFF
--- a/include/common/list.h
+++ b/include/common/list.h
@@ -20,4 +20,13 @@ wl_list_append(struct wl_list *list, struct wl_list *elm)
 	wl_list_insert(list->prev, elm);
 }
 
+/**
+ * WL_LIST_INIT() - initialize a list when defining it
+ * @head: pointer to the head of the list to be initialized
+ *
+ * For example, this can be used like this:
+ * static struct wl_list list = WL_LIST_INIT(&list);
+ */
+#define WL_LIST_INIT(head) {.prev = (head), .next = (head)}
+
 #endif /* LABWC_LIST_H */

--- a/src/common/scaled-font-buffer.c
+++ b/src/common/scaled-font-buffer.c
@@ -53,8 +53,8 @@ scaled_font_buffer_create(struct wlr_scene_tree *parent)
 {
 	assert(parent);
 	struct scaled_font_buffer *self = znew(*self);
-	struct scaled_scene_buffer *scaled_buffer =
-		scaled_scene_buffer_create(parent, &impl, /* drop_buffer */ true);
+	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
+		parent, &impl, NULL, /* drop_buffer */ true);
 	if (!scaled_buffer) {
 		free(self);
 		return NULL;

--- a/src/common/scaled-scene-buffer.c
+++ b/src/common/scaled-scene-buffer.c
@@ -41,10 +41,10 @@ _cache_entry_destroy(struct scaled_scene_buffer_cache_entry *cache_entry, bool d
 	wl_list_remove(&cache_entry->link);
 	if (cache_entry->buffer) {
 		/* Allow the buffer to get dropped if there are no further consumers */
-		wlr_buffer_unlock(cache_entry->buffer);
-		if (drop_buffer) {
+		if (drop_buffer && !cache_entry->buffer->dropped) {
 			wlr_buffer_drop(cache_entry->buffer);
 		}
+		wlr_buffer_unlock(cache_entry->buffer);
 	}
 	free(cache_entry);
 }
@@ -82,10 +82,10 @@ _update_buffer(struct scaled_scene_buffer *self, double scale)
 		cache_entry = wl_container_of(self->cache.prev, cache_entry, link);
 		if (cache_entry->buffer) {
 			/* Allow the old buffer to get dropped if there are no further consumers */
-			wlr_buffer_unlock(cache_entry->buffer);
-			if (self->drop_buffer) {
+			if (self->drop_buffer && !cache_entry->buffer->dropped) {
 				wlr_buffer_drop(cache_entry->buffer);
 			}
+			wlr_buffer_unlock(cache_entry->buffer);
 		}
 		wl_list_remove(&cache_entry->link);
 	}


### PR DESCRIPTION
Suggested in #2352, combined with @Consolatis's work.

This PR adds `equal()` API in scaled-scene-buffer which can be used to share buffers for visually duplicated elements (e.g. scaled-font-buffer with the same text, font color and size). This PR itself isn't much beneficial as most `scaled-font-buffer`s are not duplicated, but this will greatly reduce the increased memory usage in #2352 as `scaled-rect-buffer`s used for backgrounds of menu and menu items will be visually the same.