### PR TITLE
ssd: expose resize.minimumArea parameter

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -583,6 +583,13 @@ extending outward from the snapped edge.
 	horizontally and vertically rather than one or the other. Default is
 	half the titlebar height.
 
+*<resize><minimumArea>*
+	Treat borders of server-side decorations as if they were at least the
+	indicated thickness, regardless of their visual size. Borders visually
+	narrower than the minimum effective thickness will be augmented with
+	invisible zones just beyond the window that serve as click targets for
+	mouse actions. Default is 8.
+
 ## KEYBOARD
 
 *<keyboard><numlock>* [on|off]

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -132,6 +132,8 @@
     <!-- Let client redraw its contents while resizing -->
     <drawContents>yes</drawContents>
     <cornerRange>8</cornerRange>
+    <!-- Borders are effectively 8 pixels wide regardless of visual appearance -->
+    <minimumArea>8</minimumArea>
   </resize>
 
   <focus>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -131,9 +131,16 @@
     <popupShow>Never</popupShow>
     <!-- Let client redraw its contents while resizing -->
     <drawContents>yes</drawContents>
-    <cornerRange>8</cornerRange>
     <!-- Borders are effectively 8 pixels wide regardless of visual appearance -->
     <minimumArea>8</minimumArea>
+
+    <!--
+      Set cornerRange to a positive value to increase the size of corner
+      regions for mouse actions and diagonal window resizing. When omitted,
+      the default size of the corner region is half of the titlebar height.
+
+      <cornerRange>8</cornerRange>
+    -->
   </resize>
 
   <focus>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -152,6 +152,7 @@ struct rcxml {
 	enum resize_indicator_mode resize_indicator;
 	bool resize_draw_contents;
 	int resize_corner_range;
+	int resize_minimum_area;
 
 	struct {
 		int popuptime;

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -7,8 +7,6 @@
 
 struct wlr_cursor;
 
-#define SSD_EXTENDED_AREA 8
-
 /*
  * Shadows should start at a point inset from the actual window border, see
  * discussion on https://github.com/labwc/labwc/pull/1648.  This constant

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1225,6 +1225,8 @@ entry(xmlNode *node, char *nodename, char *content, struct parser_state *state)
 		set_bool(content, &rc.resize_draw_contents);
 	} else if (!strcasecmp(nodename, "cornerRange.resize")) {
 		rc.resize_corner_range = atoi(content);
+	} else if (!strcasecmp(nodename, "minimumArea.resize")) {
+		rc.resize_minimum_area = MAX(0, atoi(content));
 	} else if (!strcasecmp(nodename, "mouseEmulation.tablet")) {
 		set_bool(content, &rc.tablet.force_mouse_emulation);
 	} else if (!strcasecmp(nodename, "mapToOutput.tablet")) {
@@ -1501,6 +1503,7 @@ rcxml_init(void)
 	rc.resize_indicator = LAB_RESIZE_INDICATOR_NEVER;
 	rc.resize_draw_contents = true;
 	rc.resize_corner_range = -1;
+	rc.resize_minimum_area = 8;
 
 	rc.workspace_config.popuptime = INT_MIN;
 	rc.workspace_config.min_nr_workspaces = 1;

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -4,6 +4,7 @@
 #include <pixman.h>
 #include "common/mem.h"
 #include "common/scene-helpers.h"
+#include "config/rcxml.h"
 #include "labwc.h"
 #include "ssd-internal.h"
 #include "theme.h"
@@ -25,7 +26,8 @@ ssd_extents_create(struct ssd *ssd)
 	struct view *view = ssd->view;
 	struct theme *theme = view->server->theme;
 	struct wl_list *part_list = &ssd->extents.parts;
-	int extended_area = SSD_EXTENDED_AREA;
+
+	int border_width = MAX(0, MAX(rc.resize_minimum_area, theme->border_width));
 
 	ssd->extents.tree = wlr_scene_tree_create(ssd->tree);
 	struct wlr_scene_tree *parent = ssd->extents.tree;
@@ -34,8 +36,7 @@ ssd_extents_create(struct ssd *ssd)
 	}
 	wl_list_init(&ssd->extents.parts);
 	wlr_scene_node_set_position(&parent->node,
-		-(theme->border_width + extended_area),
-		-(ssd->titlebar.height + theme->border_width + extended_area));
+		-border_width, -(ssd->titlebar.height + border_width));
 
 	add_extent(part_list, LAB_SSD_PART_TOP, parent);
 	add_extent(part_list, LAB_SSD_PART_LEFT, parent);
@@ -68,7 +69,8 @@ ssd_extents_update(struct ssd *ssd)
 	int height = view_effective_height(view, /* use_pending */ false);
 	int full_height = height + theme->border_width * 2 + ssd->titlebar.height;
 	int full_width = width + 2 * theme->border_width;
-	int extended_area = SSD_EXTENDED_AREA;
+	int border_width = MAX(rc.resize_minimum_area, theme->border_width);
+	int extended_area = MAX(0, rc.resize_minimum_area - theme->border_width);
 
 	struct wlr_box part_box;
 	struct wlr_box result_box;
@@ -78,8 +80,7 @@ ssd_extents_update(struct ssd *ssd)
 
 	/* Make sure we update the y offset based on titlebar shown / hidden */
 	wlr_scene_node_set_position(&ssd->extents.tree->node,
-		-(theme->border_width + extended_area),
-		-(ssd->titlebar.height + theme->border_width + extended_area));
+		-border_width, -(ssd->titlebar.height + border_width));
 
 	/*
 	 * Convert all output usable areas that the


### PR DESCRIPTION
When themes call for thick borders, having an even thicker extended area can be annoying, especially when trying to activate windows behind another when only the target window's border is visible. Let's provide a mechanism for adjusting or disabling the extension.

I'm open to suggestions for better configuration placement or option naming.