### PR TITLE
theme: don't try to load "themerc"s if theme_name is NULL

### DIFF
--- a/src/theme.c
+++ b/src/theme.c
@@ -1496,15 +1496,18 @@ theme_init(struct theme *theme, struct server *server, const char *theme_name)
 	 */
 	theme_builtin(theme, server);
 
-	/*
-	 * Read
-	 *   - <data-dir>/share/themes/$theme_name/labwc/themerc
-	 *   - <data-dir>/share/themes/$theme_name/openbox-3/themerc
-	 */
 	struct wl_list paths;
-	paths_theme_create(&paths, theme_name, "themerc");
-	theme_read(theme, &paths);
-	paths_destroy(&paths);
+
+	if (theme_name) {
+		/*
+		 * Read
+		 *   - <data-dir>/share/themes/$theme_name/labwc/themerc
+		 *   - <data-dir>/share/themes/$theme_name/openbox-3/themerc
+		 */
+		paths_theme_create(&paths, theme_name, "themerc");
+		theme_read(theme, &paths);
+		paths_destroy(&paths);
+	}
 
 	/* Read <config-dir>/labwc/themerc-override */
 	paths_config_create(&paths, "themerc-override");


### PR DESCRIPTION
    theme_name is NULL when <theme><name></name>...</theme> is in rc.xml

--8<--

I'd  guess trying to load e.g. `~/.local/share/themes/(null)/labwc/themerc`
is not a feature.