### PR TITLE
project wide: clean up event listeners on shutdown

### DIFF
--- a/include/decorations.h
+++ b/include/decorations.h
@@ -12,4 +12,7 @@ void xdg_server_decoration_init(struct server *server);
 void kde_server_decoration_update_default(void);
 void kde_server_decoration_set_view(struct view *view, struct wlr_surface *surface);
 
+void kde_server_decoration_finish(struct server *server);
+void xdg_server_decoration_finish(struct server *server);
+
 #endif /* LABWC_DECORATIONS_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -435,6 +435,7 @@ struct constraint {
 
 void xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup);
 void xdg_shell_init(struct server *server);
+void xdg_shell_finish(struct server *server);
 
 /*
  * desktop.c routines deal with a collection of views
@@ -539,6 +540,7 @@ void interactive_cancel(struct view *view);
 enum view_edge edge_from_cursor(struct seat *seat, struct output **dest_output);
 
 void output_init(struct server *server);
+void output_finish(struct server *server);
 void output_manager_init(struct server *server);
 struct output *output_from_wlr_output(struct server *server,
 	struct wlr_output *wlr_output);

--- a/include/layers.h
+++ b/include/layers.h
@@ -37,6 +37,7 @@ struct lab_layer_popup {
 };
 
 void layers_init(struct server *server);
+void layers_finish(struct server *server);
 
 void layers_arrange(struct output *output);
 void layer_try_set_focus(struct seat *seat,

--- a/src/decorations/kde-deco.c
+++ b/src/decorations/kde-deco.c
@@ -133,3 +133,8 @@ kde_server_decoration_init(struct server *server)
 	server->kde_server_decoration.notify = handle_new_server_decoration;
 }
 
+void
+kde_server_decoration_finish(struct server *server)
+{
+	wl_list_remove(&server->kde_server_decoration.link);
+}

--- a/src/decorations/xdg-deco.c
+++ b/src/decorations/xdg-deco.c
@@ -127,3 +127,9 @@ xdg_server_decoration_init(struct server *server)
 		&server->xdg_toplevel_decoration);
 	server->xdg_toplevel_decoration.notify = xdg_toplevel_decoration;
 }
+
+void
+xdg_server_decoration_finish(struct server *server)
+{
+	wl_list_remove(&server->xdg_toplevel_decoration.link);
+}

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1527,6 +1527,7 @@ void cursor_finish(struct seat *seat)
 	wl_list_remove(&seat->request_cursor.link);
 	wl_list_remove(&seat->request_set_shape.link);
 	wl_list_remove(&seat->request_set_selection.link);
+	wl_list_remove(&seat->request_set_primary_selection.link);
 
 	wlr_xcursor_manager_destroy(seat->xcursor_manager);
 	wlr_cursor_destroy(seat->cursor);

--- a/src/layers.c
+++ b/src/layers.c
@@ -600,3 +600,9 @@ layers_init(struct server *server)
 	wl_signal_add(&server->layer_shell->events.new_surface,
 		&server->new_layer_surface);
 }
+
+void
+layers_finish(struct server *server)
+{
+	wl_list_remove(&server->new_layer_surface.link);
+}

--- a/src/output.c
+++ b/src/output.c
@@ -572,6 +572,15 @@ output_init(struct server *server)
 	output_manager_init(server);
 }
 
+static void output_manager_finish(struct server *server);
+
+void
+output_finish(struct server *server)
+{
+	wl_list_remove(&server->new_output.link);
+	output_manager_finish(server);
+}
+
 static void
 output_update_for_layout_change(struct server *server)
 {
@@ -888,6 +897,15 @@ output_manager_init(struct server *server)
 	server->gamma_control_set_gamma.notify = handle_gamma_control_set_gamma;
 	wl_signal_add(&server->gamma_control_manager_v1->events.set_gamma,
 		&server->gamma_control_set_gamma);
+}
+
+static void
+output_manager_finish(struct server *server)
+{
+	wl_list_remove(&server->output_layout_change.link);
+	wl_list_remove(&server->output_manager_apply.link);
+	wl_list_remove(&server->output_manager_test.link);
+	wl_list_remove(&server->gamma_control_set_gamma.link);
 }
 
 struct output *

--- a/src/seat.c
+++ b/src/seat.c
@@ -588,6 +588,8 @@ seat_finish(struct server *server)
 	struct seat *seat = &server->seat;
 	wl_list_remove(&seat->new_input.link);
 	wl_list_remove(&seat->focus_change.link);
+	wl_list_remove(&seat->virtual_pointer_new.link);
+	wl_list_remove(&seat->virtual_keyboard_new.link);
 
 	struct input *input, *next;
 	wl_list_for_each_safe(input, next, &seat->inputs, link) {

--- a/src/server.c
+++ b/src/server.c
@@ -752,12 +752,26 @@ server_finish(struct server *server)
 		wl_event_source_remove(sighup_source);
 	}
 	wl_display_destroy_clients(server->wl_display);
+
+	seat_finish(server);
+	output_finish(server);
+	xdg_shell_finish(server);
+	layers_finish(server);
+	kde_server_decoration_finish(server);
+	xdg_server_decoration_finish(server);
+	wl_list_remove(&server->new_constraint.link);
+	wl_list_remove(&server->output_power_manager_set_mode.link);
+	wl_list_remove(&server->tearing_new_object.link);
+
 	wlr_backend_destroy(server->backend);
 	wlr_allocator_destroy(server->allocator);
+
+	wl_list_remove(&server->renderer_lost.link);
 	wlr_renderer_destroy(server->renderer);
-	seat_finish(server);
+
 	workspaces_destroy(server);
 	wlr_scene_node_destroy(&server->scene->tree.node);
+
 	wl_display_destroy(server->wl_display);
 	free(server->ssd_hover_state);
 }

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -1017,3 +1017,10 @@ xdg_shell_init(struct server *server)
 		&server->xdg_activation_new_token);
 }
 
+void
+xdg_shell_finish(struct server *server)
+{
+	wl_list_remove(&server->new_xdg_toplevel.link);
+	wl_list_remove(&server->xdg_activation_request.link);
+	wl_list_remove(&server->xdg_activation_new_token.link);
+}

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -1242,6 +1242,10 @@ void
 xwayland_server_finish(struct server *server)
 {
 	struct wlr_xwayland *xwayland = server->xwayland;
+	wl_list_remove(&server->xwayland_new_surface.link);
+	wl_list_remove(&server->xwayland_server_ready.link);
+	wl_list_remove(&server->xwayland_xwm_ready.link);
+
 	/*
 	 * Reset server->xwayland to NULL first to prevent callbacks (like
 	 * server_global_filter) from accessing it as it is destroyed


### PR DESCRIPTION
This ensures all event listeners are removed before the emitting wlroots object is being destroyed. This will be enforced with asserts in wlroots 0.19 but there is no reason to not do it right now either.

This change in wlroots 0.19 is implemented via commit 8f56f7ca43257cc05c7c4eb57a0f541e05cf9a79
"Assert (almost all) signals have no attached listeners on destroy"