### PR TITLE
cursor: fix invisible cursor on application after reconfigure

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -401,6 +401,7 @@ cursor_update_image(struct seat *seat)
 		if (seat->seat->pointer_state.focused_surface) {
 			seat->server_cursor = LAB_CURSOR_DEFAULT;
 			wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager, "");
+			wlr_seat_pointer_clear_focus(seat->seat);
 			cursor_update_focus(seat->server);
 		}
 		return;


### PR DESCRIPTION
On reconfigure, we should send `wl_pointer.{leave,enter}` events if the cursor is on an application surface to let the application update the cursor, but #2455 prevented these events from being sent.