### PR TITLE
keyboard: fix missing release event when IME is enabled while key press 

### DIFF
--- a/include/input/ime.h
+++ b/include/input/ime.h
@@ -21,6 +21,7 @@ struct input_method_relay {
 	struct wl_list text_inputs; /* struct text_input.link */
 	struct wlr_input_method_v2 *input_method;
 	struct wlr_surface *focused_surface;
+	struct lab_set pressed_keys;
 	/*
 	 * Text-input which is enabled by the client and communicating with
 	 * input-method.

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -73,9 +73,25 @@ bool
 input_method_keyboard_grab_forward_key(struct keyboard *keyboard,
 		struct wlr_keyboard_key_event *event)
 {
+	/*
+	 * We should not forward key-release events without corresponding
+	 * key-press events forwarded
+	 */
+	struct lab_set *pressed_keys =
+		&keyboard->base.seat->input_method_relay->pressed_keys;
+	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED
+			&& !lab_set_contains(pressed_keys, event->keycode)) {
+		return false;
+	}
+
 	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab =
 		get_keyboard_grab(keyboard);
 	if (keyboard_grab) {
+		if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
+			lab_set_add(pressed_keys, event->keycode);
+		} else {
+			lab_set_remove(pressed_keys, event->keycode);
+		}
 		wlr_input_method_keyboard_grab_v2_set_keyboard(keyboard_grab,
 			keyboard->wlr_keyboard);
 		wlr_input_method_keyboard_grab_v2_send_key(keyboard_grab,
@@ -328,6 +344,8 @@ handle_input_method_grab_keyboard(struct wl_listener *listener, void *data)
 		wlr_input_method_keyboard_grab_v2_set_keyboard(
 			keyboard_grab, active_keyboard);
 	}
+
+	relay->pressed_keys = (struct lab_set){0};
 
 	relay->keyboard_grab_destroy.notify = handle_keyboard_grab_destroy;
 	wl_signal_add(&keyboard_grab->events.destroy,


### PR DESCRIPTION
After commit [e2189903](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/e21899037a97dcade40149f05ab54229c0018644) in wlroots, when ctrl-f is pressed in firefox with a IME client running, the following key-release event for "f" is not sent, thus "f" is repeated like "ffffffffff..." in the input box of firefox. This is because the key-release event for "f" is firstly relayed to the IME client and then sent via the virtual keyboard created by the IME client while the key-press event is sent via physical keyboard, and with [e2189903](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/e21899037a97dcade40149f05ab54229c0018644), key-release events without a corresponding key-press event on the same keyboard is not emitted to the compositor.

https://github.com/user-attachments/assets/b87e7e7f-c288-4f50-8902-361a6f0be678

So this PR fixes this problem by not relaying the key-release event to the IME client when the corresponding key-press event was previously sent to the application.

This follows sway's behavior:
https://github.com/swaywm/sway/blob/f293418d9d8a9e71fc52bc75a83d24ec2cc934c9/sway/input/keyboard.c#L548-L561