### PR TITLE
server: on exit, destroy backend first

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -757,9 +757,9 @@ server_finish(struct server *server)
 		wl_event_source_remove(sighup_source);
 	}
 	wl_display_destroy_clients(server->wl_display);
+	wlr_backend_destroy(server->backend);
 	wlr_allocator_destroy(server->allocator);
 	wlr_renderer_destroy(server->renderer);
-	wlr_backend_destroy(server->backend);
 	seat_finish(server);
 	workspaces_destroy(server);
 	wlr_scene_node_destroy(&server->scene->tree.node);


### PR DESCRIPTION
This fixes a UAF caused by trying to update the xcursor in a output destroy handler, in turn caused by destroying the backend.

Fixes:
- #2539