### PR TITLE
scaled-scene-buffer: block sharing of buffers created before reconfigure

### DIFF
--- a/include/common/scaled-scene-buffer.h
+++ b/include/common/scaled-scene-buffer.h
@@ -128,6 +128,14 @@ struct scaled_scene_buffer *scaled_scene_buffer_create(
 void scaled_scene_buffer_request_update(struct scaled_scene_buffer *self,
 	int width, int height);
 
+/**
+ * scaled_scene_buffer_invalidate_sharing - clear the list of entire cached
+ * scaled_scene_buffers used to share visually dupliated buffers. This should
+ * be called on Reconfigure to force updates of newly created
+ * scaled_scene_buffers rather than reusing ones created before Reconfigure.
+ */
+void scaled_scene_buffer_invalidate_sharing(void);
+
 /* Private */
 struct scaled_scene_buffer_cache_entry {
 	struct wl_list link;   /* struct scaled_scene_buffer.cache */

--- a/include/common/scaled-scene-buffer.h
+++ b/include/common/scaled-scene-buffer.h
@@ -36,12 +36,7 @@ struct scaled_scene_buffer {
 	struct wl_listener destroy;
 	struct wl_listener outputs_update;
 	const struct scaled_scene_buffer_impl *impl;
-	/*
-	 * Pointer to the per-implementation list of scaled-scene-buffers.
-	 * This is used to share the backing wlr_buffers.
-	 */
-	struct wl_list *cached_buffers;
-	struct wl_list link; /* struct scaled_scene_buffer.cached_buffers */
+	struct wl_list link; /* all_scaled_buffers */
 };
 
 /*
@@ -89,8 +84,8 @@ struct scaled_scene_buffer {
  * allocations.
  *
  * Besides caching buffers for each scale per scaled_scene_buffer, we also
- * store all the scaled_scene_buffers in a per-implementer list passed as
- * @cached_buffers in order to reuse backing buffers for visually duplicated
+ * store all the scaled_scene_buffers from all the implementers in a list
+ * in order to reuse backing buffers for visually duplicated
  * scaled_scene_buffers found via impl->equal().
  *
  * All requested lab_data_buffers via impl->create_buffer() will be locked
@@ -119,7 +114,7 @@ struct scaled_scene_buffer {
 struct scaled_scene_buffer *scaled_scene_buffer_create(
 	struct wlr_scene_tree *parent,
 	const struct scaled_scene_buffer_impl *implementation,
-	struct wl_list *cached_buffers, bool drop_buffer);
+	bool drop_buffer);
 
 /**
  * scaled_scene_buffer_request_update - mark the buffer that needs to be

--- a/src/common/scaled-font-buffer.c
+++ b/src/common/scaled-font-buffer.c
@@ -7,13 +7,9 @@
 #include <wlr/util/log.h>
 #include "buffer.h"
 #include "common/font.h"
-#include "common/list.h"
 #include "common/mem.h"
 #include "common/scaled-scene-buffer.h"
 #include "common/scaled-font-buffer.h"
-
-/* This holds all the scaled-font-buffers and used for sharing backing buffers */
-static struct wl_list cached_buffers = WL_LIST_INIT(&cached_buffers);
 
 static struct lab_data_buffer *
 _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
@@ -78,7 +74,7 @@ scaled_font_buffer_create(struct wlr_scene_tree *parent)
 	assert(parent);
 	struct scaled_font_buffer *self = znew(*self);
 	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
-		parent, &impl, &cached_buffers, /* drop_buffer */ true);
+		parent, &impl, /* drop_buffer */ true);
 	if (!scaled_buffer) {
 		free(self);
 		return NULL;

--- a/src/common/scaled-img-buffer.c
+++ b/src/common/scaled-img-buffer.c
@@ -4,14 +4,11 @@
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_scene.h>
 #include "buffer.h"
-#include "common/list.h"
 #include "common/mem.h"
 #include "common/scaled-img-buffer.h"
 #include "common/scaled-scene-buffer.h"
 #include "img/img.h"
 #include "node.h"
-
-static struct wl_list cached_buffers = WL_LIST_INIT(&cached_buffers);
 
 static struct lab_data_buffer *
 _create_buffer(struct scaled_scene_buffer *scaled_buffer, double scale)
@@ -55,7 +52,7 @@ scaled_img_buffer_create(struct wlr_scene_tree *parent, struct lab_img *img,
 {
 	assert(img);
 	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
-		parent, &impl, &cached_buffers, /* drop_buffer */ true);
+		parent, &impl, /* drop_buffer */ true);
 	struct scaled_img_buffer *self = znew(*self);
 	self->scaled_buffer = scaled_buffer;
 	self->scene_buffer = scaled_buffer->scene_buffer;

--- a/src/common/scaled-rect-buffer.c
+++ b/src/common/scaled-rect-buffer.c
@@ -7,13 +7,10 @@
 #include <wlr/util/log.h>
 #include "buffer.h"
 #include "common/graphic-helpers.h"
-#include "common/list.h"
 #include "common/macros.h"
 #include "common/mem.h"
 #include "common/scaled-scene-buffer.h"
 #include "common/scaled-rect-buffer.h"
-
-static struct wl_list cached_buffers = WL_LIST_INIT(&cached_buffers);
 
 static void
 draw_rectangle_path(cairo_t *cairo, int width, int height, int border_width)
@@ -100,7 +97,7 @@ struct scaled_rect_buffer *scaled_rect_buffer_create(
 	assert(parent);
 	struct scaled_rect_buffer *self = znew(*self);
 	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
-		parent, &impl, &cached_buffers, /* drop_buffer */ true);
+		parent, &impl, /* drop_buffer */ true);
 	scaled_buffer->data = self;
 	self->scaled_buffer = scaled_buffer;
 	self->scene_buffer = scaled_buffer->scene_buffer;

--- a/src/common/scaled-scene-buffer.c
+++ b/src/common/scaled-scene-buffer.c
@@ -251,3 +251,13 @@ scaled_scene_buffer_request_update(struct scaled_scene_buffer *self,
 		_update_buffer(self, self->active_scale);
 	}
 }
+
+void
+scaled_scene_buffer_invalidate_sharing(void)
+{
+	struct scaled_scene_buffer *scene_buffer, *tmp;
+	wl_list_for_each_safe(scene_buffer, tmp, &all_scaled_buffers, link) {
+		wl_list_remove(&scene_buffer->link);
+		wl_list_init(&scene_buffer->link);
+	}
+}

--- a/src/server.c
+++ b/src/server.c
@@ -31,6 +31,7 @@
 
 #include "drm-lease-v1-protocol.h"
 #include "common/macros.h"
+#include "common/scaled-scene-buffer.h"
 #include "config/rcxml.h"
 #include "config/session.h"
 #include "decorations.h"
@@ -68,6 +69,7 @@ static struct wl_event_source *sigchld_source;
 static void
 reload_config_and_theme(struct server *server)
 {
+	scaled_scene_buffer_invalidate_sharing();
 	rcxml_finish();
 	rcxml_read(rc.config_file);
 	theme_finish(server->theme);


### PR DESCRIPTION
A possible solution for the problem in #2518 that icon theme updates are not applied to the titlebar icons on reconfigure if multiple windows with the same app-id are present.

This PR moves `cached_buffers` in `scaled-{font,rect,img}-buffer.c` into `scaled-scene-buffer.c` and clears it at the beginning of Reconfigure to prevent them from being reused by newly created scaled_scene_buffers.