### PR TITLE
Gracefully exit when no fonts are installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,3 +262,15 @@ jobs:
             meson compile -C build-gcc-gdb
             LABWC_RUNS=2 scripts/ci/smoke-test.sh build-gcc-gdb
           ' | $TARGET
+
+      - name: Build with gcc - catch no font installed case
+        if: matrix.name == 'Void-musl'
+        run: |
+          echo '
+            cd "$GITHUB_WORKSPACE"
+            xbps-remove -y dejavu-fonts-ttf
+            export CC=gcc
+            meson setup build-gcc-nofont -Dxwayland=enabled --werror
+            meson compile -C build-gcc-nofont
+            LABWC_EXPECT_RETURNCODE=1 scripts/ci/smoke-test.sh build-gcc-nofont
+          ' | $TARGET

--- a/scripts/ci/smoke-test.sh
+++ b/scripts/ci/smoke-test.sh
@@ -2,6 +2,8 @@
 
 : ${LABWC_RUNS:=1}
 : ${LABWC_LEAK_TEST:=0}
+: ${LABWC_EXPECT_RETURNCODE:=0}
+: ${LABWC_VERBOSE:=0}
 
 if ! test -x "$1/labwc"; then
 	echo "$1/labwc not found"
@@ -55,13 +57,20 @@ for((i=1; i<=LABWC_RUNS; i++)); do
 	printf "Starting run %2s\n" $i
 	output=$(gdb_run 2>&1)
 	ret=$?
-	if test $ret -ne 0; then
+	if test $ret -ne $LABWC_EXPECT_RETURNCODE; then
 		echo "Crash encountered:"
 		echo "------------------"
 		echo "$output"
 		break
+	elif test $LABWC_VERBOSE -eq 1; then
+		echo "------------------"
+		echo "$output"
 	fi
 done
 
 echo "labwc terminated with return code $ret"
-exit $ret
+if test $ret -eq $LABWC_EXPECT_RETURNCODE; then
+	exit 0;
+else
+	exit 1;
+fi


### PR DESCRIPTION
...rather than emitting ugly errors like:

```
labwc: ../src/buffer.c:85: buffer_adopt_cairo_surface: Assertion `cairo_image_surface_get_format(surface) == CAIRO_FORMAT_ARGB32' failed.
```

Ref: #1526, [labwc-git AUR](https://aur.archlinux.org/packages/labwc-git#comment-984158)