### PR TITLE
config: drop xwayland persistence workaround for wlroots < 0.18.2

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -173,7 +173,7 @@ this is for compatibility with Openbox.
   <allowTearing>no</allowTearing>
   <autoEnableOutputs>yes</autoEnableOutputs>
   <reuseOutputMode>no</reuseOutputMode>
-  <xwaylandPersistence>yes</xwaylandPersistence>
+  <xwaylandPersistence>no</xwaylandPersistence>
 </core>
 ```
 
@@ -228,12 +228,7 @@ this is for compatibility with Openbox.
 *<core><xwaylandPersistence>* [yes|no]
 	Keep XWayland alive even when no clients are connected, rather than
 	using a "lazy" policy that allows the server to launch on demand and die
-	when it is no longer needed.
-
-	When labwc is compiled with wlroots 0.18.2 or later, the default is no.
-	When labwc is compiled with wlroots < 0.18.2, the default is yes to
-	avoid a wlroots bug that can result in compositor crashes when
-	performing drag-and-drop actions when the XWayland server is shut down.
+	when it is no longer needed. Default is no.
 
 	Note: changing this setting requires a restart of labwc.
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -14,7 +14,7 @@
     <allowTearing>no</allowTearing>
     <autoEnableOutputs>yes</autoEnableOutputs>
     <reuseOutputMode>no</reuseOutputMode>
-    <xwaylandPersistence>yes</xwaylandPersistence>
+    <xwaylandPersistence>no</xwaylandPersistence>
   </core>
 
   <placement>

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -14,7 +14,6 @@
 #include <wayland-server-core.h>
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
-#include <wlr/version.h>
 #include "action.h"
 #include "common/dir.h"
 #include "common/list.h"
@@ -37,9 +36,6 @@
 #include "view.h"
 #include "window-rules.h"
 #include "workspaces.h"
-
-#define LAB_WLR_VERSION_OLDER_THAN(major, minor, micro) \
-	(WLR_VERSION_NUM < (((major) << 16) | ((minor) << 8) | (micro)))
 
 struct parser_state {
 	bool in_regions;
@@ -1126,15 +1122,6 @@ entry(xmlNode *node, char *nodename, char *content, struct parser_state *state)
 		}
 	} else if (!strcasecmp(nodename, "xwaylandPersistence.core")) {
 		set_bool(content, &rc.xwayland_persistence);
-
-#if LAB_WLR_VERSION_OLDER_THAN(0, 18, 2)
-		if (!rc.xwayland_persistence) {
-			wlr_log(WLR_ERROR, "to avoid the risk of a fatal crash, "
-				"setting xwaylandPersistence to 'no' is only "
-				"recommended when labwc is compiled against "
-				"wlroots >= 0.18.2. See #2371 for details.");
-		}
-#endif
 	} else if (!strcasecmp(nodename, "x.cascadeOffset.placement")) {
 		rc.placement_cascade_offset_x = atoi(content);
 	} else if (!strcasecmp(nodename, "y.cascadeOffset.placement")) {
@@ -1514,16 +1501,7 @@ rcxml_init(void)
 	rc.allow_tearing = false;
 	rc.auto_enable_outputs = true;
 	rc.reuse_output_mode = false;
-
-#if LAB_WLR_VERSION_OLDER_THAN(0, 18, 2)
-	/*
-	 * For wlroots < 0.18.2, keep xwayland alive by default to work around
-	 * a fatal crash when the X server is terminated during drag-and-drop.
-	 */
-	rc.xwayland_persistence = true;
-#else
 	rc.xwayland_persistence = false;
-#endif
 
 	init_font_defaults(&rc.font_activewindow);
 	init_font_defaults(&rc.font_inactivewindow);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1115,13 +1115,13 @@ entry(xmlNode *node, char *nodename, char *content, struct parser_state *state)
 		set_bool(content, &rc.auto_enable_outputs);
 	} else if (!strcasecmp(nodename, "reuseOutputMode.core")) {
 		set_bool(content, &rc.reuse_output_mode);
+	} else if (!strcasecmp(nodename, "xwaylandPersistence.core")) {
+		set_bool(content, &rc.xwayland_persistence);
 	} else if (!strcmp(nodename, "policy.placement")) {
 		enum view_placement_policy policy = view_placement_parse(content);
 		if (policy != LAB_PLACE_INVALID) {
 			rc.placement_policy = policy;
 		}
-	} else if (!strcasecmp(nodename, "xwaylandPersistence.core")) {
-		set_bool(content, &rc.xwayland_persistence);
 	} else if (!strcasecmp(nodename, "x.cascadeOffset.placement")) {
 		rc.placement_cascade_offset_x = atoi(content);
 	} else if (!strcasecmp(nodename, "y.cascadeOffset.placement")) {


### PR DESCRIPTION
We enabled xwayland persistence for wlroots < 0.18.2 to prevent crashes, but it's no longer needed since we now depend on wlroots 0.19.