### PR TITLE
rcxml: handle duplicated `<theme><titlebar><layout>` and `<windowSwitcher><fields>` entries

### DIFF
--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -202,8 +202,25 @@ fill_section(const char *content, struct wl_list *list, uint32_t *found_buttons)
 }
 
 static void
+clear_title_layout(void)
+{
+	struct title_button *button, *button_tmp;
+	wl_list_for_each_safe(button, button_tmp, &rc.title_buttons_left, link) {
+		wl_list_remove(&button->link);
+		zfree(button);
+	}
+	wl_list_for_each_safe(button, button_tmp, &rc.title_buttons_right, link) {
+		wl_list_remove(&button->link);
+		zfree(button);
+	}
+	rc.title_layout_loaded = false;
+}
+
+static void
 fill_title_layout(char *content)
 {
+	clear_title_layout();
+
 	struct wl_list *sections[] = {
 		&rc.title_buttons_left,
 		&rc.title_buttons_right,
@@ -1978,15 +1995,7 @@ rcxml_finish(void)
 	zfree(rc.workspace_config.prefix);
 	zfree(rc.tablet.output_name);
 
-	struct title_button *p, *p_tmp;
-	wl_list_for_each_safe(p, p_tmp, &rc.title_buttons_left, link) {
-		wl_list_remove(&p->link);
-		zfree(p);
-	}
-	wl_list_for_each_safe(p, p_tmp, &rc.title_buttons_right, link) {
-		wl_list_remove(&p->link);
-		zfree(p);
-	}
+	clear_title_layout();
 
 	struct usable_area_override *area, *area_tmp;
 	wl_list_for_each_safe(area, area_tmp, &rc.usable_area_overrides, link) {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -359,6 +359,16 @@ fill_window_rule(char *nodename, char *content, struct parser_state *state)
 }
 
 static void
+clear_window_switcher_fields(void)
+{
+	struct window_switcher_field *field, *field_tmp;
+	wl_list_for_each_safe(field, field_tmp, &rc.window_switcher.fields, link) {
+		wl_list_remove(&field->link);
+		osd_field_free(field);
+	}
+}
+
+static void
 fill_window_switcher_field(char *nodename, char *content, struct parser_state *state)
 {
 	if (!strcasecmp(nodename, "field.fields.windowswitcher")) {
@@ -1381,6 +1391,7 @@ xml_tree_walk(xmlNode *node, struct parser_state *state)
 			continue;
 		}
 		if (!strcasecmp((char *)n->name, "fields")) {
+			clear_window_switcher_fields();
 			state->in_window_switcher_field = true;
 			traverse(n, state);
 			state->in_window_switcher_field = false;
@@ -2042,11 +2053,7 @@ rcxml_finish(void)
 
 	regions_destroy(NULL, &rc.regions);
 
-	struct window_switcher_field *field, *field_tmp;
-	wl_list_for_each_safe(field, field_tmp, &rc.window_switcher.fields, link) {
-		wl_list_remove(&field->link);
-		osd_field_free(field);
-	}
+	clear_window_switcher_fields();
 
 	struct window_rule *rule, *rule_tmp;
 	wl_list_for_each_safe(rule, rule_tmp, &rc.window_rules, link) {


### PR DESCRIPTION
Fixes #2646.

Also handles duplicated `<windowSwitcher><fields>` entries so that users can overwrite the window switcher layout defined in `/etc/xdg/labwc/rc.xml` with `~/.config/labwc/rc.xml`, without overflowing contents.