### PR TITLE
Always send release events for modifier keys

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -1099,18 +1099,6 @@ situation.
 	can be caused by *<margin>* settings or exclusive layer-shell clients
 	such as panels.
 
-*<windowRules><windowRule wantAbsorbedModifierReleaseEvents="">* [yes|no|default]
-	*wantAbsorbedModifierReleaseEvents* allows clients to receive modifier
-	release events even if they are part of keybinds. Most clients should
-	not receive these, but some (for example blender) need it in some
-	situations.
-
-```
-<windowRules>
-  <windowRule identifier="blender" wantAbsorbedModifierReleaseEvents="yes"/>
-</windowRules>
-```
-
 ## MENU
 
 ```

--- a/include/input/key-state.h
+++ b/include/input/key-state.h
@@ -19,7 +19,7 @@
 uint32_t *key_state_pressed_sent_keycodes(void);
 int key_state_nr_pressed_sent_keycodes(void);
 
-void key_state_set_pressed(uint32_t keycode, bool is_pressed, bool is_modifier);
+void key_state_set_pressed(uint32_t keycode, bool is_pressed);
 void key_state_store_pressed_key_as_bound(uint32_t keycode);
 bool key_state_corresponding_press_event_was_bound(uint32_t keycode);
 void key_state_bound_key_remove(uint32_t keycode);

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -148,6 +148,14 @@ struct seat {
 
 	struct lab_set bound_buttons;
 
+	/*
+	 * True when key-press events for any modifier keys has been sent to
+	 * the client after the last wl_keyboard.enter event. This is used to
+	 * check whether we should send wl_keyboard.{leave,enter} action
+	 * invocations. See actions_run() for details.
+	 */
+	bool modifier_press_sent;
+
 	struct {
 		bool active;
 		struct {

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -38,7 +38,6 @@ struct window_rule {
 	enum property ignore_focus_request;
 	enum property ignore_configure_request;
 	enum property fixed_position;
-	enum property want_absorbed_modifier_release_events;
 
 	struct wl_list link; /* struct rcxml.window_rules */
 };

--- a/src/action.c
+++ b/src/action.c
@@ -1301,4 +1301,18 @@ actions_run(struct view *activator, struct server *server,
 				" This is a BUG. Please report.", action->type);
 		}
 	}
+
+	/*
+	 * We send wl_keyboard.{leave,enter} to the clint when we have sent
+	 * key-press events to it since the last wl_keyboard.leave event.
+	 * This prevents firefox to show its menu bar when a keybind with
+	 * Alt key is executed.
+	 */
+	struct seat *seat = &server->seat;
+	if (seat->modifier_press_sent) {
+		struct wlr_surface *focused_surface =
+			seat->seat->keyboard_state.focused_surface;
+		seat_focus_surface(seat, NULL);
+		seat_focus_surface(seat, focused_surface);
+	}
 }

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -358,8 +358,6 @@ fill_window_rule(char *nodename, char *content)
 		set_property(content, &current_window_rule->ignore_configure_request);
 	} else if (!strcasecmp(nodename, "fixedPosition")) {
 		set_property(content, &current_window_rule->fixed_position);
-	} else if (!strcasecmp(nodename, "wantAbsorbedModifierReleaseEvents")) {
-		set_property(content, &current_window_rule->want_absorbed_modifier_release_events);
 
 	/* Actions */
 	} else if (!strcmp(nodename, "name.action")) {

--- a/src/input/key-state.c
+++ b/src/input/key-state.c
@@ -8,7 +8,7 @@
 #include "common/set.h"
 #include "input/key-state.h"
 
-static struct lab_set pressed, pressed_mods, bound, pressed_sent;
+static struct lab_set pressed, bound, pressed_sent;
 
 static void
 report(struct lab_set *key_set, const char *msg)
@@ -54,16 +54,12 @@ key_state_nr_pressed_sent_keycodes(void)
 }
 
 void
-key_state_set_pressed(uint32_t keycode, bool is_pressed, bool is_modifier)
+key_state_set_pressed(uint32_t keycode, bool is_pressed)
 {
 	if (is_pressed) {
 		lab_set_add(&pressed, keycode);
-		if (is_modifier) {
-			lab_set_add(&pressed_mods, keycode);
-		}
 	} else {
 		lab_set_remove(&pressed, keycode);
-		lab_set_remove(&pressed_mods, keycode);
 	}
 }
 
@@ -71,15 +67,6 @@ void
 key_state_store_pressed_key_as_bound(uint32_t keycode)
 {
 	lab_set_add(&bound, keycode);
-	/*
-	 * Also store any pressed modifiers as bound. This prevents
-	 * applications from seeing and handling the release event for
-	 * a modifier key that was part of a keybinding (e.g. Firefox
-	 * displays its menu bar for a lone Alt press + release).
-	 */
-	for (int i = 0; i < pressed_mods.size; ++i) {
-		lab_set_add(&bound, pressed_mods.values[i]);
-	}
 }
 
 bool

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -512,8 +512,7 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	bool locked = seat->server->session_lock_manager->locked;
 
 	key_state_set_pressed(event->keycode,
-		event->state == WL_KEYBOARD_KEY_STATE_PRESSED,
-		keyinfo.is_modifier);
+		event->state == WL_KEYBOARD_KEY_STATE_PRESSED);
 
 	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
 		if (cur_keybind && cur_keybind->on_release) {

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -15,7 +15,6 @@
 #include "osd.h"
 #include "regions.h"
 #include "view.h"
-#include "window-rules.h"
 #include "workspaces.h"
 
 enum lab_key_handled {
@@ -364,8 +363,7 @@ get_keyinfo(struct wlr_keyboard *wlr_keyboard, uint32_t evdev_keycode)
 }
 
 static bool
-handle_key_release(struct server *server, uint32_t evdev_keycode,
-		bool is_modifier_key)
+handle_key_release(struct server *server, uint32_t evdev_keycode)
 {
 	/*
 	 * Release events for keys that were not bound should always be
@@ -388,33 +386,11 @@ handle_key_release(struct server *server, uint32_t evdev_keycode,
 		end_cycling(server);
 	}
 
-	key_state_bound_key_remove(evdev_keycode);
-
-	/*
-	 * There are some clients (for example blender) that want to see the
-	 * modifier-release-event even if it was part of a keybinds. This is
-	 * treated as a special case and can only be achieved by configuration.
-	 *
-	 * Most clients (including those using Qt and GTK) are setup to not see
-	 * these modifier release events - and actually misbehave if they do.
-	 * For example Firefox shows the menu bar if alt is pressed and then
-	 * released, whereas if only pressed (because the release is absorbed)
-	 * nothing happens. So, if Firefox saw bound modifier-release-events it
-	 * would show the menu bar every time the window-switcher is used with
-	 * alt-tab.
-	 */
-	struct view *view = server->active_view;
-	if (is_modifier_key && view) {
-		if (window_rules_get_property(view, "wantAbsorbedModifierReleaseEvents")
-				== LAB_PROP_TRUE) {
-			return false;
-		}
-	}
-
 	/*
 	 * If a press event was handled by a compositor binding, then do
 	 * not forward the corresponding release event to clients.
 	 */
+	key_state_bound_key_remove(evdev_keycode);
 	return true;
 }
 
@@ -549,8 +525,7 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 			actions_run(NULL, server, &cur_keybind->actions, NULL);
 			return true;
 		} else {
-			return handle_key_release(server, event->keycode,
-				keyinfo.is_modifier);
+			return handle_key_release(server, event->keycode);
 		}
 	}
 

--- a/src/seat.c
+++ b/src/seat.c
@@ -668,6 +668,8 @@ seat_focus(struct seat *seat, struct wlr_surface *surface, bool is_lock_surface)
 		return;
 	}
 
+	seat->modifier_press_sent = false;
+
 	if (!surface) {
 		wlr_seat_keyboard_notify_clear_focus(seat->seat);
 		input_method_relay_set_focus(seat->input_method_relay, NULL);

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -108,11 +108,6 @@ window_rules_get_property(struct view *view, const char *property)
 					&& !strcasecmp(property, "fixedPosition")) {
 				return rule->fixed_position;
 			}
-			if (rule->want_absorbed_modifier_release_events
-					&& !strcasecmp(property,
-					"wantAbsorbedModifierReleaseEvents")) {
-				return rule->want_absorbed_modifier_release_events;
-			}
 		}
 	}
 	return LAB_PROP_UNSPECIFIED;


### PR DESCRIPTION
Background: #2448

While not sending key-release events for modifier keys when they are bound to a keybind prevents Firefox to show its menu bar, it causes problems with some applications like Blender(#1507), wlfreerdp (#1537) or gzdoom (reported by 60IQ). #2377 solved this by adding `wantAbsorbedModifierReleaseEvents`, but forcing users to find it from our documentation and to apply it is not user-friendly.

So this PR reverts #1226 and #2377, and instead, sends `wl_keyboard.{leave,enter}` events on action invocations when key-press events for any modifiers have been sent. I confirmed this prevents firefox from showing its menu bar on Alt-* keybind and the issue with blender (#1507) doesn't happen. In addition, this PR prevents firefox from showing its menu bar also with the default Alt-Drag ~keybind~ mousebind.