### PR TITLE
osd: make window switcher more Openbox-like in terms of key precessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ If you have not created an rc.xml config file, default bindings will be:
 | combination              | action
 | ------------------------ | ------
 | `alt`-`tab`              | activate next window
+| `alt`-`shift`-`tab`      | activate previous window
 | `super`-`return`         | alacritty
 | `alt`-`F3`               | bemenu
 | `alt`-`F4`               | close window

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -117,8 +117,6 @@ Actions are used in menus and keyboard/mouse bindings.
 	Cycle focus to next/previous window respectively.++
 	Default keybind for NextWindow is Alt-Tab.
 
-	The shift key is used to reverse direction while cycling.
-
 	The arrow keys are used to move forwards/backwards while cycling.
 
 *<action name="Reconfigure" />*

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -648,12 +648,14 @@ extending outward from the snapped edge.
 
 ```
   A-Tab - next window
+  A-S-Tab - previous window
   W-Return - alacritty
   A-F3 - run bemenu
   A-F4 - close window
   W-a - toggle maximize
   A-<arrow> - move window to edge
   W-<arrow> - resize window to fill half the output
+  A-Space - show window menu
 ```
 
 	Audio and MonBrightness keys are also bound to amixer and

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -236,6 +236,9 @@
     <keybind key="A-Tab">
       <action name="NextWindow" />
     </keybind>
+    <keybind key="A-S-Tab">
+      <action name="PreviousWindow" />
+    </keybind>
     <keybind key="W-Return">
       <action name="Execute" command="alacritty" />
     </keybind>

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -13,6 +13,9 @@ static struct key_combos {
 		.binding = "A-Tab",
 		.action = "NextWindow",
 	}, {
+		.binding = "A-S-Tab",
+		.action = "PreviousWindow",
+	}, {
 		.binding = "W-Return",
 		.action = "Execute",
 		.attributes[0] = {

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -387,8 +387,6 @@ struct server {
 		struct wlr_scene_tree *preview_parent;
 		struct wlr_scene_node *preview_anchor;
 		struct multi_rect *preview_outline;
-		enum lab_cycle_dir initial_direction;
-		bool initial_keybind_contained_shift;
 	} osd_state;
 
 	struct theme *theme;

--- a/src/action.c
+++ b/src/action.c
@@ -955,10 +955,18 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_NEXT_WINDOW:
-			osd_begin(server, LAB_CYCLE_DIR_FORWARD);
+			if (server->input_mode == LAB_INPUT_STATE_WINDOW_SWITCHER) {
+				osd_cycle(server, LAB_CYCLE_DIR_FORWARD);
+			} else {
+				osd_begin(server, LAB_CYCLE_DIR_FORWARD);
+			}
 			break;
 		case ACTION_TYPE_PREVIOUS_WINDOW:
-			osd_begin(server, LAB_CYCLE_DIR_BACKWARD);
+			if (server->input_mode == LAB_INPUT_STATE_WINDOW_SWITCHER) {
+				osd_cycle(server, LAB_CYCLE_DIR_BACKWARD);
+			} else {
+				osd_begin(server, LAB_CYCLE_DIR_BACKWARD);
+			}
 			break;
 		case ACTION_TYPE_RECONFIGURE:
 			kill(getpid(), SIGHUP);

--- a/src/osd.c
+++ b/src/osd.c
@@ -160,14 +160,6 @@ restore_preview_node(struct server *server)
 	}
 }
 
-static bool
-shift_is_pressed(struct server *server)
-{
-	uint32_t modifiers = wlr_keyboard_get_modifiers(
-			&server->seat.keyboard_group->keyboard);
-	return modifiers & WLR_MODIFIER_SHIFT;
-}
-
 void
 osd_begin(struct server *server, enum lab_cycle_dir direction)
 {
@@ -175,10 +167,6 @@ osd_begin(struct server *server, enum lab_cycle_dir direction)
 		return;
 	}
 
-	/* Remember direction so it can be followed by subsequent key presses */
-	server->osd_state.initial_direction = direction;
-	server->osd_state.initial_keybind_contained_shift =
-		shift_is_pressed(server);
 	server->osd_state.cycle_view = get_next_cycle_view(server,
 		server->osd_state.cycle_view, direction);
 


### PR DESCRIPTION
Closes #2462.

Before this PR, keystrokes were interpreted based on following hard-coded rules while the window switcher is active:

  1. Up/Left arrow keys cycle the window forward.
  2. Down/Right arrow keys cycle the window backward.
  3. Other keystrokes cycle the window in the initial direction specified by `NextWindow`/`PreviousWindow` actions. But while Shift key is pressed, the direction is inverted.

...and keybind actions were never executed.

However, this lead to a counter-intuitive behavior for new, especially pre-Openbox users. For example, in the following keybinds, after the user activates the window switcher with `Super+n`, `Super+p` cycles the window _forward_:

```xml
  <keybind key="W-n">
    <action name="NextWindow" />
  </keybind>
  <keybind key="W-p">
    <action name="PreviousWindow" />
  </keybind>
```

This is because the key `p` is recognized just as a normal key in the third hard-coded rule.

So this PR changes the rules to be more Openbox-like:

  1. Up/Left arrow keys cycles the window forward.
  2. Down/Right arrow keys cycles the window backward.
  3. Other keystrokes are matched against keybinds and execute their actions. If they include NextWindow/PreviousWindow action, it cycles the selected window forward/backward even while the window switcher is active.

To keep using Alt-Shift-Tab to cycle the window backward, this PR adds following keybind to the default setting:
```xml
    <keybind key="A-S-Tab">
      <action name="PreviousWindow" />
    </keybind>
```