### PR TITLE
Introduce scaled_icon_buffer and <theme><fallbackAppIcon>

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -483,6 +483,12 @@ extending outward from the snapped edge.
 *<theme><icon>*
 	The name of the icon theme to use. It is not set by default.
 
+*<theme><fallbackAppIcon>*
+	The name of the icon to use as a fallback when the application icon
+	(e.g. window icon in the titlebar) is not available. The name follows
+	the ones specified in "Icon=" entries in desktop files.
+	Default is 'labwc'.
+
 *<theme><titlebar><layout>*
 	Selection and order of buttons in a window's titlebar.
 	The following identifiers can be used, each only once:

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -30,6 +30,7 @@
   <theme>
     <name></name>
     <icon></icon>
+    <fallbackAppIcon>labwc</fallbackAppIcon>
     <titlebar>
       <layout>icon:iconify,max,close</layout>
       <showTitle>yes</showTitle>

--- a/include/common/scaled-icon-buffer.h
+++ b/include/common/scaled-icon-buffer.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_SCALED_ICON_BUFFER_H
+#define LABWC_SCALED_ICON_BUFFER_H
+
+#include <stdbool.h>
+
+struct wlr_scene_tree;
+struct wlr_scene_node;
+struct wlr_scene_buffer;
+
+struct scaled_icon_buffer {
+	struct scaled_scene_buffer *scaled_buffer;
+	struct wlr_scene_buffer *scene_buffer;
+	struct server *server;
+	char *app_id;
+	char *icon_name;
+	int width;
+	int height;
+};
+
+/*
+ * Create an auto scaling icon buffer, providing a wlr_scene_buffer node for
+ * display. It gets destroyed automatically when the backing scaled_scene_buffer
+ * is being destroyed which in turn happens automatically when the backing
+ * wlr_scene_buffer (or one of its parents) is being destroyed.
+ */
+struct scaled_icon_buffer *scaled_icon_buffer_create(
+	struct wlr_scene_tree *parent, struct server *server,
+	int width, int height);
+
+void scaled_icon_buffer_set_app_id(struct scaled_icon_buffer *self,
+	const char *app_id);
+
+void scaled_icon_buffer_set_icon_name(struct scaled_icon_buffer *self,
+	const char *icon_name);
+
+/* Obtain scaled_icon_buffer from wlr_scene_node */
+struct scaled_icon_buffer *scaled_icon_buffer_from_node(struct wlr_scene_node *node);
+
+#endif /* LABWC_SCALED_ICON_BUFFER_H */

--- a/include/common/scaled-img-buffer.h
+++ b/include/common/scaled-img-buffer.h
@@ -66,10 +66,6 @@ struct scaled_img_buffer {
 struct scaled_img_buffer *scaled_img_buffer_create(struct wlr_scene_tree *parent,
 	struct lab_img *img, int width, int height);
 
-/* Update image, width and height of the scaled_img_buffer */
-void scaled_img_buffer_update(struct scaled_img_buffer *self,
-	struct lab_img *img, int width, int height);
-
 /* Obtain scaled_img_buffer from wlr_scene_node */
 struct scaled_img_buffer *scaled_img_buffer_from_node(struct wlr_scene_node *node);
 

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -84,6 +84,7 @@ struct rcxml {
 	/* theme */
 	char *theme_name;
 	char *icon_theme_name;
+	char *fallback_app_icon_name;
 	struct wl_list title_buttons_left;
 	struct wl_list title_buttons_right;
 	int corner_radius;

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -24,10 +24,16 @@ struct ssd_button {
 	 */
 	uint8_t state_set;
 	/*
-	 * Button nodes for each combination of hover/toggled/rounded states.
-	 * nodes[state_set] should be displayed.
+	 * Image buffers for each combination of hover/toggled/rounded states.
+	 * img_buffers[state_set] is displayed. Some of these can be NULL
+	 * (e.g. img_buffers[LAB_BS_ROUNDED] is set only for corner buttons).
+	 *
+	 * When "type" is LAB_SSD_BUTTON_WINDOW_ICON, these are all NULL and
+	 * window_icon is used instead.
 	 */
-	struct wlr_scene_node *nodes[LAB_BS_ALL + 1];
+	struct scaled_img_buffer *img_buffers[LAB_BS_ALL + 1];
+
+	struct scaled_icon_buffer *window_icon;
 
 	struct wl_listener destroy;
 };

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -14,6 +14,7 @@ labwc_sources += files(
   'parse-bool.c',
   'parse-double.c',
   'scaled-font-buffer.c',
+  'scaled-icon-buffer.c',
   'scaled-img-buffer.c',
   'scaled-rect-buffer.c',
   'scaled-scene-buffer.c',

--- a/src/common/scaled-icon-buffer.c
+++ b/src/common/scaled-icon-buffer.c
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <string.h>
+#include "common/macros.h"
+#include "common/mem.h"
+#include "common/scaled-icon-buffer.h"
+#include "common/scaled-scene-buffer.h"
+#include "common/string-helpers.h"
+#include "config.h"
+#include "config/rcxml.h"
+#include "desktop-entry.h"
+#include "img/img.h"
+#include "node.h"
+
+static struct lab_data_buffer *
+_create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
+{
+#if HAVE_LIBSFDO
+	struct scaled_icon_buffer *self = scaled_buffer->data;
+	int icon_size = MIN(self->width, self->height);
+	struct lab_img *img = NULL;
+
+	if (self->icon_name) {
+		img = desktop_entry_load_icon(self->server,
+			self->icon_name, icon_size, scale);
+	} else if (self->app_id) {
+		img = desktop_entry_load_icon_from_app_id(self->server,
+			self->app_id, icon_size, scale);
+	}
+
+	if (!img) {
+		return NULL;
+	}
+
+	struct lab_data_buffer *buffer =
+		lab_img_render(img, self->width, self->height, scale);
+	lab_img_destroy(img);
+
+	return buffer;
+#else
+	return NULL;
+#endif
+}
+
+static void
+_destroy(struct scaled_scene_buffer *scaled_buffer)
+{
+	struct scaled_icon_buffer *self = scaled_buffer->data;
+	free(self->app_id);
+	free(self->icon_name);
+	free(self);
+}
+
+static bool
+_equal(struct scaled_scene_buffer *scaled_buffer_a,
+	struct scaled_scene_buffer *scaled_buffer_b)
+{
+	struct scaled_icon_buffer *a = scaled_buffer_a->data;
+	struct scaled_icon_buffer *b = scaled_buffer_b->data;
+
+	return str_equal(a->app_id, b->app_id)
+		&& str_equal(a->icon_name, b->icon_name)
+		&& a->width == b->width
+		&& a->height == b->height;
+}
+
+static struct scaled_scene_buffer_impl impl = {
+	.create_buffer = _create_buffer,
+	.destroy = _destroy,
+	.equal = _equal,
+};
+
+struct scaled_icon_buffer *
+scaled_icon_buffer_create(struct wlr_scene_tree *parent, struct server *server,
+	int width, int height)
+{
+	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
+		parent, &impl, /* drop_buffer */ true);
+	struct scaled_icon_buffer *self = znew(*self);
+	self->scaled_buffer = scaled_buffer;
+	self->scene_buffer = scaled_buffer->scene_buffer;
+	self->server = server;
+	self->width = width;
+	self->height = height;
+
+	scaled_buffer->data = self;
+
+	return self;
+}
+
+void
+scaled_icon_buffer_set_app_id(struct scaled_icon_buffer *self,
+	const char *app_id)
+{
+	assert(app_id);
+	if (str_equal(self->app_id, app_id)) {
+		return;
+	}
+	xstrdup_replace(self->app_id, app_id);
+	scaled_scene_buffer_request_update(self->scaled_buffer, self->width, self->height);
+}
+
+void
+scaled_icon_buffer_set_icon_name(struct scaled_icon_buffer *self,
+	const char *icon_name)
+{
+	assert(icon_name);
+	if (str_equal(self->icon_name, icon_name)) {
+		return;
+	}
+	xstrdup_replace(self->icon_name, icon_name);
+	scaled_scene_buffer_request_update(self->scaled_buffer, self->width, self->height);
+}
+
+struct scaled_icon_buffer *
+scaled_icon_buffer_from_node(struct wlr_scene_node *node)
+{
+	struct scaled_scene_buffer *scaled_buffer =
+		node_scaled_scene_buffer_from_node(node);
+	assert(scaled_buffer->impl == &impl);
+	return scaled_buffer->data;
+}

--- a/src/common/scaled-icon-buffer.c
+++ b/src/common/scaled-icon-buffer.c
@@ -27,6 +27,10 @@ _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
 	} else if (self->app_id) {
 		img = desktop_entry_load_icon_from_app_id(self->server,
 			self->app_id, icon_size, scale);
+		if (!img) {
+			img = desktop_entry_load_icon(self->server,
+				rc.fallback_app_icon_name, icon_size, scale);
+		}
 	}
 
 	if (!img) {

--- a/src/common/scaled-img-buffer.c
+++ b/src/common/scaled-img-buffer.c
@@ -66,18 +66,6 @@ scaled_img_buffer_create(struct wlr_scene_tree *parent, struct lab_img *img,
 	return self;
 }
 
-void
-scaled_img_buffer_update(struct scaled_img_buffer *self, struct lab_img *img,
-	int width, int height)
-{
-	assert(img);
-	lab_img_destroy(self->img);
-	self->img = lab_img_copy(img);
-	self->width = width;
-	self->height = height;
-	scaled_scene_buffer_request_update(self->scaled_buffer, width, height);
-}
-
 struct scaled_img_buffer *
 scaled_img_buffer_from_node(struct wlr_scene_node *node)
 {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1073,6 +1073,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		xstrdup_replace(rc.theme_name, content);
 	} else if (!strcmp(nodename, "icon.theme")) {
 		xstrdup_replace(rc.icon_theme_name, content);
+	} else if (!strcasecmp(nodename, "fallbackAppIcon.theme")) {
+		xstrdup_replace(rc.fallback_app_icon_name, content);
 	} else if (!strcasecmp(nodename, "layout.titlebar.theme")) {
 		fill_title_layout(content);
 	} else if (!strcasecmp(nodename, "showTitle.titlebar.theme")) {
@@ -1677,6 +1679,10 @@ post_processing(void)
 		load_default_mouse_bindings();
 	}
 
+	if (!rc.fallback_app_icon_name) {
+		rc.fallback_app_icon_name = xstrdup("labwc");
+	}
+
 	if (!rc.title_layout_loaded) {
 #if HAVE_LIBSFDO
 		fill_title_layout("icon:iconify,max,close");
@@ -1928,6 +1934,7 @@ rcxml_finish(void)
 	zfree(rc.font_osd.name);
 	zfree(rc.theme_name);
 	zfree(rc.icon_theme_name);
+	zfree(rc.fallback_app_icon_name);
 	zfree(rc.workspace_config.prefix);
 	zfree(rc.tablet.output_name);
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -294,12 +294,6 @@ load_buttons(struct theme *theme)
 		.state_set = 0,
 		.fallback_button = (const char[]){ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
 	}, {
-		/* menu icon is loaded again as a fallback of window icon */
-		.name = "menu",
-		.type = LAB_SSD_BUTTON_WINDOW_ICON,
-		.state_set = 0,
-		.fallback_button = (const char[]){ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
-	}, {
 		.name = "iconify",
 		.type = LAB_SSD_BUTTON_ICONIFY,
 		.state_set = 0,
@@ -342,12 +336,6 @@ load_buttons(struct theme *theme)
 	}, {
 		.name = "menu_hover",
 		.type = LAB_SSD_BUTTON_WINDOW_MENU,
-		.state_set = LAB_BS_HOVERD,
-		/* no fallback (non-hover variant is used instead) */
-	}, {
-		/* menu_hover icon is loaded again as a fallback of window icon */
-		.name = "menu_hover",
-		.type = LAB_SSD_BUTTON_WINDOW_ICON,
 		.state_set = LAB_BS_HOVERD,
 		/* no fallback (non-hover variant is used instead) */
 	}, {


### PR DESCRIPTION
- The 3rd commit is just a refactor of `lab_img`. The horizontal padding in titlebar app icon is now applied by horizontally shrinking and shifting the icon buffer rather than adding empty spaces in the buffer in `lab_img_render()`.

- The 4th commit adds `str_equal()`. This is used by `_equal()` in `scaled_img_buffer` and `scaled_font_buffer`.

- The 5th commit introduces `scaled_icon_buffer`. Its benefits are:
  - The best icon file is now dynamically chosen for each output scales.
  - The titlebar app icons for the same application now shares its buffers and file handlers. This will also work for menu icons (#2509).

- The 6th commit adds `<theme><fallbackAppIcon>` used by `scaled_icon_buffer` when the icon for an app-id cannot be loaded. Its default value is 'labwc', which means we now fall back to the labwc icon (rather than 'menu' icon) when titlebar icon cannot be not loaded.