### PR TITLE
keyboard: add keyboard_get_all_modifiers()

### DIFF
--- a/include/input/keyboard.h
+++ b/include/input/keyboard.h
@@ -22,6 +22,6 @@ void keyboard_update_layout(struct seat *seat, xkb_layout_index_t layout);
 void keyboard_cancel_keybind_repeat(struct keyboard *keyboard);
 void keyboard_cancel_all_keybind_repeats(struct seat *seat);
 
-bool keyboard_any_modifiers_pressed(struct wlr_keyboard *keyboard);
+uint32_t keyboard_get_all_modifiers(struct seat *seat);
 
 #endif /* LABWC_KEYBOARD_H */

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -17,9 +17,10 @@
 #include "dnd.h"
 #include "idle.h"
 #include "input/gestures.h"
-#include "input/touch.h"
+#include "input/keyboard.h"
 #include "input/tablet.h"
 #include "input/tablet-tool.h"
+#include "input/touch.h"
 #include "labwc.h"
 #include "layers.h"
 #include "menu/menu.h"
@@ -892,9 +893,7 @@ handle_release_mousebinding(struct server *server,
 	}
 
 	struct mousebind *mousebind;
-
-	uint32_t modifiers = wlr_keyboard_get_modifiers(
-			&server->seat.keyboard_group->keyboard);
+	uint32_t modifiers = keyboard_get_all_modifiers(&server->seat);
 
 	wl_list_for_each(mousebind, &rc.mousebinds, link) {
 		if (ssd_part_contains(mousebind->context, ctx->type)
@@ -961,9 +960,7 @@ handle_press_mousebinding(struct server *server, struct cursor_context *ctx,
 	struct mousebind *mousebind;
 	bool double_click = is_double_click(rc.doubleclick_time, button, ctx);
 	bool consumed_by_frame_context = false;
-
-	uint32_t modifiers = wlr_keyboard_get_modifiers(
-			&server->seat.keyboard_group->keyboard);
+	uint32_t modifiers = keyboard_get_all_modifiers(&server->seat);
 
 	wl_list_for_each(mousebind, &rc.mousebinds, link) {
 		if (ssd_part_contains(mousebind->context, ctx->type)
@@ -1287,9 +1284,7 @@ handle_cursor_axis(struct server *server, struct cursor_context *ctx,
 {
 	struct mousebind *mousebind;
 	bool handled = false;
-
-	uint32_t modifiers = wlr_keyboard_get_modifiers(
-			&server->seat.keyboard_group->keyboard);
+	uint32_t modifiers = keyboard_get_all_modifiers(&server->seat);
 
 	enum direction direction = LAB_DIRECTION_INVALID;
 	if (event->orientation == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -95,8 +95,7 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 		}
 
 		/* Prevent region snapping when just moving via A-Left mousebind */
-		struct wlr_keyboard *keyboard = &seat->keyboard_group->keyboard;
-		seat->region_prevent_snap = keyboard_any_modifiers_pressed(keyboard);
+		seat->region_prevent_snap = keyboard_get_all_modifiers(seat);
 
 		cursor_shape = LAB_CURSOR_GRAB;
 		break;

--- a/src/regions.c
+++ b/src/regions.c
@@ -25,8 +25,7 @@ regions_should_snap(struct server *server)
 		return false;
 	}
 
-	struct wlr_keyboard *keyboard = &server->seat.keyboard_group->keyboard;
-	return keyboard_any_modifiers_pressed(keyboard);
+	return keyboard_get_all_modifiers(&server->seat);
 }
 
 struct region *

--- a/src/seat.c
+++ b/src/seat.c
@@ -305,14 +305,14 @@ new_pointer(struct seat *seat, struct wlr_input_device *dev)
 }
 
 static struct input *
-new_keyboard(struct seat *seat, struct wlr_input_device *device, bool virtual)
+new_keyboard(struct seat *seat, struct wlr_input_device *device, bool is_virtual)
 {
 	struct wlr_keyboard *kb = wlr_keyboard_from_input_device(device);
 
 	struct keyboard *keyboard = znew(*keyboard);
 	keyboard->base.wlr_input_device = device;
 	keyboard->wlr_keyboard = kb;
-	keyboard->is_virtual = virtual;
+	keyboard->is_virtual = is_virtual;
 
 	if (!seat->keyboard_group->keyboard.keymap) {
 		wlr_log(WLR_ERROR, "cannot set keymap");
@@ -329,7 +329,10 @@ new_keyboard(struct seat *seat, struct wlr_input_device *device, bool virtual)
 	 */
 	keyboard_set_numlock(kb);
 
-	if (!virtual) {
+	if (is_virtual) {
+		/* key repeat information is usually synchronized via the keyboard group */
+		wlr_keyboard_set_repeat_info(kb, rc.repeat_rate, rc.repeat_delay);
+	} else {
 		wlr_keyboard_group_add_keyboard(seat->keyboard_group, kb);
 	}
 

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -287,8 +287,7 @@ _osd_show(struct server *server)
 			wlr_scene_node_set_enabled(&output->workspace_osd->node, true);
 		}
 	}
-	struct wlr_keyboard *keyboard = &server->seat.keyboard_group->keyboard;
-	if (keyboard_any_modifiers_pressed(keyboard)) {
+	if (keyboard_get_all_modifiers(&server->seat)) {
 		/* Hidden by release of all modifiers */
 		server->seat.workspace_osd_shown_by_modifier = true;
 	} else {


### PR DESCRIPTION
And make mousebind handlers use that one.
Also remove `keyboard_any_modifiers_pressed()` and replace its usage with the new function.

Without this patch we would only request the modifier state of the keyboard group which makes mousebinds involving keyboard modifiers break for virtual keyboards like when using wayvnc. Same story for hiding the workspace overlay or snapping to regions.

Also includes a commit to set the repeat info for new virtual keyboards as we usually use the keyboard group for synchronizing that property.

Fixes:
- #2511
- #2513