### PR TITLE
project wide: clean up event listeners on shutdown (part 2)

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1504,8 +1504,6 @@ cursor_init(struct seat *seat)
 
 void cursor_finish(struct seat *seat)
 {
-	/* TODO: either clean up all the listeners or none of them */
-
 	wl_list_remove(&seat->cursor_motion.link);
 	wl_list_remove(&seat->cursor_motion_absolute.link);
 	wl_list_remove(&seat->cursor_button.link);

--- a/src/server.c
+++ b/src/server.c
@@ -762,6 +762,10 @@ server_finish(struct server *server)
 	wl_list_remove(&server->new_constraint.link);
 	wl_list_remove(&server->output_power_manager_set_mode.link);
 	wl_list_remove(&server->tearing_new_object.link);
+	if (server->drm_lease_request.notify) {
+		wl_list_remove(&server->drm_lease_request.link);
+		server->drm_lease_request.notify = NULL;
+	}
 
 	wlr_backend_destroy(server->backend);
 	wlr_allocator_destroy(server->allocator);

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -469,6 +469,8 @@ destroy_workspace(struct workspace *workspace)
 	wlr_scene_node_destroy(&workspace->tree->node);
 	zfree(workspace->name);
 	wl_list_remove(&workspace->link);
+	wl_list_remove(&workspace->on_cosmic.activate.link);
+	wl_list_remove(&workspace->on_ext.activate.link);
 
 	lab_cosmic_workspace_destroy(workspace->cosmic_workspace);
 	lab_ext_workspace_destroy(workspace->ext_workspace);


### PR DESCRIPTION
Follow-up for #2596