### PR TITLE
menu: fix misplaced top-left window menu when window is maximized

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -867,10 +867,7 @@ menu_configure(struct menu *menu, int lx, int ly, enum menu_align align)
 	/* Get output local coordinates + output usable area */
 	double ox = lx;
 	double oy = ly;
-	struct wlr_output *wlr_output = wlr_output_layout_output_at(
-		menu->server->output_layout, lx, ly);
-	struct output *output = wlr_output ? output_from_wlr_output(
-		menu->server, wlr_output) : NULL;
+	struct output *output = output_nearest_to(menu->server, lx, ly);
 	if (!output) {
 		wlr_log(WLR_ERROR,
 			"Failed to position menu %s (%s) and its submenus: "
@@ -878,7 +875,7 @@ menu_configure(struct menu *menu, int lx, int ly, enum menu_align align)
 		return;
 	}
 	wlr_output_layout_output_coords(menu->server->output_layout,
-		wlr_output, &ox, &oy);
+		output->wlr_output, &ox, &oy);
 
 	if (align == LAB_MENU_OPEN_AUTO) {
 		int full_width = menu_get_full_width(menu);


### PR DESCRIPTION
Fixes #2404.

With 2ade6a1, negative x-values can be passed to `menu_configure()` when the window menu is opened from top-left button in a maximized window, but `wlr_output_layout_output_at()` couldn't find the output for the coordinate since it's out of the output layout, thus it just opened the menu without updating its position.

So let's replace `wlr_output_layout_output_at()` in `menu_configure()` with `output_nearest_to()`, which searches for the output more roughly.
