### PR TITLE
src/magnifier: fix compile on ancient GCC versions

### DIFF
--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -150,6 +150,7 @@ magnifier_draw(struct output *output, struct wlr_buffer *output_buffer, struct w
 				.b = theme->mag_border_color[2],
 				.a = theme->mag_border_color[3]
 			},
+			.clip = NULL,
 		};
 		wlr_render_pass_add_rect(tmp_render_pass, &bg_opts);
 		wlr_box_intersection(&damage_box, &border_box, &output_box);


### PR DESCRIPTION
[On behalf of @Consolatis]

Fixes
```
../src/magnifier.c:153:3: error: missing initializer for field ‘clip’ of ‘struct wlr_render_rect_options’ [-Werror=missing-field-initializers]
  153 |   };
      |   ^
In file included from ../subprojects/wlroots/include/wlr/render/wlr_renderer.h:14,
                 from ../subprojects/wlroots/include/wlr/types/wlr_output.h:17,
                 from ../src/magnifier.c:5:
../subprojects/wlroots/include/wlr/render/pass.h:115:27: note: ‘clip’ declared here
  115 |  const pixman_region32_t *clip
```