### PR TITLE
menu: don't include menu.border.width for menu title height

### DIFF
--- a/src/theme.c
+++ b/src/theme.c
@@ -1457,8 +1457,7 @@ post_processing(struct theme *theme)
 		+ 2 * theme->menu_items_padding_y;
 
 	theme->menu_header_height = font_height(&rc.font_menuheader)
-		+ 2 * theme->menu_items_padding_y
-		+ 2 * theme->menu_border_width;
+		+ 2 * theme->menu_items_padding_y;
 
 	theme->osd_window_switcher_item_height = font_height(&rc.font_osd)
 		+ 2 * theme->osd_window_switcher_item_padding_y


### PR DESCRIPTION
It was a cruft from my experiment of adding borders around titles.

It even caused an integer overflow because `theme->menu_border_width` can be `INT_MIN` when `menu_header_height` is calculated. This didn't cause sigfault, however, because `INT_MIN * 2` becomes 0.