### PR TITLE
menu: support borders

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -60,10 +60,10 @@ labwc-config(5).
 	Default is 0.
 
 *window.active.border.color*
-	Border color of active window. Default is #e1dedb.
+	Border color of active window. Default is #aaaaaa.
 
 *window.inactive.border.color*
-	Border color of inactive window. Default is #f6f5f4.
+	Border color of inactive window. Default is #aaaaaa.
 
 *window.active.indicator.toggled-keybind.color*
 	Status indicator for the ToggleKeybinds action. Can be set to the same

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -166,6 +166,12 @@ all are supported.
 	A fixed width can be achieved by setting .min and .max to the same
 	value.
 
+*menu.border.width*
+	Border width of menus in pixels. Inherits *border.width* if not set.
+
+*menu.border.color*
+	Border color of menus. Inherits *window.active.border.color* if not set.
+
 *menu.items.padding.x*
 	Horizontal padding of menu text entries in pixels.
 	Default is 7.

--- a/docs/themerc
+++ b/docs/themerc
@@ -16,8 +16,8 @@ window.titlebar.padding.width: 0
 window.titlebar.padding.height: 0
 
 # window border
-window.active.border.color: #e1dedb
-window.inactive.border.color: #f6f5f4
+window.active.border.color: #aaaaaa
+window.inactive.border.color: #aaaaaa
 
 # ToggleKeybinds status indicator
 window.active.indicator.toggled-keybind.color: #ff0000

--- a/docs/themerc
+++ b/docs/themerc
@@ -59,6 +59,8 @@ menu.overlap.x: 0
 menu.overlap.y: 0
 menu.width.min: 20
 menu.width.max: 200
+menu.border.width: 1
+menu.border.color: #aaaaaa
 menu.items.bg.color: #fcfbfa
 menu.items.text.color: #000000
 menu.items.active.bg.color: #e1dedb

--- a/include/common/scaled-rect-buffer.h
+++ b/include/common/scaled-rect-buffer.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_SCALED_RECT_BUFFER_H
+#define LABWC_SCALED_RECT_BUFFER_H
+
+#include <stdint.h>
+
+struct wlr_scene_tree;
+struct wlr_scene_buffer;
+struct scaled_scene_buffer;
+
+struct scaled_rect_buffer {
+	struct wlr_scene_buffer *scene_buffer;
+	struct scaled_scene_buffer *scaled_buffer;
+	int width;
+	int height;
+	int border_width;
+	float fill_color[4];
+	float border_color[4];
+};
+
+/*
+ * Create an auto scaling borderd-rectangle buffer, providing a wlr_scene_buffer
+ * node for display. It gets destroyed automatically when the backing
+ * scaled_scene_buffer is being destroyed which in turn happens automatically
+ * when the backing wlr_scene_buffer (or one of its parents) is being destroyed.
+ */
+struct scaled_rect_buffer *scaled_rect_buffer_create(
+	struct wlr_scene_tree *parent, int width, int height, int border_width,
+	float fill_color[4], float border_color[4]);
+
+#endif /* LABWC_SCALED_RECT_BUFFER_H */

--- a/include/theme.h
+++ b/include/theme.h
@@ -101,6 +101,8 @@ struct theme {
 	int menu_overlap_y;
 	int menu_min_width;
 	int menu_max_width;
+	int menu_border_width;
+	float menu_border_color[4];
 
 	int menu_items_padding_x;
 	int menu_items_padding_y;

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -14,6 +14,7 @@ labwc_sources += files(
   'parse-bool.c',
   'parse-double.c',
   'scaled-font-buffer.c',
+  'scaled-rect-buffer.c',
   'scaled-scene-buffer.c',
   'scene-helpers.c',
   'set.c',

--- a/src/common/scaled-rect-buffer.c
+++ b/src/common/scaled-rect-buffer.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wayland-server-core.h>
+#include <wlr/util/log.h>
+#include "buffer.h"
+#include "common/graphic-helpers.h"
+#include "common/list.h"
+#include "common/macros.h"
+#include "common/mem.h"
+#include "common/scaled-scene-buffer.h"
+#include "common/scaled-rect-buffer.h"
+
+static struct wl_list cached_buffers = WL_LIST_INIT(&cached_buffers);
+
+static void
+draw_rectangle_path(cairo_t *cairo, int width, int height, int border_width)
+{
+	double offset = border_width / 2.0;
+	double right_x = width - offset;
+	double bottom_y = height - offset;
+
+	cairo_move_to(cairo, offset, offset);
+	cairo_line_to(cairo, right_x, offset);
+	cairo_line_to(cairo, right_x, bottom_y);
+	cairo_line_to(cairo, offset, bottom_y);
+	cairo_close_path(cairo);
+}
+
+static struct lab_data_buffer *
+_create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
+{
+	struct scaled_rect_buffer *self = scaled_buffer->data;
+	struct lab_data_buffer *buffer = buffer_create_cairo(
+		self->width, self->height, scale);
+	if (!buffer) {
+		return NULL;
+	}
+
+	cairo_t *cairo = buffer->cairo;
+
+	/* Clear background */
+	cairo_set_operator(cairo, CAIRO_OPERATOR_CLEAR);
+	cairo_paint(cairo);
+	cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
+
+	/* Fill rectangle */
+	draw_rectangle_path(cairo, self->width, self->height, 0);
+	set_cairo_color(cairo, self->fill_color);
+	cairo_fill(cairo);
+
+	/* Draw borders */
+	draw_rectangle_path(cairo, self->width, self->height,
+		self->border_width);
+	cairo_set_line_width(cairo, self->border_width);
+	set_cairo_color(cairo, self->border_color);
+	cairo_stroke(cairo);
+
+	return buffer;
+}
+
+static void
+_destroy(struct scaled_scene_buffer *scaled_buffer)
+{
+	struct scaled_rect_buffer *self = scaled_buffer->data;
+	scaled_buffer->data = NULL;
+	free(self);
+}
+
+static bool
+_equal(struct scaled_scene_buffer *scaled_buffer_a, struct scaled_scene_buffer *scaled_buffer_b)
+{
+	struct scaled_rect_buffer *a = scaled_buffer_a->data;
+	struct scaled_rect_buffer *b = scaled_buffer_b->data;
+
+	return a->width == b->width
+		&& a->height == b->height
+		&& a->border_width == b->border_width
+		&& !memcmp(a->fill_color, b->fill_color, sizeof(a->fill_color))
+		&& !memcmp(a->border_color, b->border_color, sizeof(a->border_color));
+}
+
+static const struct scaled_scene_buffer_impl impl = {
+	.create_buffer = _create_buffer,
+	.destroy = _destroy,
+	.equal = _equal,
+};
+
+struct scaled_rect_buffer *scaled_rect_buffer_create(
+	struct wlr_scene_tree *parent, int width, int height, int border_width,
+	float fill_color[4], float border_color[4])
+{
+	/* TODO: support rounded corners for menus and OSDs */
+
+	assert(parent);
+	struct scaled_rect_buffer *self = znew(*self);
+	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
+		parent, &impl, &cached_buffers, /* drop_buffer */ true);
+	scaled_buffer->data = self;
+	self->scaled_buffer = scaled_buffer;
+	self->scene_buffer = scaled_buffer->scene_buffer;
+	self->width = MAX(width, 1);
+	self->height = MAX(height, 1);
+	self->border_width = border_width;
+	memcpy(self->fill_color, fill_color, sizeof(self->fill_color));
+	memcpy(self->border_color, border_color, sizeof(self->border_color));
+
+	scaled_scene_buffer_invalidate_cache(scaled_buffer);
+
+	return self;
+}

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -819,7 +819,9 @@ parse_xml(const char *filename, struct server *server)
 static int
 menu_get_full_width(struct menu *menu)
 {
-	int width = menu->size.width - menu->server->theme->menu_overlap_x;
+	struct theme *theme = menu->server->theme;
+	int width = menu->size.width - theme->menu_overlap_x
+		- theme->menu_border_width;
 	int child_width;
 	int max_child_width = 0;
 	struct menuitem *item;
@@ -849,9 +851,11 @@ get_submenu_position(struct menuitem *item, enum menu_align align)
 	pos.y = menu->scene_tree->node.y;
 
 	if (align & LAB_MENU_OPEN_RIGHT) {
-		pos.x += menu->size.width - theme->menu_overlap_x;
+		pos.x += menu->size.width - theme->menu_overlap_x
+			- theme->menu_border_width;
 	}
-	pos.y += item->tree->node.y - theme->menu_overlap_y;
+	pos.y += item->tree->node.y - theme->menu_overlap_y
+		- theme->menu_border_width;
 	return pos;
 }
 
@@ -894,7 +898,7 @@ menu_configure(struct menu *menu, int lx, int ly, enum menu_align align)
 	}
 
 	if (align & LAB_MENU_OPEN_LEFT) {
-		lx -= menu->size.width - theme->menu_overlap_x;
+		lx -= menu->size.width - theme->menu_overlap_x - theme->menu_border_width;
 	}
 	if (align & LAB_MENU_OPEN_TOP) {
 		ly -= menu->size.height;

--- a/src/theme.c
+++ b/src/theme.c
@@ -597,6 +597,8 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->menu_overlap_y = 0;
 	theme->menu_min_width = 20;
 	theme->menu_max_width = 200;
+	theme->menu_border_width = INT_MIN;
+	theme->menu_border_color[0] = FLT_MIN;
 
 	theme->menu_items_padding_x = 7;
 	theme->menu_items_padding_y = 4;
@@ -863,6 +865,13 @@ entry(struct theme *theme, const char *key, const char *value)
 	if (match_glob(key, "menu.width.max")) {
 		theme->menu_max_width = get_int_if_positive(
 			value, "menu.width.max");
+	}
+	if (match_glob(key, "menu.border.width")) {
+		theme->menu_border_width = get_int_if_positive(
+			value, "menu.border.width");
+	}
+	if (match_glob(key, "menu.border.color")) {
+		parse_hexstr(value, theme->menu_border_color);
 	}
 
 	if (match_glob(key, "menu.items.padding.x")) {
@@ -1448,7 +1457,8 @@ post_processing(struct theme *theme)
 		+ 2 * theme->menu_items_padding_y;
 
 	theme->menu_header_height = font_height(&rc.font_menuheader)
-		+ 2 * theme->menu_items_padding_y;
+		+ 2 * theme->menu_items_padding_y
+		+ 2 * theme->menu_border_width;
 
 	theme->osd_window_switcher_item_height = font_height(&rc.font_osd)
 		+ 2 * theme->osd_window_switcher_item_padding_y
@@ -1469,6 +1479,15 @@ post_processing(struct theme *theme)
 			"Adjusting menu.width.max: .max (%d) lower than .min (%d)",
 			theme->menu_max_width, theme->menu_min_width);
 		theme->menu_max_width = theme->menu_min_width;
+	}
+
+	if (theme->menu_border_width == INT_MIN) {
+		theme->menu_border_width = theme->border_width;
+	}
+	if (theme->menu_border_color[0] == FLT_MIN) {
+		memcpy(theme->menu_border_color,
+			theme->window[THEME_ACTIVE].border_color,
+			sizeof(theme->menu_border_color));
 	}
 
 	/* Inherit OSD settings if not set */

--- a/src/theme.c
+++ b/src/theme.c
@@ -563,8 +563,8 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->window_titlebar_padding_height = 0;
 	theme->window_titlebar_padding_width = 0;
 
-	parse_hexstr("#e1dedb", theme->window[THEME_ACTIVE].border_color);
-	parse_hexstr("#f6f5f4", theme->window[THEME_INACTIVE].border_color);
+	parse_hexstr("#aaaaaa", theme->window[THEME_ACTIVE].border_color);
+	parse_hexstr("#aaaaaa", theme->window[THEME_INACTIVE].border_color);
 
 	parse_hexstr("#ff0000", theme->window_toggled_keybinds_color);
 


### PR DESCRIPTION
Since #2352 is so large and contains many things to discuss (e.g. default values of new theme configs), I decided to create another PR that only adds support for menu borders.

This PR adds following theme configurations:
```
menu.border.width: 1
menu.border.color: #a8a5a2
```

Currently, `menu.border.width` inherits `border.width` and `menu.border.color` inherits `window.active.border.color` just like Openbox does. However, as I explained in https://github.com/labwc/labwc/pull/2352#issuecomment-2478479590, the default value of `window.active.border.color` is the same as that of `window.active.title.bg.color` and `menu.items.active.bg.color`, so menu borders can be invisible with the default configuration like this:

<img src="https://github.com/user-attachments/assets/1f9bc726-9ce3-4ad5-b76d-a6284ad7710c" />

So, I'm thinking of setting the default value of `menu.border.color` to another constant value (for example, I set it to `#a8a5a2` in #2352). Another option is to make it inherit `menu.items.text.color` (black by default), which is similar to what we're doing for `osd.border.color`:

https://github.com/labwc/labwc/blob/c2928027becba26f058b544d4bd8c72895c8d7cf/src/theme.c#L1488-L1501

@johanmalm @Consolatis Do you have any ideas on this?