### PR TITLE
docs/environment: remove example MOZ_ENABLE_WAYLAND=1

### DIFF
--- a/docs/environment
+++ b/docs/environment
@@ -23,14 +23,6 @@
 # XKB_DEFAULT_OPTIONS=grp:shift_caps_toggle
 
 ##
-## Force Mozilla software like Firefox and Thunderbird to use wayland backend.
-## Firefox (>= v121) enables Wayland by default, but this note is included here
-## for those on non-rolling distributions.
-##
-
-# MOZ_ENABLE_WAYLAND=1
-
-##
 ## Set cursor theme and size. Find system icons themes with:
 ## `find /usr/share/icons/ -type d -name "cursors"`
 ##


### PR DESCRIPTION
...because it has not been relevant since before firefox v121 and even firefox-esr on Debian bullseye is now at v128.

Suggested-by: cry0xen