### PR TITLE
ssd: fix pixman error when SSD is created for tiny windows

### DIFF
--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -95,14 +95,16 @@ ssd_titlebar_create(struct ssd *ssd)
 	ssd_update_title(ssd);
 	ssd_update_window_icon(ssd);
 
-	set_squared_corners(ssd, false);
-
 	bool maximized = view->maximized == VIEW_AXIS_BOTH;
+	bool squared = ssd_should_be_squared(ssd);
 	if (maximized) {
-		set_squared_corners(ssd, true);
 		set_alt_button_icon(ssd, LAB_SSD_BUTTON_MAXIMIZE, true);
 		ssd->state.was_maximized = true;
 	}
+	if (squared) {
+		ssd->state.was_squared = true;
+	}
+	set_squared_corners(ssd, maximized || squared);
 
 	if (view->shaded) {
 		set_alt_button_icon(ssd, LAB_SSD_BUTTON_SHADE, true);
@@ -110,11 +112,6 @@ ssd_titlebar_create(struct ssd *ssd)
 
 	if (view->visible_on_all_workspaces) {
 		set_alt_button_icon(ssd, LAB_SSD_BUTTON_OMNIPRESENT, true);
-	}
-
-	if (ssd_should_be_squared(ssd)) {
-		set_squared_corners(ssd, true);
-		ssd->state.was_squared = true;
 	}
 }
 


### PR DESCRIPTION
I think it's fine to merge this PR for the next release.

This fixes the pixman error (which causes `assert()` failure in wlroots 0.19 https://github.com/labwc/labwc/pull/2388#issue-2696997166) when a tiny window is decorated.

In #2213, `set_squared_corners(false)` was always called when titlebar is created. However, `set_squared_corners(false)` sets the width of the titlebar background buffer to `(view width) - (corner radius)`, which causes pixman errors due to the negative width set for titlebar background buffer when the view is so small.

Note: `ssd_should_be_squared()` returns `true` when the titlebar corners should be un-rounded as the view is so small or tiled, but maximization state is not considered. `set_squared_corners()` rounds/un-rounds the titlebar corners, so `true` should be passed when `ssd_should_be_squared()` returns true or the view is maximized. This might be unclear and need refactoring or renaming.