### PR TITLE
Guard against negative sizes in `wlr_scene_rect/buffer`

### DIFF
--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -8,6 +8,7 @@
 #include <wlr/util/box.h>
 #include "buffer.h"
 #include "common/graphic-helpers.h"
+#include "common/macros.h"
 #include "common/mem.h"
 
 static void
@@ -57,7 +58,7 @@ multi_rect_set_size(struct multi_rect *rect, int width, int height)
 	 * +-+-----+-+   |
 	 * +---------+  ---
 	 */
-	for (size_t i = 0; i < 3; i++) {
+	for (int i = 0; i < 3; i++) {
 		/* Reposition, top and left don't ever change */
 		wlr_scene_node_set_position(&rect->right[i]->node,
 			width - (i + 1) * line_width, (i + 1) * line_width);
@@ -66,13 +67,17 @@ multi_rect_set_size(struct multi_rect *rect, int width, int height)
 
 		/* Update sizes */
 		wlr_scene_rect_set_size(rect->top[i],
-			width - i * line_width * 2, line_width);
+			MAX(width - i * line_width * 2, 0),
+			line_width);
 		wlr_scene_rect_set_size(rect->bottom[i],
-			width - i * line_width * 2, line_width);
+			MAX(width - i * line_width * 2, 0),
+			line_width);
 		wlr_scene_rect_set_size(rect->left[i],
-			line_width, height - (i + 1) * line_width * 2);
+			line_width,
+			MAX(height - (i + 1) * line_width * 2, 0));
 		wlr_scene_rect_set_size(rect->right[i],
-			line_width, height - (i + 1) * line_width * 2);
+			line_width,
+			MAX(height - (i + 1) * line_width * 2, 0));
 	}
 }
 

--- a/src/common/scaled-icon-buffer.c
+++ b/src/common/scaled-icon-buffer.c
@@ -79,6 +79,9 @@ struct scaled_icon_buffer *
 scaled_icon_buffer_create(struct wlr_scene_tree *parent, struct server *server,
 	int width, int height)
 {
+	assert(parent);
+	assert(width >= 0 && height >= 0);
+
 	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
 		parent, &impl, /* drop_buffer */ true);
 	struct scaled_icon_buffer *self = znew(*self);

--- a/src/common/scaled-img-buffer.c
+++ b/src/common/scaled-img-buffer.c
@@ -49,7 +49,10 @@ struct scaled_img_buffer *
 scaled_img_buffer_create(struct wlr_scene_tree *parent, struct lab_img *img,
 	int width, int height)
 {
+	assert(parent);
 	assert(img);
+	assert(width >= 0 && height >= 0);
+
 	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
 		parent, &impl, /* drop_buffer */ true);
 	struct scaled_img_buffer *self = znew(*self);

--- a/src/common/scaled-rect-buffer.c
+++ b/src/common/scaled-rect-buffer.c
@@ -95,14 +95,16 @@ struct scaled_rect_buffer *scaled_rect_buffer_create(
 	/* TODO: support rounded corners for menus and OSDs */
 
 	assert(parent);
+	assert(width >= 0 && height >= 0);
+
 	struct scaled_rect_buffer *self = znew(*self);
 	struct scaled_scene_buffer *scaled_buffer = scaled_scene_buffer_create(
 		parent, &impl, /* drop_buffer */ true);
 	scaled_buffer->data = self;
 	self->scaled_buffer = scaled_buffer;
 	self->scene_buffer = scaled_buffer->scene_buffer;
-	self->width = MAX(width, 1);
-	self->height = MAX(height, 1);
+	self->width = width;
+	self->height = height;
 	self->border_width = border_width;
 	memcpy(self->fill_color, fill_color, sizeof(self->fill_color));
 	memcpy(self->border_color, border_color, sizeof(self->border_color));

--- a/src/common/scaled-scene-buffer.c
+++ b/src/common/scaled-scene-buffer.c
@@ -227,6 +227,9 @@ scaled_scene_buffer_request_update(struct scaled_scene_buffer *self,
 		int width, int height)
 {
 	assert(self);
+	assert(width >= 0);
+	assert(height >= 0);
+
 	struct scaled_scene_buffer_cache_entry *cache_entry, *cache_entry_tmp;
 	wl_list_for_each_safe(cache_entry, cache_entry_tmp, &self->cache, link) {
 		_cache_entry_destroy(cache_entry, self->drop_buffer);

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -49,7 +49,7 @@ ssd_border_create(struct ssd *ssd)
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_BOTTOM, parent,
 			full_width, theme->border_width, 0, height, color);
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_TOP, parent,
-			width - 2 * corner_width, theme->border_width,
+			MAX(width - 2 * corner_width, 0), theme->border_width,
 			theme->border_width + corner_width,
 			-(ssd->titlebar.height + theme->border_width), color);
 	} FOR_EACH_END
@@ -123,7 +123,7 @@ ssd_border_update(struct ssd *ssd)
 		: 0;
 	int top_width = ssd->titlebar.height <= 0 || ssd->state.was_squared
 		? full_width
-		: width - 2 * corner_width;
+		: MAX(width - 2 * corner_width, 0);
 	int top_x = ssd->titlebar.height <= 0 || ssd->state.was_squared
 		? 0
 		: theme->border_width + corner_width;

--- a/src/ssd/ssd-part.c
+++ b/src/ssd/ssd-part.c
@@ -55,15 +55,7 @@ add_scene_rect(struct wl_list *list, enum ssd_part_type type,
 	struct wlr_scene_tree *parent, int width, int height,
 	int x, int y, float color[4])
 {
-	/*
-	 * When initialized without surface being mapped,
-	 * size may be negative. Just set to 0, next call
-	 * to ssd_*_update() will update the rect to use
-	 * its correct size.
-	 */
-	width = width >= 0 ? width : 0;
-	height = height >= 0 ? height : 0;
-
+	assert(width >= 0 && height >= 0);
 	struct ssd_part *part = add_scene_part(list, type);
 	part->node = &wlr_scene_rect_create(
 		parent, width, height, color)->node;

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -32,8 +32,8 @@ static void
 corner_scale_crop(struct wlr_scene_buffer *buffer, int horizontal_overlap,
 		int vertical_overlap, int corner_size)
 {
-	int width = corner_size - horizontal_overlap;
-	int height = corner_size - vertical_overlap;
+	int width = MAX(corner_size - horizontal_overlap, 0);
+	int height = MAX(corner_size - vertical_overlap, 0);
 	struct wlr_fbox src_box = {
 		.x = horizontal_overlap,
 		.y = vertical_overlap,
@@ -127,7 +127,7 @@ set_shadow_part_geometry(struct ssd_part *part, int width, int height,
 		y = -titlebar_height + inset;
 		wlr_scene_node_set_position(part->node, x, y);
 		wlr_scene_buffer_set_dest_size(
-			scene_buf, visible_shadow_width, height - 2 * inset);
+			scene_buf, visible_shadow_width, MAX(height - 2 * inset, 0));
 		wlr_scene_node_set_enabled(part->node, show_sides);
 		break;
 	case LAB_SSD_PART_BOTTOM:
@@ -135,7 +135,7 @@ set_shadow_part_geometry(struct ssd_part *part, int width, int height,
 		y = -titlebar_height + height;
 		wlr_scene_node_set_position(part->node, x, y);
 		wlr_scene_buffer_set_dest_size(
-			scene_buf, width - 2 * inset, visible_shadow_width);
+			scene_buf, MAX(width - 2 * inset, 0), visible_shadow_width);
 		wlr_scene_node_set_enabled(part->node, show_topbottom);
 		break;
 	case LAB_SSD_PART_LEFT:
@@ -143,7 +143,7 @@ set_shadow_part_geometry(struct ssd_part *part, int width, int height,
 		y = -titlebar_height + inset;
 		wlr_scene_node_set_position(part->node, x, y);
 		wlr_scene_buffer_set_dest_size(
-			scene_buf, visible_shadow_width, height - 2 * inset);
+			scene_buf, visible_shadow_width, MAX(height - 2 * inset, 0));
 		wlr_scene_node_set_enabled(part->node, show_sides);
 		break;
 	case LAB_SSD_PART_TOP:
@@ -151,7 +151,7 @@ set_shadow_part_geometry(struct ssd_part *part, int width, int height,
 		y = -titlebar_height - visible_shadow_width;
 		wlr_scene_node_set_position(part->node, x, y);
 		wlr_scene_buffer_set_dest_size(
-			scene_buf, width - 2 * inset, visible_shadow_width);
+			scene_buf, MAX(width - 2 * inset, 0), visible_shadow_width);
 		wlr_scene_node_set_enabled(part->node, show_topbottom);
 		break;
 	default:

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -58,7 +58,7 @@ ssd_titlebar_create(struct ssd *ssd)
 
 		/* Background */
 		add_scene_rect(&subtree->parts, LAB_SSD_PART_TITLEBAR, parent,
-			width - corner_width * 2, theme->titlebar_height,
+			MAX(width - corner_width * 2, 0), theme->titlebar_height,
 			corner_width, 0, color);
 		add_scene_buffer(&subtree->parts, LAB_SSD_PART_TITLEBAR_CORNER_LEFT, parent,
 			corner_top_left, -rc.theme->border_width, -rc.theme->border_width);
@@ -153,7 +153,7 @@ set_squared_corners(struct ssd *ssd, bool enable)
 		part = ssd_get_part(&subtree->parts, LAB_SSD_PART_TITLEBAR);
 		wlr_scene_node_set_position(part->node, x, 0);
 		wlr_scene_rect_set_size(wlr_scene_rect_from_node(part->node),
-			width - 2 * x, theme->titlebar_height);
+			MAX(width - 2 * x, 0), theme->titlebar_height);
 
 		part = ssd_get_part(&subtree->parts, LAB_SSD_PART_TITLEBAR_CORNER_LEFT);
 		wlr_scene_node_set_enabled(part->node, !enable);
@@ -204,9 +204,10 @@ static void
 update_visible_buttons(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
-	int width = view->current.width - (2 * view->server->theme->window_titlebar_padding_width);
-	int button_width = view->server->theme->window_button_width;
-	int button_spacing = view->server->theme->window_button_spacing;
+	struct theme *theme = view->server->theme;
+	int width = MAX(view->current.width - 2 * theme->window_titlebar_padding_width, 0);
+	int button_width = theme->window_button_width;
+	int button_spacing = theme->window_button_spacing;
 	int button_count_left = wl_list_length(&rc.title_buttons_left);
 	int button_count_right = wl_list_length(&rc.title_buttons_right);
 
@@ -301,7 +302,7 @@ ssd_titlebar_update(struct ssd *ssd)
 		part = ssd_get_part(&subtree->parts, LAB_SSD_PART_TITLEBAR);
 		wlr_scene_rect_set_size(
 			wlr_scene_rect_from_node(part->node),
-			width - bg_offset * 2, theme->titlebar_height);
+			MAX(width - bg_offset * 2, 0), theme->titlebar_height);
 
 		x = theme->window_titlebar_padding_width;
 		wl_list_for_each(b, &rc.title_buttons_left, link) {


### PR DESCRIPTION
This PR ensures that the sizes set in `wlr_scene_{rect,buffer}` never goes negative, which crashes in wlroots 0.19.

The 1st commit temporarily updates `wlroots.wrap` to depend on my fork of wlroots which has cherry-picked the commits that added abortions for negative sizes. This should be dropped before merging.

The 2nd commit guards against negative sizes in menu scenes (possible with `menu.width.{min,max}: 1`). It checks the lengths marked with red in the diagram below:

![menu-coordinates](https://github.com/user-attachments/assets/0573130e-9589-4245-a0fb-eb77e7d5bbd8)

Likewise, the 3rd commit handles negative sizes in window switcher OSD (possible with `osd.window-switcher.width: 1`):

![osd-coordinates](https://github.com/user-attachments/assets/9ba742de-ad9f-47cc-9db6-ed13028d0672)

The 4th commit handles negative sizes in SSD by just adding `MAX()` macros. Another possible solution suggested by @Consolatis in IRC is to enforce minimal window size so that sizes of components like edge drop-shadows never become negative, but I prefer just adding `MAX()` macros because:
- Enforcing minimal window sizes via `xdg_toplevel.set_min_size` doesn't prevent ridiculously small window sizes, since some clients (e.g. workrave #1947) can still submit tiny buffers. Maybe we can add some padding between the client surface and SSD like #1959 in such cases to prevent broken look, but I prefer the current behavior and implementation.
- We are always calling `ssd_create()` for 0x0 window size when a client enables decorations before mapping a surface. If we try to prevent negative sizes by not creating SSD for tiny windows, we will need change this to call `ssd_create()` on map, which sounds a bit annoying to address.

The 5th commit handles negative sizes in `multi_rect`, which can happen when a tiny window is selected with window switcher and `osd.window-switcher.preview.border.width` is large, by just adding `MAX()` macros. This can be improved by #2241 which hides inner outlines when the rectangle size is smaller than (border width) * 6 and bigger than (border width) * 2.

The 6th commit adds asserts for negative sizes passed to `scaled_*_buffer`s to make it easier to find bugs in the future.