### PR TITLE
ssd-titlebar: show fallback icon when no app_id is set

### DIFF
--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -83,8 +83,6 @@ struct ssd {
 			struct ssd_state_title_width active;
 			struct ssd_state_title_width inactive;
 		} title;
-
-		char *app_id;
 	} state;
 
 	/* An invisible area around the view which allows resizing */

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -343,9 +343,6 @@ ssd_titlebar_destroy(struct ssd *ssd)
 	if (ssd->state.title.text) {
 		zfree(ssd->state.title.text);
 	}
-	if (ssd->state.app_id) {
-		zfree(ssd->state.app_id);
-	}
 
 	wlr_scene_node_destroy(&ssd->titlebar.tree->node);
 	ssd->titlebar.tree = NULL;
@@ -575,16 +572,12 @@ ssd_update_window_icon(struct ssd *ssd)
 		return;
 	}
 
+	/*
+	 * When app id is not set, an empty string is stored here and the
+	 * fallback icon is always rendered.
+	 */
 	const char *app_id = view_get_string_prop(ssd->view, "app_id");
-	if (string_null_or_empty(app_id)) {
-		return;
-	}
-	if (ssd->state.app_id && !strcmp(ssd->state.app_id, app_id)) {
-		return;
-	}
-
-	free(ssd->state.app_id);
-	ssd->state.app_id = xstrdup(app_id);
+	assert(app_id);
 
 	struct ssd_sub_tree *subtree;
 	FOR_EACH_STATE(ssd, subtree) {


### PR DESCRIPTION
Before this PR, nothing was rendered in window icon button if the application doesn't set its app_id (e.g. nested kwin_wayland). This was my oversight in #2518.

This PR makes sure the fallback icon (set via `<theme><fallbackAppIcon>`) is shown instead, by removing `ssd->state.app_id` and the early-return in `ssd_update_window_icon()`. Note that `view_get_string_prop(view, "app_id")` returns an empty string if app id is not set, and passing an empty string to `scaled_icon_buffer_set_app_id()` always renders the fallback icon.

Removing `ssd->state.app_id` doesn't affect performance because `scaled_icon_buffer` caches app_id and `scaled_icon_buffer_set_app_id()` does nothing when a duplicated app_id is passed.