### PR TITLE
keyboard: optionally send release-events

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -1055,6 +1055,18 @@ situation.
 	can be caused by *<margin>* settings or exclusive layer-shell clients
 	such as panels.
 
+*<windowRules><windowRule wantAbsorbedModifierReleaseEvents="">* [yes|no|default]
+	*wantAbsorbedModifierReleaseEvents* allows clients to receive modifier
+	release events even if they are part of keybinds. Most clients should
+	not receive these, but some (for example blender) need it in some
+	situations.
+
+```
+<windowRules>
+  <windowRule identifier="blender" wantAbsorbedModifierReleaseEvents="yes"/>
+</windowRules>
+```
+
 ## MENU
 
 ```

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -38,6 +38,7 @@ struct window_rule {
 	enum property ignore_focus_request;
 	enum property ignore_configure_request;
 	enum property fixed_position;
+	enum property want_absorbed_modifier_release_events;
 
 	struct wl_list link; /* struct rcxml.window_rules */
 };

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -354,6 +354,8 @@ fill_window_rule(char *nodename, char *content)
 		set_property(content, &current_window_rule->ignore_configure_request);
 	} else if (!strcasecmp(nodename, "fixedPosition")) {
 		set_property(content, &current_window_rule->fixed_position);
+	} else if (!strcasecmp(nodename, "wantAbsorbedModifierReleaseEvents")) {
+		set_property(content, &current_window_rule->want_absorbed_modifier_release_events);
 
 	/* Actions */
 	} else if (!strcmp(nodename, "name.action")) {

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -108,6 +108,11 @@ window_rules_get_property(struct view *view, const char *property)
 					&& !strcasecmp(property, "fixedPosition")) {
 				return rule->fixed_position;
 			}
+			if (rule->want_absorbed_modifier_release_events
+					&& !strcasecmp(property,
+					"wantAbsorbedModifierReleaseEvents")) {
+				return rule->want_absorbed_modifier_release_events;
+			}
 		}
 	}
 	return LAB_PROP_UNSPECIFIED;


### PR DESCRIPTION
...for modifiers which are part of keybinds. This supports clients (for example blender) that want to see the modifier-release-event even if it was part of a keybinds. This is treated as a special case and can only be achieved by configuration.

Most clients (including those using Qt and GTK) are setup to not see these modifier release events - and actually misbehave if they do.  For example Firefox shows the menu bar if alt is pressed and then released, whereas if only pressed (because the release is absorbed) nothing happens. So, if Firefox saw bound modifier-release-events it would show the menu bar every time the window-switcher is used with alt-tab.

Issue #1507

Cc @charbelnicolas 

Testing appreciated.

TODO

- [x] Testing
- [x] Config options
- [x] Documentation
- [x] Consider making this app_id specific in the configuration (e.g. window-rule)

