### PR TITLE
osd: prevent preview outlines to be above OSD

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -511,6 +511,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 	 * Set the z-positions to achieve the following order (from top to
 	 * bottom):
 	 *	- session lock layer
+	 *	- window switcher osd
 	 *	- compositor menu
 	 *	- layer-shell popups
 	 *	- overlay layer
@@ -525,6 +526,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 	wlr_scene_node_raise_to_top(&output->layer_tree[3]->node);
 	wlr_scene_node_raise_to_top(&output->layer_popup_tree->node);
 	wlr_scene_node_raise_to_top(&server->menu_tree->node);
+	wlr_scene_node_raise_to_top(&output->osd_tree->node);
 	wlr_scene_node_raise_to_top(&output->session_lock_tree->node);
 
 	if (rc.auto_enable_outputs) {

--- a/src/server.c
+++ b/src/server.c
@@ -561,6 +561,7 @@ server_init(struct server *server)
 	 * | Type              | Scene Tree       | Per Output | Example
 	 * | ----------------- | ---------------- | ---------- | -------
 	 * | ext-session       | lock-screen      | Yes        | swaylock
+	 * | osd               | osd_tree         | Yes        |
 	 * | compositor-menu   | menu_tree        | No         | root-menu
 	 * | layer-shell       | layer-popups     | Yes        |
 	 * | layer-shell       | overlay-layer    | Yes        |


### PR DESCRIPTION
Fixes #2465 by placing `osd_tree` above `menu_tree`.

This also prevents layer-shell surfaces from covering the OSD. I'm not sure whether to be higher, I prefer server-side component to be higher.

Before (higher-first):
- preview outlines (just above menu)
- menu
- layer-shell (top/overlay/popup)
- osd

After (higher-first):
- osd
- preview outlines (just above menu)
- menu
- layer-shell (top/overlay/popup)