### PR TITLE
Some more minor prep work for ext-workspaces

### DIFF
--- a/include/protocols/cosmic-workspaces-internal.h
+++ b/include/protocols/cosmic-workspaces-internal.h
@@ -16,9 +16,9 @@ enum pending_change {
 	CW_PENDING_WS_REMOVE     = 1 << 3,
 };
 
-void group_output_send_initial_state(struct lab_cosmic_workspace_group *group,
+void cosmic_group_output_send_initial_state(struct lab_cosmic_workspace_group *group,
 	struct wl_resource *group_resource);
 
-void manager_schedule_done_event(struct lab_cosmic_workspace_manager *manager);
+void cosmic_manager_schedule_done_event(struct lab_cosmic_workspace_manager *manager);
 
 #endif /* LABWC_PROTOCOLS_COSMIC_WORKSPACES_INTERNAL_H */

--- a/include/workspaces.h
+++ b/include/workspaces.h
@@ -26,7 +26,7 @@ struct workspace {
 		struct wl_listener activate;
 		struct wl_listener deactivate;
 		struct wl_listener remove;
-	} on;
+	} on_cosmic;
 };
 
 void workspaces_init(struct server *server);

--- a/src/protocols/cosmic_workspaces/cosmic-workspaces.c
+++ b/src/protocols/cosmic_workspaces/cosmic-workspaces.c
@@ -219,7 +219,7 @@ workspace_set_state(struct lab_cosmic_workspace *workspace,
 	} else {
 		workspace->state_pending &= ~state;
 	}
-	manager_schedule_done_event(workspace->group->manager);
+	cosmic_manager_schedule_done_event(workspace->group->manager);
 }
 
 /* Group */
@@ -306,7 +306,7 @@ group_send_state(struct lab_cosmic_workspace_group *group, struct wl_resource *r
 	zcosmic_workspace_group_handle_v1_send_capabilities(
 		resource, &group->capabilities);
 
-	group_output_send_initial_state(group, resource);
+	cosmic_group_output_send_initial_state(group, resource);
 }
 
 /* Manager itself */
@@ -385,7 +385,8 @@ manager_handle_bind(struct wl_client *client, void *data,
 		return;
 	}
 
-	struct lab_wl_resource_addon *addon = lab_resource_addon_create(/* session context*/ NULL);
+	struct lab_wl_resource_addon *addon =
+		lab_resource_addon_create(/* session context*/ NULL);
 	addon->data = manager;
 
 	wl_resource_set_implementation(resource, &manager_impl,
@@ -462,7 +463,7 @@ manager_idle_send_done(void *data)
 
 /* Internal API */
 void
-manager_schedule_done_event(struct lab_cosmic_workspace_manager *manager)
+cosmic_manager_schedule_done_event(struct lab_cosmic_workspace_manager *manager)
 {
 	if (manager->idle_source) {
 		return;
@@ -529,7 +530,7 @@ lab_cosmic_workspace_group_create(struct lab_cosmic_workspace_manager *manager)
 		zcosmic_workspace_manager_v1_send_workspace_group(resource, group_resource);
 		group_send_state(group, group_resource);
 	}
-	manager_schedule_done_event(manager);
+	cosmic_manager_schedule_done_event(manager);
 
 	return group;
 }
@@ -618,7 +619,7 @@ lab_cosmic_workspace_create(struct lab_cosmic_workspace_group *group)
 			group_resource, workspace_resource);
 		workspace_send_initial_state(workspace, workspace_resource);
 	}
-	manager_schedule_done_event(group->manager);
+	cosmic_manager_schedule_done_event(group->manager);
 
 	return workspace;
 }
@@ -637,7 +638,7 @@ lab_cosmic_workspace_set_name(struct lab_cosmic_workspace *workspace, const char
 			zcosmic_workspace_handle_v1_send_name(resource, workspace->name);
 		}
 	}
-	manager_schedule_done_event(workspace->group->manager);
+	cosmic_manager_schedule_done_event(workspace->group->manager);
 }
 
 void
@@ -670,7 +671,7 @@ lab_cosmic_workspace_set_coordinates(struct lab_cosmic_workspace *workspace,
 	wl_resource_for_each(resource, &workspace->resources) {
 		zcosmic_workspace_handle_v1_send_coordinates(resource, &workspace->coordinates);
 	}
-	manager_schedule_done_event(workspace->group->manager);
+	cosmic_manager_schedule_done_event(workspace->group->manager);
 }
 
 void
@@ -692,7 +693,7 @@ lab_cosmic_workspace_destroy(struct lab_cosmic_workspace *workspace)
 		wl_list_remove(wl_resource_get_link(resource));
 		wl_list_init(wl_resource_get_link(resource));
 	}
-	manager_schedule_done_event(workspace->group->manager);
+	cosmic_manager_schedule_done_event(workspace->group->manager);
 
 	/* Cancel pending transaction operations involving this workspace */
 	struct lab_transaction_op *trans_op, *trans_op_tmp;

--- a/src/protocols/cosmic_workspaces/output.c
+++ b/src/protocols/cosmic_workspaces/output.c
@@ -44,7 +44,7 @@ group_output_destroy(struct group_output *group_output)
 		&group_output->wlr_output->resources,
 		zcosmic_workspace_group_handle_v1_send_output_leave);
 
-	manager_schedule_done_event(group_output->group->manager);
+	cosmic_manager_schedule_done_event(group_output->group->manager);
 
 	wl_list_remove(&group_output->link);
 	wl_list_remove(&group_output->on.group_destroy.link);
@@ -103,7 +103,7 @@ handle_group_destroy(struct wl_listener *listener, void *data)
 
 /* Internal API*/
 void
-group_output_send_initial_state(struct lab_cosmic_workspace_group *group,
+cosmic_group_output_send_initial_state(struct lab_cosmic_workspace_group *group,
 		struct wl_resource *group_resource)
 {
 	struct group_output *group_output;
@@ -150,7 +150,7 @@ lab_cosmic_workspace_group_output_enter(struct lab_cosmic_workspace_group *group
 		&group_output->wlr_output->resources,
 		zcosmic_workspace_group_handle_v1_send_output_enter);
 
-	manager_schedule_done_event(group->manager);
+	cosmic_manager_schedule_done_event(group->manager);
 }
 
 void

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -206,7 +206,6 @@ add_workspace(struct server *server, const char *name)
 	workspace->cosmic_workspace = lab_cosmic_workspace_create(server->workspaces.cosmic_group);
 	lab_cosmic_workspace_set_name(workspace->cosmic_workspace, name);
 	lab_cosmic_workspace_set_active(workspace->cosmic_workspace, active);
-	lab_cosmic_workspace_set_hidden(workspace->cosmic_workspace, !active);
 
 	workspace->on_cosmic.activate.notify = handle_cosmic_workspace_activate;
 	wl_signal_add(&workspace->cosmic_workspace->events.activate,
@@ -320,8 +319,6 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 
 	lab_cosmic_workspace_set_active(
 		server->workspaces.current->cosmic_workspace, false);
-	lab_cosmic_workspace_set_hidden(
-		server->workspaces.current->cosmic_workspace, true);
 
 	/* Move Omnipresent views to new workspace */
 	struct view *view;
@@ -377,7 +374,6 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	desktop_update_top_layer_visiblity(server);
 
 	lab_cosmic_workspace_set_active(target->cosmic_workspace, true);
-	lab_cosmic_workspace_set_hidden(target->cosmic_workspace, false);
 }
 
 void

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -178,11 +178,11 @@ _osd_update(struct server *server)
 
 /* cosmic workspace handlers */
 static void
-handle_workspace_activate(struct wl_listener *listener, void *data)
+handle_cosmic_workspace_activate(struct wl_listener *listener, void *data)
 {
-	struct workspace *workspace = wl_container_of(listener, workspace, on.activate);
+	struct workspace *workspace = wl_container_of(listener, workspace, on_cosmic.activate);
 	workspaces_switch_to(workspace, /* update_focus */ true);
-	wlr_log(WLR_INFO, "activating workspace %s", workspace->name);
+	wlr_log(WLR_INFO, "cosmic activating workspace %s", workspace->name);
 }
 
 /* Internal API */
@@ -201,13 +201,16 @@ add_workspace(struct server *server, const char *name)
 	}
 
 	bool active = server->workspaces.current == workspace;
+
+	/* cosmic */
 	workspace->cosmic_workspace = lab_cosmic_workspace_create(server->workspaces.cosmic_group);
 	lab_cosmic_workspace_set_name(workspace->cosmic_workspace, name);
 	lab_cosmic_workspace_set_active(workspace->cosmic_workspace, active);
 	lab_cosmic_workspace_set_hidden(workspace->cosmic_workspace, !active);
 
-	workspace->on.activate.notify = handle_workspace_activate;
-	wl_signal_add(&workspace->cosmic_workspace->events.activate, &workspace->on.activate);
+	workspace->on_cosmic.activate.notify = handle_cosmic_workspace_activate;
+	wl_signal_add(&workspace->cosmic_workspace->events.activate,
+		&workspace->on_cosmic.activate);
 }
 
 static struct workspace *


### PR DESCRIPTION
Split of from
- #2365

Some more minor prep work:
- Removes `lab_cosmic_workspace_set_hidden()` calls as its a concept labwc does not support.
- Prefixes some cosmic internal API naming to not clash with a future ext-workspace implementation