### PR TITLE
config/rcxml.c: fix crash in <touch> section

### DIFF
--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -646,7 +646,14 @@ fill_touch(char *nodename, char *content)
 	if (!strcasecmp(nodename, "touch")) {
 		current_touch = znew(*current_touch);
 		wl_list_append(&rc.touch_configs, &current_touch->link);
-	} else if (!strcasecmp(nodename, "deviceName.touch")) {
+		return;
+	}
+
+	if (!content) {
+		return;
+	}
+
+	if (!strcasecmp(nodename, "deviceName.touch")) {
 		xstrdup_replace(current_touch->device_name, content);
 	} else if (!strcasecmp(nodename, "mapToOutput.touch")) {
 		xstrdup_replace(current_touch->output_name, content);


### PR DESCRIPTION
...when options are specified as elements leading to hitting the assert() in xstrdup().

Reproduce by using this rc.xml:

```
<?xml version="1.0"?>
<labwc_config>
  <touch>
    <deviceName>foo</deviceName>
    <mapToOutput>bar</mapToOutput>
  </touch>
</labwc_config>
```

It is likely that <touch> was only tested with options as attributes.

Discovered when playing with https://github.com/johanmalm/yaml2xml/ (thought I'd pull the code out of that yaml-PR and get a CLI tool going). Cc: @tokyo4j 