### PR TITLE
menu: invert the y-offset of submenus applied by menu.overlap.y

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -854,7 +854,7 @@ get_submenu_position(struct menuitem *item, enum menu_align align)
 		pos.x += menu->size.width - theme->menu_overlap_x
 			- theme->menu_border_width;
 	}
-	pos.y += item->tree->node.y - theme->menu_overlap_y
+	pos.y += item->tree->node.y + theme->menu_overlap_y
 		- theme->menu_border_width;
 	return pos;
 }


### PR DESCRIPTION
In Openbox, `menu.overlap.y: 3` is applied like:

![20241126_06h02m59s_grim](https://github.com/user-attachments/assets/d38b833c-89d5-4a58-896e-71a53b59811f)

However, in the current labwc, the y-offset is inverted like:

![20241126_06h03m49s_grim](https://github.com/user-attachments/assets/e2a7c4cf-bce5-4280-bfa2-18974b99b4cb)

This PR fixes it to follow Openbox's behavior.