### PR TITLE
Revert "menu: slightly slide menus opened from buttons"

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -678,7 +678,6 @@ show_menu(struct server *server, struct view *view, struct cursor_context *ctx,
 			assert(ctx->node);
 			int ly;
 			wlr_scene_node_coords(ctx->node, &x, &ly);
-			x -= server->theme->menu_border_width;
 		}
 	}
 


### PR DESCRIPTION
This PR reverts #2403 due to the regression (#2404). #2406 might be fine for fixing the regression, but introducing an unknown code path would increase the risk of another regression.