### PR TITLE
osd: add osd.window-switcher.item.icon.size

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -256,6 +256,11 @@ all are supported.
 	Border width of the selection box in the window switcher in pixels.
 	Default is 2.
 
+*osd.window-switcher.item.icon.size*
+	Size of the icon in window switcher, in pixels.
+	If not set, the font size derived from <theme><font place="OnScreenDisplay">
+	is used.
+
 *osd.window-switcher.preview.border.width*
 	Border width of the outlines shown as the preview of the window selected
 	by window switcher. Inherits *osd.border.width* if not set.

--- a/docs/themerc
+++ b/docs/themerc
@@ -89,6 +89,8 @@ osd.window-switcher.padding: 4
 osd.window-switcher.item.padding.x: 10
 osd.window-switcher.item.padding.y: 1
 osd.window-switcher.item.active.border.width: 2
+# The icon size the same as the font size by default
+# osd.window-switcher.item.icon.size: 50
 osd.window-switcher.preview.border.width: 1
 osd.window-switcher.preview.border.color: #dddda6,#000000,#dddda6
 

--- a/include/theme.h
+++ b/include/theme.h
@@ -135,6 +135,7 @@ struct theme {
 	int osd_window_switcher_item_padding_x;
 	int osd_window_switcher_item_padding_y;
 	int osd_window_switcher_item_active_border_width;
+	int osd_window_switcher_item_icon_size;
 	bool osd_window_switcher_width_is_percent;
 	int osd_window_switcher_preview_border_width;
 	float osd_window_switcher_preview_border_color[3][4];

--- a/src/osd.c
+++ b/src/osd.c
@@ -6,6 +6,7 @@
 #include "common/array.h"
 #include "common/buf.h"
 #include "common/font.h"
+#include "common/macros.h"
 #include "common/scaled-font-buffer.h"
 #include "common/scaled-icon-buffer.h"
 #include "common/scaled-rect-buffer.h"
@@ -352,15 +353,18 @@ create_osd_scene(struct output *output, struct wl_array *views)
 				* theme->osd_window_switcher_item_padding_x)
 				* field->width / 100.0;
 			struct wlr_scene_node *node = NULL;
+			int height = -1;
 
 			if (field->content == LAB_FIELD_ICON) {
-				int icon_size = font_height(&rc.font_osd);
+				int icon_size = MIN(field_width,
+					theme->osd_window_switcher_item_icon_size);
 				struct scaled_icon_buffer *icon_buffer =
 					scaled_icon_buffer_create(item_root,
 						server, icon_size, icon_size);
 				scaled_icon_buffer_set_app_id(icon_buffer,
 					view_get_string_prop(*view, "app_id"));
 				node = &icon_buffer->scene_buffer->node;
+				height = icon_size;
 			} else {
 				buf_clear(&buf);
 				osd_field_get_content(field, &buf, *view);
@@ -370,11 +374,11 @@ create_osd_scene(struct output *output, struct wl_array *views)
 				scaled_font_buffer_update(font_buffer, buf.data, field_width,
 					&rc.font_osd, text_color, bg_color);
 				node = &font_buffer->scene_buffer->node;
+				height = font_height(&rc.font_osd);
 			}
 
 			wlr_scene_node_set_position(node, x,
-				y + theme->osd_window_switcher_item_padding_y
-					+ theme->osd_window_switcher_item_active_border_width);
+				y + (theme->osd_window_switcher_item_height - height) / 2);
 			x += field_width + theme->osd_window_switcher_item_padding_x;
 		}
 

--- a/src/osd.c
+++ b/src/osd.c
@@ -302,7 +302,8 @@ create_osd_scene(struct output *output, struct wl_array *views)
 		struct scaled_font_buffer *font_buffer =
 			scaled_font_buffer_create(output->osd_scene.tree);
 		wlr_scene_node_set_position(&font_buffer->scene_buffer->node,
-			x, y + theme->osd_window_switcher_item_active_border_width);
+			x, y + (theme->osd_window_switcher_item_height
+				- font_height(&font)) / 2);
 		scaled_font_buffer_update(font_buffer, workspace_name, 0,
 			&font, text_color, bg_color);
 		y += theme->osd_window_switcher_item_height;

--- a/src/theme.c
+++ b/src/theme.c
@@ -542,6 +542,7 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->osd_window_switcher_item_padding_x = 10;
 	theme->osd_window_switcher_item_padding_y = 1;
 	theme->osd_window_switcher_item_active_border_width = 2;
+	theme->osd_window_switcher_item_icon_size = -1;
 
 	/* inherit settings in post_processing() if not set elsewhere */
 	theme->osd_window_switcher_preview_border_width = INT_MIN;
@@ -878,6 +879,11 @@ entry(struct theme *theme, const char *key, const char *value)
 		theme->osd_window_switcher_item_active_border_width =
 			get_int_if_positive(
 				value, "osd.window-switcher.item.active.border.width");
+	}
+	if (match_glob(key, "osd.window-switcher.item.icon.size")) {
+		theme->osd_window_switcher_item_icon_size =
+			get_int_if_positive(
+				value, "osd.window-switcher.item.icon.size");
 	}
 	if (match_glob(key, "osd.window-switcher.preview.border.width")) {
 		theme->osd_window_switcher_preview_border_width =
@@ -1380,7 +1386,13 @@ post_processing(struct theme *theme)
 	theme->menu_header_height = font_height(&rc.font_menuheader)
 		+ 2 * theme->menu_items_padding_y;
 
-	theme->osd_window_switcher_item_height = font_height(&rc.font_osd)
+	int osd_font_height = font_height(&rc.font_osd);
+	if (theme->osd_window_switcher_item_icon_size <= 0) {
+		theme->osd_window_switcher_item_icon_size = osd_font_height;
+	}
+	int osd_field_height =
+		MAX(osd_font_height, theme->osd_window_switcher_item_icon_size);
+	theme->osd_window_switcher_item_height = osd_field_height
 		+ 2 * theme->osd_window_switcher_item_padding_y
 		+ 2 * theme->osd_window_switcher_item_active_border_width;
 


### PR DESCRIPTION
Suggested in https://github.com/labwc/labwc/pull/2621#issuecomment-2727469687.

This allows users to make the icon in window switcher bigger (or smaller) than the font size, which enables more Openbox-like appearance.

Example:
```
  osd.window-switcher.item.icon.size: 50
```

```xml
  <windowSwitcher>
    <fields>
      <field content="icon" width="15%" />
      <field content="title" width="85%" />
    </fields>
  </windowSwitcher>
```

![20250401_19h26m10s_grim](https://github.com/user-attachments/assets/3c53582c-a367-4e3d-bb58-f8cd4d38e6f6)

The default value is set to `font_height(&rc.font_osd)`, as it is right now. @johanmalm suggested deriving from the icon size in the titlebar (https://github.com/labwc/labwc/pull/2621#issuecomment-2727469687), but I personally don't think it's intuitive that changing the button size in titlebar changes the icon size in window switcher. This is not a strong preference, though.

This PR also makes the icon smaller than the font size when the width allocated with `<windowSwitcher><fields><field width="">` is smaller than that.

The first commit fixes the placement of workspace name at the top of window switcher. Previously we didn't take into account `theme->osd_window_switcher_item_padding_y` when centering the workspace name. This problem seems to have been around since the introduction of item paddings.