### PR TITLE
CI: fix Debian build, wlroots package got renamed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           apt-get upgrade -y
           apt-get install -y git gcc clang gdb xwayland
           apt-get build-dep -y labwc
-          apt-get build-dep -y libwlroots-dev
+          #apt-get build-dep -y libwlroots-0.18-dev
 
       - name: Install FreeBSD dependencies
         if: matrix.name == 'FreeBSD'


### PR DESCRIPTION
Also disable it for now because we can just use the shipped version of libwlroots-0.18-dev rather than needing to build it ourselves.