### PR TITLE
keyboard: set numlock to off by default

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -565,7 +565,7 @@ extending outward from the snapped edge.
 
 *<keyboard><numlock>* [on|off]
 	When recognizing a new keyboard enable or disable Num Lock.
-	Default is on.
+	Default is off.
 
 *<keyboard layoutScope="">* [global|window]
 	Stores the keyboard layout either globally or per window and restores

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -229,7 +229,7 @@
     your favourite terminal or application launcher. See rc.xml for an example.
   -->
   <keyboard>
-    <numlock>on</numlock>
+    <numlock>off</numlock>
     <layoutScope>global</layoutScope>
     <repeatRate>25</repeatRate>
     <repeatDelay>600</repeatDelay>

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1497,7 +1497,7 @@ rcxml_init(void)
 
 	rc.repeat_rate = 25;
 	rc.repeat_delay = 600;
-	rc.kb_numlock_enable = true;
+	rc.kb_numlock_enable = false;
 	rc.kb_layout_per_window = false;
 	rc.screen_edge_strength = 20;
 	rc.window_edge_strength = 20;


### PR DESCRIPTION
...to avoid surprises on Acer Aspire One laptops where the numeric keyboard does not physically exist but "overlaps" the qwerty keyboard.

Reported-by: staryvyr on IRC

Note: We do not like changing defaults, but feel that there is a good reason for this one.