### PR TITLE
src/overlay.c: clean up timer on exit

### DIFF
--- a/include/overlay.h
+++ b/include/overlay.h
@@ -35,9 +35,14 @@ struct overlay {
 };
 
 void overlay_reconfigure(struct seat *seat);
+
 /* Calls overlay_hide() internally if there's no overlay to show */
 void overlay_update(struct seat *seat);
+
 /* This function must be called when server->grabbed_view is destroyed */
 void overlay_hide(struct seat *seat);
+
+/* This function is called to clean up the timer on exit */
+void overlay_finish(struct seat *seat);
 
 #endif

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -260,3 +260,12 @@ overlay_hide(struct seat *seat)
 			&server->scene->tree);
 	}
 }
+
+void
+overlay_finish(struct seat *seat)
+{
+	if (seat->overlay.timer) {
+		wl_event_source_remove(seat->overlay.timer);
+		seat->overlay.timer = NULL;
+	}
+}

--- a/src/seat.c
+++ b/src/seat.c
@@ -598,6 +598,7 @@ seat_finish(struct server *server)
 		wl_event_source_remove(seat->workspace_osd_timer);
 		seat->workspace_osd_timer = NULL;
 	}
+	overlay_finish(seat);
 
 	input_handlers_finish(seat);
 	input_method_relay_finish(seat->input_method_relay);


### PR DESCRIPTION
Prevents a leak notification on exit. I think we can merge this within the cooldown period as side effects are unlikely.
CC @tokyo4j 