### PR TITLE
rcxml: big refactor

### DIFF
--- a/include/common/string-helpers.h
+++ b/include/common/string-helpers.h
@@ -10,6 +10,12 @@
 bool string_null_or_empty(const char *s);
 
 /**
+ * str_space_only - Check if the string only contains white-space characters
+ * @s: string to check
+ */
+bool str_space_only(const char *s);
+
+/**
  * trim_last_field() - Trim last field of string splitting on provided delim
  * @buf: string to trim
  * @delim: delimitator

--- a/include/common/xml.h
+++ b/include/common/xml.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_XML_H
+#define LABWC_XML_H
+
+#include <libxml/tree.h>
+
+/*
+ * Converts dotted attributes into nested nodes.
+ * For example, the following node:
+ *
+ *   <keybind name.action="ShowMenu" menu.action="root-menu"
+ *            x.position.action="1" y.position.action="2" />
+ *
+ * is converted to:
+ *
+ *   <keybind>
+ *     <action>
+ *       <name>ShowMenu</name>
+ *       <menu>root-menu</menu>
+ *       <position>
+ *         <x>1</x>
+ *         <y>2</y>
+ *       </position>
+ *     </action>
+ *   </keybind>
+ */
+void lab_xml_expand_dotted_attributes(xmlNode *root);
+
+#endif /* LABWC_XML_H */

--- a/include/common/xml.h
+++ b/include/common/xml.h
@@ -3,6 +3,7 @@
 #define LABWC_XML_H
 
 #include <libxml/tree.h>
+#include <stdbool.h>
 
 /*
  * Converts dotted attributes into nested nodes.
@@ -25,5 +26,43 @@
  *   </keybind>
  */
 void lab_xml_expand_dotted_attributes(xmlNode *root);
+
+/* Returns true if the node only contains a string or is empty */
+bool lab_xml_node_is_leaf(xmlNode *node);
+
+bool lab_xml_get_node(xmlNode *node, const char *key, xmlNode **dst_node);
+bool lab_xml_get_string(xmlNode *node, const char *key, char *s, size_t len);
+bool lab_xml_get_int(xmlNode *node, const char *key, int *i);
+bool lab_xml_get_bool(xmlNode *node, const char *key, bool *b);
+
+static inline xmlNode *
+lab_xml_get_next_child(xmlNode *child)
+{
+	if (!child) {
+		return NULL;
+	}
+	do {
+		child = child->next;
+	} while (child && child->type != XML_ELEMENT_NODE);
+
+	return child;
+}
+
+static inline void
+lab_xml_get_key_and_content(xmlNode *node, char **name, char **content)
+{
+	if (node) {
+		*name = (char *)node->name;
+		*content = (char *)xmlNodeGetContent(node);
+	}
+}
+
+#define LAB_XML_FOR_EACH(parent, child, key, content) \
+	for ((child) = (parent)->children, \
+		lab_xml_get_key_and_content((child), &(key), &(content)); \
+		(child); \
+		xmlFree((xmlChar *)(content)), \
+		(child) = lab_xml_get_next_child(child), \
+		lab_xml_get_key_and_content((child), &(key), &(content)))
 
 #endif /* LABWC_XML_H */

--- a/include/osd.h
+++ b/include/osd.h
@@ -56,7 +56,6 @@ void osd_field_get_content(struct window_switcher_field *field,
 	struct buf *buf, struct view *view);
 
 /* Used by rcxml.c when parsing the config */
-struct window_switcher_field *osd_field_create(void);
 void osd_field_arg_from_xml_node(struct window_switcher_field *field,
 	const char *nodename, const char *content);
 bool osd_field_is_valid(struct window_switcher_field *field);

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -5532,6 +5532,7 @@ sub process {
 			if ($starts_with_if_while_etc && !length($s)
 					&& $filename ne "include/view.h"
 					&& $filename ne "include/common/array.h"
+					&& $filename ne "include/common/xml.h"
 					&& $filename ne "include/ssd-internal.h") {
 				CHK("BRACES", "[labwc-custom] open brace { expected after if/while/for/switch - even with single statement blocks");
 			}

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -23,4 +23,5 @@ labwc_sources += files(
   'surface-helpers.c',
   'spawn.c',
   'string-helpers.c',
+  'xml.c',
 )

--- a/src/common/string-helpers.c
+++ b/src/common/string-helpers.c
@@ -204,3 +204,14 @@ str_equal(const char *a, const char *b)
 {
 	return a == b || (a && b && !strcmp(a, b));
 }
+
+bool
+str_space_only(const char *s)
+{
+	for (; *s; s++) {
+		if (!isspace(*s)) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/src/common/xml.c
+++ b/src/common/xml.c
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <assert.h>
+#include <glib.h>
+#include <stdbool.h>
+#include <strings.h>
+#include "common/xml.h"
+
+/*
+ * Converts an attribute A.B.C="X" into <C><B><A>X</A></B></C>
+ */
+static xmlNode *
+create_attribute_tree(const xmlAttr *attr)
+{
+	gchar **parts = g_strsplit((char *)attr->name, ".", -1);
+	int length = g_strv_length(parts);
+	xmlNode *root_node = NULL;
+	xmlNode *parent_node = NULL;
+	xmlNode *current_node = NULL;
+
+	for (int i = length - 1; i >= 0; i--) {
+		gchar *part = parts[i];
+		if (!*part) {
+			/* Ignore empty string */
+			continue;
+		}
+		current_node = xmlNewNode(NULL, (xmlChar *)part);
+		if (parent_node) {
+			xmlAddChild(parent_node, current_node);
+		} else {
+			root_node = current_node;
+		}
+		parent_node = current_node;
+	}
+
+	/*
+	 * Note: empty attributes or attributes with only dots are forbidden
+	 * and root_node becomes never NULL here.
+	 */
+	assert(root_node);
+
+	xmlChar *content = xmlNodeGetContent(attr->children);
+	xmlNodeSetContent(current_node, content);
+	xmlFree(content);
+
+	g_strfreev(parts);
+	return root_node;
+}
+
+/*
+ * Consider <keybind name.action="ShowMenu" x.position.action="1" y.position="2" />.
+ * These three attributes are represented by following trees.
+ *    action(dst)---name
+ *    action(src)---position---x
+ *    action--------position---y
+ * When we call merge_two_trees(dst, src) for the first 2 trees above, we walk
+ * over the trees from their roots towards leaves, and merge the identical
+ * node 'action' like:
+ *    action(dst)---name
+ *         \--------position---x
+ *    action(src)---position---y
+ * And when we call merge_two_trees(dst, src) again, we walk over the dst tree
+ * like 'action'->'position'->'x' and the src tree like 'action'->'position'->'y'.
+ * First, we merge the identical node 'action' again like:
+ *    action---name
+ *         \---position(dst)---x
+ *          \--position(src)---y
+ * Next, we merge the identical node 'position' like:
+ *    action---name
+ *         \---position---x
+ *                   \----y
+ */
+static bool
+merge_two_trees(xmlNode *dst, xmlNode *src)
+{
+	bool merged = false;
+
+	while (dst && src && src->children
+			&& !strcasecmp((char *)dst->name, (char *)src->name)) {
+		xmlNode *next_dst = dst->last;
+		xmlNode *next_src = src->children;
+		xmlAddChild(dst, src->children);
+		xmlUnlinkNode(src);
+		xmlFreeNode(src);
+		src = next_src;
+		dst = next_dst;
+		merged = true;
+	}
+
+	return merged;
+}
+
+void
+lab_xml_expand_dotted_attributes(xmlNode *parent)
+{
+	xmlNode *old_first_child = parent->children;
+	xmlNode *prev_tree = NULL;
+
+	if (parent->type != XML_ELEMENT_NODE) {
+		return;
+	}
+
+	for (xmlAttr *attr = parent->properties; attr;) {
+		/* Convert the attribute with dots into an xml tree */
+		xmlNode *tree = create_attribute_tree(attr);
+		if (!tree) {
+			/* The attribute doesn't contain dots */
+			prev_tree = NULL;
+			attr = attr->next;
+			continue;
+		}
+
+		/* Try to merge the tree with the previous one */
+		if (!merge_two_trees(prev_tree, tree)) {
+			/* If not merged, add the tree as a new child */
+			if (old_first_child) {
+				xmlAddPrevSibling(old_first_child, tree);
+			} else {
+				xmlAddChild(parent, tree);
+			}
+			prev_tree = tree;
+		}
+
+		xmlAttr *next_attr = attr->next;
+		xmlRemoveProp(attr);
+		attr = next_attr;
+	}
+
+	for (xmlNode *node = parent->children; node; node = node->next) {
+		lab_xml_expand_dotted_attributes(node);
+	}
+}

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -943,6 +943,27 @@ set_font_attr(struct font *font, const char *nodename, const char *content)
 	}
 }
 
+static enum font_place
+enum_font_place(const char *place)
+{
+	if (!place || place[0] == '\0') {
+		return FONT_PLACE_NONE;
+	}
+	if (!strcasecmp(place, "ActiveWindow")) {
+		return FONT_PLACE_ACTIVEWINDOW;
+	} else if (!strcasecmp(place, "InactiveWindow")) {
+		return FONT_PLACE_INACTIVEWINDOW;
+	} else if (!strcasecmp(place, "MenuHeader")) {
+		return FONT_PLACE_MENUHEADER;
+	} else if (!strcasecmp(place, "MenuItem")) {
+		return FONT_PLACE_MENUITEM;
+	} else if (!strcasecmp(place, "OnScreenDisplay")
+			|| !strcasecmp(place, "OSD")) {
+		return FONT_PLACE_OSD;
+	}
+	return FONT_PLACE_UNKNOWN;
+}
+
 static void
 fill_font(char *nodename, char *content, enum font_place place)
 {
@@ -984,27 +1005,6 @@ fill_font(char *nodename, char *content, enum font_place place)
 	default:
 		break;
 	}
-}
-
-static enum font_place
-enum_font_place(const char *place)
-{
-	if (!place || place[0] == '\0') {
-		return FONT_PLACE_NONE;
-	}
-	if (!strcasecmp(place, "ActiveWindow")) {
-		return FONT_PLACE_ACTIVEWINDOW;
-	} else if (!strcasecmp(place, "InactiveWindow")) {
-		return FONT_PLACE_INACTIVEWINDOW;
-	} else if (!strcasecmp(place, "MenuHeader")) {
-		return FONT_PLACE_MENUHEADER;
-	} else if (!strcasecmp(place, "MenuItem")) {
-		return FONT_PLACE_MENUITEM;
-	} else if (!strcasecmp(place, "OnScreenDisplay")
-			|| !strcasecmp(place, "OSD")) {
-		return FONT_PLACE_OSD;
-	}
-	return FONT_PLACE_UNKNOWN;
 }
 
 static void

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -24,6 +24,7 @@
 #include "common/parse-double.h"
 #include "common/string-helpers.h"
 #include "common/three-state.h"
+#include "common/xml.h"
 #include "config/default-bindings.h"
 #include "config/keybind.h"
 #include "config/libinput.h"
@@ -1509,7 +1510,9 @@ rcxml_parse_xml(struct buf *b)
 		return;
 	}
 	struct parser_state init_state = {0};
-	xml_tree_walk(xmlDocGetRootElement(d), &init_state);
+	xmlNode *root = xmlDocGetRootElement(d);
+	lab_xml_expand_dotted_attributes(root);
+	xml_tree_walk(root, &init_state);
 	xmlFreeDoc(d);
 	xmlCleanupParser();
 }

--- a/src/osd-field.c
+++ b/src/osd-field.c
@@ -297,13 +297,6 @@ reset_format:
 	buf_reset(&field_result);
 }
 
-struct window_switcher_field *
-osd_field_create(void)
-{
-	struct window_switcher_field *field = znew(*field);
-	return field;
-}
-
 void
 osd_field_arg_from_xml_node(struct window_switcher_field *field,
 		const char *nodename, const char *content)

--- a/t/meson.build
+++ b/t/meson.build
@@ -3,15 +3,21 @@ test_lib = static_library(
   sources: files(
     '../src/common/buf.c',
     '../src/common/mem.c',
-    '../src/common/string-helpers.c'
+    '../src/common/string-helpers.c',
+    '../src/common/xml.c',
   ),
   include_directories: [labwc_inc],
-  dependencies: [dep_cmocka],
+  dependencies: [
+		dep_cmocka,
+		glib,
+		xml2,
+	],
 )
 
 tests = [
   'buf-simple',
   'str',
+  'xml',
 ]
 
 foreach t : tests
@@ -22,6 +28,7 @@ foreach t : tests
       sources: '@0@.c'.format(t),
       include_directories: [labwc_inc],
       link_with: [test_lib],
+			dependencies: [xml2],
     ),
     is_parallel: false,
   )

--- a/t/meson.build
+++ b/t/meson.build
@@ -5,12 +5,14 @@ test_lib = static_library(
     '../src/common/mem.c',
     '../src/common/string-helpers.c',
     '../src/common/xml.c',
+    '../src/common/parse-bool.c',
   ),
   include_directories: [labwc_inc],
   dependencies: [
 		dep_cmocka,
 		glib,
 		xml2,
+		wlroots,
 	],
 )
 

--- a/t/xml.c
+++ b/t/xml.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include <setjmp.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <cmocka.h>
+#include "common/macros.h"
+#include "common/xml.h"
+
+struct test_case {
+	const char *before, *after;
+} test_cases[] = {{
+	"<keybind name.action='ShowMenu' menu.action='root-menu' "
+		"x.position.action='1' y.position.action='2'/>",
+
+	"<keybind>"
+		"<action>"
+			"<name>ShowMenu</name>"
+			"<menu>root-menu</menu>"
+			"<position>"
+				"<x>1</x>"
+				"<y>2</y>"
+			"</position>"
+		"</action>"
+	"</keybind>"
+}, {
+	"<AAA aaa='111' bbb='222'/>",
+
+	"<AAA>"
+		"<aaa>111</aaa>"
+		"<bbb>222</bbb>"
+	"</AAA>"
+}, {
+	"<AAA aaa.bbb.ccc='111' ddd.ccc='222' eee.bbb.ccc='333'/>",
+
+	"<AAA><ccc>"
+		"<bbb><aaa>111</aaa></bbb>"
+		"<ddd>222</ddd>"
+		"<bbb><eee>333</eee></bbb>"
+	"</ccc></AAA>"
+}, {
+	"<AAA aaa.bbb.ccc='111' bbb.ccc='222' ddd.bbb.ccc='333'/>",
+
+	"<AAA><ccc><bbb>"
+		"<aaa>111</aaa>"
+		"222"
+		"<ddd>333</ddd>"
+	"</bbb></ccc></AAA>"
+}, {
+	"<AAA aaa.bbb='111' aaa.ddd='222'/>",
+
+	"<AAA>"
+		"<bbb><aaa>111</aaa></bbb>"
+		"<ddd><aaa>222</aaa></ddd>"
+	"</AAA>"
+}, {
+	"<AAA aaa.bbb='111' bbb='222' ccc.bbb='333'/>",
+
+	"<AAA><bbb>"
+		"<aaa>111</aaa>"
+		"222"
+		"<ccc>333</ccc>"
+	"</bbb></AAA>",
+}, {
+	"<AAA>"
+		"<BBB aaa.bbb='111'/>"
+		"<BBB aaa.bbb='111'/>"
+	"</AAA>",
+
+	"<AAA>"
+		"<BBB><bbb><aaa>111</aaa></bbb></BBB>"
+		"<BBB><bbb><aaa>111</aaa></bbb></BBB>"
+	"</AAA>",
+}, {
+	"<AAA bbb.ccc='111'>"
+		"<BBB>222</BBB>"
+	"</AAA>",
+
+	"<AAA>"
+		"<ccc><bbb>111</bbb></ccc>"
+		"<BBB>222</BBB>"
+	"</AAA>",
+}, {
+	"<AAA>"
+		"<BBB><CCC>111</CCC></BBB>"
+		"<BBB><CCC>111</CCC></BBB>"
+	"</AAA>",
+
+	"<AAA>"
+		"<BBB><CCC>111</CCC></BBB>"
+		"<BBB><CCC>111</CCC></BBB>"
+	"</AAA>",
+}, {
+	"<AAA aaa..bbb.ccc.='111' />",
+
+	"<AAA><ccc><bbb><aaa>111</aaa></bbb></ccc></AAA>"
+}};
+
+static void
+test_lab_xml_expand_dotted_attributes(void **state)
+{
+	(void)state;
+
+	for (size_t i = 0; i < ARRAY_SIZE(test_cases); i++) {
+		xmlDoc *doc = xmlReadDoc((xmlChar *)test_cases[i].before,
+					NULL, NULL, 0);
+		xmlNode *root = xmlDocGetRootElement(doc);
+
+		lab_xml_expand_dotted_attributes(root);
+
+		xmlBuffer *buf = xmlBufferCreate();
+		xmlNodeDump(buf, root->doc, root, 0, 0);
+		assert_string_equal(test_cases[i].after, (char *)buf->content);
+		xmlBufferFree(buf);
+
+		xmlFreeDoc(doc);
+	}
+}
+
+int main(int argc, char **argv)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_lab_xml_expand_dotted_attributes),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
- Remove state-machine variables in `rcxml.c`
- Convert all the attributes into nested/non-nested nodes so that we can just traverse `node->children`. This should also fix https://github.com/labwc/labwc/pull/2603#issuecomment-2708643312
- Support nested `If` actions
- Support `CDATA`
- Remove ordering constraint of attributes in `<keybind>`, `<mousebind>` and `<windowRule>` (#2391)

TODO:
- [ ] Do testing
- [ ] Decide how we should merge this giant patch. Perhaps we can create another branch in labwc repo, merge my patches above to it one-by-one, and eventually merge it to the master branch.
- [ ] Decide whether we should go with `LAB_XML_FOR_EACH()` macro. `scripts/check` is not happy with that.