### PR TITLE
theme: demote padding.height warning

### DIFF
--- a/src/theme.c
+++ b/src/theme.c
@@ -637,7 +637,7 @@ entry(struct theme *theme, const char *key, const char *value)
 		wlr_log(WLR_ERROR, "titlebar.height is no longer supported");
 	}
 	if (match_glob(key, "padding.height")) {
-		wlr_log(WLR_ERROR, "padding.height is no longer supported");
+		wlr_log(WLR_INFO, "padding.height is no longer supported");
 	}
 
 	if (match_glob(key, "window.active.border.color")) {


### PR DESCRIPTION
...from WLR_ERROR to WLR_INFO to avoid 'false' logging when Openbox themes contain the padding.height settings. Whilst this option is not supported, the visual appearance is very close to that of Openbox with common themes.

The background to this is that Labwc theme specification has diverged slightly from that of Openbox with respect to titlebar padding to support more contemporary looks whilst avoiding breaking changes. For full details see commit: e16e78e7a4a6e40c8184edd7bb483b0f395482d0

Suggested-by: @Consolatis