### PR TITLE
keyboard: cancel keybind_repeat on reconfigure

### DIFF
--- a/include/input/keyboard.h
+++ b/include/input/keyboard.h
@@ -20,6 +20,8 @@ void keyboard_setup_handlers(struct keyboard *keyboard);
 void keyboard_set_numlock(struct wlr_keyboard *keyboard);
 void keyboard_update_layout(struct seat *seat, xkb_layout_index_t layout);
 void keyboard_cancel_keybind_repeat(struct keyboard *keyboard);
+void keyboard_cancel_all_keybind_repeats(struct seat *seat);
+
 bool keyboard_any_modifiers_pressed(struct wlr_keyboard *keyboard);
 
 #endif /* LABWC_KEYBOARD_H */

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -619,6 +619,19 @@ keyboard_cancel_keybind_repeat(struct keyboard *keyboard)
 	}
 }
 
+void
+keyboard_cancel_all_keybind_repeats(struct seat *seat)
+{
+	struct input *input;
+	struct keyboard *kb;
+	wl_list_for_each(input, &seat->inputs, link) {
+		if (input->wlr_input_device->type == WLR_INPUT_DEVICE_KEYBOARD) {
+			kb = wl_container_of(input, kb, base);
+			keyboard_cancel_keybind_repeat(kb);
+		}
+	}
+}
+
 static void
 keyboard_key_notify(struct wl_listener *listener, void *data)
 {

--- a/src/server.c
+++ b/src/server.c
@@ -28,15 +28,19 @@
 #include <wlr/xwayland.h>
 #include "xwayland-shell-v1-protocol.h"
 #endif
+
 #include "drm-lease-v1-protocol.h"
 #include "common/macros.h"
 #include "config/rcxml.h"
 #include "config/session.h"
 #include "decorations.h"
+
 #if HAVE_LIBSFDO
 #include "desktop-entry.h"
 #endif
+
 #include "idle.h"
+#include "input/keyboard.h"
 #include "labwc.h"
 #include "layers.h"
 #include "magnifier.h"
@@ -92,6 +96,7 @@ handle_sighup(int signal, void *data)
 {
 	struct server *server = data;
 
+	keyboard_cancel_all_keybind_repeats(&server->seat);
 	session_environment_init();
 	reload_config_and_theme(server);
 	output_virtual_update_fallback(server);


### PR DESCRIPTION
Currently we may end up in an endless loop of Reconfigure requests if the Reconfigure action was called by a keybind. If the reconfigure takes too long (which may happen on slow systems with libsfdo full debug logging for example) the reconfigure might be triggered again and again.

To prevent that, simply cancel all keybind_repeat timers on reconfigure.

---

Only slightly tested.