### PR TITLE
menu icon support

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -481,7 +481,7 @@ extending outward from the snapped edge.
 	The name of the Openbox theme to use. It is not set by default.
 
 *<theme><icon>*
-	The name of the icon theme to use. It is not set by default.
+	The name of the icon theme to use. Inherits *<theme><name>* if not set.
 
 *<theme><fallbackAppIcon>*
 	The name of the icon to use as a fallback when the application icon

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -1121,6 +1121,7 @@ situation.
 ```
 <menu>
   <ignoreButtonReleasePeriod>250</ignoreButtonReleasePeriod>
+  <showIcons>yes</showIcons>
 </menu>
 ```
 
@@ -1133,6 +1134,11 @@ situation.
 	anticipated that most users will want to change this, but the config
 	option has been exposed for unusual use-cases. It is equivalent to
 	Openbox's `<hideDelay>`. Default is 250 ms.
+
+*<menu><showIcons>*
+	Show menu icons based on the `icon` attribute of menu label elements.
+	Default is yes. Requires libsfdo. If labwc is built without it, no
+	icons will be shown.
 
 ## MAGNIFIER
 

--- a/docs/labwc-menu.5.scd
+++ b/docs/labwc-menu.5.scd
@@ -2,11 +2,11 @@ labwc-menu(5)
 
 # NAME
 
-labwc - menu files
+labwc - menu file
 
 # DESCRIPTION
 
-Static menus are built based on content of XML files located at
+Static menus are built based on the menu.xml file located at
 "~/.config/labwc" and equivalent XDG Base Directories.
 
 # SYNTAX

--- a/docs/labwc-menu.5.scd
+++ b/docs/labwc-menu.5.scd
@@ -15,29 +15,37 @@ The menu file must be entirely enclosed within <openbox_menu> and
 </openbox_menu> tags.  Inside these tags, menus are specified as follows:
 
 ```
+<!-- A toplevel menu -->
+<menu id="external_menu_settings" label="External Settings" icon="preferences-other">
+  <item label="Display setting">
+    <action name="Execute" command="wdisplays" />
+  </item>
+</menu>
+
+<!-- Another toplevel menu -->
 <menu id="">
 
   <!-- A menu entry with an action, for example to execute an application -->
-  <item label="">
+  <item label="" icon="">
     <action></action>
   </item>
 
-  <!-- A submenu defined elsewhere -->
-  <menu id="" />
+  <!-- A submenu defined elsewhere, uses external label and icon attributes -->
+  <menu id="external_menu_settings" />
 
   <!-- Horizontal line -->
   <separator />
 
   <!-- An inline submenu -->
-  <menu id="" label="">
+  <menu id="" label="" icon="">
     ...some content...
   </menu>
 
   <!-- Title -->
-  <separator label=""/>
+  <separator label="" />
 
   <!-- Pipemenu -->
-  <menu id="" label="" execute="COMMAND"/>
+  <menu id="" label="" icon="" execute="COMMAND" />
 
 </menu>
 ```
@@ -56,14 +64,27 @@ The menu file must be entirely enclosed within <openbox_menu> and
 		  view to that workspace when selected.
 
 *menu.id* (when nested under other *<menu>* element)
-	Link to a submenu defined elsewhere (by a *<menu id="">* at toplevel)
+	Link to a submenu defined elsewhere (by a *<menu id="">* at toplevel).
 
 *menu.label*
 	The title of the menu, shown in its parent. A label must be given when
 	defining a menu.
 
+*menu.icon*
+	An icon to be rendered, shown in its parent. This argument is optional.
+	See *menu.item.icon* for further details.
+
 *menu.item.label*
 	The visible name of the menu item.
+
+*menu.item.icon*
+	The name of an icon to be rendered in front of the menu entry. This
+	attribute is optional. The name follows naming conventions of "Icon="
+	entries in .desktop files. If used, it is recommended to use the name of
+	the icon only rather than a full path. This ensures that the icon will
+	be looked up in the scale of the output where the menu is rendered. E.g.
+	use of icon="vlc" is suggested over using
+	icon="/usr/share/icons/hicolor/16x16/apps/vlc.png".
 
 *menu.item.action*
 	See labwc-actions(5). Note: XML CDATA is supported for this node in

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -676,6 +676,7 @@
 
   <menu>
     <ignoreButtonReleasePeriod>250</ignoreButtonReleasePeriod>
+    <showIcons>yes</showIcons>
   </menu>
 
   <!--

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -175,6 +175,7 @@ struct rcxml {
 
 	/* Menu */
 	unsigned int menu_ignore_button_release_period;
+	bool menu_show_icons;
 
 	/* Magnifier */
 	int mag_width;

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -23,6 +23,7 @@ struct menuitem {
 	char *execute;
 	char *id; /* needed for pipemenus */
 	char *text;
+	char *icon_name;
 	const char *arrow;
 	struct menu *parent;
 	struct menu *submenu;
@@ -41,6 +42,7 @@ struct menuitem {
 struct menu {
 	char *id;
 	char *label;
+	char *icon_name;
 	struct menu *parent;
 	struct menu_pipe_context *pipe_ctx;
 
@@ -57,6 +59,7 @@ struct menu {
 	struct wlr_scene_tree *scene_tree;
 	bool is_pipemenu;
 	bool align_left;
+	bool has_icons;
 
 	/* Used to match a window-menu to the view that triggered it. */
 	struct view *triggered_by_view;  /* may be NULL */

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1683,6 +1683,10 @@ post_processing(void)
 		rc.fallback_app_icon_name = xstrdup("labwc");
 	}
 
+	if (!rc.icon_theme_name && rc.theme_name) {
+		rc.icon_theme_name = xstrdup(rc.theme_name);
+	}
+
 	if (!rc.title_layout_loaded) {
 #if HAVE_LIBSFDO
 		fill_title_layout("icon:iconify,max,close");

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1252,6 +1252,8 @@ entry(xmlNode *node, char *nodename, char *content)
 			tablet_get_dbl_if_positive(content, "relativeMotionSensitivity");
 	} else if (!strcasecmp(nodename, "ignoreButtonReleasePeriod.menu")) {
 		rc.menu_ignore_button_release_period = atoi(content);
+	} else if (!strcasecmp(nodename, "showIcons.menu")) {
+		set_bool(content, &rc.menu_show_icons);
 	} else if (!strcasecmp(nodename, "width.magnifier")) {
 		rc.mag_width = atoi(content);
 	} else if (!strcasecmp(nodename, "height.magnifier")) {
@@ -1497,6 +1499,7 @@ rcxml_init(void)
 	rc.workspace_config.min_nr_workspaces = 1;
 
 	rc.menu_ignore_button_release_period = 250;
+	rc.menu_show_icons = true;
 
 	rc.mag_width = 400;
 	rc.mag_height = 400;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -459,8 +459,7 @@ fill_item(char *nodename, char *content)
 			"nodename: '%s' content: '%s'", nodename, content);
 	} else if (!strcmp(nodename, "icon")) {
 #if HAVE_LIBSFDO
-		// TODO: add some rc.menu_icons bool
-		if (true && !string_null_or_empty(content)) {
+		if (rc.menu_show_icons && !string_null_or_empty(content)) {
 			xstrdup_replace(current_item->icon_name, content);
 			current_menu->has_icons = true;
 		}


### PR DESCRIPTION
![20250129_12h00m18s_grim](https://github.com/user-attachments/assets/557c7061-8977-4f88-b635-cdda3d7175f4)

Can be tested with a toplevel "applications" menu (or some usual pipe menu)
```xml
<menu id="applications" label="foo" execute="labwc-menu-generator --icons --pipemenu" />
```
or a usual static menu item
```xml
<menu id="root-menu">
	<item label="Terminal" icon="foot">
		<action name="Execute" command="foot" />
	</item>
	[..]
</menu>
```

Open questions:
- [x] do we want this feature in the first place
- [x] how can we provide a toggle to deactivate menu icons
- [x] how do we allow a theme to define the width of menu icons, should a width of 0 be used to disable menu icons?