### PR TITLE
cursor: don't un-minimize previewed window while window switching

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -641,10 +641,15 @@ _cursor_update_focus(struct server *server)
 	struct cursor_context ctx = get_cursor_context(server);
 
 	if ((ctx.view || ctx.surface) && rc.focus_follow_mouse
-			&& !rc.focus_follow_mouse_requires_movement) {
+			&& !rc.focus_follow_mouse_requires_movement
+			&& server->input_mode
+				!= LAB_INPUT_STATE_WINDOW_SWITCHER) {
 		/*
 		 * Always focus the surface below the cursor when
 		 * followMouse=yes and followMouseRequiresMovement=no.
+		 *
+		 * We should ignore them while window-switching though, because
+		 * calling desktop_focus_view() un-minimizes previewed window.
 		 */
 		desktop_focus_view_or_surface(&server->seat, ctx.view,
 			ctx.surface, rc.raise_on_focus);


### PR DESCRIPTION
This PR fixes the issue reported by @domo141 in #2582, by restoring the check I removed in #2476.

Without the check, if `followMouse` is yes and `followMouseRequiresMovement` is no, `osd_update()` => `cursor_update_focus()` => `desktop_focus_view()` unexpectedly un-minimizes the window on cursor even when the window is just a preview of window switcher. This caused some strange behavior that a minimized window selected with window switcher is immediately hidden after finishing window switching (please ignore the preview outline overlapping OSD):

https://github.com/user-attachments/assets/6ae8a5b5-23c1-4eb1-88c8-48f801dc78bb