### PR TITLE
Always send modifier release events, and clear focus on Move/Resize, window switcher and menu interactions

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -1099,18 +1099,6 @@ situation.
 	can be caused by *<margin>* settings or exclusive layer-shell clients
 	such as panels.
 
-*<windowRules><windowRule wantAbsorbedModifierReleaseEvents="">* [yes|no|default]
-	*wantAbsorbedModifierReleaseEvents* allows clients to receive modifier
-	release events even if they are part of keybinds. Most clients should
-	not receive these, but some (for example blender) need it in some
-	situations.
-
-```
-<windowRules>
-  <windowRule identifier="blender" wantAbsorbedModifierReleaseEvents="yes"/>
-</windowRules>
-```
-
 ## MENU
 
 ```

--- a/include/input/key-state.h
+++ b/include/input/key-state.h
@@ -19,7 +19,7 @@
 uint32_t *key_state_pressed_sent_keycodes(void);
 int key_state_nr_pressed_sent_keycodes(void);
 
-void key_state_set_pressed(uint32_t keycode, bool is_pressed, bool is_modifier);
+void key_state_set_pressed(uint32_t keycode, bool is_pressed);
 void key_state_store_pressed_key_as_bound(uint32_t keycode);
 bool key_state_corresponding_press_event_was_bound(uint32_t keycode);
 void key_state_bound_key_remove(uint32_t keycode);

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -38,7 +38,6 @@ struct window_rule {
 	enum property ignore_focus_request;
 	enum property ignore_configure_request;
 	enum property fixed_position;
-	enum property want_absorbed_modifier_release_events;
 
 	struct wl_list link; /* struct rcxml.window_rules */
 };

--- a/src/action.c
+++ b/src/action.c
@@ -810,7 +810,9 @@ start_window_cycling(struct server *server, enum lab_cycle_dir direction)
 		shift_is_pressed(server);
 	server->osd_state.cycle_view = desktop_cycle_view(server,
 		server->osd_state.cycle_view, direction);
-	server->input_mode = LAB_INPUT_STATE_WINDOW_SWITCHER;
+
+	seat_focus_override_begin(&server->seat,
+		LAB_INPUT_STATE_WINDOW_SWITCHER, LAB_CURSOR_DEFAULT);
 	osd_update(server);
 }
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -358,8 +358,6 @@ fill_window_rule(char *nodename, char *content)
 		set_property(content, &current_window_rule->ignore_configure_request);
 	} else if (!strcasecmp(nodename, "fixedPosition")) {
 		set_property(content, &current_window_rule->fixed_position);
-	} else if (!strcasecmp(nodename, "wantAbsorbedModifierReleaseEvents")) {
-		set_property(content, &current_window_rule->want_absorbed_modifier_release_events);
 
 	/* Actions */
 	} else if (!strcmp(nodename, "name.action")) {

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -496,7 +496,8 @@ cursor_update_common(struct server *server, struct cursor_context *ctx,
 	if (server->input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
 		/*
 		 * Prevent updating focus/cursor image during
-		 * interactive move/resize
+		 * interactive move/resize, window switcher and
+		 * menu interaction.
 		 */
 		return false;
 	}
@@ -524,28 +525,9 @@ cursor_update_common(struct server *server, struct cursor_context *ctx,
 		 * cursor image will be set by request_cursor_notify()
 		 * in response to the enter event.
 		 */
-		bool has_focus = (ctx->surface ==
-			wlr_seat->pointer_state.focused_surface);
-
-		if (!has_focus || seat->server_cursor != LAB_CURSOR_CLIENT) {
-			/*
-			 * Enter the surface if necessary.  Usually we
-			 * prevent re-entering an already focused
-			 * surface, because the extra leave and enter
-			 * events can confuse clients (e.g. break
-			 * double-click detection).
-			 *
-			 * We do however send a leave/enter event pair
-			 * if a server-side cursor was set and we need
-			 * to trigger a cursor image update.
-			 */
-			if (has_focus) {
-				wlr_seat_pointer_notify_clear_focus(wlr_seat);
-			}
-			wlr_seat_pointer_notify_enter(wlr_seat, ctx->surface,
-				ctx->sx, ctx->sy);
-			seat->server_cursor = LAB_CURSOR_CLIENT;
-		}
+		wlr_seat_pointer_notify_enter(wlr_seat, ctx->surface,
+			ctx->sx, ctx->sy);
+		seat->server_cursor = LAB_CURSOR_CLIENT;
 		if (cursor_has_moved) {
 			*sx = ctx->sx;
 			*sy = ctx->sy;

--- a/src/input/key-state.c
+++ b/src/input/key-state.c
@@ -8,7 +8,7 @@
 #include "common/set.h"
 #include "input/key-state.h"
 
-static struct lab_set pressed, pressed_mods, bound, pressed_sent;
+static struct lab_set pressed, bound, pressed_sent;
 
 static void
 report(struct lab_set *key_set, const char *msg)
@@ -54,16 +54,12 @@ key_state_nr_pressed_sent_keycodes(void)
 }
 
 void
-key_state_set_pressed(uint32_t keycode, bool is_pressed, bool is_modifier)
+key_state_set_pressed(uint32_t keycode, bool is_pressed)
 {
 	if (is_pressed) {
 		lab_set_add(&pressed, keycode);
-		if (is_modifier) {
-			lab_set_add(&pressed_mods, keycode);
-		}
 	} else {
 		lab_set_remove(&pressed, keycode);
-		lab_set_remove(&pressed_mods, keycode);
 	}
 }
 
@@ -71,15 +67,6 @@ void
 key_state_store_pressed_key_as_bound(uint32_t keycode)
 {
 	lab_set_add(&bound, keycode);
-	/*
-	 * Also store any pressed modifiers as bound. This prevents
-	 * applications from seeing and handling the release event for
-	 * a modifier key that was part of a keybinding (e.g. Firefox
-	 * displays its menu bar for a lone Alt press + release).
-	 */
-	for (int i = 0; i < pressed_mods.size; ++i) {
-		lab_set_add(&bound, pressed_mods.values[i]);
-	}
 }
 
 bool

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -15,7 +15,6 @@
 #include "osd.h"
 #include "regions.h"
 #include "view.h"
-#include "window-rules.h"
 #include "workspaces.h"
 
 enum lab_key_handled {
@@ -366,8 +365,7 @@ get_keyinfo(struct wlr_keyboard *wlr_keyboard, uint32_t evdev_keycode)
 }
 
 static bool
-handle_key_release(struct server *server, uint32_t evdev_keycode,
-		bool is_modifier_key)
+handle_key_release(struct server *server, uint32_t evdev_keycode)
 {
 	/*
 	 * Release events for keys that were not bound should always be
@@ -390,33 +388,11 @@ handle_key_release(struct server *server, uint32_t evdev_keycode,
 		end_cycling(server);
 	}
 
-	key_state_bound_key_remove(evdev_keycode);
-
-	/*
-	 * There are some clients (for example blender) that want to see the
-	 * modifier-release-event even if it was part of a keybinds. This is
-	 * treated as a special case and can only be achieved by configuration.
-	 *
-	 * Most clients (including those using Qt and GTK) are setup to not see
-	 * these modifier release events - and actually misbehave if they do.
-	 * For example Firefox shows the menu bar if alt is pressed and then
-	 * released, whereas if only pressed (because the release is absorbed)
-	 * nothing happens. So, if Firefox saw bound modifier-release-events it
-	 * would show the menu bar every time the window-switcher is used with
-	 * alt-tab.
-	 */
-	struct view *view = server->active_view;
-	if (is_modifier_key && view) {
-		if (window_rules_get_property(view, "wantAbsorbedModifierReleaseEvents")
-				== LAB_PROP_TRUE) {
-			return false;
-		}
-	}
-
 	/*
 	 * If a press event was handled by a compositor binding, then do
 	 * not forward the corresponding release event to clients.
 	 */
+	key_state_bound_key_remove(evdev_keycode);
 	return true;
 }
 
@@ -551,8 +527,7 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 			actions_run(NULL, server, &cur_keybind->actions, NULL);
 			return true;
 		} else {
-			return handle_key_release(server, event->keycode,
-				keyinfo.is_modifier);
+			return handle_key_release(server, event->keycode);
 		}
 	}
 

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -514,8 +514,7 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 	bool locked = seat->server->session_lock_manager->locked;
 
 	key_state_set_pressed(event->keycode,
-		event->state == WL_KEYBOARD_KEY_STATE_PRESSED,
-		keyinfo.is_modifier);
+		event->state == WL_KEYBOARD_KEY_STATE_PRESSED);
 
 	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
 		if (cur_keybind && cur_keybind->on_release) {

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -69,15 +69,18 @@ keyboard_any_modifiers_pressed(struct wlr_keyboard *keyboard)
 static void
 end_cycling(struct server *server)
 {
-	osd_preview_restore(server);
-	if (server->osd_state.cycle_view) {
-		desktop_focus_view(server->osd_state.cycle_view,
-			/*raise*/ true);
+	should_cancel_cycling_on_next_key_release = false;
+
+	if (server->input_mode != LAB_INPUT_STATE_WINDOW_SWITCHER) {
+		return;
 	}
 
-	/* osd_finish() additionally resets cycle_view to NULL */
+	struct view *cycle_view = server->osd_state.cycle_view;
+	osd_preview_restore(server);
+	/* FIXME: osd_finish() transiently sets focus to the old surface */
 	osd_finish(server);
-	should_cancel_cycling_on_next_key_release = false;
+	/* Note that server->osd_state.cycle_view is cleared at this point */
+	desktop_focus_view(cycle_view, /*raise*/ true);
 }
 
 static struct wlr_seat_client *

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1336,8 +1336,9 @@ menu_open_root(struct menu *menu, int x, int y)
 	menu_configure(menu, (struct wlr_box){.x = x, .y = y});
 	wlr_scene_node_set_enabled(&menu->scene_tree->node, true);
 	menu->server->menu_current = menu;
-	menu->server->input_mode = LAB_INPUT_STATE_MENU;
 	selected_item = NULL;
+	seat_focus_override_begin(&menu->server->seat,
+		LAB_INPUT_STATE_MENU, LAB_CURSOR_DEFAULT);
 }
 
 static void
@@ -1628,8 +1629,7 @@ menu_execute_item(struct menuitem *item)
 	 */
 	struct server *server = item->parent->server;
 	menu_close(server->menu_current);
-	server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
-	cursor_update_focus(server);
+	seat_focus_override_end(&server->seat);
 
 	/*
 	 * We call the actions after closing the menu so that virtual keyboard
@@ -1739,7 +1739,7 @@ menu_close_root(struct server *server)
 		server->menu_current = NULL;
 		destroy_pipemenus(server);
 	}
-	server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
+	seat_focus_override_end(&server->seat);
 }
 
 void

--- a/src/osd.c
+++ b/src/osd.c
@@ -105,7 +105,8 @@ osd_on_view_destroy(struct view *view)
 void
 osd_finish(struct server *server)
 {
-	server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
+	seat_focus_override_end(&server->seat);
+
 	server->osd_state.preview_node = NULL;
 	server->osd_state.preview_anchor = NULL;
 

--- a/src/view.c
+++ b/src/view.c
@@ -2531,9 +2531,7 @@ view_destroy(struct view *view)
 
 	if (server->grabbed_view == view) {
 		/* Application got killed while moving around */
-		server->input_mode = LAB_INPUT_STATE_PASSTHROUGH;
-		server->grabbed_view = NULL;
-		overlay_hide(&server->seat);
+		interactive_cancel(view);
 	}
 
 	if (server->active_view == view) {

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -108,11 +108,6 @@ window_rules_get_property(struct view *view, const char *property)
 					&& !strcasecmp(property, "fixedPosition")) {
 				return rule->fixed_position;
 			}
-			if (rule->want_absorbed_modifier_release_events
-					&& !strcasecmp(property,
-					"wantAbsorbedModifierReleaseEvents")) {
-				return rule->want_absorbed_modifier_release_events;
-			}
 		}
 	}
 	return LAB_PROP_UNSPECIFIED;


### PR DESCRIPTION
First, this PR reverts #1226 and #2377, because:
- Not sending modifier release events (#1226) for keybinds (for not showing firefox's menu bar) is very problematic with some applications (#1537, #1507).
- Forcing users to define `wantAbsorbedModifierReleaseEvents` window rule (#2377) to fix it is also undesirable, since it doesn't provide a good out-of-the-box experience and requires users to read through our documentation.

After some discussion in #2448 and #2452, we decided to follow KWin's approach that always sends modifier release events, but clears keyboard focus when activating window switcher (typically triggered by Alt-Tab) to prevent firefox from showing menu bar. Of course, this doesn't work for other actions like `Execute` and makes existing Alt-* keybinds show firefox's menu bar, but we concluded this approach is the most robust.

So in this PR, keyboard and pointer focus are temporarily cleared while Move/Resize, window switcher and menu interactions and restored after them, which basically follows KWin's behavior.

We slightly deviate from KWin as KWin doesn't clear the keyboard focus while Move/Resize, but it solves our existing problem that Firefox shows its menu bar after dragging it with default Alt-Drag mousebind, and this is what Mutter does.

Testing is appreciated.