### PR TITLE
graphic-helpers: fix segfault when medium-size icon file is loaded

### DIFF
--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -125,8 +125,8 @@ get_cairo_surface_from_lab_data_buffer(struct lab_data_buffer *buffer)
 	}
 
 	/* Handle DRM_FORMAT_ARGB8888 buffers */
-	int w = buffer->logical_width;
-	int h = buffer->logical_height;
+	int w = buffer->base.width;
+	int h = buffer->base.height;
 	cairo_surface_t *surface =
 		cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
 	if (!surface) {


### PR DESCRIPTION
`lab_data_buffer->logical_{width,height}` are not the actual size of the backing buffer, so `wlr_buffer.{width,height}` should be used when duplicating it in `get_cairo_surface_from_lab_data_buffer()`.

This mistake caused segfault when an icon file 1~2 times larger than `window.button.{width,height}` is loaded, because the buffer for the raw icon file is reused by setting `lab_data_buffer->logical_{width,height}` with the size for display which is different from `wlr_buffer.{width,height}` (see `buffer_convert_cairo_surface_for_icon()`), and it is duplicated with `get_cairo_surface_from_lab_data_buffer()` for hovered/rounded variants of titlebar button.