### PR TITLE
menu: fix unexpected behavior when a menu is opened from another menu

### DIFF
--- a/include/action.h
+++ b/include/action.h
@@ -23,6 +23,7 @@ struct action {
 struct action *action_create(const char *action_name);
 
 bool action_is_valid(struct action *action);
+bool action_is_show_menu(struct action *action);
 
 void action_arg_add_str(struct action *action, const char *key, const char *value);
 void action_arg_add_actionlist(struct action *action, const char *key);

--- a/src/action.c
+++ b/src/action.c
@@ -606,6 +606,12 @@ action_is_valid(struct action *action)
 	return false;
 }
 
+bool
+action_is_show_menu(struct action *action)
+{
+	return action->type == ACTION_TYPE_SHOW_MENU;
+}
+
 void
 action_free(struct action *action)
 {

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1327,20 +1327,6 @@ menu_set_selection(struct menu *menu, struct menuitem *item)
 	menu->selection.item = item;
 }
 
-static void
-close_all_submenus(struct menu *menu)
-{
-	struct menuitem *item;
-	wl_list_for_each(item, &menu->menuitems, link) {
-		if (item->submenu) {
-			wlr_scene_node_set_enabled(
-				&item->submenu->scene_tree->node, false);
-			close_all_submenus(item->submenu);
-		}
-	}
-	menu->selection.menu = NULL;
-}
-
 /*
  * We only destroy pipemenus when closing the entire menu-tree so that pipemenu
  * are cached (for as long as the menu is open). This drastically improves the
@@ -1388,17 +1374,14 @@ menu_close(struct menu *menu)
 void
 menu_open_root(struct menu *menu, int x, int y)
 {
+	assert(menu);
+
 	if (menu->server->input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
 		return;
 	}
 
-	assert(menu);
-	if (menu->server->menu_current) {
-		menu_close(menu->server->menu_current);
-		destroy_pipemenus(menu->server);
-	}
-	close_all_submenus(menu);
-	menu_set_selection(menu, NULL);
+	assert(!menu->server->menu_current);
+
 	menu_configure(menu, (struct wlr_box){.x = x, .y = y});
 	wlr_scene_node_set_enabled(&menu->scene_tree->node, true);
 	menu->server->menu_current = menu;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1720,13 +1720,9 @@ menu_execute_item(struct menuitem *item)
 		return false;
 	}
 
-	/*
-	 * We close the menu here to provide a faster feedback to the user.
-	 * We do that without resetting the input state so src/cursor.c
-	 * can do its own clean up on the following RELEASE event.
-	 */
 	struct server *server = item->parent->server;
 	menu_close(server->menu_current);
+	server->menu_current = NULL;
 	seat_focus_override_end(&server->seat);
 
 	/*
@@ -1746,7 +1742,6 @@ menu_execute_item(struct menuitem *item)
 				&item->actions, NULL);
 	}
 
-	server->menu_current = NULL;
 	destroy_pipemenus(server);
 	return true;
 }

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -115,7 +115,12 @@ validate_menu(struct menu *menu)
 	struct action *action, *action_tmp;
 	wl_list_for_each(item, &menu->menuitems, link) {
 		wl_list_for_each_safe(action, action_tmp, &item->actions, link) {
-			if (!action_is_valid(action)) {
+			bool is_show_menu = action_is_show_menu(action);
+			if (!action_is_valid(action) || is_show_menu) {
+				if (is_show_menu) {
+					wlr_log(WLR_ERROR, "'ShowMenu' action is"
+						" not allowed in menu items");
+				}
 				wl_list_remove(&action->link);
 				action_free(action);
 				wlr_log(WLR_ERROR, "Removed invalid menu action");


### PR DESCRIPTION
Fixes #2526.

`server->menu_current` should be cleared before calling `actions_run()` as it may internally call `menu_open_root()`. Clearing it after `actions_run()` leads to an inconsistent state where a menu is opened but `server->menu_current` is
`NULL`. It even lead to a segfault when the item opening another menu is contained in a pipemenu, because `menu_open_root()` calls `destroy_pipemenu()` when `server->menu_current` is set, which makes accessing `item->actions` a UAF.

This PR also replaces some code that ensures the menu is closed in `menu_open_root()` with `assert(!menu->server->menu_current);`.