### PR TITLE
docs: list all supported font weights

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -546,7 +546,8 @@ extending outward from the snapped edge.
 	Font slant (normal, oblique or italic). Default is normal.
 
 *<theme><font place=""><weight>*
-	Font weight (normal or bold). Default is normal.
+	Font weight (normal, thin, ultralight, light, semilight, book, medium,
+	semibold, bold, ultrabold, heavy, ultraheavy). Default is normal.
 
 ## MARGIN
 


### PR DESCRIPTION
Forgot to check for in #2692.