### PR TITLE
docs: rc.xml.all: Fix reference to labwc-config manpage. Unwefify.

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -86,9 +86,9 @@
   </windowSwitcher>
 
   <!--
-    We support many other kinds of contents in the window switcher like below.
+    Many other kinds of content are supported in the window switcher like below.
     Some contents are fixed-length and others are variable-length.
-    See "man 5 labwc" for details.
+    See "man 5 labwc-config" for details.
 
     <windowSwitcher show="yes" preview="no" outlines="no" allWorkspaces="yes">
       <fields>


### PR DESCRIPTION
There is no "labwc" manpage in section 5 (man 5 labwc may fail or show e.g. labwc-action manpage).

Replaced one 'we' with passive form, to match the common style in docs/.

--

For the 'unwefify' part I did just somewhat straightforward active->passive change, but
there is change from 'contents' to 'content' - one reason is that it fits into 80 chars as
2 chars less (is->are would be the other). Also the 'content' match the 'content=...' in there.

One page that shows the difference of meaning of that with 'contents' alternative can be
seen in
https://textranch.com/c/many-kinds-of-things-or-many-kinds-of-thing/