### PR TITLE
view: handle initially minimized views (simple approach)

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2436,7 +2436,18 @@ static void
 handle_map(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, mappable.map);
-	view->impl->map(view);
+	if (view->minimized) {
+		/*
+		 * The view->impl functions do not directly support
+		 * mapping a view while minimized. Instead, mark it as
+		 * not minimized, map it, and then minimize it again.
+		 */
+		view->minimized = false;
+		view->impl->map(view);
+		view_minimize(view, true);
+	} else {
+		view->impl->map(view);
+	}
 }
 
 static void


### PR DESCRIPTION
Taking the simplistic approach of waiting until the view is mapped to minimize it. A more optimal but invasive approach could be to modify the `view->impl->map` functions to directly support map-while-minimized, but this would require some careful disentangling of the concepts of "minimized" and "unmapped", which overlap a bit in labwc.

Fixes: #2627

@tokyo4j if you could test that this fixes the issue you saw, I'd appreciate it.