### PR TITLE
action: ignore Focus action while window switching

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -1042,7 +1042,12 @@ actions_run(struct view *activator, struct server *server,
 			}
 			break;
 		case ACTION_TYPE_FOCUS:
-			if (view) {
+			if (view && server->input_mode
+					!= LAB_INPUT_STATE_WINDOW_SWITCHER) {
+				/*
+				 * TODO: check against server->input_mode
+				 * inside desktop_focus_view()
+				 */
 				desktop_focus_view(view, /*raise*/ false);
 			}
 			break;


### PR DESCRIPTION
Fixes #2582.

We could check against `server->input_mode` inside `desktop_focus_view()`, but I think this is the most predictable and least impactful approach that we can merge before 0.8.3.