### PR TITLE
Some fixes about focus or stacking order management while window switching

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -877,6 +877,14 @@ actions_run(struct view *activator, struct server *server,
 	}
 
 	wl_list_for_each(action, actions, link) {
+		if (server->input_mode == LAB_INPUT_STATE_WINDOW_SWITCHER
+				&& action->type != ACTION_TYPE_NEXT_WINDOW
+				&& action->type != ACTION_TYPE_PREVIOUS_WINDOW) {
+			wlr_log(WLR_INFO, "Only NextWindow or PreviousWindow "
+				"actions are accepted while window switching.");
+			continue;
+		}
+
 		wlr_log(WLR_DEBUG, "Handling action %u: %s", action->type,
 			action_names[action->type]);
 

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -51,6 +51,11 @@ desktop_focus_view(struct view *view, bool raise)
 		return;
 	}
 
+	if (view->server->input_mode == LAB_INPUT_STATE_WINDOW_SWITCHER) {
+		wlr_log(WLR_DEBUG, "not focusing window while window switching");
+		return;
+	}
+
 	if (view->minimized) {
 		/*
 		 * Unminimizing will map the view which triggers a call to this

--- a/src/foreign-toplevel/foreign.c
+++ b/src/foreign-toplevel/foreign.c
@@ -29,12 +29,6 @@ foreign_request_fullscreen(struct foreign_toplevel *toplevel, bool fullscreen)
 void
 foreign_request_activate(struct foreign_toplevel *toplevel)
 {
-	if (toplevel->view->server->input_mode
-			== LAB_INPUT_STATE_WINDOW_SWITCHER) {
-		wlr_log(WLR_INFO, "Preventing focus request while in window switcher");
-		return;
-	}
-
 	desktop_focus_view(toplevel->view, /*raise*/ true);
 }
 

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -599,9 +599,7 @@ cursor_process_motion(struct server *server, uint32_t time, double *sx, double *
 		dnd_icons_move(seat, seat->cursor->x, seat->cursor->y);
 	}
 
-	if ((ctx.view || ctx.surface) && rc.focus_follow_mouse
-			&& server->input_mode
-				!= LAB_INPUT_STATE_WINDOW_SWITCHER) {
+	if ((ctx.view || ctx.surface) && rc.focus_follow_mouse) {
 		desktop_focus_view_or_surface(seat, ctx.view, ctx.surface,
 			rc.raise_on_focus);
 	}
@@ -641,15 +639,10 @@ _cursor_update_focus(struct server *server)
 	struct cursor_context ctx = get_cursor_context(server);
 
 	if ((ctx.view || ctx.surface) && rc.focus_follow_mouse
-			&& !rc.focus_follow_mouse_requires_movement
-			&& server->input_mode
-				!= LAB_INPUT_STATE_WINDOW_SWITCHER) {
+			&& !rc.focus_follow_mouse_requires_movement) {
 		/*
 		 * Always focus the surface below the cursor when
 		 * followMouse=yes and followMouseRequiresMovement=no.
-		 *
-		 * We should ignore them while window-switching though, because
-		 * calling desktop_focus_view() un-minimizes previewed window.
 		 */
 		desktop_focus_view_or_surface(&server->seat, ctx.view,
 			ctx.surface, rc.raise_on_focus);

--- a/src/osd.c
+++ b/src/osd.c
@@ -173,6 +173,9 @@ osd_begin(struct server *server, enum lab_cycle_dir direction)
 	seat_focus_override_begin(&server->seat,
 		LAB_INPUT_STATE_WINDOW_SWITCHER, LAB_CURSOR_DEFAULT);
 	osd_update(server);
+
+	/* Update cursor, in case it is within the area covered by OSD */
+	cursor_update_focus(server);
 }
 
 void
@@ -425,9 +428,6 @@ display_osd(struct output *output, struct wl_array *views)
 		- h / 2 + output_box.y;
 	wlr_scene_node_set_position(&scene_buffer->node, lx, ly);
 	wlr_scene_node_set_enabled(&output->osd_tree->node, true);
-
-	/* Update cursor, in case it is within the area covered by OSD */
-	cursor_update_focus(server);
 }
 
 void

--- a/src/view.c
+++ b/src/view.c
@@ -803,6 +803,12 @@ void
 view_minimize(struct view *view, bool minimized)
 {
 	assert(view);
+
+	if (view->server->input_mode == LAB_INPUT_STATE_WINDOW_SWITCHER) {
+		wlr_log(WLR_ERROR, "not minimizing window while window switching");
+		return;
+	}
+
 	/*
 	 * Minimize the root window first because some xwayland clients send a
 	 * request-unmap to sub-windows at this point (for example gimp and its

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -875,11 +875,6 @@ xdg_activation_handle_request(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	if (view->server->input_mode == LAB_INPUT_STATE_WINDOW_SWITCHER) {
-		wlr_log(WLR_INFO, "Preventing focus request while in window switcher");
-		return;
-	}
-
 	wlr_log(WLR_DEBUG, "Activating surface");
 	desktop_focus_view(view, /*raise*/ true);
 }

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -402,11 +402,6 @@ handle_request_activate(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	if (view->server->input_mode == LAB_INPUT_STATE_WINDOW_SWITCHER) {
-		wlr_log(WLR_INFO, "Preventing focus request while in window switcher");
-		return;
-	}
-
 	desktop_focus_view(view, /*raise*/ true);
 }
 


### PR DESCRIPTION
- Don't call `cursor_update_focus()` every time the OSD is updated as it is no-op while window switching. Instead, they should be called at the beginning/end of window switching. This change functionally does nothing. Ref: https://github.com/labwc/labwc/pull/2584#issuecomment-2663425104
- Make it harder to mess up the window stacking order while window switching by adding a check for `server->input_mode` in `desktop_focus_view()` and `view_minimize()`. Especially the check in `view_minimize()` should prevent panels from minimizing a window while window switching.
- Allow only `PreviousWindow`/`NextWindow` actions while window switching. This should catch some actions that could not be filtered by the 2nd commit e.g. `SendToDesktop`. This was suggested by @Consolatis in IRC.

Both/either of the 2nd and 3rd commit prevent `<action name="NextWindow" /><action name="Focus" />` keybinds from messing up the window stacking order while window switching, which was found in #2582.