### PR TITLE
Ci: reduce timeout to 10 minutes and add b_sanitize=address,undefined to detect leaks in the runtime test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,8 +166,6 @@ jobs:
             meson compile -C build-gcc-static_analyzer
           ' | $TARGET
 
-
-      # Runtime tests, these run on Debian and Void only (the later due to libmusl being used)
       - name: Build with clang - release
         run: |
           echo '
@@ -177,6 +175,8 @@ jobs:
               -Dbuildtype=release -Db_ndebug=true --werror
             meson compile -C build-clang-release
           ' | $TARGET
+
+      # Runtime tests, these run on Debian and Void only (the later due to libmusl being used)
 
       - name: Build with gcc - runtime test
         if: matrix.name == 'Debian'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     needs: codestyle
-    timeout-minutes: 20
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         name: [
           Arch,
-#          Debian,
+          Debian,
           FreeBSD,
           Void-musl
         ]
@@ -40,11 +40,11 @@ jobs:
             env:
               TARGET: 'sh -xe'
 
-#          - name: Debian
-#            os: ubuntu-latest
-#            container: debian:testing
-#            env:
-#              TARGET: 'sh -xe'
+          - name: Debian
+            os: ubuntu-latest
+            container: debian:testing
+            env:
+              TARGET: 'sh -xe'
 
           - name: FreeBSD
             os: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
           apt-get upgrade -y
           apt-get install -y git gcc clang gdb xwayland
           apt-get build-dep -y labwc
-          apt-get install libwlroots-0.18-dev
+          apt-get build-dep -y libwlroots-dev
 
       - name: Install FreeBSD dependencies
         if: matrix.name == 'FreeBSD'
@@ -153,6 +153,7 @@ jobs:
             export CC=gcc
             meson setup build-gcc-release -Dxwayland=enabled \
               -Dbuildtype=release -Db_ndebug=true --werror
+            meson configure build-gcc-release -Dwlroots:b_ndebug=false || true
             meson compile -C build-gcc-release
           ' | $TARGET
 
@@ -173,6 +174,7 @@ jobs:
             export CC=clang
             meson setup build-clang-release -Dxwayland=enabled \
               -Dbuildtype=release -Db_ndebug=true --werror
+            meson configure build-clang-release -Dwlroots:b_ndebug=false || true
             meson compile -C build-clang-release
           ' | $TARGET
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm git meson clang wlroots libdrm libinput \
             wayland-protocols cairo pango libxml2 xorg-xwayland librsvg \
-            libdisplay-info gdb ttf-dejavu
+            libdisplay-info gdb ttf-dejavu foot
 
       - name: Install Debian Testing dependencies
         if: matrix.name == 'Debian'
@@ -107,7 +107,7 @@ jobs:
           xbps-install -y git meson gcc clang pkg-config scdoc \
             cairo-devel glib-devel libpng-devel librsvg-devel libxml2-devel \
             pango-devel wlroots0.18-devel gdb bash xorg-server-xwayland \
-            dejavu-fonts-ttf libsfdo-devel
+            dejavu-fonts-ttf libsfdo-devel foot
 
       # These build are executed on all runners
       - name: Build with gcc
@@ -235,5 +235,5 @@ jobs:
             export CC=gcc
             meson setup build-gcc-gdb -Dxwayland=enabled --werror
             meson compile -C build-gcc-gdb
-            LABWC_RUNS=20 scripts/ci/smoke-test.sh build-gcc-gdb
+            LABWC_RUNS=2 scripts/ci/smoke-test.sh build-gcc-gdb
           ' | $TARGET

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,9 +186,9 @@ jobs:
           echo '
             cd "$GITHUB_WORKSPACE"
             export CC=gcc
-            meson setup build-gcc-ci -Dxwayland=enabled -Db_sanitize=undefined --werror
-            meson compile -C build-gcc-ci
-            scripts/ci/smoke-test.sh build-gcc-ci
+            meson setup build-gcc-gdb -Dxwayland=enabled -Db_sanitize=undefined --werror
+            meson compile -C build-gcc-gdb
+            scripts/ci/smoke-test.sh build-gcc-gdb
           ' | $TARGET
 
       - name: Build with clang - runtime test
@@ -197,9 +197,31 @@ jobs:
           echo '
             cd "$GITHUB_WORKSPACE"
             export CC=clang
-            meson setup build-clang-ci -Dxwayland=enabled -Db_sanitize=undefined --werror
-            meson compile -C build-clang-ci
-            scripts/ci/smoke-test.sh build-clang-ci
+            meson setup build-clang-gdb -Dxwayland=enabled -Db_sanitize=undefined --werror
+            meson compile -C build-clang-gdb
+            scripts/ci/smoke-test.sh build-clang-gdb
+          ' | $TARGET
+
+      - name: Build with gcc - runtime leak test
+        if: matrix.name == 'Debian'
+        run: |
+          echo '
+            cd "$GITHUB_WORKSPACE"
+            export CC=gcc
+            meson setup build-gcc-leak -Dxwayland=enabled -Db_sanitize=address,undefined --werror
+            meson compile -C build-gcc-leak
+            LABWC_LEAK_TEST=1 scripts/ci/smoke-test.sh build-gcc-leak
+          ' | $TARGET
+
+      - name: Build with clang - runtime leak test
+        if: matrix.name == 'Debian'
+        run: |
+          echo '
+            cd "$GITHUB_WORKSPACE"
+            export CC=clang
+            meson setup build-clang-leak -Dxwayland=enabled -Db_sanitize=address,undefined --werror
+            meson compile -C build-clang-leak
+            LABWC_LEAK_TEST=1 scripts/ci/smoke-test.sh build-clang-leak
           ' | $TARGET
 
       # Void-musl doesn't support sanitizer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm git meson clang wlroots libdrm libinput \
             wayland-protocols cairo pango libxml2 xorg-xwayland librsvg \
-            libdisplay-info
+            libdisplay-info gdb ttf-dejavu
 
       - name: Install Debian Testing dependencies
         if: matrix.name == 'Debian'
@@ -178,10 +178,10 @@ jobs:
             meson compile -C build-clang-release
           ' | $TARGET
 
-      # Runtime tests, these run on Debian and Void only (the later due to libmusl being used)
+      # Runtime tests, these run on Arch and Void only (the later due to libmusl being used)
 
       - name: Build with gcc - runtime test
-        if: matrix.name == 'Debian'
+        if: matrix.name == 'Arch'
         run: |
           echo '
             cd "$GITHUB_WORKSPACE"
@@ -192,7 +192,7 @@ jobs:
           ' | $TARGET
 
       - name: Build with clang - runtime test
-        if: matrix.name == 'Debian'
+        if: matrix.name == 'Arch'
         run: |
           echo '
             cd "$GITHUB_WORKSPACE"
@@ -203,23 +203,25 @@ jobs:
           ' | $TARGET
 
       - name: Build with gcc - runtime leak test
-        if: matrix.name == 'Debian'
+        if: matrix.name == 'Arch'
         run: |
           echo '
             cd "$GITHUB_WORKSPACE"
             export CC=gcc
-            meson setup build-gcc-leak -Dxwayland=enabled -Db_sanitize=address,undefined --werror
+            meson setup build-gcc-leak -Dxwayland=enabled -Db_sanitize=address,undefined \
+              --werror --force-fallback-for=wlroots
             meson compile -C build-gcc-leak
             LABWC_LEAK_TEST=1 scripts/ci/smoke-test.sh build-gcc-leak
           ' | $TARGET
 
       - name: Build with clang - runtime leak test
-        if: matrix.name == 'Debian'
+        if: matrix.name == 'Arch'
         run: |
           echo '
             cd "$GITHUB_WORKSPACE"
             export CC=clang
-            meson setup build-clang-leak -Dxwayland=enabled -Db_sanitize=address,undefined --werror
+            meson setup build-clang-leak -Dxwayland=enabled -Db_sanitize=address,undefined \
+              --werror --force-fallback-for=wlroots
             meson compile -C build-clang-leak
             LABWC_LEAK_TEST=1 scripts/ci/smoke-test.sh build-clang-leak
           ' | $TARGET
@@ -231,7 +233,7 @@ jobs:
           echo '
             cd "$GITHUB_WORKSPACE"
             export CC=gcc
-            meson setup build-gcc-ci -Dxwayland=enabled --werror
-            meson compile -C build-gcc-ci
-            LABWC_RUNS=20 scripts/ci/smoke-test.sh build-gcc-ci
+            meson setup build-gcc-gdb -Dxwayland=enabled --werror
+            meson compile -C build-gcc-gdb
+            LABWC_RUNS=20 scripts/ci/smoke-test.sh build-gcc-gdb
           ' | $TARGET

--- a/scripts/asan_leak_suppressions
+++ b/scripts/asan_leak_suppressions
@@ -1,0 +1,1 @@
+leak:libfontconfig.so

--- a/scripts/ci/ci_autostart.sh
+++ b/scripts/ci/ci_autostart.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+exec 1>&2
 
 if test -z "$LABWC_PID"; then
 	echo "LABWC_PID not set" >&2
@@ -7,7 +8,10 @@ fi
 
 echo "Running with pid $LABWC_PID"
 
-# Could add runtime tests here
+# Runtime tests
+echo "Executing foot"
+foot sh -c 'sleep 1; exit'
+echo "Foot exited with $?"
 
-echo "killing labwc"
+echo "Killing labwc"
 kill -s TERM $LABWC_PID

--- a/scripts/ci/smoke-test.sh
+++ b/scripts/ci/smoke-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 : ${LABWC_RUNS:=1}
+: ${LABWC_LEAK_TEST:=0}
 
 if ! test -x "$1/labwc"; then
 	echo "$1/labwc not found"
@@ -43,6 +44,11 @@ gdb_run() {
 }
 
 echo "Running with LABWC_RUNS=$LABWC_RUNS"
+
+if test "$LABWC_LEAK_TEST" != "0"; then
+	LSAN_OPTIONS=suppressions=scripts/asan_leak_suppressions "${args[@]}"
+	exit $?
+fi
 
 ret=0
 for((i=1; i<=LABWC_RUNS; i++)); do


### PR DESCRIPTION
Since GitHub runners now support hardware virtualization, the maximal runtime of the FreeBSD runner is somewhere around 3 to 6 minutes. It may still fail sometimes so keep the timeout parameter around.

Also re-enable the Debian build job (by compiling the wlroots subproject) and add the address sanitizer to the Debian smoke-test now that we should be leak free on shutdown.