### PR TITLE
osd: draw window switcher with scene-nodes

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -412,6 +412,12 @@ struct output {
 	struct wlr_scene_tree *osd_tree;
 	struct wlr_scene_tree *session_lock_tree;
 	struct wlr_scene_buffer *workspace_osd;
+
+	struct osd_scene {
+		struct wl_array items; /* struct osd_scene_item */
+		struct wlr_scene_tree *tree;
+	} osd_scene;
+
 	/* In output-relative scene coordinates */
 	struct wlr_box usable_area;
 

--- a/include/osd.h
+++ b/include/osd.h
@@ -44,9 +44,6 @@ void osd_begin(struct server *server, enum lab_cycle_dir direction);
 /* Cycle the selected view in the window switcher */
 void osd_cycle(struct server *server, enum lab_cycle_dir direction);
 
-/* Updates onscreen display 'alt-tab' buffer */
-void osd_update(struct server *server);
-
 /* Closes the OSD */
 void osd_finish(struct server *server);
 

--- a/src/osd.c
+++ b/src/osd.c
@@ -21,6 +21,8 @@
 #include "window-rules.h"
 #include "workspaces.h"
 
+static void update_osd(struct server *server);
+
 static void
 destroy_osd_nodes(struct output *output)
 {
@@ -119,7 +121,7 @@ osd_on_view_destroy(struct view *view)
 
 	if (osd_state->cycle_view) {
 		/* Update the OSD to reflect the view has now gone. */
-		osd_update(view->server);
+		update_osd(view->server);
 	}
 
 	if (view->scene_tree) {
@@ -172,7 +174,7 @@ osd_begin(struct server *server, enum lab_cycle_dir direction)
 
 	seat_focus_override_begin(&server->seat,
 		LAB_INPUT_STATE_WINDOW_SWITCHER, LAB_CURSOR_DEFAULT);
-	osd_update(server);
+	update_osd(server);
 
 	/* Update cursor, in case it is within the area covered by OSD */
 	cursor_update_focus(server);
@@ -185,7 +187,7 @@ osd_cycle(struct server *server, enum lab_cycle_dir direction)
 
 	server->osd_state.cycle_view = get_next_cycle_view(server,
 		server->osd_state.cycle_view, direction);
-	osd_update(server);
+	update_osd(server);
 }
 
 void
@@ -430,8 +432,8 @@ display_osd(struct output *output, struct wl_array *views)
 	wlr_scene_node_set_enabled(&output->osd_tree->node, true);
 }
 
-void
-osd_update(struct server *server)
+static void
+update_osd(struct server *server)
 {
 	struct wl_array views;
 	wl_array_init(&views);

--- a/src/output.c
+++ b/src/output.c
@@ -486,6 +486,7 @@ new_output_notify(struct wl_listener *listener, void *data)
 	wl_signal_add(&wlr_output->events.request_state, &output->request_state);
 
 	wl_list_init(&output->regions);
+	wl_array_init(&output->osd_scene.items);
 
 	/*
 	 * Create layer-trees (background, bottom, top and overlay) and


### PR DESCRIPTION
This PR is a preparation for icons in the window switcher (https://github.com/labwc/labwc/discussions/2172#discussioncomment-12297481) which will be achieved by using `scaled_icon_buffer`. Also, this PR may reduce the overhead by not redrawing the whole osd when the selected item is updated.

This PR adds `output->osd_scene` which has 2 fields:
- `tree`: a scene-tree of per-output osd inserted as a child of `output->osd_tree`.
- `items`: a list of `osd_scene_item`s which are used to toggle the highlights for selected window item. In the future, `osd_scene_item` may be extended to support filled highlights for selected window item, or mouse interaction.

A concern about this PR is the ugly look of the window switcher when `osd.window-switcher.width` is too small:
|Before|After|
|-|-|
|![20250314_18h57m38s_grim](https://github.com/user-attachments/assets/83447d71-5e92-440a-9dff-4c6cb3d297d4)|![20250314_18h56m10s_grim](https://github.com/user-attachments/assets/a5d8df74-a5f0-4662-92bf-711b2d745168)|

But I think this is tolerable and I'd like to deliver icon support first. Any ideas to fix this without adding too much complexity are welcome.