### PR TITLE
cursor.c: use subsurface as reference for out-of-surface movement

### DIFF
--- a/src/common/surface-helpers.c
+++ b/src/common/surface-helpers.c
@@ -10,7 +10,6 @@ subsurface_parent_layer(struct wlr_surface *wlr_surface)
 	struct wlr_subsurface *subsurface =
 		wlr_subsurface_try_from_wlr_surface(wlr_surface);
 	if (!subsurface) {
-		wlr_log(WLR_DEBUG, "surface %p is not subsurface", subsurface);
 		return NULL;
 	}
 	struct wlr_surface *parent = subsurface->parent;


### PR DESCRIPTION
The protocol states that the wl_pointer motion coordinates must be relative to the focused surface (e.g. the surface that last received a wl_pointer enter event).

Before this patch, the coordinates were relative to the toplevel surface instead, resulting in subsurface events having the wrong coordinates when pressing a button over a subsurface and moving the cursor outside of that subsurface.

Fixes:
- #2542