### PR TITLE
s/xmlParseMemory/xmlReadMemory/

### DIFF
--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1392,7 +1392,8 @@ xml_tree_walk(xmlNode *node)
 void
 rcxml_parse_xml(struct buf *b)
 {
-	xmlDoc *d = xmlParseMemory(b->data, b->len);
+	int options = 0;
+	xmlDoc *d = xmlReadMemory(b->data, b->len, NULL, NULL, options);
 	if (!d) {
 		wlr_log(WLR_ERROR, "error parsing config file");
 		return;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -755,7 +755,8 @@ xml_tree_walk(xmlNode *node, struct server *server)
 static bool
 parse_buf(struct server *server, struct buf *buf)
 {
-	xmlDoc *d = xmlParseMemory(buf->data, buf->len);
+	int options = 0;
+	xmlDoc *d = xmlReadMemory(buf->data, buf->len, NULL, NULL, options);
 	if (!d) {
 		wlr_log(WLR_ERROR, "xmlParseMemory()");
 		return false;


### PR DESCRIPTION
...as xmlParseMemory() is deprecated

To be merged after `0.8.2`