### PR TITLE
view: fix NULL string_prop crash

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -3,6 +3,7 @@
 #include <wlr/types/wlr_scene.h>
 #include "common/graphic-helpers.h"
 #include "common/scene-helpers.h"
+#include "common/string-helpers.h"
 #include "debug.h"
 #include "input/ime.h"
 #include "labwc.h"
@@ -69,7 +70,7 @@ get_view_part(struct view *view, struct wlr_scene_node *node)
 	}
 	if (node == &view->scene_tree->node) {
 		const char *app_id = view_get_string_prop(view, "app_id");
-		if (!app_id) {
+		if (!string_null_or_empty(app_id)) {
 			return "view";
 		}
 		snprintf(view_name, sizeof(view_name), "view (%s)", app_id);

--- a/src/desktop-entry.c
+++ b/src/desktop-entry.c
@@ -280,6 +280,10 @@ struct lab_img *
 desktop_entry_icon_lookup(struct server *server, const char *app_id, int size,
 		float scale)
 {
+	if (string_null_or_empty(app_id)) {
+		return NULL;
+	}
+
 	struct sfdo *sfdo = server->sfdo;
 	if (!sfdo) {
 		return NULL;
@@ -328,6 +332,10 @@ desktop_entry_icon_lookup(struct server *server, const char *app_id, int size,
 const char *
 desktop_entry_name_lookup(struct server *server, const char *app_id)
 {
+	if (string_null_or_empty(app_id)) {
+		return NULL;
+	}
+
 	struct sfdo *sfdo = server->sfdo;
 	if (!sfdo) {
 		return NULL;

--- a/src/osd-field.c
+++ b/src/osd-field.c
@@ -37,7 +37,7 @@ get_app_id_or_class(struct view *view, bool trim)
 	const char *identifier = view_get_string_prop(view, "app_id");
 
 	/* remove the first two nodes of 'org.' strings */
-	if (trim && identifier && !strncmp(identifier, "org.", 4)) {
+	if (trim && !strncmp(identifier, "org.", 4)) {
 		char *p = (char *)identifier + 4;
 		p = strchr(p, '.');
 		if (p) {

--- a/src/view.c
+++ b/src/view.c
@@ -2352,12 +2352,7 @@ void
 view_update_title(struct view *view)
 {
 	assert(view);
-	const char *title = view_get_string_prop(view, "title");
-	if (!title) {
-		return;
-	}
 	ssd_update_title(view->ssd);
-
 	wl_signal_emit_mutable(&view->events.new_title, NULL);
 }
 
@@ -2365,15 +2360,9 @@ void
 view_update_app_id(struct view *view)
 {
 	assert(view);
-	const char *app_id = view_get_string_prop(view, "app_id");
-	if (!app_id) {
-		return;
-	}
-
 	if (view->ssd_enabled) {
 		ssd_update_window_icon(view->ssd);
 	}
-
 	wl_signal_emit_mutable(&view->events.new_app_id, NULL);
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -2335,13 +2335,15 @@ view_has_strut_partial(struct view *view)
 		view->impl->has_strut_partial(view);
 }
 
+/* Note: It is safe to assume that this function never returns NULL */
 const char *
 view_get_string_prop(struct view *view, const char *prop)
 {
 	assert(view);
 	assert(prop);
 	if (view->impl->get_string_prop) {
-		return view->impl->get_string_prop(view, prop);
+		const char *ret = view->impl->get_string_prop(view, prop);
+		return ret ? ret : "";
 	}
 	return "";
 }

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -660,10 +660,10 @@ xdg_toplevel_view_get_string_prop(struct view *view, const char *prop)
 	}
 
 	if (!strcmp(prop, "title")) {
-		return xdg_toplevel->title;
+		return xdg_toplevel->title ? xdg_toplevel->title : "";
 	}
 	if (!strcmp(prop, "app_id")) {
-		return xdg_toplevel->app_id;
+		return xdg_toplevel->app_id ? xdg_toplevel->app_id : "";
 	}
 	return "";
 }

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -485,10 +485,10 @@ xwayland_view_get_string_prop(struct view *view, const char *prop)
 	}
 
 	if (!strcmp(prop, "title")) {
-		return xwayland_surface->title;
+		return xwayland_surface->title ? xwayland_surface->title : "";
 	}
 	if (!strcmp(prop, "class")) {
-		return xwayland_surface->class;
+		return xwayland_surface->class ? xwayland_surface->class : "";
 	}
 	/*
 	 * Use the WM_CLASS 'instance' (1st string) for the app_id. Per
@@ -500,7 +500,7 @@ xwayland_view_get_string_prop(struct view *view, const char *prop)
 	 * here since we use the app_id for icon lookups.
 	 */
 	if (!strcmp(prop, "app_id")) {
-		return xwayland_surface->instance;
+		return xwayland_surface->instance ? xwayland_surface->instance : "";
 	}
 	return "";
 }


### PR DESCRIPTION
...when app_id is NULL.

Make sure view_get_string_prop() never returns NULL because it is so easy to misuse. Same for the respective xwayland/xdg impl methods in case anyone decides to (incorrectly) call them directly in future.

Fixes: #2453