### PR TITLE
output: fix assert() fail when enabling an output that was disabled

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -1048,8 +1048,6 @@ handle_output_power_manager_set_mode(struct wl_listener *listener, void *data)
 void
 output_enable_adaptive_sync(struct output *output, bool enabled)
 {
-	assert(output_is_usable(output));
-
 	wlr_output_state_set_adaptive_sync_enabled(&output->pending, enabled);
 	if (!wlr_output_test_state(output->wlr_output, &output->pending)) {
 		wlr_output_state_set_adaptive_sync_enabled(&output->pending, false);


### PR DESCRIPTION
When the output is in the process of being enabled, but the new state has not been committed yet, wlr_output->enabled is still false. So it's not safe to assert that it's true in output_enable_adaptive_sync().

Fixes: 36e099fc93b3caf87e7f390a732fcec69373de8c
"view: ensure output is usable before setting adaptive sync"