### PR TITLE
rcxml: validate total osd field width

### DIFF
--- a/include/osd.h
+++ b/include/osd.h
@@ -59,7 +59,7 @@ void osd_field_get_content(struct window_switcher_field *field,
 struct window_switcher_field *osd_field_create(void);
 void osd_field_arg_from_xml_node(struct window_switcher_field *field,
 	const char *nodename, const char *content);
-bool osd_field_validate(struct window_switcher_field *field);
+bool osd_field_is_valid(struct window_switcher_field *field);
 void osd_field_free(struct window_switcher_field *field);
 
 #endif // LABWC_OSD_H

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1941,9 +1941,11 @@ validate(void)
 	validate_actions();
 
 	/* OSD fields */
+	int field_width_sum = 0;
 	struct window_switcher_field *field, *field_tmp;
 	wl_list_for_each_safe(field, field_tmp, &rc.window_switcher.fields, link) {
-		if (!osd_field_validate(field)) {
+		field_width_sum += field->width;
+		if (!osd_field_is_valid(field) || field_width_sum > 100) {
 			wlr_log(WLR_ERROR, "Deleting invalid window switcher field %p", field);
 			wl_list_remove(&field->link);
 			osd_field_free(field);

--- a/src/osd-field.c
+++ b/src/osd-field.c
@@ -352,7 +352,7 @@ osd_field_arg_from_xml_node(struct window_switcher_field *field,
 }
 
 bool
-osd_field_validate(struct window_switcher_field *field)
+osd_field_is_valid(struct window_switcher_field *field)
 {
 	if (field->content == LAB_FIELD_NONE) {
 		wlr_log(WLR_ERROR, "Invalid OSD field: no content set");


### PR DESCRIPTION
Before this patch, window switcher fields could overflow if the sum of `<windowSwitcher><fields><field width="">` exceeds 100%.