### PR TITLE
osd: prevent preview outlines from overlapping OSD in first output

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -512,20 +512,22 @@ new_output_notify(struct wl_listener *listener, void *data)
 	 * bottom):
 	 *	- session lock layer
 	 *	- window switcher osd
-	 *	- compositor menu
+	 *	- (compositor menu)
 	 *	- layer-shell popups
 	 *	- overlay layer
 	 *	- top layer
-	 *	- views
+	 *	- (views)
 	 *	- bottom layer
 	 *	- background layer
 	 */
 	wlr_scene_node_lower_to_bottom(&output->layer_tree[1]->node);
 	wlr_scene_node_lower_to_bottom(&output->layer_tree[0]->node);
-	wlr_scene_node_raise_to_top(&output->layer_tree[2]->node);
-	wlr_scene_node_raise_to_top(&output->layer_tree[3]->node);
-	wlr_scene_node_raise_to_top(&output->layer_popup_tree->node);
-	wlr_scene_node_raise_to_top(&server->menu_tree->node);
+
+	struct wlr_scene_node *menu_node = &server->menu_tree->node;
+	wlr_scene_node_place_below(&output->layer_tree[2]->node, menu_node);
+	wlr_scene_node_place_below(&output->layer_tree[3]->node, menu_node);
+	wlr_scene_node_place_below(&output->layer_popup_tree->node, menu_node);
+
 	wlr_scene_node_raise_to_top(&output->osd_tree->node);
 	wlr_scene_node_raise_to_top(&output->session_lock_tree->node);
 

--- a/src/server.c
+++ b/src/server.c
@@ -580,11 +580,6 @@ server_init(struct server *server)
 #if HAVE_XWAYLAND
 	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->tree);
 #endif
-
-	/*
-	 * menu_tree is moved to top in new_output_notify() when layer-shell
-	 * layers are positioned
-	 */
 	server->menu_tree = wlr_scene_tree_create(&server->scene->tree);
 
 	workspaces_init(server);


### PR DESCRIPTION
See https://github.com/labwc/labwc/issues/2465#issuecomment-2661511564.

Honestly I'm not 100% sure this PR doesn't introduce another regression... but I believe the issue is something we should fix before 0.8.3.

Testing is appreciated.