### PR TITLE
string-helpers: rtrim() with just char *s, call it later in string_strip

### DIFF
--- a/src/common/string-helpers.c
+++ b/src/common/string-helpers.c
@@ -30,14 +30,14 @@ trim_last_field(char *buf, char delim)
 }
 
 static void
-rtrim(char **s)
+rtrim(char *s)
 {
-	size_t len = strlen(*s);
+	size_t len = strlen(s);
 	if (!len) {
 		return;
 	}
-	char *end = *s + len - 1;
-	while (end >= *s && isspace(*end)) {
+	char *end = s + len - 1;
+	while (end >= s && isspace(*end)) {
 		end--;
 	}
 	*(end + 1) = '\0';
@@ -46,10 +46,10 @@ rtrim(char **s)
 char *
 string_strip(char *s)
 {
-	rtrim(&s);
 	while (isspace(*s)) {
 		s++;
 	}
+	rtrim(s);
 	return s;
 }
 


### PR DESCRIPTION
char **s not needed to get trailing whitespace trimmed, and rtrim() does not return anything

if there is leading whitespace in *s in call to string_strip(), there is less chars left to scan in rtrim().

---
noticed this while doing something; if it supposed to be as it is, i can amend this commit w/ comment