### PR TITLE
wlr-foreign: send `output_enter` on initialization

### DIFF
--- a/src/foreign-toplevel/wlr-foreign.c
+++ b/src/foreign-toplevel/wlr-foreign.c
@@ -240,6 +240,7 @@ wlr_foreign_toplevel_init(struct foreign_toplevel *toplevel)
 	handle_new_title(&wlr_toplevel->on_view.new_title, NULL);
 	handle_maximized(&wlr_toplevel->on_view.maximized, NULL);
 	handle_fullscreened(&wlr_toplevel->on_view.fullscreened, NULL);
+	handle_new_outputs(&wlr_toplevel->on_view.new_outputs, NULL);
 
 	/* Client side requests */
 	CONNECT_SIGNAL(wlr_toplevel->handle, &wlr_toplevel->on, request_maximize);


### PR DESCRIPTION
This fixes a bug that `output_enter` events are not sent when a Slack window running in background is re-mapped, which caused missing taskbar items in Waybar when it's configured to show windows per output.