### PR TITLE
Update for wlroots 0.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           apt-get upgrade -y
           apt-get install -y git gcc clang gdb xwayland
           apt-get build-dep -y labwc
-          #apt-get build-dep -y libwlroots-0.18-dev
+          apt-get build-dep -y libwlroots-0.18-dev
 
       - name: Install FreeBSD dependencies
         if: matrix.name == 'FreeBSD'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
           xbps-install -Syu
           xbps-install -y git meson gcc clang pkg-config scdoc \
             cairo-devel glib-devel libpng-devel librsvg-devel libxml2-devel \
-            pango-devel wlroots0.18-devel gdb bash xorg-server-xwayland \
+            pango-devel wlroots0.19-devel gdb bash xorg-server-xwayland \
             dejavu-fonts-ttf libsfdo-devel foot
 
       # These builds are executed on all runners

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -21,7 +21,6 @@
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_keyboard_group.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
-#include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_output_power_management_v1.h>

--- a/include/view.h
+++ b/include/view.h
@@ -140,7 +140,7 @@ struct view_impl {
 	 * minimizing we don't destroy the foreign toplevel handle).
 	 */
 	void (*unmap)(struct view *view, bool client_request);
-	void (*maximize)(struct view *view, bool maximize);
+	void (*maximize)(struct view *view, enum view_axis maximized);
 	void (*minimize)(struct view *view, bool minimize);
 	struct view *(*get_root)(struct view *self);
 	void (*append_children)(struct view *self, struct wl_array *children);

--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -59,9 +59,6 @@ struct xwayland_view {
 	struct view base;
 	struct wlr_xwayland_surface *xwayland_surface;
 
-	/* Used to detect stacking order updates */
-	int stacking_order;
-
 	/* Events unique to XWayland views */
 	struct wl_listener associate;
 	struct wl_listener dissociate;
@@ -84,8 +81,6 @@ void xwayland_unmanaged_create(struct server *server,
 
 void xwayland_view_create(struct server *server,
 	struct wlr_xwayland_surface *xsurface, bool mapped);
-
-void xwayland_adjust_stacking_order(struct server *server);
 
 struct wlr_xwayland_surface *xwayland_surface_from_view(struct view *view);
 

--- a/meson.build
+++ b/meson.build
@@ -50,9 +50,9 @@ endif
 add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 
 wlroots = dependency(
-  'wlroots-0.18',
+  'wlroots-0.19',
   default_options: ['default_library=static', 'examples=false'],
-  version: ['>=0.18.1', '<0.19.0'],
+  version: ['>=0.19.0', '<0.20.0'],
 )
 
 wlroots_has_xwayland = wlroots.get_variable('have_xwayland') == 'true'

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -49,6 +49,7 @@ data_buffer_destroy(struct wlr_buffer *wlr_buffer)
 	if (!buffer->surface_owns_data) {
 		free(buffer->data);
 	}
+	wlr_buffer_finish(wlr_buffer);
 	free(buffer);
 }
 

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -58,8 +58,8 @@ scene_output_damage(struct wlr_scene_output *scene_output,
 
 	if (pixman_region32_not_empty(&clipped)) {
 		wlr_damage_ring_add(&scene_output->damage_ring, &clipped);
-		pixman_region32_union(&scene_output->pending_commit_damage,
-			&scene_output->pending_commit_damage, &clipped);
+		pixman_region32_union(&scene_output->WLR_PRIVATE.pending_commit_damage,
+			&scene_output->WLR_PRIVATE.pending_commit_damage, &clipped);
 	}
 
 	pixman_region32_fini(&clipped);
@@ -85,8 +85,10 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 	 * rendering on every output commit and overloads CPU.
 	 * We also need to verify the necessity of wants_magnification.
 	 */
-	if (!wlr_output->needs_frame && !pixman_region32_not_empty(
-			&scene_output->pending_commit_damage) && !wants_magnification) {
+	if (!wlr_output->needs_frame
+			&& !pixman_region32_not_empty(
+				&scene_output->WLR_PRIVATE.pending_commit_damage)
+			&& !wants_magnification) {
 		return true;
 	}
 

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -50,9 +50,7 @@ static void
 scene_output_damage(struct wlr_scene_output *scene_output,
 		const pixman_region32_t *region)
 {
-	if (!wlr_damage_ring_add(&scene_output->damage_ring, region)) {
-		return;
-	}
+	wlr_damage_ring_add(&scene_output->damage_ring, region);
 
 	struct wlr_output *output = scene_output->output;
 	enum wl_output_transform transform =

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -106,7 +106,7 @@ desktop_focus_view_or_surface(struct seat *seat, struct view *view,
 	} else {
 		struct wlr_xwayland_surface *xsurface =
 			wlr_xwayland_surface_try_from_wlr_surface(surface);
-		if (xsurface && wlr_xwayland_or_surface_wants_focus(xsurface)) {
+		if (xsurface && wlr_xwayland_surface_override_redirect_wants_focus(xsurface)) {
 			seat_focus_surface(seat, surface);
 		}
 #endif

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -463,10 +463,9 @@ process_cursor_motion_out_of_surface(struct server *server,
 		ly = view->current.y;
 		/* Take into account invisible xdg-shell CSD borders */
 		if (view->type == LAB_XDG_SHELL_VIEW) {
-			struct wlr_box geo;
-			wlr_xdg_surface_get_geometry(xdg_surface_from_view(view), &geo);
-			lx -= geo.x;
-			ly -= geo.y;
+			struct wlr_xdg_surface *xdg_surface = xdg_surface_from_view(view);
+			lx -= xdg_surface->geometry.x;
+			ly -= xdg_surface->geometry.y;
 		}
 	} else if (node && wlr_layer_surface_v1_try_from_wlr_surface(surface)) {
 		wlr_scene_node_coords(node, &lx, &ly);

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -230,10 +230,8 @@ update_popup_position(struct input_method_popup *popup)
 
 		if (xdg_surface) {
 			/* Take into account invisible xdg-shell CSD borders */
-			struct wlr_box geo;
-			wlr_xdg_surface_get_geometry(xdg_surface, &geo);
-			cursor_rect.x -= geo.x;
-			cursor_rect.y -= geo.y;
+			cursor_rect.x -= xdg_surface->geometry.x;
+			cursor_rect.y -= xdg_surface->geometry.y;
 		}
 	} else {
 		cursor_rect = (struct wlr_box){0};

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -169,7 +169,7 @@ tablet_get_coords(struct drawing_tablet *tablet, double *x, double *y, double *d
 	/* find the surface and return it if it accepts tablet events */
 	struct wlr_surface *surface = lab_wlr_surface_from_node(node);
 
-	if (surface && !wlr_surface_accepts_tablet_v2(tablet->tablet_v2, surface)) {
+	if (surface && !wlr_surface_accepts_tablet_v2(surface, tablet->tablet_v2)) {
 		return NULL;
 	}
 	return surface;

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -50,7 +50,7 @@ touch_get_coords(struct seat *seat, struct wlr_touch *touch, double x, double y,
 	/* Find the surface and return it if it accepts touch events */
 	struct wlr_surface *surface = lab_wlr_surface_from_node(node);
 
-	if (surface && !wlr_surface_accepts_touch(seat->seat, surface)) {
+	if (surface && !wlr_surface_accepts_touch(surface, seat->seat)) {
 		surface = NULL;
 	}
 	return surface;

--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -237,7 +237,7 @@ static void
 enable_magnifier(struct server *server, bool enable)
 {
 	magnify_on = enable;
-	server->scene->direct_scanout = enable ? false
+	server->scene->WLR_PRIVATE.direct_scanout = enable ? false
 		: server->direct_scanout_enabled;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -549,7 +549,7 @@ server_init(struct server *server)
 		wlr_log(WLR_ERROR, "unable to create scene");
 		exit(EXIT_FAILURE);
 	}
-	server->direct_scanout_enabled = server->scene->direct_scanout;
+	server->direct_scanout_enabled = server->scene->WLR_PRIVATE.direct_scanout;
 
 	/*
 	 * The order in which the scene-trees below are created determines the

--- a/src/server.c
+++ b/src/server.c
@@ -55,6 +55,7 @@
 #define LAB_WLR_FRACTIONAL_SCALE_V1_VERSION 1
 #define LAB_WLR_LINUX_DMABUF_VERSION 4
 #define EXT_FOREIGN_TOPLEVEL_LIST_VERSION 1
+#define LAB_WLR_PRESENTATION_TIME_VERSION 2
 
 static struct wlr_compositor *compositor;
 static struct wl_event_source *sighup_source;
@@ -629,8 +630,9 @@ server_init(struct server *server)
 	kde_server_decoration_init(server);
 	xdg_server_decoration_init(server);
 
-	struct wlr_presentation *presentation =
-		wlr_presentation_create(server->wl_display, server->backend);
+	struct wlr_presentation *presentation = wlr_presentation_create(
+		server->wl_display, server->backend,
+		LAB_WLR_PRESENTATION_TIME_VERSION);
 	if (!presentation) {
 		wlr_log(WLR_ERROR, "unable to create presentation interface");
 		exit(EXIT_FAILURE);

--- a/src/view.c
+++ b/src/view.c
@@ -2283,12 +2283,6 @@ view_move_to_front(struct view *view)
 		move_to_front(view);
 	}
 
-#if HAVE_XWAYLAND
-	if (view->type == LAB_XWAYLAND_VIEW) {
-		xwayland_adjust_stacking_order(view->server);
-	}
-#endif
-
 	cursor_update_focus(view->server);
 	desktop_update_top_layer_visibility(view->server);
 }
@@ -2302,12 +2296,6 @@ view_move_to_back(struct view *view)
 
 	for_each_subview(root, move_to_back);
 	move_to_back(root);
-
-#if HAVE_XWAYLAND
-	if (view->type == LAB_XWAYLAND_VIEW) {
-		xwayland_adjust_stacking_order(view->server);
-	}
-#endif
 
 	cursor_update_focus(view->server);
 	desktop_update_top_layer_visibility(view->server);
@@ -2491,12 +2479,6 @@ view_set_shade(struct view *view, bool shaded)
 	view->shaded = shaded;
 	ssd_enable_shade(view->ssd, view->shaded);
 	wlr_scene_node_set_enabled(&view->content_tree->node, !view->shaded);
-
-#if HAVE_XWAYLAND
-	if (view->type == LAB_XWAYLAND_VIEW) {
-		xwayland_adjust_stacking_order(view->server);
-	}
-#endif
 }
 
 void

--- a/src/view.c
+++ b/src/view.c
@@ -552,7 +552,7 @@ view_update_outputs(struct view *view)
 	wl_list_for_each(output, &view->server->outputs, link) {
 		if (output_is_usable(output) && wlr_output_layout_intersects(
 				layout, output->wlr_output, &view->current)) {
-			new_outputs |= (1ull << output->scene_output->index);
+			new_outputs |= (1ull << output->scene_output->WLR_PRIVATE.index);
 		}
 	}
 
@@ -569,7 +569,7 @@ view_on_output(struct view *view, struct output *output)
 	assert(view);
 	assert(output);
 	return output->scene_output
-			&& (view->outputs & (1ull << output->scene_output->index));
+			&& (view->outputs & (1ull << output->scene_output->WLR_PRIVATE.index));
 }
 
 void

--- a/src/view.c
+++ b/src/view.c
@@ -1339,7 +1339,7 @@ static void
 set_maximized(struct view *view, enum view_axis maximized)
 {
 	if (view->impl->maximize) {
-		view->impl->maximize(view, (maximized == VIEW_AXIS_BOTH));
+		view->impl->maximize(view, maximized);
 	}
 
 	view->maximized = maximized;

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -395,10 +395,6 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	/* And finally show the OSD */
 	_osd_show(server);
 
-#if HAVE_XWAYLAND
-	/* Ensure xwayland internal stacking order corresponds to the current workspace  */
-	xwayland_adjust_stacking_order(server);
-#endif
 	/*
 	 * Make sure we are not carrying around a
 	 * cursor image from the previous desktop

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -149,8 +149,7 @@ handle_commit(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	struct wlr_box size;
-	wlr_xdg_surface_get_geometry(xdg_surface, &size);
+	struct wlr_box size = xdg_surface->geometry;
 	bool update_required = false;
 
 	/*
@@ -727,10 +726,8 @@ xdg_toplevel_view_map(struct view *view)
 		 * dimensions remain zero until handle_commit().
 		 */
 		if (wlr_box_empty(&view->pending)) {
-			struct wlr_box size;
-			wlr_xdg_surface_get_geometry(xdg_surface, &size);
-			view->pending.width = size.width;
-			view->pending.height = size.height;
+			view->pending.width = xdg_surface->geometry.width;
+			view->pending.height = xdg_surface->geometry.height;
 		}
 
 		/*

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -493,9 +493,10 @@ xdg_toplevel_view_close(struct view *view)
 }
 
 static void
-xdg_toplevel_view_maximize(struct view *view, bool maximized)
+xdg_toplevel_view_maximize(struct view *view, enum view_axis maximized)
 {
-	wlr_xdg_toplevel_set_maximized(xdg_toplevel_from_view(view), maximized);
+	wlr_xdg_toplevel_set_maximized(xdg_toplevel_from_view(view),
+		maximized == VIEW_AXIS_BOTH);
 }
 
 static void

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -46,7 +46,7 @@ handle_map(struct wl_listener *listener, void *data)
 
 	CONNECT_SIGNAL(xsurface, unmanaged, set_geometry);
 
-	if (wlr_xwayland_or_surface_wants_focus(xsurface)) {
+	if (wlr_xwayland_surface_override_redirect_wants_focus(xsurface)) {
 		seat_focus_surface(&unmanaged->server->seat, xsurface->surface);
 	}
 
@@ -66,7 +66,7 @@ focus_next_surface(struct server *server, struct wlr_xwayland_surface *xsurface)
 	struct wl_list *list = &server->unmanaged_surfaces;
 	wl_list_for_each_reverse(u, list, link) {
 		struct wlr_xwayland_surface *prev = u->xwayland_surface;
-		if (wlr_xwayland_or_surface_wants_focus(prev)) {
+		if (wlr_xwayland_surface_override_redirect_wants_focus(prev)) {
 			seat_focus_surface(&server->seat, prev->surface);
 			return;
 		}

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -66,7 +66,7 @@ xwayland_view_wants_focus(struct view *view)
 	struct wlr_xwayland_surface *xsurface =
 		xwayland_surface_from_view(view);
 
-	switch (wlr_xwayland_icccm_input_model(xsurface)) {
+	switch (wlr_xwayland_surface_icccm_input_model(xsurface)) {
 	/*
 	 * Abbreviated from ICCCM section 4.1.7 (Input Focus):
 	 *

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -810,10 +810,10 @@ out:
 }
 
 static void
-xwayland_view_maximize(struct view *view, bool maximized)
+xwayland_view_maximize(struct view *view, enum view_axis maximized)
 {
 	wlr_xwayland_surface_set_maximized(xwayland_surface_from_view(view),
-		maximized);
+		maximized & VIEW_AXIS_HORIZONTAL, maximized & VIEW_AXIS_VERTICAL);
 }
 
 static void

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 7963ba6a0deb5b696050d914ac395bca9c4c06b2
+revision = 9b55737cf512ae5132b10633b83e099d46fa259f
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 5ecbd23c1d44119cb32b345782d50c9664853109
+revision = d3b7e040af46ab03114d5a40e9ed0c7c6aff15be
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = b10516e1e8352f3140d68fa580b0ed32e13c2d58
+revision = 5ecbd23c1d44119cb32b345782d50c9664853109
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 4c74a8843a08a39d6278de4a26759d93155feb2c
+revision = 7963ba6a0deb5b696050d914ac395bca9c4c06b2
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 009515161bd97d8f920d72d31ef462f2608688e8
+revision = 6006023a377868187f73d2e0922bbe952072684f
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = d3b7e040af46ab03114d5a40e9ed0c7c6aff15be
+revision = ceb4fcedca30d323a05836b0872bfe773a047ccc
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 6006023a377868187f73d2e0922bbe952072684f
+revision = 4c74a8843a08a39d6278de4a26759d93155feb2c
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 1133bc15ceb2c2bcb6df692acda6bfa39a292ab5
+revision = 5c98d1a04a1439bf40c6e516086cfaff2d67f135
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 502eb38d80eb5a273f5481ec8559cb35d726f5da
+revision = 009515161bd97d8f920d72d31ef462f2608688e8
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 9b55737cf512ae5132b10633b83e099d46fa259f
+revision = 0.19.0
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 0.18
+revision = b10516e1e8352f3140d68fa580b0ed32e13c2d58
 
 [provide]
-dependency_names = wlroots-0.18
-wlroots-0.18=wlroots
+dependency_names = wlroots-0.19
+wlroots-0.19=wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = ceb4fcedca30d323a05836b0872bfe773a047ccc
+revision = 1133bc15ceb2c2bcb6df692acda6bfa39a292ab5
 
 [provide]
 dependency_names = wlroots-0.19

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 5c98d1a04a1439bf40c6e516086cfaff2d67f135
+revision = 502eb38d80eb5a273f5481ec8559cb35d726f5da
 
 [provide]
 dependency_names = wlroots-0.19


### PR DESCRIPTION
You know the drill.

Not intended to be merged anytime soon but it can be used to develop against the wlroots master branch for changes proposed there. Feel free to push chase commits to this branch (include the wlroots MR in he commit subject) but please don't do force pushes.

I do not recommend running this branch outside of dev work.

Upstream list of breaking changes:
https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3869

Issues:
- [x] when the SSD titlebar gets created the view width is now `0` for some reason and thus it triggers an assert() in wlroots because we now set the width to a negative value. Bypassed with a hacky `MAX(0, width - 2 * x)`. Needs further investigation
- [x] `wlr_damage_ring_add()` removed the return value, evaluate if we need to check against wlr_scene_output size when adding damage due to the magnifier
- [x] commits miss references to the actual wlroots commits, are in the wrong order and do not have proper subjects
- [x] wlroots.wrap file is not synced with each chase commit

JFYI @jlindgren90