### PR TITLE
font: remove arrow character from font buffer

### DIFF
--- a/include/common/font.h
+++ b/include/common/font.h
@@ -44,11 +44,10 @@ int font_width(struct font *font, const char *string);
  * @font: font description
  * @color: foreground color in rgba format
  * @bg_color: background color in rgba format
- * @arrow: arrow (utf8) character to show or NULL for none
  */
 void font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	const char *text, struct font *font, const float *color,
-	const float *bg_color, const char *arrow, double scale);
+	const float *bg_color, double scale);
 
 /**
  * font_finish - free some font related resources

--- a/include/common/scaled-font-buffer.h
+++ b/include/common/scaled-font-buffer.h
@@ -18,7 +18,6 @@ struct scaled_font_buffer {
 	int max_width;
 	float color[4];
 	float bg_color[4];
-	char *arrow;
 	struct font font;
 	struct scaled_scene_buffer *scaled_buffer;
 };
@@ -48,7 +47,7 @@ struct scaled_font_buffer *scaled_font_buffer_create(struct wlr_scene_tree *pare
  */
 void scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
 	int max_width, struct font *font, const float *color,
-	const float *bg_color, const char *arrow);
+	const float *bg_color);
 
 /**
  * Update the max width of an existing auto scaling font buffer

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -20,13 +20,6 @@ enum menu_align {
 	LAB_MENU_OPEN_BOTTOM = 1 << 3,
 };
 
-struct menu_scene {
-	struct wlr_scene_tree *tree;
-	struct wlr_scene_node *text;
-	struct wlr_scene_node *background;
-	struct scaled_font_buffer *buffer;
-};
-
 enum menuitem_type {
 	LAB_MENU_ITEM = 0,
 	LAB_MENU_SEPARATOR_LINE,
@@ -45,8 +38,8 @@ struct menuitem {
 	enum menuitem_type type;
 	int native_width;
 	struct wlr_scene_tree *tree;
-	struct menu_scene normal;
-	struct menu_scene selected;
+	struct wlr_scene_tree *normal_tree;
+	struct wlr_scene_tree *selected_tree;
 	struct menu_pipe_context *pipe_ctx;
 	struct view *client_list_view;  /* used by internal client-list */
 	struct wl_list link; /* menu.menuitems */

--- a/src/common/font.c
+++ b/src/common/font.c
@@ -82,34 +82,19 @@ font_width(struct font *font, const char *string)
 void
 font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	const char *text, struct font *font, const float *color,
-	const float *bg_color, const char *arrow, double scale)
+	const float *bg_color, double scale)
 {
-	/* Allow a minimum of one pixel each for text and arrow */
-	if (max_width < 2) {
-		max_width = 2;
-	}
-
 	if (string_null_or_empty(text)) {
 		return;
 	}
 
 	PangoRectangle text_extents = font_extents(font, text);
-	PangoRectangle arrow_extents = font_extents(font, arrow);
 
-	if (arrow) {
-		if (arrow_extents.width >= max_width - 1) {
-			/* It would be weird to get here, but just in case */
-			arrow_extents.width = max_width - 1;
-			text_extents.width = 1;
-		} else {
-			text_extents.width = max_width - arrow_extents.width;
-		}
-	} else if (text_extents.width > max_width) {
+	if (max_width > 0 && text_extents.width > max_width) {
 		text_extents.width = max_width;
 	}
 
-	*buffer = buffer_create_cairo(text_extents.width + arrow_extents.width,
-			text_extents.height, scale);
+	*buffer = buffer_create_cairo(text_extents.width, text_extents.height, scale);
 	if (!*buffer) {
 		wlr_log(WLR_ERROR, "Failed to create font buffer");
 		return;
@@ -160,13 +145,6 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	pango_font_description_free(desc);
 	pango_cairo_update_layout(cairo, layout);
 	pango_cairo_show_layout(cairo, layout);
-
-	if (arrow) {
-		cairo_move_to(cairo, text_extents.width, 0);
-		pango_layout_set_width(layout, arrow_extents.width * PANGO_SCALE);
-		pango_layout_set_text(layout, arrow, -1);
-		pango_cairo_show_layout(cairo, layout);
-	}
 
 	g_object_unref(layout);
 

--- a/src/common/scaled-font-buffer.c
+++ b/src/common/scaled-font-buffer.c
@@ -23,7 +23,7 @@ _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
 
 	/* Buffer gets free'd automatically along the backing wlr_buffer */
 	font_buffer_create(&buffer, self->max_width, self->text,
-		&self->font, self->color, self->bg_color, self->arrow, scale);
+		&self->font, self->color, self->bg_color, scale);
 
 	if (!buffer) {
 		wlr_log(WLR_ERROR, "font_buffer_create() failed");
@@ -40,7 +40,6 @@ _destroy(struct scaled_scene_buffer *scaled_buffer)
 
 	zfree(self->text);
 	zfree(self->font.name);
-	zfree(self->arrow);
 	free(self);
 }
 
@@ -63,8 +62,7 @@ _equal(struct scaled_scene_buffer *scaled_buffer_a,
 		&& a->font.slant == b->font.slant
 		&& a->font.weight == b->font.weight
 		&& !memcmp(a->color, b->color, sizeof(a->color))
-		&& !memcmp(a->bg_color, b->bg_color, sizeof(a->bg_color))
-		&& str_equal(a->arrow, b->arrow);
+		&& !memcmp(a->bg_color, b->bg_color, sizeof(a->bg_color));
 }
 
 static const struct scaled_scene_buffer_impl impl = {
@@ -95,7 +93,7 @@ scaled_font_buffer_create(struct wlr_scene_tree *parent)
 void
 scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
 		int max_width, struct font *font, const float *color,
-		const float *bg_color, const char *arrow)
+		const float *bg_color)
 {
 	assert(self);
 	assert(text);
@@ -105,7 +103,6 @@ scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
 	/* Clean up old internal state */
 	zfree(self->text);
 	zfree(self->font.name);
-	zfree(self->arrow);
 
 	/* Update internal state */
 	self->text = xstrdup(text);
@@ -118,7 +115,6 @@ scaled_font_buffer_update(struct scaled_font_buffer *self, const char *text,
 	self->font.weight = font->weight;
 	memcpy(self->color, color, sizeof(self->color));
 	memcpy(self->bg_color, bg_color, sizeof(self->bg_color));
-	self->arrow = arrow ? xstrdup(arrow) : NULL;
 
 	/* Invalidate cache and force a new render */
 	scaled_scene_buffer_invalidate_cache(self->scaled_buffer);

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -168,17 +168,31 @@ item_create_scene_for_state(struct menuitem *item, float *text_color,
 
 	int arrow_width = item->arrow ?
 		font_width(&rc.font_menuitem, item->arrow) : 0;
-	int text_width = bg_width - 2 * theme->menu_items_padding_x - arrow_width;
+	int label_max_width = bg_width - 2 * theme->menu_items_padding_x - arrow_width;
 
 	/* Create label */
 	struct scaled_font_buffer *label_buffer = scaled_font_buffer_create(tree);
 	assert(label_buffer);
-	scaled_font_buffer_update(label_buffer, item->text, text_width,
-		&rc.font_menuitem, text_color, bg_color, item->arrow);
+	scaled_font_buffer_update(label_buffer, item->text, label_max_width,
+		&rc.font_menuitem, text_color, bg_color);
 	/* Vertically center and left-align label */
 	int x = theme->menu_items_padding_x;
 	int y = (theme->menu_item_height - label_buffer->height) / 2;
 	wlr_scene_node_set_position(&label_buffer->scene_buffer->node, x, y);
+
+	if (!item->arrow) {
+		return tree;
+	}
+
+	/* Create arrow for submenu items */
+	struct scaled_font_buffer *arrow_buffer = scaled_font_buffer_create(tree);
+	assert(arrow_buffer);
+	scaled_font_buffer_update(arrow_buffer, item->arrow, -1,
+		&rc.font_menuitem, text_color, bg_color);
+	/* Vertically center and right-align arrow */
+	x += label_max_width;
+	y = (theme->menu_item_height - label_buffer->height) / 2;
+	wlr_scene_node_set_position(&arrow_buffer->scene_buffer->node, x, y);
 
 	return tree;
 }
@@ -298,7 +312,7 @@ title_create_scene(struct menuitem *menuitem, int *item_y)
 	assert(title_font_buffer);
 	scaled_font_buffer_update(title_font_buffer, menuitem->text,
 		bg_width - 2 * theme->menu_items_padding_x,
-		&rc.font_menuheader, text_color, bg_color, /* arrow */ NULL);
+		&rc.font_menuheader, text_color, bg_color);
 
 	int title_x = 0;
 	switch (theme->menu_title_text_justify) {

--- a/src/ssd/resize-indicator.c
+++ b/src/ssd/resize-indicator.c
@@ -205,8 +205,7 @@ resize_indicator_update(struct view *view)
 	wlr_scene_node_set_position(&indicator->tree->node, x, y);
 
 	scaled_font_buffer_update(indicator->text, text, width, &rc.font_osd,
-		rc.theme->osd_label_text_color, rc.theme->osd_bg_color,
-		NULL /* const char *arrow */);
+		rc.theme->osd_label_text_color, rc.theme->osd_bg_color);
 }
 
 void

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -504,7 +504,7 @@ ssd_update_title(struct ssd *ssd)
 		if (part->buffer) {
 			scaled_font_buffer_update(part->buffer, title,
 				title_bg_width, font,
-				text_color, bg_color, NULL);
+				text_color, bg_color);
 		}
 
 		/* And finally update the cache */


### PR DESCRIPTION
Split from #2399. This PR removes `arrow` argument from `font_buffer_create()` and `scaled_font_buffer_update()` so that we can simplify the calculation of the size of a font buffer. Now, 2 separate scaled-font-buffers for a label and a arrow sign are created for a submenu item. 

Other changes are:
- Now `font_buffer_create()` accepts non-positive numbers for `max_width`, in which case the natural font width is always used for buffer creation.
- `menuitem->{normal,selected}` are replaced by simple `menuitem->{normal_tree,selected_tree}`, since we no longer dynamically update buffers of existing menuitems.