### PR TITLE
feat: add scroll wheel emulation for cursor motion

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -361,6 +361,17 @@ Actions are used in menus and keyboard/mouse bindings.
 	Use together with the WarpCursor action to not just hide the cursor but
 	to additionally move it away to prevent e.g. hover effects.
 
+*<action name="EnableScrollWheelEmulation" />*++
+*<action name="DisableScrollWheelEmulation" />*++
+*<action name="ToggleScrollWheelEmulation">*
+	Enable, disable or toggle scroll wheel emulation on cursor motion,
+	respectively. This can be useful for trackball mouses to use the
+	rotating ball not just for moving the cursor, but also for (mouse wheel)
+	scrolling.
+
+	See also *<libinput><scrollFactor>* in labwc-config(5) for fine tuning
+	the scroll speed.
+
 *<action name="EnableTabletMouseEmulation" />*++
 *<action name="DisableTabletMouseEmulation" />*++
 *<action name="ToggleTabletMouseEmulation">*

--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -156,6 +156,10 @@ void cursor_emulate_move_absolute(struct seat *seat,
 		double x, double y, uint32_t time_msec);
 void cursor_emulate_button(struct seat *seat,
 		uint32_t button, enum wl_pointer_button_state state, uint32_t time_msec);
+void cursor_emulate_axis(struct seat *seat,
+		struct wlr_input_device *device,
+		enum wl_pointer_axis orientation, double delta, double delta_discrete,
+		enum wl_pointer_axis_source source, uint32_t time_msec);
 void cursor_finish(struct seat *seat);
 
 #endif /* LABWC_CURSOR_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -115,6 +115,7 @@ struct seat {
 	struct {
 		double x, y;
 	} smooth_scroll_offset;
+	bool cursor_scroll_wheel_emulation;
 
 	/*
 	 * The surface whose keyboard focus is temporarily cleared with

--- a/src/action.c
+++ b/src/action.c
@@ -116,6 +116,9 @@ enum action_type {
 	ACTION_TYPE_SHADE,
 	ACTION_TYPE_UNSHADE,
 	ACTION_TYPE_TOGGLE_SHADE,
+	ACTION_TYPE_ENABLE_SCROLL_WHEEL_EMULATION,
+	ACTION_TYPE_DISABLE_SCROLL_WHEEL_EMULATION,
+	ACTION_TYPE_TOGGLE_SCROLL_WHEEL_EMULATION,
 	ACTION_TYPE_ENABLE_TABLET_MOUSE_EMULATION,
 	ACTION_TYPE_DISABLE_TABLET_MOUSE_EMULATION,
 	ACTION_TYPE_TOGGLE_TABLET_MOUSE_EMULATION,
@@ -182,6 +185,9 @@ const char *action_names[] = {
 	"Shade",
 	"Unshade",
 	"ToggleShade",
+	"EnableScrollWheelEmulation",
+	"DisableScrollWheelEmulation",
+	"ToggleScrollWheelEmulation",
 	"EnableTabletMouseEmulation",
 	"DisableTabletMouseEmulation",
 	"ToggleTabletMouseEmulation",
@@ -1308,6 +1314,16 @@ actions_run(struct view *activator, struct server *server,
 			if (view) {
 				view_set_shade(view, false);
 			}
+			break;
+		case ACTION_TYPE_ENABLE_SCROLL_WHEEL_EMULATION:
+			server->seat.cursor_scroll_wheel_emulation = true;
+			break;
+		case ACTION_TYPE_DISABLE_SCROLL_WHEEL_EMULATION:
+			server->seat.cursor_scroll_wheel_emulation = false;
+			break;
+		case ACTION_TYPE_TOGGLE_SCROLL_WHEEL_EMULATION:
+			server->seat.cursor_scroll_wheel_emulation =
+				!server->seat.cursor_scroll_wheel_emulation;
 			break;
 		case ACTION_TYPE_ENABLE_TABLET_MOUSE_EMULATION:
 			rc.tablet.force_mouse_emulation = true;


### PR DESCRIPTION
Solution for https://github.com/labwc/labwc/discussions/2672

Simple keybinding example:

```xml
<keybind key="A-W-s">
  <action name="ToggleScrollWheelEmulation" />
</keybind>
```

But this should also work for mouse bindings, like enabling emulation on button down and disabling on button up.

Includes https://github.com/labwc/labwc/pull/2704