### PR TITLE
src/output.c: remove output_usable_area_scaled()

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -547,7 +547,6 @@ void output_update_usable_area(struct output *output);
 void output_update_all_usable_areas(struct server *server, bool layout_changed);
 bool output_get_tearing_allowance(struct output *output);
 struct wlr_box output_usable_area_in_layout_coords(struct output *output);
-struct wlr_box output_usable_area_scaled(struct output *output);
 void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
 void output_enable_adaptive_sync(struct output *output, bool enabled);

--- a/src/output.c
+++ b/src/output.c
@@ -1008,24 +1008,6 @@ output_usable_area_in_layout_coords(struct output *output)
 	return box;
 }
 
-struct wlr_box
-output_usable_area_scaled(struct output *output)
-{
-	if (!output) {
-		return (struct wlr_box){0};
-	}
-	struct wlr_box usable = output_usable_area_in_layout_coords(output);
-	if (usable.height == output->wlr_output->height
-			&& output->wlr_output->scale != 1) {
-		usable.height /= output->wlr_output->scale;
-	}
-	if (usable.width == output->wlr_output->width
-			&& output->wlr_output->scale != 1) {
-		usable.width /= output->wlr_output->scale;
-	}
-	return usable;
-}
-
 void
 handle_output_power_manager_set_mode(struct wl_listener *listener, void *data)
 {

--- a/src/view.c
+++ b/src/view.c
@@ -417,7 +417,7 @@ static struct wlr_box
 view_get_edge_snap_box(struct view *view, struct output *output,
 		enum view_edge edge)
 {
-	struct wlr_box usable = output_usable_area_scaled(output);
+	struct wlr_box usable = output_usable_area_in_layout_coords(output);
 	int x_offset = edge == VIEW_EDGE_RIGHT
 		? (usable.width + rc.gap) / 2 : rc.gap;
 	int y_offset = edge == VIEW_EDGE_DOWN


### PR DESCRIPTION
I'm opening a PR as I just recalled an old discussion: #1620

`output_usable_area_scaled()` doesn't make sense; the geometry returned from `output_usable_area_in_layout_coords()` is already divided by the output scale, so we don't need to divide it again.