### PR TITLE
data: center logo vertically

### DIFF
--- a/data/labwc-symbolic.svg
+++ b/data/labwc-symbolic.svg
@@ -3,6 +3,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="256px" height="256px"
      viewbox="0 0 256 256"
      stroke-linecap="round" stroke-linejoin="round" stroke-width="12">
-  <path fill="#ffffff" stroke="#ffffff" d="m 26 68 91 55 v 108 l -76 -61 z" />
-  <path fill="#000000" stroke="#000000" d="m 229 68 -91 55 v 108 l 76 -61 z" />
+  <path fill="#ffffff" stroke="#ffffff" d="m 26 46 91 55 v 108 l -76 -61 z" />
+  <path fill="#000000" stroke="#000000" d="m 229 46 -91 55 v 108 l 76 -61 z" />
 </svg>

--- a/data/labwc.svg
+++ b/data/labwc.svg
@@ -3,6 +3,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="256px" height="256px"
      viewbox="0 0 256 256"
      stroke-linecap="round" stroke-linejoin="round" stroke-width="12">
-  <path fill="#f0d70f" stroke="#f0d70f" d="m 26 68 91 55 v 108 l -76 -61 z" />
-  <path fill="#d02f90" stroke="#d02f90" d="m 229 68 -91 55 v 108 l 76 -61 z" />
+  <path fill="#f0d70f" stroke="#f0d70f" d="m 26 46 91 55 v 108 l -76 -61 z" />
+  <path fill="#d02f90" stroke="#d02f90" d="m 229 46 -91 55 v 108 l 76 -61 z" />
 </svg>


### PR DESCRIPTION
The current logo has asymmetrical 62/19 px top/bottom padding. Let's center it (40/41 px top/bottom) so it looks better in the titlebar.