### PR TITLE
magnifier: scale/transform the magnifier

### DIFF
--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -143,6 +143,13 @@ lab_wlr_scene_output_commit(struct wlr_scene_output *scene_output,
 		pixman_region32_init_rect(&region,
 			additional_damage.x, additional_damage.y,
 			additional_damage.width, additional_damage.height);
+		/*
+		 * Region passed to scene_output_damage() should have the same
+		 * scale as the output buffer but have a different transform.
+		 */
+		wlr_region_transform(&region, &region, wlr_output->transform,
+			wlr_output->width, wlr_output->height);
+
 		scene_output_damage(scene_output, &region);
 		pixman_region32_fini(&region);
 	}

--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -57,9 +57,8 @@ magnifier_draw(struct output *output, struct wlr_buffer *output_buffer, struct w
 	};
 	box_logical_to_physical(&cursor_pos, output->wlr_output);
 
-	bool cursor_in_output = wlr_box_contains_point(&output_box,
-		cursor_pos.x, cursor_pos.y);
-	if (fullscreen && !cursor_in_output) {
+	if (!wlr_box_contains_point(&output_box,
+			cursor_pos.x, cursor_pos.y)) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #2082 and #2591.

But I'm setting this PR as draft since this PR causes huge overhead for reallocation of the temporary buffer when the magnifier spans 2 outputs with different scales/transforms.

Possible solutions are:
1. Use a single temporary buffer with the biggest size (https://github.com/labwc/labwc/issues/2082#issuecomment-2292441444)
2. Always draw magnifier only in the output that contains the cursor and reallocate the buffer when the cursor moves between outputs
3. Allocate temporary buffers for each output (e.g. adding `output->magnifier_buffer`)

I'm not sure which one to choose, but I personally like (2.) since it will be the easiest to implement, like:
```diff
diff --git a/src/magnifier.c b/src/magnifier.c
index 9bf3c599..86c9cc4d 100644
--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -54,9 +54,8 @@ magnifier_draw(struct output *output, struct wlr_buffer *output_buffer, struct w
 	struct wlr_box cursor_pos = {.x = cursor_lx, .y = cursor_ly};
 	box_logical_to_physical(&cursor_pos, output->wlr_output);
 
-	bool cursor_in_output = wlr_box_contains_point(&output_box,
-		cursor_pos.x, cursor_pos.y);
-	if (fullscreen && !cursor_in_output) {
+	if (!wlr_box_contains_point(&output_box,
+			cursor_pos.x, cursor_pos.y)) {
 		return;
 	}
```