### PR TITLE
CI: unbreak FreeBSD after a package rename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
             sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
             pkg set -yn pkg:mesa-dri # hack to skip llvm dependency
             pkg install -y git meson gcc pkgconf cairo pango evdev-proto \
-              hwdata wayland-protocols wlroots libdisplay-info
+              hwdata wayland-protocols wlroots018 libdisplay-info
           run: echo "setup done"
 
       - name: Install Void Linux dependencies


### PR DESCRIPTION
I've renamed `wlroots` to `wlroots018`, similar to Void. As labwc uses `latest` package set CI may break once [downstream package build](https://pkg-status.freebsd.org/beefy22/build.html?mastername=141amd64-default&build=1bb147345dca) finishes.

Without the rename it was expected to happen during wlroots 0.19 release unless labwc switched to the new API at exactly the same time.