### PR TITLE
menu: slightly slide menus opened from buttons

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -678,6 +678,7 @@ show_menu(struct server *server, struct view *view, struct cursor_context *ctx,
 			assert(ctx->node);
 			int ly;
 			wlr_scene_node_coords(ctx->node, &x, &ly);
+			x -= server->theme->menu_border_width;
 		}
 	}
 


### PR DESCRIPTION
Suggested by stormshadow in IRC.

This PR slides menus opened from buttons (with `atCursor="no"`) to the left by `menu.border.width`.

|before|after|
|-|-|
|![20241206_13h17m28s_grim](https://github.com/user-attachments/assets/32fd5bcf-88ba-4dd6-b8b1-9a375af5e0ca)|![20241206_13h17m11s_grim](https://github.com/user-attachments/assets/a7000720-020b-481a-a103-ca8e542ea5de)|

This change is primarily for the default window menu opened from the left-corner window icon, but I think it doesn't sacrifice the look when the button from which the menu is opened is not placed in the left corner:

![20241206_13h18m26s_grim](https://github.com/user-attachments/assets/4f1aa0dd-135e-42aa-af6f-cf457194fe8b)

I think we can merge this PR before the next release, as the change is quite small.