### PR TITLE
menu: improve algorithm for menu placement with xdg-positioner

### DIFF
--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -12,14 +12,6 @@ struct wlr_scene_tree;
 struct wlr_scene_node;
 struct scaled_font_buffer;
 
-enum menu_align {
-	LAB_MENU_OPEN_AUTO   = 0,
-	LAB_MENU_OPEN_LEFT   = 1 << 0,
-	LAB_MENU_OPEN_RIGHT  = 1 << 1,
-	LAB_MENU_OPEN_TOP    = 1 << 2,
-	LAB_MENU_OPEN_BOTTOM = 1 << 3,
-};
-
 enum menuitem_type {
 	LAB_MENU_ITEM = 0,
 	LAB_MENU_SEPARATOR_LINE,
@@ -63,7 +55,7 @@ struct menu {
 	} selection;
 	struct wlr_scene_tree *scene_tree;
 	bool is_pipemenu;
-	enum menu_align align;
+	bool align_left;
 
 	/* Used to match a window-menu to the view that triggered it. */
 	struct view *triggered_by_view;  /* may be NULL */


### PR DESCRIPTION
For post-0.8.2. I wrote this patch some weeks ago, but now I think it's more useful than just a refactoring since this PR fixes the the root cause of #2404.

---

Since wlroots already provides a mechanism to place popups via `wlr_xdg_positioner_rules_get_geometry()` and `wlr_xdg_positioner_rules_unconstrain_box()`, I think we can simplify the codebase by applying them also for compositor-side menus. 

Notable functional changes are:
- Slide the menu to fit in the output when it's opened out of the output (e.g. when top-left window menu is opened when the window is overflowing to the left), rather than not updating the menu at all. This should prevent reintroducing #2404 when we reland #2403.

|before|after|
|-|-|
|![20241208_17h39m10s_grim](https://github.com/user-attachments/assets/1147bc8d-cff9-4f87-a244-b7becebdda0f)|![20241208_17h39m29s_grim](https://github.com/user-attachments/assets/5826b58d-d2d0-4c8b-88b5-b6fc62620825)|

- The horizontal alignment of menus is now determined based on the size of each (sub)menu alone rather than the total width of entire menu tree. This means submenus can now overlap with its parents, but this is no longer a problem since we recently added support for menu borders.

|before|after|
|-|-|
|![20241208_17h30m13s_grim](https://github.com/user-attachments/assets/a3978b05-6619-4574-8902-9074ef5a7053)|![20241208_17h29m39s_grim](https://github.com/user-attachments/assets/e584d560-5dde-4b01-b7eb-f5a7b26bde91)|

- Fixed that pipemenus always follow the alignment of its parent even when it overflows from the output.

|before|after|
|-|-|
|![20241208_17h32m45s_grim](https://github.com/user-attachments/assets/5cd21889-f54a-4e4e-8631-56063d6fb0d2)|![20241208_17h33m01s_grim](https://github.com/user-attachments/assets/84fc91fa-7edb-4ebe-8ced-801594e0a4f1)|

