### PR TITLE
magnifier: refactor

### DIFF
--- a/include/common/box.h
+++ b/include/common/box.h
@@ -22,4 +22,6 @@ void box_union(struct wlr_box *box_dest, struct wlr_box *box_a,
  */
 struct wlr_box box_fit_within(int width, int height, struct wlr_box *bounding_box);
 
+struct wlr_fbox box_to_fbox(struct wlr_box *box);
+
 #endif /* LABWC_BOX_H */

--- a/include/magnifier.h
+++ b/include/magnifier.h
@@ -14,12 +14,12 @@ enum magnify_dir {
 	MAGNIFY_DECREASE
 };
 
-void magnify_toggle(struct server *server);
-void magnify_set_scale(struct server *server, enum magnify_dir dir);
+void magnifier_toggle(struct server *server);
+void magnifier_set_scale(struct server *server, enum magnify_dir dir);
 bool output_wants_magnification(struct output *output);
-void magnify(struct output *output, struct wlr_buffer *output_buffer,
+void magnifier_draw(struct output *output, struct wlr_buffer *output_buffer,
 	struct wlr_box *damage);
-bool is_magnify_on(void);
-void magnify_reset(void);
+bool magnifier_is_enabled(void);
+void magnifier_reset(void);
 
 #endif /* LABWC_MAGNIFIER_H */

--- a/src/action.c
+++ b/src/action.c
@@ -1319,13 +1319,13 @@ actions_run(struct view *activator, struct server *server,
 			rc.tablet.force_mouse_emulation = !rc.tablet.force_mouse_emulation;
 			break;
 		case ACTION_TYPE_TOGGLE_MAGNIFY:
-			magnify_toggle(server);
+			magnifier_toggle(server);
 			break;
 		case ACTION_TYPE_ZOOM_IN:
-			magnify_set_scale(server, MAGNIFY_INCREASE);
+			magnifier_set_scale(server, MAGNIFY_INCREASE);
 			break;
 		case ACTION_TYPE_ZOOM_OUT:
-			magnify_set_scale(server, MAGNIFY_DECREASE);
+			magnifier_set_scale(server, MAGNIFY_DECREASE);
 			break;
 		case ACTION_TYPE_WARP_CURSOR:
 			{

--- a/src/common/box.c
+++ b/src/common/box.c
@@ -73,3 +73,14 @@ box_fit_within(int width, int height, struct wlr_box *bound)
 
 	return box;
 }
+
+struct wlr_fbox
+box_to_fbox(struct wlr_box *box)
+{
+	return (struct wlr_fbox){
+		.x = box->x,
+		.y = box->y,
+		.width = box->width,
+		.height = box->height,
+	};
+}

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -114,8 +114,8 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 	}
 
 	struct wlr_box additional_damage = {0};
-	if (state->buffer && is_magnify_on()) {
-		magnify(output, state->buffer, &additional_damage);
+	if (state->buffer && magnifier_is_enabled()) {
+		magnifier_draw(output, state->buffer, &additional_damage);
 	}
 
 	bool committed = wlr_output_commit_state(wlr_output, state);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1267,8 +1267,10 @@ entry(xmlNode *node, char *nodename, char *content, struct parser_state *state)
 		rc.mag_height = atoi(content);
 	} else if (!strcasecmp(nodename, "initScale.magnifier")) {
 		set_float(content, &rc.mag_scale);
+		rc.mag_scale = MAX(1.0, rc.mag_scale);
 	} else if (!strcasecmp(nodename, "increment.magnifier")) {
 		set_float(content, &rc.mag_increment);
+		rc.mag_increment = MAX(0, rc.mag_increment);
 	} else if (!strcasecmp(nodename, "useFilter.magnifier")) {
 		set_bool(content, &rc.mag_filter);
 	}
@@ -1774,10 +1776,6 @@ post_processing(void)
 	if (!wl_list_length(&rc.window_switcher.fields)) {
 		wlr_log(WLR_INFO, "load default window switcher fields");
 		load_default_window_switcher_fields();
-	}
-
-	if (rc.mag_scale <= 0.0) {
-		rc.mag_scale = 1.0;
 	}
 }
 

--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <assert.h>
+#include <wlr/render/swapchain.h>
 #include <wlr/types/wlr_output.h>
 #include "common/macros.h"
 #include "labwc.h"
@@ -24,21 +25,6 @@ magnifier_draw(struct output *output, struct wlr_buffer *output_buffer, struct w
 	struct wlr_box border_box, dst_box;
 	struct wlr_fbox src_box;
 	bool fullscreen = false;
-
-	/* TODO: This looks way too complicated to just get the used format */
-	struct wlr_drm_format wlr_drm_format = {0};
-	struct wlr_shm_attributes shm_attribs = {0};
-	struct wlr_dmabuf_attributes dma_attribs = {0};
-	if (wlr_buffer_get_dmabuf(output_buffer, &dma_attribs)) {
-		wlr_drm_format.format = dma_attribs.format;
-		wlr_drm_format.len = 1;
-		wlr_drm_format.modifiers = &dma_attribs.modifier;
-	} else if (wlr_buffer_get_shm(output_buffer, &shm_attribs)) {
-		wlr_drm_format.format = shm_attribs.format;
-	} else {
-		wlr_log(WLR_ERROR, "Failed to read buffer format");
-		return;
-	}
 
 	/* Fetch scale-adjusted cursor coordinates */
 	struct server *server = output->server;
@@ -105,7 +91,8 @@ magnifier_draw(struct output *output, struct wlr_buffer *output_buffer, struct w
 	}
 	if (!tmp_buffer) {
 		tmp_buffer = wlr_allocator_create_buffer(
-			server->allocator, width, height, &wlr_drm_format);
+			server->allocator, width, height,
+			&output->wlr_output->swapchain->format);
 	}
 	if (!tmp_buffer) {
 		wlr_log(WLR_ERROR, "Failed to allocate temporary magnifier buffer");

--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -17,7 +17,7 @@ static struct wlr_texture *tmp_texture = NULL;
 #define CLAMP(in, lower, upper) MAX(MIN((in), (upper)), (lower))
 
 void
-magnify(struct output *output, struct wlr_buffer *output_buffer, struct wlr_box *damage)
+magnifier_draw(struct output *output, struct wlr_buffer *output_buffer, struct wlr_box *damage)
 {
 	int width, height;
 	double x, y;
@@ -258,7 +258,7 @@ enable_magnifier(struct server *server, bool enable)
 
 /* Toggles magnification on and off */
 void
-magnify_toggle(struct server *server)
+magnifier_toggle(struct server *server)
 {
 	enable_magnifier(server, !magnify_on);
 
@@ -270,7 +270,7 @@ magnify_toggle(struct server *server)
 
 /* Increases and decreases magnification scale */
 void
-magnify_set_scale(struct server *server, enum magnify_dir dir)
+magnifier_set_scale(struct server *server, enum magnify_dir dir)
 {
 	struct output *output = output_nearest_to_cursor(server);
 
@@ -296,7 +296,7 @@ magnify_set_scale(struct server *server, enum magnify_dir dir)
 
 /* Reset any buffers held by the magnifier */
 void
-magnify_reset(void)
+magnifier_reset(void)
 {
 	if (tmp_texture && tmp_buffer) {
 		wlr_texture_destroy(tmp_texture);
@@ -308,7 +308,7 @@ magnify_reset(void)
 
 /* Report whether magnification is enabled */
 bool
-is_magnify_on(void)
+magnifier_is_enabled(void)
 {
 	return magnify_on;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -413,7 +413,7 @@ handle_renderer_lost(struct wl_listener *listener, void *data)
 
 	reload_config_and_theme(server);
 
-	magnify_reset();
+	magnifier_reset();
 
 	wlr_allocator_destroy(old_allocator);
 	wlr_renderer_destroy(old_renderer);


### PR DESCRIPTION
...in preparation for fixing #2591.

- Functions defined in `magnifier.c` are renamed to have the prefix `magnifier_`.
- Use `wlr_output.swapchain.format` to obtain buffer format.
- Make sure magnifier scale never goes below 1.0. This should remove the need for `CLAMP()` macro defined in `magnifier.c`.
- Refactor `magnifier_draw()` (previously `magnify()`) to make it easier to follow.