### PR TITLE
Remove cruft related to window switcher and keyboard focus

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -637,10 +637,11 @@ _cursor_update_focus(struct server *server)
 	struct cursor_context ctx = get_cursor_context(server);
 
 	if ((ctx.view || ctx.surface) && rc.focus_follow_mouse
-			&& !rc.focus_follow_mouse_requires_movement
-			&& server->input_mode
-				!= LAB_INPUT_STATE_WINDOW_SWITCHER) {
-		/* Prevents changing keyboard focus during A-Tab */
+			&& !rc.focus_follow_mouse_requires_movement) {
+		/*
+		 * Always focus the surface below the cursor when
+		 * followMouse=yes and followMouseRequiresMovement=no.
+		 */
 		desktop_focus_view_or_surface(&server->seat, ctx.view,
 			ctx.surface, rc.raise_on_focus);
 	}

--- a/src/osd.c
+++ b/src/osd.c
@@ -205,6 +205,7 @@ osd_finish(struct server *server)
 
 	server->osd_state.preview_node = NULL;
 	server->osd_state.preview_anchor = NULL;
+	server->osd_state.cycle_view = NULL;
 
 	struct output *output;
 	wl_list_for_each(output, &server->outputs, link) {
@@ -219,15 +220,6 @@ osd_finish(struct server *server)
 
 	/* Hiding OSD may need a cursor change */
 	cursor_update_focus(server);
-
-	/*
-	 * We delay resetting cycle_view until after cursor_update_focus()
-	 * has been called to allow A-Tab keyboard focus switching even if
-	 * followMouse has been configured and the cursor is on a different
-	 * surface. Otherwise cursor_update_focus() would automatically
-	 * refocus the surface the cursor is currently on.
-	 */
-	server->osd_state.cycle_view = NULL;
 }
 
 static void


### PR DESCRIPTION
This PR cleans up the cruft and comments from e45fe08 (ref. #2475).

Background:

- With e45fe08, the keyboard focus is always moved to the switched window on finishing window switcher, even with `<focus followMouse="yes">`. Since `followMouseRequiresMovement` was not implemented at that time (behaved like it was always "no"), e45fe08 was necessary to allow users users who use `followMouse="yes"` to move the keyboard focus with window switcher.
- 9a9e20d added `followMouseRequiresMovement`, but it kept the behavior described above even with `followMouse="yes"` and `followMouseRequiresMovement="no"`.
- 398b80b accidentally invalidated e45fe08, which means the keyboard focus is now always moved to the window below the cursor on finishing window switcher with `followMouse="yes"` and `followMouseRequiresMovement="no"`.

Although the invalidation was a accident, I think always setting the keyboard focus on the window below the cursor is what users expect from `followMouse="yes"` and `followMouseRequiresMovement="no"`.