### PR TITLE
img: apply padding around window icon only horizontally

### DIFF
--- a/include/img/img.h
+++ b/include/img/img.h
@@ -63,11 +63,11 @@ void lab_img_add_modifier(struct lab_img *img, lab_img_modifier_func_t modifier,
  * @img: source image
  * @width: width of the created buffer
  * @height: height of the created buffer
- * @padding: padding around the rendered image in the buffer
+ * @padding_x: horizontal padding around the rendered image in the buffer
  * @scale: scale of the created buffer
  */
 struct lab_data_buffer *lab_img_render(struct lab_img *img,
-	int width, int height, int padding, double scale);
+	int width, int height, int padding_x, double scale);
 
 /**
  * lab_img_destroy() - destroy lab_img

--- a/src/img/img-svg.c
+++ b/src/img/img-svg.c
@@ -36,7 +36,7 @@ img_svg_load(const char *filename)
 }
 
 struct lab_data_buffer *
-img_svg_render(RsvgHandle *svg, int w, int h, int padding, double scale)
+img_svg_render(RsvgHandle *svg, int w, int h, int padding_x, double scale)
 {
 	struct lab_data_buffer *buffer = buffer_create_cairo(w, h, scale);
 	cairo_surface_t *image = buffer->surface;
@@ -44,10 +44,10 @@ img_svg_render(RsvgHandle *svg, int w, int h, int padding, double scale)
 	GError *err = NULL;
 
 	RsvgRectangle viewport = {
-		.x = padding,
-		.y = padding,
-		.width = w - 2 * padding,
-		.height = h - 2 * padding,
+		.x = padding_x,
+		.y = 0,
+		.width = w - 2 * padding_x,
+		.height = h,
 	};
 	rsvg_handle_render_document(svg, cr, &viewport, &err);
 	if (err) {

--- a/src/img/img.c
+++ b/src/img/img.c
@@ -121,7 +121,7 @@ lab_img_add_modifier(struct lab_img *img,  lab_img_modifier_func_t modifier,
  */
 static struct lab_data_buffer *
 render_cairo_surface(cairo_surface_t *surface, int width, int height,
-	int padding, double scale)
+	int padding_x, double scale)
 {
 	assert(surface);
 	int src_w = cairo_image_surface_get_width(surface);
@@ -132,10 +132,10 @@ render_cairo_surface(cairo_surface_t *surface, int width, int height,
 	cairo_t *cairo = cairo_create(buffer->surface);
 
 	struct wlr_box container = {
-		.x = padding,
-		.y = padding,
-		.width = width - 2 * padding,
-		.height = height - 2 * padding,
+		.x = padding_x,
+		.y = 0,
+		.width = width - 2 * padding_x,
+		.height = height,
 	};
 
 	struct wlr_box dst_box = box_fit_within(src_w, src_h, &container);

--- a/src/ssd/ssd-part.c
+++ b/src/ssd/ssd-part.c
@@ -107,7 +107,7 @@ add_scene_button(struct wl_list *part_list, enum ssd_part_type type,
 		struct ssd_part *icon_part = add_scene_part(part_list, type);
 		struct scaled_img_buffer *img_buffer = scaled_img_buffer_create(
 			parent, imgs[state_set], rc.theme->window_button_width,
-			rc.theme->window_button_height, /* padding */ 0);
+			rc.theme->window_button_height, /* padding_x */ 0);
 		assert(img_buffer);
 		icon_part->node = &img_buffer->scene_buffer->node;
 		wlr_scene_node_set_enabled(icon_part->node, false);

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -600,7 +600,7 @@ ssd_update_window_icon(struct ssd *ssd)
 	 */
 	int icon_padding = theme->window_button_width / 10;
 	int icon_size = MIN(theme->window_button_width - 2 * icon_padding,
-		theme->window_button_height - 2 * icon_padding);
+		theme->window_button_height);
 
 	/*
 	 * Load/render icons at the max scale of any usable output (at


### PR DESCRIPTION
Closes #2450.

16dbdc64 changed the padding around the app icon in the titlebar to be applied both vertically and horizontally rather than only horizontally because it was more natural from a developer's perspective, but some users complained about the smaller icons in certain configurations.

So let's undo the change in 16dbdc64 and apply the icon padding only horizontally for now.

We can add configurations for the icon padding (or icon size independent from `window.button.{width,height}`?) later.