### PR TITLE
Fix rare, intermittent dnd crash

### DIFF
--- a/src/dnd.c
+++ b/src/dnd.c
@@ -21,6 +21,7 @@ handle_drag_request(struct wl_listener *listener, void *data)
 			event->serial);
 	} else {
 		wlr_data_source_destroy(event->drag->source);
+		event->drag->source = NULL;
 		wlr_log(WLR_ERROR, "wrong source for drag request");
 	}
 }


### PR DESCRIPTION
Set source to NULL to avoid passing null to wl_signal_emit_mutable() in wlr_data_source_destroy()

Ref:
- https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/types/data_device/wlr_data_source.c#L38
- https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/types/data_device/wlr_data_device.c?ref_type=heads#L194

Fixes #2287 #2371