### PR TITLE
img: fix UAF on Reconfigure by refcounting (attempt 2)

### DIFF
--- a/include/common/scaled-img-buffer.h
+++ b/include/common/scaled-img-buffer.h
@@ -23,6 +23,9 @@ struct scaled_img_buffer {
  * display. It gets destroyed automatically when the backing scaled_scene_buffer
  * is being destroyed which in turn happens automatically when the backing
  * wlr_scene_buffer (or one of its parents) is being destroyed.
+ *
+ * This function clones the lab_img passed as the image source, so callers are
+ * free to destroy it.
  */
 struct scaled_img_buffer *scaled_img_buffer_create(struct wlr_scene_tree *parent,
 	struct lab_img *img, int width, int height, int padding);

--- a/include/img/img.h
+++ b/include/img/img.h
@@ -3,6 +3,7 @@
 #define LABWC_IMG_H
 
 #include <cairo.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <wayland-util.h>
 
@@ -71,5 +72,10 @@ struct lab_data_buffer *lab_img_render(struct lab_img *img,
  * @img: lab_img to destroy
  */
 void lab_img_destroy(struct lab_img *img);
+
+/**
+ * lab_img_equal() - Returns true if two images draw the same content
+ */
+bool lab_img_equal(struct lab_img *img_a, struct lab_img *img_b);
 
 #endif /* LABWC_IMG_H */

--- a/include/img/img.h
+++ b/include/img/img.h
@@ -16,7 +16,6 @@ enum lab_img_type {
 };
 
 struct lab_img {
-	struct theme *theme; /* Used by modifier functions */
 	struct wl_array modifiers; /* lab_img_modifier_func_t */
 	struct lab_img_cache *cache;
 };
@@ -33,8 +32,7 @@ struct lab_img *lab_img_load(enum lab_img_type type, const char *path,
  */
 struct lab_img *lab_img_load_from_bitmap(const char *bitmap, float *rgba);
 
-typedef void (*lab_img_modifier_func_t)(struct theme *theme, cairo_t *cairo,
-	int w, int h);
+typedef void (*lab_img_modifier_func_t)(cairo_t *cairo, int w, int h);
 
 /**
  * lab_img_copy() - Copy lab_img
@@ -55,8 +53,7 @@ struct lab_img *lab_img_copy(struct lab_img *img);
  * after the image is rendered on a buffer with lab_img_render(). For example,
  * hover effects for window buttons can be drawn over the rendered image.
  */
-void lab_img_add_modifier(struct lab_img *img, lab_img_modifier_func_t modifier,
-	struct theme *theme);
+void lab_img_add_modifier(struct lab_img *img, lab_img_modifier_func_t modifier);
 
 /**
  * lab_img_render() - Render lab_img to a buffer

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -79,7 +79,6 @@ struct ssd {
 		} title;
 
 		char *app_id;
-		struct lab_img *icon_img;
 	} state;
 
 	/* An invisible area around the view which allows resizing */

--- a/src/common/scaled-img-buffer.c
+++ b/src/common/scaled-img-buffer.c
@@ -26,6 +26,7 @@ static void
 _destroy(struct scaled_scene_buffer *scaled_buffer)
 {
 	struct scaled_img_buffer *self = scaled_buffer->data;
+	lab_img_destroy(self->img);
 	free(self);
 }
 
@@ -36,7 +37,7 @@ _equal(struct scaled_scene_buffer *scaled_buffer_a,
 	struct scaled_img_buffer *a = scaled_buffer_a->data;
 	struct scaled_img_buffer *b = scaled_buffer_b->data;
 
-	return a->img == b->img
+	return lab_img_equal(a->img, b->img)
 		&& a->width == b->width
 		&& a->height == b->height
 		&& a->padding == b->padding;
@@ -52,12 +53,13 @@ struct scaled_img_buffer *
 scaled_img_buffer_create(struct wlr_scene_tree *parent, struct lab_img *img,
 	int width, int height, int padding)
 {
+	assert(img);
 	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
 		parent, &impl, &cached_buffers, /* drop_buffer */ true);
 	struct scaled_img_buffer *self = znew(*self);
 	self->scaled_buffer = scaled_buffer;
 	self->scene_buffer = scaled_buffer->scene_buffer;
-	self->img = img;
+	self->img = lab_img_copy(img);
 	self->width = width;
 	self->height = height;
 	self->padding = padding;
@@ -73,7 +75,9 @@ void
 scaled_img_buffer_update(struct scaled_img_buffer *self, struct lab_img *img,
 	int width, int height, int padding)
 {
-	self->img = img;
+	assert(img);
+	lab_img_destroy(self->img);
+	self->img = lab_img_copy(img);
 	self->width = width;
 	self->height = height;
 	self->padding = padding;

--- a/src/img/img.c
+++ b/src/img/img.c
@@ -106,10 +106,8 @@ lab_img_copy(struct lab_img *img)
 }
 
 void
-lab_img_add_modifier(struct lab_img *img,  lab_img_modifier_func_t modifier,
-	struct theme *theme)
+lab_img_add_modifier(struct lab_img *img,  lab_img_modifier_func_t modifier)
 {
-	img->theme = theme;
 	lab_img_modifier_func_t *mod = wl_array_add(&img->modifiers, sizeof(*mod));
 	*mod = modifier;
 }
@@ -185,7 +183,7 @@ lab_img_render(struct lab_img *img, int width, int height, int padding,
 	lab_img_modifier_func_t *modifier;
 	wl_array_for_each(modifier, &img->modifiers) {
 		cairo_save(cairo);
-		(*modifier)(img->theme, cairo, width, height);
+		(*modifier)(cairo, width, height);
 		cairo_restore(cairo);
 	}
 

--- a/src/img/img.c
+++ b/src/img/img.c
@@ -218,3 +218,18 @@ lab_img_destroy(struct lab_img *img)
 	wl_array_release(&img->modifiers);
 	free(img);
 }
+
+bool
+lab_img_equal(struct lab_img *img_a, struct lab_img *img_b)
+{
+	if (img_a == img_b) {
+		return true;
+	}
+	if (!img_a || !img_b || img_a->cache != img_b->cache
+			|| img_a->modifiers.size != img_b->modifiers.size) {
+		return false;
+	}
+	return img_a->modifiers.size == 0
+		|| !memcmp(img_a->modifiers.data, img_b->modifiers.data,
+			img_a->modifiers.size);
+}

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -345,9 +345,6 @@ ssd_titlebar_destroy(struct ssd *ssd)
 	if (ssd->state.app_id) {
 		zfree(ssd->state.app_id);
 	}
-	if (ssd->state.icon_img) {
-		lab_img_destroy(ssd->state.icon_img);
-	}
 
 	wlr_scene_node_destroy(&ssd->titlebar.tree->node);
 	ssd->titlebar.tree = NULL;
@@ -642,10 +639,7 @@ ssd_update_window_icon(struct ssd *ssd)
 		}
 	} FOR_EACH_END
 
-	if (ssd->state.icon_img) {
-		lab_img_destroy(ssd->state.icon_img);
-	}
-	ssd->state.icon_img = icon_img;
+	lab_img_destroy(icon_img);
 #endif
 }
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -76,12 +76,12 @@ zdrop(struct lab_data_buffer **buffer)
 
 /* Draw rounded-rectangular hover overlay on the button buffer */
 static void
-draw_hover_overlay_on_button(struct theme *theme, cairo_t *cairo, int w, int h)
+draw_hover_overlay_on_button(cairo_t *cairo, int w, int h)
 {
 	/* Overlay (pre-multiplied alpha) */
 	float overlay_color[4] = { 0.15f, 0.15f, 0.15f, 0.3f};
 	set_cairo_color(cairo, overlay_color);
-	int r = theme->window_button_hover_bg_corner_radius;
+	int r = rc.theme->window_button_hover_bg_corner_radius;
 
 	cairo_new_sub_path(cairo);
 	cairo_arc(cairo, r, r, r, 180 * deg, 270 * deg);
@@ -97,16 +97,16 @@ draw_hover_overlay_on_button(struct theme *theme, cairo_t *cairo, int w, int h)
 
 /* Round the buffer for the leftmost button in the titlebar */
 static void
-round_left_corner_button(struct theme *theme, cairo_t *cairo, int w, int h)
+round_left_corner_button(cairo_t *cairo, int w, int h)
 {
 	/*
 	 * Position of the topleft corner of the titlebar relative to the
 	 * leftmost button
 	 */
-	double x = -theme->window_titlebar_padding_width;
-	double y = -(theme->titlebar_height - theme->window_button_height) / 2;
+	double x = -rc.theme->window_titlebar_padding_width;
+	double y = -(rc.theme->titlebar_height - rc.theme->window_button_height) / 2;
 
-	double r = rc.corner_radius - (double)theme->border_width / 2.0;
+	double r = rc.corner_radius - (double)rc.theme->border_width / 2.0;
 
 	cairo_new_sub_path(cairo);
 	cairo_arc(cairo, x + r, y + r, r, deg * 180, deg * 270);
@@ -122,7 +122,7 @@ round_left_corner_button(struct theme *theme, cairo_t *cairo, int w, int h)
 
 /* Round the buffer for the rightmost button in the titlebar */
 static void
-round_right_corner_button(struct theme *theme, cairo_t *cairo, int w, int h)
+round_right_corner_button(cairo_t *cairo, int w, int h)
 {
 	/*
 	 * Horizontally flip the cairo context so we can reuse
@@ -130,7 +130,7 @@ round_right_corner_button(struct theme *theme, cairo_t *cairo, int w, int h)
 	 */
 	cairo_scale(cairo, -1, 1);
 	cairo_translate(cairo, -w, 0);
-	round_left_corner_button(theme, cairo, w, h);
+	round_left_corner_button(cairo, w, h);
 }
 
 /*
@@ -223,7 +223,7 @@ load_button(struct theme *theme, struct button *b, int active)
 			button_imgs[b->type][b->state_set & ~LAB_BS_HOVERD];
 		*img = lab_img_copy(non_hover_img);
 		lab_img_add_modifier(*img,
-			draw_hover_overlay_on_button, theme);
+			draw_hover_overlay_on_button);
 	}
 
 	/*
@@ -239,7 +239,7 @@ load_button(struct theme *theme, struct button *b, int active)
 		if (leftmost_button->type == b->type) {
 			*rounded_img = lab_img_copy(*img);
 			lab_img_add_modifier(*rounded_img,
-				round_left_corner_button, theme);
+				round_left_corner_button);
 		}
 		break;
 	}
@@ -249,7 +249,7 @@ load_button(struct theme *theme, struct button *b, int active)
 		if (rightmost_button->type == b->type) {
 			*rounded_img = lab_img_copy(*img);
 			lab_img_add_modifier(*rounded_img,
-				round_right_corner_button, theme);
+				round_right_corner_button);
 		}
 		break;
 	}


### PR DESCRIPTION
This PR implements the approach I proposed in https://github.com/labwc/labwc/pull/2481#issuecomment-2569384105.

Like #2481, this PR makes `lab_img` outlive `theme_finish()` by refcounting, but without adding new APIs:
- When creating a `scaled_img_buffer`, `lab_img` is replicated via `lab_img_copy()`
- When destroying a `scaled_img_buffer`, `lab_img` is destroyed via `lab_img_destroy()`

Let me explain how this works.

## The lifetime of `lab_img` and `lab_img_cache`

After startup, `theme` struct references `lab_img`, which references `lab_img_cache` with `refcount=1`. Here, `lab_img_cache` is the wrapper for `lab_data_buffer` or `RsvgHandle` and represents the actual content of the loaded image file.

![first](https://github.com/user-attachments/assets/8fecd0b2-d117-443a-bbec-9dca393f3aa9)

When a window is opened and its decoration is created, the `lab_img` is copied via `lab_img_copy()` and a new `scaled_img_buffer` references it. Note that the image content is not copied here; instead, the refcount of `lab_img_cache` is incremented.

![second](https://github.com/user-attachments/assets/9872e6a7-2dd5-4fa8-b3ab-f5bb4b339041)

When the theme is de-initialized in `theme_finish()` and the `lab_img` referenced by `theme` is destroyed, the `lab_img` referenced by the `scaled_img_buffer` and `lab_img_cache` outlive. Therefore, it's safe for `_update_buffer()` in `scaled-img-buffer.c` to be called.

![third](https://github.com/user-attachments/assets/1b434c89-6817-40ac-b7a9-f51baa591ccc)

And when the decoration is destroyed via `undecorate()`, the `scaled_img_buffer`, `lab_img` and `lab_img_cache` are finally destroyed.

## Motivation of `lab_img_copy()` and `lab_img_cache`

For better understanding of `lab_img` API in general, let me explain the initial motivation of `lab_img_copy()` and `lab_img_cache` in #2444. `lab_img_copy()` was introduced to share the image content with different variants of buttons including normal, hovered, rounded, rounded-hovered buttons:

![foo](https://github.com/user-attachments/assets/9977f063-1657-4533-99c6-092690b4f768)

For example, when `close_hover-active.png` is not found, the `lab_img` for `close-active.png` is copied via `lab_img_copy()` and a "modifier" function that draws a hover overlay on it is added to the copied `lab_img` via `lab_img_add_modifier()`. And if the close button is placed at the corner of the titlebar, the `lab_img` is further copied and the modifier function that cuts its corner is applied.