### PR TITLE
config: increase default <snapping><range> to 10

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -409,7 +409,7 @@ extending outward from the snapped edge.
 	If an interactive move ends with the cursor a maximum distance *range*,
 	(in pixels) from the edge of an output, the move will trigger a
 	SnapToEdge action for that edge. A *range* of 0 disables snapping via
-	interactive moves. Default is 1.
+	interactive moves. Default is 10.
 
 *<snapping><overlay><enabled>* [yes|no]
 	Show an overlay when snapping to a window to an edge. Default is yes.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -151,7 +151,7 @@
 
   <snapping>
     <!-- Set range to 0 to disable window snapping completely -->
-    <range>1</range>
+    <range>10</range>
     <overlay enabled="yes">
       <delay inner="500" outer="500" />
     </overlay>

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1486,7 +1486,7 @@ rcxml_init(void)
 	rc.unsnap_threshold = 20;
 	rc.unmaximize_threshold = 150;
 
-	rc.snap_edge_range = 1;
+	rc.snap_edge_range = 10;
 	rc.snap_overlay_enabled = true;
 	rc.snap_overlay_delay_inner = 500;
 	rc.snap_overlay_delay_outer = 500;


### PR DESCRIPTION
...to make it easier to snap windows on the edge between two monitors.

Fixes: #2602

@Consolatis @jlindgren90 @ahesford @tokyo4j - at the back of my mind there is something telling me that we picked `1` to avoid some other behaviour, but I have tested it with `10` on a multi-output setup and it seems to work really well. Just wanted to see if I could jog your memories on anything. If not, I suggest we try this value.