### PR TITLE
buffer: always set buffer->surface and remove buffer->cairo

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -32,10 +32,11 @@
 struct lab_data_buffer {
 	struct wlr_buffer base;
 
-	cairo_surface_t *surface; /* optional */
-	cairo_t *cairo;           /* optional */
-	void *data; /* owned by surface if surface != NULL */
-	uint32_t format;
+	bool surface_owns_data;
+	cairo_surface_t *surface;
+	cairo_t *cairo;
+	void *data;
+	uint32_t format; /* currently always DRM_FORMAT_ARGB8888 */
 	size_t stride;
 	/*
 	 * The logical size of the surface in layout pixels.
@@ -50,7 +51,7 @@ struct lab_data_buffer {
  * CAIRO_FORMAT_ARGB32 image surface.
  *
  * The logical size is set to the surface size in pixels, ignoring
- * device scale. No cairo context is created.
+ * device scale.
  */
 struct lab_data_buffer *buffer_adopt_cairo_surface(cairo_surface_t *surface);
 
@@ -78,7 +79,6 @@ struct lab_data_buffer *buffer_convert_cairo_surface_for_icon(
  * in pre-multiplied ARGB32 format.
  *
  * The logical size is set to the width and height of the pixel data.
- * No cairo surface or context is created.
  */
 struct lab_data_buffer *buffer_create_from_data(void *pixel_data, uint32_t width,
 	uint32_t height, uint32_t stride);

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -34,7 +34,6 @@ struct lab_data_buffer {
 
 	bool surface_owns_data;
 	cairo_surface_t *surface;
-	cairo_t *cairo;
 	void *data;
 	uint32_t format; /* currently always DRM_FORMAT_ARGB8888 */
 	size_t stride;

--- a/include/common/graphic-helpers.h
+++ b/include/common/graphic-helpers.h
@@ -49,12 +49,4 @@ void draw_cairo_border(cairo_t *cairo, struct wlr_fbox fbox, double line_width);
 
 struct lab_data_buffer;
 
-struct surface_context {
-	bool is_duplicate;
-	cairo_surface_t *surface;
-};
-
-struct surface_context get_cairo_surface_from_lab_data_buffer(
-	struct lab_data_buffer *buffer);
-
 #endif /* LABWC_GRAPHIC_HELPERS_H */

--- a/src/common/font.c
+++ b/src/common/font.c
@@ -115,8 +115,8 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 		return;
 	}
 
-	cairo_t *cairo = (*buffer)->cairo;
-	cairo_surface_t *surf = cairo_get_target(cairo);
+	cairo_surface_t *surf = (*buffer)->surface;
+	cairo_t *cairo = cairo_create(surf);
 
 	/*
 	 * Fill with the background color first IF the background color
@@ -171,6 +171,7 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	g_object_unref(layout);
 
 	cairo_surface_flush(surf);
+	cairo_destroy(cairo);
 }
 
 void

--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -112,32 +112,3 @@ set_cairo_color(cairo_t *cairo, const float *c)
 	cairo_set_source_rgba(cairo, c[0] / alpha, c[1] / alpha,
 		c[2] / alpha, alpha);
 }
-
-struct surface_context
-get_cairo_surface_from_lab_data_buffer(struct lab_data_buffer *buffer)
-{
-	/* Handle CAIRO_FORMAT_ARGB32 buffers */
-	if (buffer->cairo) {
-		return (struct surface_context){
-			.is_duplicate = false,
-			.surface = cairo_get_target(buffer->cairo),
-		};
-	}
-
-	/* Handle DRM_FORMAT_ARGB8888 buffers */
-	int w = buffer->base.width;
-	int h = buffer->base.height;
-	cairo_surface_t *surface =
-		cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
-	if (!surface) {
-		return (struct surface_context){0};
-	}
-	unsigned char *data = cairo_image_surface_get_data(surface);
-	cairo_surface_flush(surface);
-	memcpy(data, buffer->data, h * buffer->stride);
-	cairo_surface_mark_dirty(surface);
-	return (struct surface_context){
-		.is_duplicate = true,
-		.surface = surface,
-	};
-}

--- a/src/common/scaled-rect-buffer.c
+++ b/src/common/scaled-rect-buffer.c
@@ -39,7 +39,7 @@ _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
 		return NULL;
 	}
 
-	cairo_t *cairo = buffer->cairo;
+	cairo_t *cairo = cairo_create(buffer->surface);
 
 	/* Clear background */
 	cairo_set_operator(cairo, CAIRO_OPERATOR_CLEAR);
@@ -57,6 +57,8 @@ _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
 	cairo_set_line_width(cairo, self->border_width);
 	set_cairo_color(cairo, self->border_color);
 	cairo_stroke(cairo);
+
+	cairo_destroy(cairo);
 
 	return buffer;
 }

--- a/src/common/scaled-rect-buffer.c
+++ b/src/common/scaled-rect-buffer.c
@@ -58,6 +58,7 @@ _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
 	set_cairo_color(cairo, self->border_color);
 	cairo_stroke(cairo);
 
+	cairo_surface_flush(buffer->surface);
 	cairo_destroy(cairo);
 
 	return buffer;

--- a/src/img/img-svg.c
+++ b/src/img/img-svg.c
@@ -41,7 +41,7 @@ img_svg_load(const char *filename, struct lab_data_buffer **buffer, int size,
 
 	*buffer = buffer_create_cairo(size, size, scale);
 	cairo_surface_t *image = (*buffer)->surface;
-	cairo_t *cr = (*buffer)->cairo;
+	cairo_t *cr = cairo_create(image);
 
 	rsvg_handle_render_document(svg, cr, &viewport, &err);
 	if (err) {
@@ -55,6 +55,7 @@ img_svg_load(const char *filename, struct lab_data_buffer **buffer, int size,
 		goto error;
 	}
 	cairo_surface_flush(image);
+	cairo_destroy(cr);
 
 	g_object_unref(svg);
 	return;
@@ -62,5 +63,6 @@ img_svg_load(const char *filename, struct lab_data_buffer **buffer, int size,
 error:
 	wlr_buffer_drop(&(*buffer)->base);
 	*buffer = NULL;
+	cairo_destroy(cr);
 	g_object_unref(svg);
 }

--- a/src/osd.c
+++ b/src/osd.c
@@ -354,8 +354,9 @@ display_osd(struct output *output, struct wl_array *views)
 	}
 
 	/* Render OSD image */
-	cairo_t *cairo = buffer->cairo;
+	cairo_t *cairo = cairo_create(buffer->surface);
 	render_osd(server, cairo, w, h, show_workspace, workspace_name, views);
+	cairo_destroy(cairo);
 
 	struct wlr_scene_buffer *scene_buffer = wlr_scene_buffer_create(
 		output->osd_tree, &buffer->base);

--- a/src/theme.c
+++ b/src/theme.c
@@ -85,10 +85,9 @@ copy_icon_buffer(struct theme *theme, struct lab_data_buffer *icon_buffer)
 {
 	assert(icon_buffer);
 
-	struct surface_context icon =
-		get_cairo_surface_from_lab_data_buffer(icon_buffer);
-	int icon_width = cairo_image_surface_get_width(icon.surface);
-	int icon_height = cairo_image_surface_get_height(icon.surface);
+	cairo_surface_t *surface = icon_buffer->surface;
+	int icon_width = cairo_image_surface_get_width(surface);
+	int icon_height = cairo_image_surface_get_height(surface);
 
 	int width = theme->window_button_width;
 	int height = theme->window_button_height;
@@ -113,7 +112,7 @@ copy_icon_buffer(struct theme *theme, struct lab_data_buffer *icon_buffer)
 		buffer_width, buffer_height, 1.0);
 	cairo_t *cairo = buffer->cairo;
 
-	cairo_set_source_surface(cairo, icon.surface,
+	cairo_set_source_surface(cairo, surface,
 		(buffer_width - icon_width) / 2, (buffer_height - icon_height) / 2);
 	cairo_paint(cairo);
 
@@ -122,10 +121,6 @@ copy_icon_buffer(struct theme *theme, struct lab_data_buffer *icon_buffer)
 	 * corner on this buffer in the scene coordinates.
 	 */
 	cairo_scale(cairo, scale, scale);
-
-	if (icon.is_duplicate) {
-		cairo_surface_destroy(icon.surface);
-	}
 
 	return buffer;
 }

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -90,7 +90,7 @@ _osd_update(struct server *server)
 			continue;
 		}
 
-		cairo = buffer->cairo;
+		cairo = cairo_create(buffer->surface);
 
 		/* Background */
 		set_cairo_color(cairo, theme->osd_bg_color);
@@ -150,6 +150,7 @@ _osd_update(struct server *server)
 		g_object_unref(layout);
 		surface = cairo_get_target(cairo);
 		cairo_surface_flush(surface);
+		cairo_destroy(cairo);
 
 		if (!output->workspace_osd) {
 			output->workspace_osd = wlr_scene_buffer_create(


### PR DESCRIPTION
I think `memcpy()` in `get_cairo_surface_from_lab_data_buffer()` is redundant as we can use `cairo_image_surface_create_for_data()` instead. Also we can always set `buffer->{cairo,surface}` so that we can just access them when we start writing on/from the buffer.