### PR TITLE
config: only default to xwayland persistence on old wlroots versions

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -219,13 +219,12 @@ this is for compatibility with Openbox.
 *<core><xwaylandPersistence>* [yes|no]
 	Keep XWayland alive even when no clients are connected, rather than
 	using a "lazy" policy that allows the server to launch on demand and die
-	when it is no longer needed. Default is yes.
+	when it is no longer needed.
 
-	This is only temporarily defaulting to yes to avoid a bug that is
-	present in wlroots <0.18.2 resulting in a compositor crash when
-	performing a drag-and-drop action at the same time as the XWayland
-	server is shutting down. This will be reverted to a default "no" when
-	wlroots-0.18.2 can be linked with.
+	When labwc is compiled with wlroots 0.18.2 or later, the default is no.
+	When labwc is compiled with wlroots < 0.18.2, the default is yes to
+	avoid a wlroots bug that can result in compositor crashes when
+	performing drag-and-drop actions when the XWayland server is shut down.
 
 	Note: changing this setting requires a restart of labwc.
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -14,6 +14,7 @@
 #include <wayland-server-core.h>
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
+#include <wlr/version.h>
 #include "action.h"
 #include "common/dir.h"
 #include "common/list.h"
@@ -35,6 +36,9 @@
 #include "view.h"
 #include "window-rules.h"
 #include "workspaces.h"
+
+#define LAB_WLR_VERSION_OLDER_THAN(major, minor, micro) \
+	(WLR_VERSION_NUM < (((major) << 16) | ((minor) << 8) | (micro)))
 
 static bool in_regions;
 static bool in_usable_area_override;
@@ -1089,16 +1093,14 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "xwaylandPersistence.core")) {
 		set_bool(content, &rc.xwayland_persistence);
 
-		/*
-		 * TODO: Temporary warning message. Revert when wlroots-0.18.2
-		 * can be linked with.
-		 */
+#if LAB_WLR_VERSION_OLDER_THAN(0, 18, 2)
 		if (!rc.xwayland_persistence) {
-			wlr_log(WLR_ERROR, "setting xwaylandPersistence to 'no' "
-				"is not encouraged unless wlroots-0.18.2 is used "
-				"since it has a potential risk of crashing the "
-				"entire session. See #2371 for details.");
+			wlr_log(WLR_ERROR, "to avoid the risk of a fatal crash, "
+				"setting xwaylandPersistence to 'no' is only "
+				"recommended when labwc is compiled against "
+				"wlroots >= 0.18.2. See #2371 for details.");
 		}
+#endif
 	} else if (!strcasecmp(nodename, "x.cascadeOffset.placement")) {
 		rc.placement_cascade_offset_x = atoi(content);
 	} else if (!strcasecmp(nodename, "y.cascadeOffset.placement")) {
@@ -1463,7 +1465,16 @@ rcxml_init(void)
 	rc.adaptive_sync = LAB_ADAPTIVE_SYNC_DISABLED;
 	rc.allow_tearing = false;
 	rc.reuse_output_mode = false;
+
+#if LAB_WLR_VERSION_OLDER_THAN(0, 18, 2)
+	/*
+	 * For wlroots < 0.18.2, keep xwayland alive by default to work around
+	 * a fatal crash when the X server is terminated during drag-and-drop.
+	 */
 	rc.xwayland_persistence = true;
+#else
+	rc.xwayland_persistence = false;
+#endif
 
 	init_font_defaults(&rc.font_activewindow);
 	init_font_defaults(&rc.font_inactivewindow);


### PR DESCRIPTION
This is a compile-time check, so it will be too conservative if somebody updates wlroots after building labwc, but that is still better than the alternatives.

I don't like the idea of hard-depending on `wlroots >= 0.18.2` after that is released. It isn't necessary for core (or even expected) functionality in labwc, and changing the default persistence flag effectively renders inoperable the bug we are trying to avoid. Strict version requirements are an unnecessary burden on distribution packagers as well as end users that may be balancing competing interests (imaging an end user trying to build the latest release, but who prefers to keep a system version of wlroots that has not yet been updated).

At the same time, forcing xwayland to persist by default when somebody *has* updated wlroots is also undesirable, so let's split the baby and choose the bug-avoiding default only when it seems necessary. If there is a runtime check for wlroots versions, we can consider doing that instead, but a compile-time check is straightforward and we can change the wording of the warning to suggest to users that they can avoid this problem either by changing settings or recompiling.

I think this behavior should persist until we have an actual hard requirement on newer wlroots, which probably means 0.19.