### PR TITLE
add realtime round-robin scheduling capability

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -584,6 +584,8 @@ void output_enable_adaptive_sync(struct output *output, bool enabled);
  */
 float output_max_scale(struct server *server);
 
+void set_rr_scheduling(void);
+
 void new_tearing_hint(struct wl_listener *listener, void *data);
 
 void server_init(struct server *server);

--- a/src/main.c
+++ b/src/main.c
@@ -205,6 +205,8 @@ main(int argc, char *argv[])
 
 	increase_nofile_limit();
 
+	set_rr_scheduling();
+	
 	struct server server = { 0 };
 	server_init(&server);
 	server_start(&server);

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,6 +18,7 @@ labwc_sources = files(
   'output-virtual.c',
   'overlay.c',
   'placement.c',
+  'realtime.c',
   'regions.c',
   'resistance.c',
   'resize-outlines.c',

--- a/src/realtime.c
+++ b/src/realtime.c
@@ -1,0 +1,37 @@
+#include <sys/resource.h>
+#include <sched.h>
+#include <unistd.h>
+#include <pthread.h>
+#include "labwc.h"
+ 
+static void child_fork_callback(void) {
+ 
+	struct sched_param param;
+	param.sched_priority = 0;
+	int ret = pthread_setschedparam(pthread_self(), SCHED_OTHER, &param);
+	if (ret != 0) {
+		wlr_log(WLR_ERROR, "Failed to reset scheduler policy on fork");
+	}
+}
+
+void set_rr_scheduling(void) {
+	int prio = sched_get_priority_min(SCHED_RR);
+	int old_policy;
+	int ret;
+	struct sched_param param;
+	ret = pthread_getschedparam(pthread_self(), &old_policy, &param);
+	if (ret != 0) {
+		wlr_log(WLR_DEBUG, "Failed to get old scheduling priority");
+		return;
+	}
+  
+	param.sched_priority = prio;
+	ret = pthread_setschedparam(pthread_self(), SCHED_RR, &param);
+  
+	if (ret != 0) {
+		wlr_log(WLR_INFO, "Failed to set scheduling priority to %d", prio);
+		return;
+	}
+  
+	pthread_atfork(NULL, NULL, child_fork_callback);
+}


### PR DESCRIPTION
This patch is based on https://github.com/swaywm/sway/commit/a3a82efbf6b5b3af840c70038b1b599ba29003ac
Eliminates the libinput error "your system is too slow".
Enable by giving the labwc binary CAP_SYS_NICE capability, ie `setcap cap_sys_nice+ep usr/bin/labwc`

 