### PR TITLE
osd: some refactor

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -482,14 +482,6 @@ struct view *desktop_topmost_focusable_view(struct server *server);
 void desktop_update_top_layer_visiblity(struct server *server);
 
 /**
- * desktop_cycle_view - return view to 'cycle' to
- * @start_view: reference point for finding next view to cycle to
- * Note: If !start_view, the second focusable view is returned
- */
-struct view *desktop_cycle_view(struct server *server, struct view *start_view,
-	enum lab_cycle_dir dir);
-
-/**
  * desktop_focus_topmost_view() - focus the topmost view on the current
  * workspace, skipping views that claim not to want focus (those can
  * still be focused by explicit request, e.g. by clicking in them).

--- a/include/osd.h
+++ b/include/osd.h
@@ -43,9 +43,6 @@ void osd_update(struct server *server);
 /* Closes the OSD */
 void osd_finish(struct server *server);
 
-/* Moves preview views back into their original stacking order and state */
-void osd_preview_restore(struct server *server);
-
 /* Notify OSD about a destroying view */
 void osd_on_view_destroy(struct view *view);
 

--- a/include/osd.h
+++ b/include/osd.h
@@ -36,6 +36,13 @@ struct window_switcher_field {
 struct buf;
 struct view;
 struct server;
+enum lab_cycle_dir;
+
+/* Begin window switcher */
+void osd_begin(struct server *server, enum lab_cycle_dir direction);
+
+/* Cycle the selected view in the window switcher */
+void osd_cycle(struct server *server, enum lab_cycle_dir direction);
 
 /* Updates onscreen display 'alt-tab' buffer */
 void osd_update(struct server *server);

--- a/src/action.c
+++ b/src/action.c
@@ -789,33 +789,6 @@ run_if_action(struct view *view, struct server *server, struct action *action)
 	return !strcmp(branch, "then");
 }
 
-static bool
-shift_is_pressed(struct server *server)
-{
-	uint32_t modifiers = wlr_keyboard_get_modifiers(
-			&server->seat.keyboard_group->keyboard);
-	return modifiers & WLR_MODIFIER_SHIFT;
-}
-
-static void
-start_window_cycling(struct server *server, enum lab_cycle_dir direction)
-{
-	if (server->input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
-		return;
-	}
-
-	/* Remember direction so it can be followed by subsequent key presses */
-	server->osd_state.initial_direction = direction;
-	server->osd_state.initial_keybind_contained_shift =
-		shift_is_pressed(server);
-	server->osd_state.cycle_view = desktop_cycle_view(server,
-		server->osd_state.cycle_view, direction);
-
-	seat_focus_override_begin(&server->seat,
-		LAB_INPUT_STATE_WINDOW_SWITCHER, LAB_CURSOR_DEFAULT);
-	osd_update(server);
-}
-
 static struct output *
 get_target_output(struct output *output, struct server *server,
 	struct action *action)
@@ -982,10 +955,10 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_NEXT_WINDOW:
-			start_window_cycling(server, LAB_CYCLE_DIR_FORWARD);
+			osd_begin(server, LAB_CYCLE_DIR_FORWARD);
 			break;
 		case ACTION_TYPE_PREVIOUS_WINDOW:
-			start_window_cycling(server, LAB_CYCLE_DIR_BACKWARD);
+			osd_begin(server, LAB_CYCLE_DIR_BACKWARD);
 			break;
 		case ACTION_TYPE_RECONFIGURE:
 			kill(getpid(), SIGHUP);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -109,34 +109,6 @@ desktop_focus_view_or_surface(struct seat *seat, struct view *view,
 }
 
 struct view *
-desktop_cycle_view(struct server *server, struct view *start_view,
-		enum lab_cycle_dir dir)
-{
-	struct view *(*iter)(struct wl_list *head, struct view *view,
-		enum lab_view_criteria criteria);
-	bool forwards = dir == LAB_CYCLE_DIR_FORWARD;
-	iter = forwards ? view_next_no_head_stop : view_prev_no_head_stop;
-
-	enum lab_view_criteria criteria = rc.window_switcher.criteria;
-
-	/*
-	 * Views are listed in stacking order, topmost first.  Usually the
-	 * topmost view is already focused, so when iterating in the forward
-	 * direction we pre-select the view second from the top:
-	 *
-	 *   View #1 (on top, currently focused)
-	 *   View #2 (pre-selected)
-	 *   View #3
-	 *   ...
-	 */
-	if (!start_view && forwards) {
-		start_view = iter(&server->views, NULL, criteria);
-	}
-
-	return iter(&server->views, start_view, criteria);
-}
-
-struct view *
 desktop_topmost_focusable_view(struct server *server)
 {
 	struct view *view;

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -112,9 +112,6 @@ struct view *
 desktop_cycle_view(struct server *server, struct view *start_view,
 		enum lab_cycle_dir dir)
 {
-	/* Make sure to have all nodes in their actual ordering */
-	osd_preview_restore(server);
-
 	struct view *(*iter)(struct wl_list *head, struct view *view,
 		enum lab_view_criteria criteria);
 	bool forwards = dir == LAB_CYCLE_DIR_FORWARD;

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -76,7 +76,6 @@ end_cycling(struct server *server)
 	}
 
 	struct view *cycle_view = server->osd_state.cycle_view;
-	osd_preview_restore(server);
 	/* FIXME: osd_finish() transiently sets focus to the old surface */
 	osd_finish(server);
 	/* Note that server->osd_state.cycle_view is cleared at this point */
@@ -464,7 +463,6 @@ handle_cycle_view_key(struct server *server, struct keyinfo *keyinfo)
 	for (int i = 0; i < keyinfo->translated.nr_syms; i++) {
 		if (keyinfo->translated.syms[i] == XKB_KEY_Escape) {
 			/* cancel view-cycle */
-			osd_preview_restore(server);
 			osd_finish(server);
 			return;
 		}

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -497,10 +497,7 @@ handle_cycle_view_key(struct server *server, struct keyinfo *keyinfo)
 
 	/* Only one direction modifier is allowed, either arrow keys OR shift */
 miss_shift_toggle:
-
-		server->osd_state.cycle_view = desktop_cycle_view(server,
-			server->osd_state.cycle_view, direction);
-		osd_update(server);
+		osd_cycle(server, direction);
 	}
 }
 

--- a/src/seat.c
+++ b/src/seat.c
@@ -725,8 +725,7 @@ void
 seat_focus_surface(struct seat *seat, struct wlr_surface *surface)
 {
 	/* Don't update focus while window switcher, Move/Resize and menu interaction */
-	if (seat->server->osd_state.cycle_view || seat->server->input_mode
-			!= LAB_INPUT_STATE_PASSTHROUGH) {
+	if (seat->server->input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
 		return;
 	}
 	seat_focus(seat, surface, /*replace_exclusive_layer*/ false,


### PR DESCRIPTION
1. Remove the call to `osd_review_restore()` in `desktop_cycle_view()`. I guess this is just a cruft from days when the next view to cycle is determined by traversing scene-nodes (ref. #1479).
2. Make `osd_preview_restore()` private in `osd.c` and call it inside `osd_finish()`. I renamed it to `restore_preview_node()`.
3. Replace `seat->server->osd_state.cycle_view || seat->server->input_mode != LAB_INPUT_STATE_PASSTHROUGH` with just `seat->server->input_mode != LAB_INPUT_STATE_PASSTHROUGH`. I missed to do this when rebasing #2455.
4. Refactor to not update values in `server->osd_state` outside `osd.c` by adding `osd_begin()` and `osd_cycle()`.
5. Make `desktop_cycle_view()` private in `osd.c`, renaming it to `get_next_cycle_view()`.

The primary goal in this PR is (4). In the future, `osd_begin()` will create the scene graph for the window switcher (rather than drawing it on a single texture) and `osd_cycle()` will update the scene-node of the highlight for the selected window. This will make it easier to add mouse interactions or other forms of window switcher like #2172.