### PR TITLE
Parse touch configs in reverse order to enable overriding

### DIFF
--- a/src/config/touch.c
+++ b/src/config/touch.c
@@ -9,7 +9,7 @@ static struct touch_config_entry *
 find_default_config(void)
 {
 	struct touch_config_entry *entry;
-	wl_list_for_each(entry, &rc.touch_configs, link) {
+	wl_list_for_each_reverse(entry, &rc.touch_configs, link) {
 		if (!entry->device_name) {
 			wlr_log(WLR_INFO, "found default touch configuration");
 			return entry;
@@ -23,7 +23,7 @@ touch_find_config_for_device(char *device_name)
 {
 	wlr_log(WLR_INFO, "find touch configuration for %s", device_name);
 	struct touch_config_entry *entry;
-	wl_list_for_each(entry, &rc.touch_configs, link) {
+	wl_list_for_each_reverse(entry, &rc.touch_configs, link) {
 		if (entry->device_name && !strcasecmp(entry->device_name, device_name)) {
 			wlr_log(WLR_INFO, "found touch configuration for %s", device_name);
 			return entry;


### PR DESCRIPTION
I'm not sure if this is the best fix for the problem I have found, but it is the shortest...

If multiple touch configurations for the same device are defined - so more than one is defined in /etc/xdg/labwc/rc.xml, or one is defined in /etc/xdg/labwc/rc.xml and another is defined in ~/.config/labwc/rc.xml, I would expect the one which is read in last to be the one which takes effect. So I would expect the config in the local file to override that in the global file, or a config at the bottom of the global file to override one higher up in the file.

But what happens is that the first config found is the one which takes effect. This means that it is impossible to override a global config for a touch device with one in the local config file; the one in the global file takes precedence.

This seems to be handled in the cases of mouse and keyboard keybinds by the deduplicate functions which are used to validate the bindings after they are loaded, which may be a better solution, but simply reversing the order in which the loaded touch configs are parsed so they are searched from end to start for the relevant device rather than from start to end seems to work for me.