### PR TITLE
 scaled-scene-buffer: reduce unnecessary renderings

### DIFF
--- a/include/common/font.h
+++ b/include/common/font.h
@@ -37,6 +37,12 @@ int font_height(struct font *font);
 int font_width(struct font *font, const char *string);
 
 /**
+ * font_get_buffer_size - dry-run font_buffer_create() to get buffer size
+ */
+void font_get_buffer_size(int max_width, const char *text, struct font *font,
+	int *width, int *height);
+
+/**
  * font_buffer_create - Create ARGB8888 lab_data_buffer using pango
  * @buffer: buffer pointer
  * @max_width: max allowable width; will be ellipsized if longer

--- a/include/common/scaled-scene-buffer.h
+++ b/include/common/scaled-scene-buffer.h
@@ -96,8 +96,17 @@ struct scaled_scene_buffer *scaled_scene_buffer_create(
 	const struct scaled_scene_buffer_impl *implementation,
 	struct wl_list *cached_buffers, bool drop_buffer);
 
-/* Clear the cache of existing buffers, useful in case the content changes */
-void scaled_scene_buffer_invalidate_cache(struct scaled_scene_buffer *self);
+/**
+ * scaled_scene_buffer_request_update - mark the buffer that needs to be
+ * updated
+ * @width: the width of the buffer to be rendered, in scene coordinates
+ * @height: the height of the buffer to be rendered, in scene coordinates
+ *
+ * This function should be called when the states bound to the buffer are
+ * updated and ready for rendering.
+ */
+void scaled_scene_buffer_request_update(struct scaled_scene_buffer *self,
+	int width, int height);
 
 /* Private */
 struct scaled_scene_buffer_cache_entry {

--- a/src/common/font.c
+++ b/src/common/font.c
@@ -80,6 +80,18 @@ font_width(struct font *font, const char *string)
 }
 
 void
+font_get_buffer_size(int max_width, const char *text, struct font *font,
+	int *width, int *height)
+{
+	PangoRectangle text_extents = font_extents(font, text);
+	if (max_width > 0 && text_extents.width > max_width) {
+		text_extents.width = max_width;
+	}
+	*width = text_extents.width;
+	*height = text_extents.height;
+}
+
+void
 font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	const char *text, struct font *font, const float *color,
 	const float *bg_color, double scale)
@@ -88,13 +100,10 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 		return;
 	}
 
-	PangoRectangle text_extents = font_extents(font, text);
+	int width, height;
+	font_get_buffer_size(max_width, text, font, &width, &height);
 
-	if (max_width > 0 && text_extents.width > max_width) {
-		text_extents.width = max_width;
-	}
-
-	*buffer = buffer_create_cairo(text_extents.width, text_extents.height, scale);
+	*buffer = buffer_create_cairo(width, height, scale);
 	if (!*buffer) {
 		wlr_log(WLR_ERROR, "Failed to create font buffer");
 		return;
@@ -127,7 +136,7 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 
 	PangoLayout *layout = pango_cairo_create_layout(cairo);
 	pango_context_set_round_glyph_positions(pango_layout_get_context(layout), false);
-	pango_layout_set_width(layout, text_extents.width * PANGO_SCALE);
+	pango_layout_set_width(layout, width * PANGO_SCALE);
 	pango_layout_set_text(layout, text, -1);
 	pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
 

--- a/src/common/scaled-font-buffer.c
+++ b/src/common/scaled-font-buffer.c
@@ -116,21 +116,20 @@ scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
 	memcpy(self->color, color, sizeof(self->color));
 	memcpy(self->bg_color, bg_color, sizeof(self->bg_color));
 
-	/* Invalidate cache and force a new render */
-	scaled_scene_buffer_invalidate_cache(self->scaled_buffer);
-
-	/* Ensure the height / width is up-to-date */
-	self->width = self->scaled_buffer->width;
-	self->height = self->scaled_buffer->height;
+	/* Calculate the size of font buffer and request re-rendering */
+	font_get_buffer_size(self->max_width, self->text, &self->font,
+		&self->width, &self->height);
+	scaled_scene_buffer_request_update(self->scaled_buffer,
+		self->width, self->height);
 }
 
 void
 scaled_font_buffer_set_max_width(struct scaled_font_buffer *self, int max_width)
 {
 	self->max_width = max_width;
-	scaled_scene_buffer_invalidate_cache(self->scaled_buffer);
 
-	/* Ensure the height / width is up-to-date */
-	self->width = self->scaled_buffer->width;
-	self->height = self->scaled_buffer->height;
+	font_get_buffer_size(self->max_width, self->text, &self->font,
+		&self->width, &self->height);
+	scaled_scene_buffer_request_update(self->scaled_buffer,
+		self->width, self->height);
 }

--- a/src/common/scaled-rect-buffer.c
+++ b/src/common/scaled-rect-buffer.c
@@ -110,7 +110,8 @@ struct scaled_rect_buffer *scaled_rect_buffer_create(
 	memcpy(self->fill_color, fill_color, sizeof(self->fill_color));
 	memcpy(self->border_color, border_color, sizeof(self->border_color));
 
-	scaled_scene_buffer_invalidate_cache(scaled_buffer);
+	scaled_scene_buffer_request_update(scaled_buffer,
+		self->width, self->height);
 
 	return self;
 }


### PR DESCRIPTION
For post-0.8.2.

Prior to this PR, a backing buffer with scale 1 was always created for a `scaled_scene_buffer` before showing it, and backing buffers for specific scales were created on `output_enter` events.

This PR removes this redundant re-renderings by calling `wlr_scene_buffer_set_dest_size()` upon `scaled_scene_buffer` creation so that we can receive `output_enter` events without creating a backing buffer, and delaying the first rendering to the first `output_enter` event.

This PR includes some refactors in `font.c` and `menu.c`, so I'm thinking of splitting this to smaller ones after we release 0.8.2.