### PR TITLE
Pipemenu rework

### DIFF
--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -20,8 +20,6 @@ enum menuitem_type {
 
 struct menuitem {
 	struct wl_list actions;
-	char *execute;
-	char *id; /* needed for pipemenus */
 	char *text;
 	char *icon_name;
 	const char *arrow;
@@ -33,7 +31,6 @@ struct menuitem {
 	struct wlr_scene_tree *tree;
 	struct wlr_scene_tree *normal_tree;
 	struct wlr_scene_tree *selected_tree;
-	struct menu_pipe_context *pipe_ctx;
 	struct view *client_list_view;  /* used by internal client-list */
 	struct wl_list link; /* menu.menuitems */
 };
@@ -43,6 +40,7 @@ struct menu {
 	char *id;
 	char *label;
 	char *icon_name;
+	char *execute;
 	struct menu *parent;
 	struct menu_pipe_context *pipe_ctx;
 
@@ -57,7 +55,7 @@ struct menu {
 		struct menuitem *item;
 	} selection;
 	struct wlr_scene_tree *scene_tree;
-	bool is_pipemenu;
+	bool is_pipemenu_child;
 	bool align_left;
 	bool has_icons;
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1062,7 +1062,6 @@ update_client_list_combined_menu(struct server *server)
 				buf_add(&buffer, title);
 
 				current_item = item_create(menu, buffer.data, /*show arrow*/ false);
-				current_item->id = xstrdup(menu->id);
 				current_item->client_list_view = view;
 				fill_item("name.action", "Focus");
 				fill_item("name.action", "Raise");
@@ -1070,7 +1069,6 @@ update_client_list_combined_menu(struct server *server)
 			}
 		}
 		current_item = item_create(menu, _("Go there..."), /*show arrow*/ false);
-		current_item->id = xstrdup(menu->id);
 		fill_item("name.action", "GoToDesktop");
 		fill_item("to.action", workspace->name);
 	}
@@ -1682,7 +1680,7 @@ menu_execute_item(struct menuitem *item)
 	 * menu_close() and destroy_pipemenus() which we have to handle
 	 * before/after action_run() respectively.
 	 */
-	if (item->id && !strcmp(item->id, "client-list-combined-menu")
+	if (!strcmp(item->parent->id, "client-list-combined-menu")
 			&& item->client_list_view) {
 		actions_run(item->client_list_view, server, &item->actions, NULL);
 	} else {

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1085,8 +1085,6 @@ init_rootmenu(struct server *server)
 	if (!menu) {
 		current_menu = NULL;
 		menu = menu_create(server, "root-menu", "");
-	}
-	if (wl_list_empty(&menu->menuitems)) {
 		current_item = item_create(menu, _("Reconfigure"), false);
 		fill_item("name.action", "Reconfigure");
 		current_item = item_create(menu, _("Exit"), false);
@@ -1103,8 +1101,6 @@ init_windowmenu(struct server *server)
 	if (!menu) {
 		current_menu = NULL;
 		menu = menu_create(server, "client-menu", "");
-	}
-	if (wl_list_empty(&menu->menuitems)) {
 		current_item = item_create(menu, _("Minimize"), false);
 		fill_item("name.action", "Iconify");
 		current_item = item_create(menu, _("Maximize"), false);


### PR DESCRIPTION
In this PR, top-level pipemenus are dynamically generated rather than generating only on initialization.

But this PR also includes many refactors about how menus are generated and opened. Notably:
- All the menu scene-graphs are now lazily generated and repositioned when being opened. This fixes the problem of incorrect submenu position in configurations like:
```xml
  <menu id="foo" label="foo">
    <item label="aaaaaa"/>
    <item label="bbbbbb"/>
  </menu>
  <menu id="root-menu">
    <menu id="foo" />
    <menu id="foo" />
  </menu>
```
- `struct menu` for pipemenus are created on initialization rather than after the execution of pipemenu script
- `update_client_list_combined_menu()` and `update_client_send_to_menu()` are called only when the corresponding menus are being opened

I admit this is a dangerous move as this touches the core of menu management, but I believe the UX enhancement and simplification in this PR is worth the risk.

I tested with following conditions:
- Closing menu while pipemenu script is running
- Running `labwc -r` while pipemenu script is running
- Let the pipemenu script print an invalid output