### PR TITLE
ssd: rework titlebar button rendering 

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -62,18 +62,6 @@ struct lab_data_buffer *buffer_create_cairo(uint32_t logical_width,
 	uint32_t logical_height, float scale);
 
 /*
- * Create a buffer from an image surface, for display as an icon.
- *
- * The surface is either adopted by the buffer (which takes ownership),
- * or copied and then destroyed.
- *
- * This function allows non-ARGB32 source images and converts to
- * CAIRO_FORMAT_ARGB32 if needed.
- */
-struct lab_data_buffer *buffer_convert_cairo_surface_for_icon(
-	cairo_surface_t *surface, uint32_t icon_size, float scale);
-
-/*
  * Create a buffer which holds (and takes ownership of) raw pixel data
  * in pre-multiplied ARGB32 format.
  *

--- a/include/common/box.h
+++ b/include/common/box.h
@@ -13,14 +13,13 @@ void box_union(struct wlr_box *box_dest, struct wlr_box *box_a,
 	struct wlr_box *box_b);
 
 /*
- * Fits and centers a content box (width & height) within a bounding box
- * (max_width & max_height). The content box is downscaled if necessary
- * (preserving aspect ratio) but not upscaled.
+ * Fits and centers a content box (width & height) within a bounding box.
+ * The content box is downscaled if necessary (preserving aspect ratio) but
+ * not upscaled.
  *
  * The returned x & y coordinates are the centered content position
  * relative to the top-left corner of the bounding box.
  */
-struct wlr_box box_fit_within(int width, int height, int max_width,
-	int max_height);
+struct wlr_box box_fit_within(int width, int height, struct wlr_box *bounding_box);
 
 #endif /* LABWC_BOX_H */

--- a/include/common/scaled-img-buffer.h
+++ b/include/common/scaled-img-buffer.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_SCALED_IMG_BUFFER_H
+#define LABWC_SCALED_IMG_BUFFER_H
+
+#include <stdbool.h>
+
+struct wlr_scene_tree;
+struct wlr_scene_node;
+struct wlr_scene_buffer;
+struct lab_img;
+
+struct scaled_img_buffer {
+	struct scaled_scene_buffer *scaled_buffer;
+	struct wlr_scene_buffer *scene_buffer;
+	struct lab_img *img;
+	int width;
+	int height;
+	int padding;
+};
+
+/*
+ * Create an auto scaling image buffer, providing a wlr_scene_buffer node for
+ * display. It gets destroyed automatically when the backing scaled_scene_buffer
+ * is being destroyed which in turn happens automatically when the backing
+ * wlr_scene_buffer (or one of its parents) is being destroyed.
+ */
+struct scaled_img_buffer *scaled_img_buffer_create(struct wlr_scene_tree *parent,
+	struct lab_img *img, int width, int height, int padding);
+
+/* Update image, width, height and padding of the scaled_img_buffer */
+void scaled_img_buffer_update(struct scaled_img_buffer *self,
+	struct lab_img *img, int width, int height, int padding);
+
+/* Obtain scaled_img_buffer from wlr_scene_node */
+struct scaled_img_buffer *scaled_img_buffer_from_node(struct wlr_scene_node *node);
+
+#endif /* LABWC_SCALED_IMG_BUFFER_H */

--- a/include/desktop-entry.h
+++ b/include/desktop-entry.h
@@ -7,7 +7,7 @@ struct server;
 void desktop_entry_init(struct server *server);
 void desktop_entry_finish(struct server *server);
 
-struct lab_data_buffer *desktop_entry_icon_lookup(struct server *server,
+struct lab_img *desktop_entry_icon_lookup(struct server *server,
 	const char *app_id, int size, float scale);
 
 /**

--- a/include/img/img-png.h
+++ b/include/img/img-png.h
@@ -2,9 +2,6 @@
 #ifndef LABWC_IMG_PNG_H
 #define LABWC_IMG_PNG_H
 
-struct lab_data_buffer;
-
-void img_png_load(const char *filename, struct lab_data_buffer **buffer,
-	int size, float scale);
+struct lab_data_buffer *img_png_load(const char *filename);
 
 #endif /* LABWC_IMG_PNG_H */

--- a/include/img/img-svg.h
+++ b/include/img/img-svg.h
@@ -2,9 +2,13 @@
 #ifndef LABWC_IMG_SVG_H
 #define LABWC_IMG_SVG_H
 
+#include <librsvg/rsvg.h>
+
 struct lab_data_buffer;
 
-void img_svg_load(const char *filename, struct lab_data_buffer **buffer,
-	int size, float scale);
+RsvgHandle *img_svg_load(const char *filename);
+
+struct lab_data_buffer *img_svg_render(RsvgHandle *svg, int w, int h,
+	int padding, double scale);
 
 #endif /* LABWC_IMG_SVG_H */

--- a/include/img/img-xbm.h
+++ b/include/img/img-xbm.h
@@ -5,18 +5,15 @@
 struct lab_data_buffer;
 
 /**
- * img_xbm_from_bitmap() - create button from monochrome bitmap
+ * img_xbm_load_from_bitmap() - create button from monochrome bitmap
  * @bitmap: bitmap data array in hexadecimal xbm format
- * @buffer: cairo-surface-buffer to create
  * @rgba: color
  *
  * Example bitmap: char button[6] = { 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f };
  */
-void img_xbm_from_bitmap(const char *bitmap, struct lab_data_buffer **buffer,
-	float *rgba);
+struct lab_data_buffer *img_xbm_load_from_bitmap(const char *bitmap, float *rgba);
 
 /* img_xbm_load - Convert xbm file to buffer with cairo surface */
-void img_xbm_load(const char *filename, struct lab_data_buffer **buffer,
-	float *rgba);
+struct lab_data_buffer *img_xbm_load(const char *filename, float *rgba);
 
 #endif /* LABWC_IMG_XBM_H */

--- a/include/img/img-xpm.h
+++ b/include/img/img-xpm.h
@@ -4,7 +4,6 @@
 
 struct lab_data_buffer;
 
-void img_xpm_load(const char *filename, struct lab_data_buffer **buffer,
-	int size, float scale);
+struct lab_data_buffer *img_xpm_load(const char *filename);
 
 #endif /* LABWC_IMG_XPM_H */

--- a/include/img/img.h
+++ b/include/img/img.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_IMG_H
+#define LABWC_IMG_H
+
+#include <cairo.h>
+#include <stdint.h>
+#include <wayland-util.h>
+
+struct lab_img_cache;
+
+enum lab_img_type {
+	LAB_IMG_PNG,
+	LAB_IMG_SVG,
+	LAB_IMG_XBM,
+	LAB_IMG_XPM,
+};
+
+struct lab_img {
+	struct theme *theme; /* Used by modifier functions */
+	struct wl_array modifiers; /* lab_img_modifier_func_t */
+	struct lab_img_cache *cache;
+};
+
+struct lab_img *lab_img_load(enum lab_img_type type, const char *path,
+	float *xbm_color);
+
+/**
+ * lab_img_load_from_bitmap() - create button from monochrome bitmap
+ * @bitmap: bitmap data array in hexadecimal xbm format
+ * @rgba: color
+ *
+ * Example bitmap: char button[6] = { 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f };
+ */
+struct lab_img *lab_img_load_from_bitmap(const char *bitmap, float *rgba);
+
+typedef void (*lab_img_modifier_func_t)(struct theme *theme, cairo_t *cairo,
+	int w, int h);
+
+/**
+ * lab_img_copy() - Copy lab_img
+ * @img: source image
+ *
+ * This function duplicates lab_img, but its internal cache for the image is
+ * shared.
+ */
+struct lab_img *lab_img_copy(struct lab_img *img);
+
+/**
+ * lab_img_add_modifier() - Add a modifier function to lab_img
+ * @img: source image
+ * @modifier: function that applies modifications to the image.
+ * @theme: pointer to theme passed to @modifier.
+ *
+ * "Modifiers" are functions that perform some additional drawing operation
+ * after the image is rendered on a buffer with lab_img_render(). For example,
+ * hover effects for window buttons can be drawn over the rendered image.
+ */
+void lab_img_add_modifier(struct lab_img *img, lab_img_modifier_func_t modifier,
+	struct theme *theme);
+
+/**
+ * lab_img_render() - Render lab_img to a buffer
+ * @img: source image
+ * @width: width of the created buffer
+ * @height: height of the created buffer
+ * @padding: padding around the rendered image in the buffer
+ * @scale: scale of the created buffer
+ */
+struct lab_data_buffer *lab_img_render(struct lab_img *img,
+	int width, int height, int padding, double scale);
+
+/**
+ * lab_img_destroy() - destroy lab_img
+ * @img: lab_img to destroy
+ */
+void lab_img_destroy(struct lab_img *img);
+
+#endif /* LABWC_IMG_H */

--- a/include/node.h
+++ b/include/node.h
@@ -8,6 +8,7 @@ struct lab_layer_surface;
 struct lab_layer_popup;
 struct menuitem;
 struct ssd_button;
+struct scaled_scene_buffer;
 
 enum node_descriptor_type {
 	LAB_NODE_DESC_NODE = 0,
@@ -19,6 +20,7 @@ enum node_descriptor_type {
 	LAB_NODE_DESC_IME_POPUP,
 	LAB_NODE_DESC_MENUITEM,
 	LAB_NODE_DESC_TREE,
+	LAB_NODE_DESC_SCALED_SCENE_BUFFER,
 	LAB_NODE_DESC_SSD_BUTTON,
 };
 
@@ -79,6 +81,13 @@ struct menuitem *node_menuitem_from_node(
  * @wlr_scene_node: wlr_scene_node from which to return data
  */
 struct ssd_button *node_ssd_button_from_node(
+	struct wlr_scene_node *wlr_scene_node);
+
+/**
+ * node_scaled_scene_buffer_from_node - return scaled_scene_buffer from node
+ * @wlr_scene_node: wlr_scene_node from which to return data
+ */
+struct scaled_scene_buffer *node_scaled_scene_buffer_from_node(
 	struct wlr_scene_node *wlr_scene_node);
 
 #endif /* LABWC_NODE_DESCRIPTOR_H */

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -79,6 +79,7 @@ struct ssd {
 		} title;
 
 		char *app_id;
+		struct lab_img *icon_img;
 	} state;
 
 	/* An invisible area around the view which allows resizing */
@@ -146,10 +147,8 @@ struct ssd_part *add_scene_buffer(
 	struct wlr_scene_tree *parent, struct wlr_buffer *buffer, int x, int y);
 struct ssd_part *add_scene_button(struct wl_list *part_list,
 	enum ssd_part_type type, struct wlr_scene_tree *parent,
-	struct lab_data_buffer *buffers[LAB_BS_ALL + 1], int x, int y,
+	struct lab_img *buffers[LAB_BS_ALL + 1], int x, int y,
 	struct view *view);
-void update_window_icon_buffer(struct wlr_scene_node *button_node,
-	struct lab_data_buffer *buffer);
 
 /* SSD internal helpers */
 struct ssd_part *ssd_get_part(

--- a/include/theme.h
+++ b/include/theme.h
@@ -12,6 +12,8 @@
 #include <wlr/render/wlr_renderer.h>
 #include "ssd.h"
 
+struct lab_img;
+
 enum lab_justification {
 	LAB_JUSTIFY_LEFT,
 	LAB_JUSTIFY_CENTER,
@@ -82,7 +84,7 @@ struct theme {
 		 *
 		 * Elements in buttons[0] are all NULL since LAB_SSD_BUTTON_FIRST is 1.
 		 */
-		struct lab_data_buffer *buttons
+		struct lab_img *button_imgs
 			[LAB_SSD_BUTTON_LAST + 1][LAB_BS_ALL + 1];
 
 		struct lab_data_buffer *corner_top_left_normal;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -29,7 +29,6 @@
 #include <drm_fourcc.h>
 #include <wlr/interfaces/wlr_buffer.h>
 #include "buffer.h"
-#include "common/box.h"
 #include "common/mem.h"
 
 static const struct wlr_buffer_impl data_buffer_impl;
@@ -126,59 +125,6 @@ buffer_create_cairo(uint32_t logical_width, uint32_t logical_height, float scale
 	struct lab_data_buffer *buffer = buffer_adopt_cairo_surface(surface);
 	buffer->logical_width = logical_width;
 	buffer->logical_height = logical_height;
-
-	return buffer;
-}
-
-struct lab_data_buffer *
-buffer_convert_cairo_surface_for_icon(cairo_surface_t *surface,
-		uint32_t icon_size, float scale)
-{
-	assert(cairo_surface_get_type(surface) == CAIRO_SURFACE_TYPE_IMAGE);
-
-	/*
-	 * Compute logical size for display and decide whether we can
-	 * use the image data directly (fast path). Requirements are:
-	 *
-	 *  - The pixel format must be ARGB32.
-	 *  - The image must not be so large as to need downsampling by
-	 *    more than 2x when displayed at the target scale. wlr_scene
-	 *    uses linear interpolation without pixel averaging, which
-	 *    starts to skip samples if downsampling more than 2x,
-	 *    resulting in a grainy look.
-	 */
-	int width = cairo_image_surface_get_width(surface);
-	int height = cairo_image_surface_get_height(surface);
-	struct wlr_box logical =
-		box_fit_within(width, height, icon_size, icon_size);
-	struct lab_data_buffer *buffer;
-
-	if (cairo_image_surface_get_format(surface) == CAIRO_FORMAT_ARGB32
-			&& width <= 2 * logical.width * scale
-			&& height <= 2 * logical.height * scale) {
-		buffer = buffer_adopt_cairo_surface(surface);
-		/* set logical size for display */
-		buffer->logical_width = logical.width;
-		buffer->logical_height = logical.height;
-	} else {
-		/* convert to ARGB32 and scale for display (slow path) */
-		buffer = buffer_create_cairo(logical.width,
-			logical.height, scale);
-
-		cairo_t *cairo = cairo_create(buffer->surface);
-		cairo_scale(cairo, (double)logical.width / width,
-			(double)logical.height / height);
-		cairo_set_source_surface(cairo, surface, 0, 0);
-		cairo_pattern_set_filter(cairo_get_source(cairo),
-			CAIRO_FILTER_GOOD);
-		cairo_paint(cairo);
-
-		/* ensure pixel data is updated */
-		cairo_surface_flush(buffer->surface);
-		/* destroy original cairo surface & context */
-		cairo_surface_destroy(surface);
-		cairo_destroy(cairo);
-	}
 
 	return buffer;
 }

--- a/src/common/box.c
+++ b/src/common/box.c
@@ -49,27 +49,27 @@ box_union(struct wlr_box *box_dest, struct wlr_box *box_a, struct wlr_box *box_b
 }
 
 struct wlr_box
-box_fit_within(int width, int height, int max_width, int max_height)
+box_fit_within(int width, int height, struct wlr_box *bound)
 {
 	struct wlr_box box;
 
-	if (width <= max_width && height <= max_height) {
+	if (width <= bound->width && height <= bound->height) {
 		/* No downscaling needed */
 		box.width = width;
 		box.height = height;
-	} else if (width * max_height > height * max_width) {
+	} else if (width * bound->height > height * bound->width) {
 		/* Wider content, fit width */
-		box.width = max_width;
-		box.height = (height * max_width + (width / 2)) / width;
+		box.width = bound->width;
+		box.height = (height * bound->width + (width / 2)) / width;
 	} else {
 		/* Taller content, fit height */
-		box.width = (width * max_height + (height / 2)) / height;
-		box.height = max_height;
+		box.width = (width * bound->height + (height / 2)) / height;
+		box.height = bound->height;
 	}
 
 	/* Compute centered position */
-	box.x = (max_width - box.width) / 2;
-	box.y = (max_height - box.height) / 2;
+	box.x = bound->x + (bound->width - box.width) / 2;
+	box.y = bound->y + (bound->height - box.height) / 2;
 
 	return box;
 }

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -14,6 +14,7 @@ labwc_sources += files(
   'parse-bool.c',
   'parse-double.c',
   'scaled-font-buffer.c',
+  'scaled-img-buffer.c',
   'scaled-rect-buffer.c',
   'scaled-scene-buffer.c',
   'scene-helpers.c',

--- a/src/common/scaled-img-buffer.c
+++ b/src/common/scaled-img-buffer.c
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_scene.h>
+#include "buffer.h"
+#include "common/list.h"
+#include "common/mem.h"
+#include "common/scaled-img-buffer.h"
+#include "common/scaled-scene-buffer.h"
+#include "img/img.h"
+#include "node.h"
+
+static struct wl_list cached_buffers = WL_LIST_INIT(&cached_buffers);
+
+static struct lab_data_buffer *
+_create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
+{
+	struct scaled_img_buffer *self = scaled_buffer->data;
+	struct lab_data_buffer *buffer = lab_img_render(self->img,
+		self->width, self->height, self->padding, scale);
+	return buffer;
+}
+
+static void
+_destroy(struct scaled_scene_buffer *scaled_buffer)
+{
+	struct scaled_img_buffer *self = scaled_buffer->data;
+	free(self);
+}
+
+static bool
+_equal(struct scaled_scene_buffer *scaled_buffer_a,
+	struct scaled_scene_buffer *scaled_buffer_b)
+{
+	struct scaled_img_buffer *a = scaled_buffer_a->data;
+	struct scaled_img_buffer *b = scaled_buffer_b->data;
+
+	return a->img == b->img
+		&& a->width == b->width
+		&& a->height == b->height
+		&& a->padding == b->padding;
+}
+
+static struct scaled_scene_buffer_impl impl = {
+	.create_buffer = _create_buffer,
+	.destroy = _destroy,
+	.equal = _equal,
+};
+
+struct scaled_img_buffer *
+scaled_img_buffer_create(struct wlr_scene_tree *parent, struct lab_img *img,
+	int width, int height, int padding)
+{
+	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
+		parent, &impl, &cached_buffers, /* drop_buffer */ true);
+	struct scaled_img_buffer *self = znew(*self);
+	self->scaled_buffer = scaled_buffer;
+	self->scene_buffer = scaled_buffer->scene_buffer;
+	self->img = img;
+	self->width = width;
+	self->height = height;
+	self->padding = padding;
+
+	scaled_buffer->data = self;
+
+	scaled_scene_buffer_request_update(scaled_buffer, width, height);
+
+	return self;
+}
+
+void
+scaled_img_buffer_update(struct scaled_img_buffer *self, struct lab_img *img,
+	int width, int height, int padding)
+{
+	self->img = img;
+	self->width = width;
+	self->height = height;
+	self->padding = padding;
+	scaled_scene_buffer_request_update(self->scaled_buffer, width, height);
+}
+
+struct scaled_img_buffer *
+scaled_img_buffer_from_node(struct wlr_scene_node *node)
+{
+	struct scaled_scene_buffer *scaled_buffer =
+		node_scaled_scene_buffer_from_node(node);
+	assert(scaled_buffer->impl == &impl);
+	return scaled_buffer->data;
+}

--- a/src/common/scaled-scene-buffer.c
+++ b/src/common/scaled-scene-buffer.c
@@ -10,6 +10,7 @@
 #include "buffer.h"
 #include "common/mem.h"
 #include "common/scaled-scene-buffer.h"
+#include "node.h"
 
 /**
  * TODO
@@ -226,6 +227,8 @@ scaled_scene_buffer_create(struct wlr_scene_tree *parent,
 		free(self);
 		return NULL;
 	}
+	node_descriptor_create(&self->scene_buffer->node,
+		LAB_NODE_DESC_SCALED_SCENE_BUFFER, self);
 
 	self->impl = impl;
 	/*

--- a/src/desktop-entry.c
+++ b/src/desktop-entry.c
@@ -8,14 +8,8 @@
 #include "common/macros.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"
-#include "config.h"
 #include "desktop-entry.h"
-#include "img/img-png.h"
-#include "img/img-xpm.h"
-
-#if HAVE_RSVG
-#include "img/img-svg.h"
-#endif
+#include "img/img.h"
 
 #include "labwc.h"
 
@@ -267,7 +261,22 @@ get_desktop_entry(struct sfdo *sfdo, const char *app_id)
 	return entry;
 }
 
-struct lab_data_buffer *
+static enum lab_img_type
+convert_img_type(enum sfdo_icon_file_format fmt)
+{
+	switch (fmt) {
+	case SFDO_ICON_FILE_FORMAT_PNG:
+		return LAB_IMG_PNG;
+	case SFDO_ICON_FILE_FORMAT_SVG:
+		return LAB_IMG_SVG;
+	case SFDO_ICON_FILE_FORMAT_XPM:
+		return LAB_IMG_XPM;
+	default:
+		abort();
+	}
+}
+
+struct lab_img *
 desktop_entry_icon_lookup(struct server *server, const char *app_id, int size,
 		float scale)
 {
@@ -308,26 +317,12 @@ desktop_entry_icon_lookup(struct server *server, const char *app_id, int size,
 		return NULL;
 	}
 
-	struct lab_data_buffer *icon_buffer = NULL;
-
 	wlr_log(WLR_DEBUG, "loading icon file %s", ctx.path);
-
-	switch (ctx.format) {
-	case SFDO_ICON_FILE_FORMAT_PNG:
-		img_png_load(ctx.path, &icon_buffer, size, scale);
-		break;
-	case SFDO_ICON_FILE_FORMAT_SVG:
-#if HAVE_RSVG
-		img_svg_load(ctx.path, &icon_buffer, size, scale);
-#endif
-		break;
-	case SFDO_ICON_FILE_FORMAT_XPM:
-		img_xpm_load(ctx.path, &icon_buffer, size, scale);
-		break;
-	}
+	struct lab_img *img = lab_img_load(convert_img_type(ctx.format), ctx.path, NULL);
 
 	free(ctx.path);
-	return icon_buffer;
+
+	return img;
 }
 
 const char *

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -348,6 +348,7 @@ get_cursor_context(struct server *server)
 				return ret;
 			case LAB_NODE_DESC_NODE:
 			case LAB_NODE_DESC_TREE:
+			case LAB_NODE_DESC_SCALED_SCENE_BUFFER:
 				break;
 			}
 		}

--- a/src/img/img-xbm.c
+++ b/src/img/img-xbm.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <drm_fourcc.h>
+#include "img/img.h"
 #include "img/img-xbm.h"
 #include "common/grab-file.h"
 #include "common/mem.h"
@@ -255,32 +256,23 @@ parse_xbm_builtin(const char *button, int size)
 	return pixmap;
 }
 
-void
-img_xbm_from_bitmap(const char *bitmap, struct lab_data_buffer **buffer,
-		float *rgba)
+struct lab_data_buffer *
+img_xbm_load_from_bitmap(const char *bitmap, float *rgba)
 {
 	struct pixmap pixmap = {0};
-	if (*buffer) {
-		wlr_buffer_drop(&(*buffer)->base);
-		*buffer = NULL;
-	}
 	color = argb32(rgba);
 	pixmap = parse_xbm_builtin(bitmap, 6);
-	*buffer = buffer_create_from_data(pixmap.data, pixmap.width, pixmap.height,
+
+	return buffer_create_from_data(pixmap.data, pixmap.width, pixmap.height,
 		pixmap.width * 4);
 }
 
-void
-img_xbm_load(const char *filename, struct lab_data_buffer **buffer,
-		float *rgba)
+struct lab_data_buffer *
+img_xbm_load(const char *filename, float *rgba)
 {
 	struct pixmap pixmap = {0};
-	if (*buffer) {
-		wlr_buffer_drop(&(*buffer)->base);
-		*buffer = NULL;
-	}
 	if (string_null_or_empty(filename)) {
-		return;
+		return NULL;
 	}
 	color = argb32(rgba);
 
@@ -295,12 +287,9 @@ img_xbm_load(const char *filename, struct lab_data_buffer **buffer,
 	}
 	buf_reset(&token_buf);
 	if (!pixmap.data) {
-		return;
+		return NULL;
 	}
 
-	/* Create buffer */
-	if (pixmap.data) {
-		*buffer = buffer_create_from_data(pixmap.data, pixmap.width,
-			pixmap.height, pixmap.width * 4);
-	}
+	return buffer_create_from_data(pixmap.data, pixmap.width,
+		pixmap.height, pixmap.width * 4);
 }

--- a/src/img/img-xpm.c
+++ b/src/img/img-xpm.c
@@ -397,30 +397,26 @@ out:
 	return surface;
 }
 
-void
-img_xpm_load(const char *filename, struct lab_data_buffer **buffer, int size,
-		float scale)
+struct lab_data_buffer *
+img_xpm_load(const char *filename)
 {
-	if (*buffer) {
-		wlr_buffer_drop(&(*buffer)->base);
-		*buffer = NULL;
-	}
-
 	struct file_handle h = {0};
 	h.infile = fopen(filename, "rb");
 	if (!h.infile) {
 		wlr_log(WLR_ERROR, "error opening '%s'", filename);
-		return;
+		return NULL;
 	}
 
 	cairo_surface_t *surface = xpm_load_to_surface(&h);
+	struct lab_data_buffer *buffer = NULL;
 	if (surface) {
-		*buffer = buffer_convert_cairo_surface_for_icon(surface, size,
-			scale);
+		buffer = buffer_adopt_cairo_surface(surface);
 	} else {
 		wlr_log(WLR_ERROR, "error loading '%s'", filename);
 	}
 
 	fclose(h.infile);
 	buf_reset(&h.buf);
+
+	return buffer;
 }

--- a/src/img/img.c
+++ b/src/img/img.c
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <assert.h>
+#include <wlr/util/log.h>
+#include "buffer.h"
+#include "config.h"
+#include "common/box.h"
+#include "common/graphic-helpers.h"
+#include "common/macros.h"
+#include "common/mem.h"
+#include "common/string-helpers.h"
+#include "img/img.h"
+#include "img/img-png.h"
+#if HAVE_RSVG
+#include "img/img-svg.h"
+#endif
+#include "img/img-xbm.h"
+#include "img/img-xpm.h"
+#include "labwc.h"
+#include "theme.h"
+
+struct lab_img_cache {
+	enum lab_img_type type;
+	/* lab_img_cache is refcounted to be shared by multiple lab_imgs */
+	int refcount;
+
+	/* Handler for the loaded image file */
+	struct lab_data_buffer *buffer; /* for PNG/XBM/XPM image */
+#if HAVE_RSVG
+	RsvgHandle *svg; /* for SVG image */
+#endif
+};
+
+static struct lab_img *
+create_img(struct lab_img_cache *cache)
+{
+	struct lab_img *img = znew(*img);
+	img->cache = cache;
+	cache->refcount++;
+	wl_array_init(&img->modifiers);
+	return img;
+}
+
+struct lab_img *
+lab_img_load(enum lab_img_type type, const char *path, float *xbm_color)
+{
+	if (string_null_or_empty(path)) {
+		return NULL;
+	}
+
+	struct lab_img_cache *cache = znew(*cache);
+	cache->type = type;
+
+	switch (type) {
+	case LAB_IMG_PNG:
+		cache->buffer = img_png_load(path);
+		break;
+	case LAB_IMG_XBM:
+		assert(xbm_color);
+		cache->buffer = img_xbm_load(path, xbm_color);
+		break;
+	case LAB_IMG_XPM:
+		cache->buffer = img_xpm_load(path);
+		break;
+	case LAB_IMG_SVG:
+#if HAVE_RSVG
+		cache->svg = img_svg_load(path);
+#endif
+		break;
+	}
+
+	bool img_is_loaded = (bool)cache->buffer;
+#if HAVE_RSVG
+	img_is_loaded |= (bool)cache->svg;
+#endif
+
+	if (img_is_loaded) {
+		return create_img(cache);
+	} else {
+		free(cache);
+		return NULL;
+	}
+}
+
+struct lab_img *
+lab_img_load_from_bitmap(const char *bitmap, float *rgba)
+{
+	struct lab_data_buffer *buffer = img_xbm_load_from_bitmap(bitmap, rgba);
+	if (!buffer) {
+		return NULL;
+	}
+
+	struct lab_img_cache *cache = znew(*cache);
+	cache->type = LAB_IMG_XBM;
+	cache->buffer = buffer;
+
+	return create_img(cache);
+}
+
+struct lab_img *
+lab_img_copy(struct lab_img *img)
+{
+	struct lab_img *new_img = create_img(img->cache);
+	wl_array_copy(&new_img->modifiers, &img->modifiers);
+	return new_img;
+}
+
+void
+lab_img_add_modifier(struct lab_img *img,  lab_img_modifier_func_t modifier,
+	struct theme *theme)
+{
+	img->theme = theme;
+	lab_img_modifier_func_t *mod = wl_array_add(&img->modifiers, sizeof(*mod));
+	*mod = modifier;
+}
+
+/*
+ * Takes a source surface from PNG/XBM/XPM file and output a buffer for the
+ * given size. The source surface is placed at the center of the output buffer
+ * and shrunk if it overflows from the output buffer.
+ */
+static struct lab_data_buffer *
+render_cairo_surface(cairo_surface_t *surface, int width, int height,
+	int padding, double scale)
+{
+	assert(surface);
+	int src_w = cairo_image_surface_get_width(surface);
+	int src_h = cairo_image_surface_get_height(surface);
+
+	struct lab_data_buffer *buffer =
+		buffer_create_cairo(width, height, scale);
+	cairo_t *cairo = cairo_create(buffer->surface);
+
+	struct wlr_box container = {
+		.x = padding,
+		.y = padding,
+		.width = width - 2 * padding,
+		.height = height - 2 * padding,
+	};
+
+	struct wlr_box src_box = box_fit_within(src_w, src_h, &container);
+	double scene_scale = MIN(1.0, (double_t)container.width / (double)src_w);
+	cairo_translate(cairo, src_box.x, src_box.y);
+	cairo_scale(cairo, scene_scale, scene_scale);
+	cairo_set_source_surface(cairo, surface, 0, 0);
+	cairo_pattern_set_filter(cairo_get_source(cairo), CAIRO_FILTER_GOOD);
+	cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
+	cairo_paint(cairo);
+
+	cairo_destroy(cairo);
+
+	return buffer;
+}
+
+struct lab_data_buffer *
+lab_img_render(struct lab_img *img, int width, int height, int padding,
+	double scale)
+{
+	struct lab_data_buffer *buffer = NULL;
+
+	/* Render the image into the buffer for the given size */
+	switch (img->cache->type) {
+	case LAB_IMG_PNG:
+	case LAB_IMG_XBM:
+	case LAB_IMG_XPM:
+		buffer = render_cairo_surface(img->cache->buffer->surface,
+			width, height, padding, scale);
+		break;
+#if HAVE_RSVG
+	case LAB_IMG_SVG:
+		buffer = img_svg_render(img->cache->svg, width, height,
+			padding, scale);
+		break;
+#endif
+	default:
+		break;
+	}
+
+	if (!buffer) {
+		return NULL;
+	}
+
+	/* Apply modifiers to the buffer (e.g. draw hover overlay) */
+	cairo_t *cairo = cairo_create(buffer->surface);
+	lab_img_modifier_func_t *modifier;
+	wl_array_for_each(modifier, &img->modifiers) {
+		cairo_save(cairo);
+		(*modifier)(img->theme, cairo, width, height);
+		cairo_restore(cairo);
+	}
+
+	cairo_surface_flush(buffer->surface);
+	cairo_destroy(cairo);
+
+	return buffer;
+}
+
+void
+lab_img_destroy(struct lab_img *img)
+{
+	if (!img) {
+		return;
+	}
+
+	struct lab_img_cache *cache = img->cache;
+	cache->refcount--;
+
+	if (cache->refcount == 0) {
+		if (cache->buffer) {
+			wlr_buffer_drop(&cache->buffer->base);
+		}
+#if HAVE_RSVG
+		if (cache->svg) {
+			g_object_unref(cache->svg);
+		}
+#endif
+		free(cache);
+	}
+
+	wl_array_release(&img->modifiers);
+	free(img);
+}

--- a/src/img/meson.build
+++ b/src/img/meson.build
@@ -1,4 +1,5 @@
 labwc_sources += files(
+  'img.c',
   'img-png.c',
   'img-xbm.c',
   'img-xpm.c'

--- a/src/node.c
+++ b/src/node.c
@@ -79,3 +79,12 @@ node_ssd_button_from_node(struct wlr_scene_node *wlr_scene_node)
 	assert(node_descriptor->type == LAB_NODE_DESC_SSD_BUTTON);
 	return (struct ssd_button *)node_descriptor->data;
 }
+
+struct scaled_scene_buffer *
+node_scaled_scene_buffer_from_node(struct wlr_scene_node *wlr_scene_node)
+{
+	assert(wlr_scene_node->data);
+	struct node_descriptor *node_descriptor = wlr_scene_node->data;
+	assert(node_descriptor->type == LAB_NODE_DESC_SCALED_SCENE_BUFFER);
+	return (struct scaled_scene_buffer *)node_descriptor->data;
+}


### PR DESCRIPTION
## What this PR does

- Fix #2286
- Fix blurry window button icons in outputs with a scale larger than 1

## Implementation

### `lab_img`

- `lab_img` holds a cache for a loaded image (`lab_data_buffer` for PNG/XBM/XPM images and `RsvgHandle` for SVG images).
- `lab_img` is created with `lab_img_load()` and rendered to a buffer with `lab_img_render()`. This allows rendering the same images for different sizes/scales.
- __"Modifier"__ functions can be applied to `lab_img` with `lab_img_add_modifier()`. This applies additional drawing operations in `lab_img_render()`. In this PR, this is used for overlaying hover effects on window buttons and rounding the corner buttons.
- The cache in `lab_img` is refcounted and can be shared by multiple `lab_img`s when they are duplicated with `lab_img_copy()`. In this PR, `lab_img`s for builtin normal/hovered buttons share the same caches while having different "modifiers".

### `scaled_img_buffer`

- This inherits `scaled_scene_buffer` and wraps `lab_img` to render it as a scene-node. When it enters an output with a different scale, it calls `lab_img_render()` to render the image in that scale.
- `scaled_scene_buffer_update()` allows updating its `lab_img` and geometry. This PR uses this to update the image when the new icon is loaded from app-id.

### Additional notes

- Now the process of rendering button icons are split into 2 phases: loading with lab_img_load() and creating scene-nodes for them with scaled_img_buffer_create(). This might incur some additional overhead since we no longer preload icon textures, but I believe its overhead won't be noticeable. In addition, the rendering of icon only happens for the first window as their backing buffers are shared (#2363).
- We had some complexity around placing icon buffer at the center of the space for titlebar button, and around calculating the geometry for hovered/rounded icon buffers. This PR simplifies it by always rendering icon on a buffer in a fixed geometry (`window.button.width`x`window.button.height`). This might incur some additional overhead for copying buffers or shrinking icons with `CAIRO_FILTER_GOOD` (which was previously handled by `buffer_convert_cairo_surface_for_icon()`), but I believe its overhead is also not noticeable and its simplification is worth it.
