### PR TITLE
IME: fix stuck Ctrl when pressed Ctrl+F in Firefox with Fcitx5

### DIFF
--- a/include/input/ime.h
+++ b/include/input/ime.h
@@ -21,7 +21,7 @@ struct input_method_relay {
 	struct wl_list text_inputs; /* struct text_input.link */
 	struct wlr_input_method_v2 *input_method;
 	struct wlr_surface *focused_surface;
-	struct lab_set pressed_keys;
+	struct lab_set forwarded_pressed_keys;
 	/*
 	 * Text-input which is enabled by the client and communicating with
 	 * input-method.

--- a/include/input/ime.h
+++ b/include/input/ime.h
@@ -21,7 +21,10 @@ struct input_method_relay {
 	struct wl_list text_inputs; /* struct text_input.link */
 	struct wlr_input_method_v2 *input_method;
 	struct wlr_surface *focused_surface;
+
 	struct lab_set forwarded_pressed_keys;
+	struct wlr_keyboard_modifiers forwarded_modifiers;
+
 	/*
 	 * Text-input which is enabled by the client and communicating with
 	 * input-method.

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -78,7 +78,7 @@ input_method_keyboard_grab_forward_key(struct keyboard *keyboard,
 	 * key-press events forwarded
 	 */
 	struct lab_set *pressed_keys =
-		&keyboard->base.seat->input_method_relay->pressed_keys;
+		&keyboard->base.seat->input_method_relay->forwarded_pressed_keys;
 	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED
 			&& !lab_set_contains(pressed_keys, event->keycode)) {
 		return false;
@@ -345,7 +345,7 @@ handle_input_method_grab_keyboard(struct wl_listener *listener, void *data)
 			keyboard_grab, active_keyboard);
 	}
 
-	relay->pressed_keys = (struct lab_set){0};
+	relay->forwarded_pressed_keys = (struct lab_set){0};
 
 	relay->keyboard_grab_destroy.notify = handle_keyboard_grab_destroy;
 	wl_signal_add(&keyboard_grab->events.destroy,


### PR DESCRIPTION
This PR fixes a problem after 683f67b that Ctrl modifier state is stuck when pressed Ctrl+F (shortcut for word-search) in Firefox while Fcitx5 is running, which makes mouse scrolls zoom in/out the UI even after Ctrl key is released.

This doesn't affect the code path without input method running. Below is the detailed explanation:

<details><summary>details</summary>

When Ctrl+F is pressed, an input box is opened in the application and Fcitx5 creates a new virtual keyboard
(VK), whose initial modifiers is empty. Then prior to 683f67b, the key/modifiers events flowed like this:

- The compositor detects F key-release
  - Modifiers (Ctrl pressed) are notified via `wlr_input_method_keyboard_grab_v2_set_keyboard()`
  - F key-release is forwarded to IM
- IM sends modifiers (Ctrl) back to the compositor via VK
  - **The modifiers on VK is updated (empty->Ctrl)**
  - **Modifers (Ctrl) are notified to the app**
- IM sends F key-release back to the compositor via VK
  - F key-release is notified to the app
- The compositor detects Ctrl key-release
  - Ctrl key-release is forwarded to IM
  - Modifiers (empty) are forwarded to IM
- IM sends Ctrl key-release back to the compsitor via VK
  - Ctrl key-release is notified to IM
- IM sends modifiers (empty) back to the compositor via VK
  - **The modifiers on VK is updated again (Ctrl->empty)**
  - **Modifiers (empty) are notified to the app**

Thus, the final modifiers (empty) is notified to the application a expected. However, after 683f67b, the key/modifiers events flowed like this:

- The compositor detects F key-release
  - F key-release is directly notified to the app
  - The modifiers (Ctrl) is also notified to the app
- The compositor detects Ctrl key-release
  - Ctrl key-release is directly notified to the app
  - Modifiers (empty) are forwarded to IM
- IM sends modifiers (empty) back to the compositor via VK
  - **Modifier on VK is not updated (empty->empty)**
  - **The compositor ignores it**

So the final modifier (empty) is never notified to the application, which causes stuck Ctrl modifier.

This PR fixes this by not forwarding the modifiers when it hasn't been updated since it was forwarded previously. So after this commit, the key/modifiers events flow like this:

- The compositor detects F key-release
  - F key-release is directly notified to the app
  - The modifiers (Ctrl) is also notified to the app
- The compositor detects Ctrl key-release
  - Ctrl key-release is directly notified to the app
  - The modifiers are directly notified to the app because the modifiers (empty) are the same as the last forwarded modifier (empty).

</details>

I've been testing this PR for a day and it's been working well so far.