### PR TITLE
osd: workspace switcher boxes improvements

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -281,6 +281,9 @@ all are supported.
 	Height of boxes in workspace switcher in pixels. Setting to 0 disables
 	boxes. Default is 20.
 
+*osd.workspace-switcher.boxes.border.width*
+	Border width of boxes in workspace switcher in pixels. Default is 2.
+
 *snapping.overlay.region.bg.enabled* [yes|no]
 	Show a filled rectangle as an overlay when a window is snapped to a
 	region. Default is yes for hardware-based renderers and no for

--- a/docs/themerc
+++ b/docs/themerc
@@ -96,6 +96,7 @@ osd.window-switcher.preview.border.color: #dddda6,#000000,#dddda6
 
 osd.workspace-switcher.boxes.width: 20
 osd.workspace-switcher.boxes.height: 20
+osd.workspace-switcher.boxes.border.width: 2
 
 # Default values for following options change depending on the rendering
 # backend. For software-based renderers, *.bg.enabled is "no" and

--- a/include/theme.h
+++ b/include/theme.h
@@ -142,6 +142,7 @@ struct theme {
 
 	int osd_workspace_switcher_boxes_width;
 	int osd_workspace_switcher_boxes_height;
+	int osd_workspace_switcher_boxes_border_width;
 
 	struct theme_snapping_overlay
 		snapping_overlay_region, snapping_overlay_edge;

--- a/src/theme.c
+++ b/src/theme.c
@@ -551,6 +551,7 @@ theme_builtin(struct theme *theme, struct server *server)
 
 	theme->osd_workspace_switcher_boxes_width = 20;
 	theme->osd_workspace_switcher_boxes_height = 20;
+	theme->osd_workspace_switcher_boxes_border_width = 2;
 
 	/* inherit settings in post_processing() if not set elsewhere */
 	theme->osd_bg_color[0] = FLT_MIN;
@@ -902,6 +903,11 @@ entry(struct theme *theme, const char *key, const char *value)
 		theme->osd_workspace_switcher_boxes_height =
 			get_int_if_positive(
 				value, "osd.workspace-switcher.boxes.height");
+	}
+	if (match_glob(key, "osd.workspace-switcher.boxes.border.width")) {
+		theme->osd_workspace_switcher_boxes_border_width =
+			get_int_if_positive(
+				value, "osd.workspace-switcher.boxes.border.width");
 	}
 	if (match_glob(key, "osd.label.text.color")) {
 		parse_hexstr(value, theme->osd_label_text_color);

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -120,7 +120,8 @@ _osd_update(struct server *server)
 					.width = rect_width,
 					.height = rect_height,
 				};
-				draw_cairo_border(cairo, fbox, 2);
+				draw_cairo_border(cairo, fbox,
+					theme->osd_workspace_switcher_boxes_border_width);
 				if (active) {
 					cairo_rectangle(cairo, x, margin,
 						rect_width, rect_height);

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -114,12 +114,16 @@ _osd_update(struct server *server)
 			wl_list_for_each(workspace, &server->workspaces.all, link) {
 				bool active =  workspace == server->workspaces.current;
 				set_cairo_color(cairo, server->theme->osd_label_text_color);
-				cairo_rectangle(cairo, x, margin,
-					rect_width - padding, rect_height);
-				cairo_stroke(cairo);
+				struct wlr_fbox fbox = {
+					.x = x,
+					.y = margin,
+					.width = rect_width,
+					.height = rect_height,
+				};
+				draw_cairo_border(cairo, fbox, 2);
 				if (active) {
 					cairo_rectangle(cairo, x, margin,
-						rect_width - padding, rect_height);
+						rect_width, rect_height);
 					cairo_fill(cairo);
 				}
 				x += rect_width + padding;


### PR DESCRIPTION
Adds a theme option to configure border width of workspace boxes in osd.

Previews:
- master defaults
- new defaults
- example osd.workspace-switcher.boxes.border.width: 8

Note that master boxes are not square and 1px off-center (blue line).

![preview](https://github.com/user-attachments/assets/2feb8f32-e12e-4703-8b79-f1792e1b979c)
