### PR TITLE
output: early return on wlopm if requested state is already set

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -1068,10 +1068,16 @@ handle_output_power_manager_set_mode(struct wl_listener *listener, void *data)
 
 	switch (event->mode) {
 	case ZWLR_OUTPUT_POWER_V1_MODE_OFF:
+		if (!event->output->enabled) {
+			return;
+		}
 		wlr_output_state_set_enabled(&output->pending, false);
 		output_state_commit(output);
 		break;
 	case ZWLR_OUTPUT_POWER_V1_MODE_ON:
+		if (event->output->enabled) {
+			return;
+		}
 		wlr_output_state_set_enabled(&output->pending, true);
 		if (!event->output->current_mode) {
 			/*


### PR DESCRIPTION
This prevents a unnecessary output commit without buffer, showing up as black flash when repeatedly calling wlopm --on.

---
Reported by @cillian64 in #2579.

Should be fine to merge within the cooldown period as chances of this having side effects is minimal.