### PR TITLE
action: Add HideCursor action

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -351,6 +351,12 @@ Actions are used in menus and keyboard/mouse bindings.
 	*y* [center|value] Equivalent for the vertical warp position within the target area.
 	Default is "center"
 
+*<action name="HideCursor" />*
+	Hide the pointer or stylus cursor. The cursor becomes visible again on following
+	pointer actions, stylus actions or touchpad gestures.
+	Use together with the WarpCursor action to not just hide the cursor but to
+	additionally move it away to prevent e.g. hover effects.
+
 *<action name="EnableTabletMouseEmulation" />*++
 *<action name="DisableTabletMouseEmulation" />*++
 *<action name="ToggleTabletMouseEmulation">*

--- a/src/action.c
+++ b/src/action.c
@@ -123,6 +123,7 @@ enum action_type {
 	ACTION_TYPE_ZOOM_IN,
 	ACTION_TYPE_ZOOM_OUT,
 	ACTION_TYPE_WARP_CURSOR,
+	ACTION_TYPE_HIDE_CURSOR,
 };
 
 const char *action_names[] = {
@@ -188,6 +189,7 @@ const char *action_names[] = {
 	"ZoomIn",
 	"ZoomOut",
 	"WarpCursor",
+	"HideCursor",
 	NULL
 };
 
@@ -1334,6 +1336,9 @@ actions_run(struct view *activator, struct server *server,
 
 				warp_cursor(view, output, to, x, y);
 			}
+			break;
+		case ACTION_TYPE_HIDE_CURSOR:
+			cursor_set_visible(&server->seat, false);
 			break;
 		case ACTION_TYPE_INVALID:
 			wlr_log(WLR_ERROR, "Not executing unknown action");


### PR DESCRIPTION
Very simple action which, well, hides the cursor. 

Tested with:

```xml
<keybind key="A-W-h">
  <action name="HideCursor" />
  <action name="WarpCursor" x="-1" y="-1" />
</keybind>
``` 

Because naming is hard, I'm not sure if this is the best name for this action. The original issue says `ToggleCursor` or `SetCursorVisibility`, but I think having a toggle or visible/not-visible like action is overkill because the cursor, when hidden, becomes visible again as soon as pointer/gestures or stylus input is detected.

This also works directly on startup by, for above key binding, adding `wtype -M alt -M logo h -m alt -m logo` to `.config/labwc/autostart`. 

CC: @justinesmithies
Closes #2614

PS: Would be nice actually to directly execute an action incl. argument from the labwc executable, similar to `labwc --reconfigure`, to not need a key binding for the "hide only at startup" use case. Hint.. hint.. ;)
