### PR TITLE
set: prevent possible segfault when keycode 0 is released

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -29,16 +29,11 @@ lab_set_add(struct lab_set *set, uint32_t value)
 void
 lab_set_remove(struct lab_set *set, uint32_t value)
 {
-	bool shifting = false;
-
-	for (int i = 0; i < LAB_SET_MAX_SIZE; ++i) {
+	for (int i = 0; i < set->size; ++i) {
 		if (set->values[i] == value) {
 			--set->size;
-			shifting = true;
-		}
-		if (shifting) {
-			set->values[i] = i < LAB_SET_MAX_SIZE - 1
-				? set->values[i + 1] : 0;
+			set->values[i] = set->values[set->size];
+			return;
 		}
 	}
 }


### PR DESCRIPTION
I encountered with segfault when I tried https://codeberg.org/vyivel/keymap-replacer while fcitx5 is running (it didn't happen without fcitx5 for some reason).

This was because `lab_set_remove()` didn't expect keycode 0. When keycode 0 is passed to it, `set->size` could be negative as the first branch in the loop `if (set->values[i] == value)` could be taken over and over.

So this PR changes `lab_set_remove()` with the wlroots' approach: https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/util/set.c#L16.

Another possible approach is like below. Maybe this is slightly easier to debug, but I prioritized the simplicity in this PR. I don't have a strong preference on it though.

```c
void
lab_set_remove(struct lab_set *set, uint32_t value)
{
	/* Find the matched element */
	int found = -1;
	for (int i = 0; i < set->size; i++) {
		if (set->values[i] == value) {
			found = i;
			break;
		}
	}
	if (found == -1) {
		return;
	}

	/* Remove the matched element by sliding the back elements */
	set->size--;
	for (int i = found; i < set->size; i++) {
		set->values[i] = set->values[i + 1];
	}
	set->values[set->size] = 0;
}
```