### PR TITLE
menu: lazily generate menu scenes

### DIFF
--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -127,7 +127,4 @@ void menu_close_root(struct server *server);
 /* menu_reconfigure - reload theme and content */
 void menu_reconfigure(struct server *server);
 
-void update_client_list_combined_menu(struct server *server);
-void update_client_send_to_menu(struct server *server);
-
 #endif /* LABWC_MENU_H */

--- a/src/action.c
+++ b/src/action.c
@@ -664,16 +664,6 @@ show_menu(struct server *server, struct view *view, struct cursor_context *ctx,
 		return;
 	}
 
-	/*
-	 * We always refresh client-list-combined-menu and client-send-to-menu
-	 * so that they are up-to-date whether they are directly opened as a
-	 * top-level menu or opened as a submenu which we don't know at this
-	 * point. It is also needed to calculate the proper width for placement
-	 * as it fluctuates depending on application/workspace titles.
-	 */
-	update_client_list_combined_menu(menu->server);
-	update_client_send_to_menu(menu->server);
-
 	int x = server->seat.cursor->x;
 	int y = server->seat.cursor->y;
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1251,31 +1251,13 @@ menu_free(struct menu *menu)
 	zfree(menu);
 }
 
-/**
- * menu_free_from - free menu list starting from current point
- * @from: point to free from (if NULL, all menus are freed)
- */
-static void
-menu_free_from(struct server *server, struct menu *from)
-{
-	bool destroying = !from;
-	struct menu *menu, *tmp_menu;
-	wl_list_for_each_safe(menu, tmp_menu, &server->menus, link) {
-		if (menu == from) {
-			destroying = true;
-		}
-		if (!destroying) {
-			continue;
-		}
-
-		menu_free(menu);
-	}
-}
-
 void
 menu_finish(struct server *server)
 {
-	menu_free_from(server, NULL);
+	struct menu *menu, *tmp_menu;
+	wl_list_for_each_safe(menu, tmp_menu, &server->menus, link) {
+		menu_free(menu);
+	}
 
 	/* Reset state vars for starting fresh when Reload is triggered */
 	current_item = NULL;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1797,11 +1797,11 @@ void
 menu_close_root(struct server *server)
 {
 	assert(server->input_mode == LAB_INPUT_STATE_MENU);
-	if (server->menu_current) {
-		menu_close(server->menu_current);
-		server->menu_current = NULL;
-		destroy_pipemenus(server);
-	}
+	assert(server->menu_current);
+
+	menu_close(server->menu_current);
+	server->menu_current = NULL;
+	destroy_pipemenus(server);
 	seat_focus_override_end(&server->seat);
 }
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -914,7 +914,7 @@ get_item_anchor_rect(struct theme *theme, struct menuitem *item)
 }
 
 static void
-menu_configure(struct menu *menu, struct wlr_box anchor_rect)
+menu_reposition(struct menu *menu, struct wlr_box anchor_rect)
 {
 	struct theme *theme = menu->server->theme;
 
@@ -969,7 +969,7 @@ menu_configure(struct menu *menu, struct wlr_box anchor_rect)
 			continue;
 		}
 		anchor_rect = get_item_anchor_rect(theme, item);
-		menu_configure(item->submenu, anchor_rect);
+		menu_reposition(item->submenu, anchor_rect);
 	}
 }
 
@@ -1369,7 +1369,7 @@ menu_open_root(struct menu *menu, int x, int y)
 
 	assert(!menu->server->menu_current);
 
-	menu_configure(menu, (struct wlr_box){.x = x, .y = y});
+	menu_reposition(menu, (struct wlr_box){.x = x, .y = y});
 	wlr_scene_node_set_enabled(&menu->scene_tree->node, true);
 	menu->server->menu_current = menu;
 	selected_item = NULL;
@@ -1450,7 +1450,7 @@ create_pipe_menu(struct menu_pipe_context *ctx)
 
 	struct wlr_box anchor_rect =
 		get_item_anchor_rect(ctx->server->theme, ctx->item);
-	menu_configure(pipe_menu, anchor_rect);
+	menu_reposition(pipe_menu, anchor_rect);
 
 	validate(ctx->server);
 


### PR DESCRIPTION
Split from #2531.

In this PR, scene-nodes of (sub)menus are lazily generated when they are being opened. This removes the need to call `update_client_list_combined_menu()` and `update_client_send_to_menu()` every time a root menu is opened. This also fixes the incorrect menu position with following configuration:
```xml
  <menu id="foo" label="foo">
    <item label="aaaaaa"/>
    <item label="bbbbbb"/>
  </menu>
  <menu id="root-menu">
    <menu id="foo" />
    <menu id="foo" />
  </menu>
```

This PR also:
- Removes `menu_free_from()` in favor of simplicity.
- Allows linking to static menu from pipemenu. I think #2339 was enough to prevent ~static menus from opening in unexpected position~ circular menus.
- Renames `menu_configure()` to `menu_reposition()`.
- Asserts `server->menu_current != NULL` in `menu_close_root()`.