### PR TITLE
treewide: remove empty statements in switch cases

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -77,10 +77,9 @@ desktop_focus_view(struct view *view, bool raise)
 		workspaces_switch_to(view->workspace, /*update_focus*/ false);
 	}
 
+	struct seat *seat = &view->server->seat;
 	switch (view_wants_focus(view)) {
 	case VIEW_WANTS_FOCUS_ALWAYS:
-		; /* works around "a label can only be part of a statement" */
-		struct seat *seat = &view->server->seat;
 		if (view->surface != seat->seat->keyboard_state.focused_surface) {
 			seat_focus_surface(seat, view->surface);
 		}

--- a/src/server.c
+++ b/src/server.c
@@ -147,6 +147,7 @@ handle_sigchld(int signal, void *data)
 		return 0;
 	}
 
+	const char *signame;
 	switch (info.si_code) {
 	case CLD_EXITED:
 		wlr_log(info.si_status == 0 ? WLR_DEBUG : WLR_ERROR,
@@ -155,8 +156,7 @@ handle_sigchld(int signal, void *data)
 		break;
 	case CLD_KILLED:
 	case CLD_DUMPED:
-		; /* works around "a label can only be part of a statement" */
-		const char *signame = strsignal(info.si_status);
+		signame = strsignal(info.si_status);
 		wlr_log(WLR_ERROR,
 			"spawned child %ld terminated with signal %d (%s)",
 				(long)info.si_pid, info.si_status,

--- a/src/ssd/resize-indicator.c
+++ b/src/ssd/resize-indicator.c
@@ -168,24 +168,19 @@ resize_indicator_update(struct view *view)
 		view_box.height = view_effective_height(view, /* use_pending */ false);
 	}
 
-	switch (view->server->input_mode) {
-	case LAB_INPUT_STATE_RESIZE:
-		; /* works around "a label can only be part of a statement" */
+	if (view->server->input_mode == LAB_INPUT_STATE_RESIZE) {
 		struct view_size_hints hints = view_get_size_hints(view);
 		snprintf(text, sizeof(text), "%d x %d",
 			MAX(0, view_box.width - hints.base_width)
 				/ MAX(1, hints.width_inc),
 			MAX(0, view_box.height - hints.base_height)
 				/ MAX(1, hints.height_inc));
-		break;
-	case LAB_INPUT_STATE_MOVE:
-		; /* works around "a label can only be part of a statement" */
+	} else if (view->server->input_mode == LAB_INPUT_STATE_MOVE) {
 		struct border margin = ssd_get_margin(view->ssd);
 		snprintf(text, sizeof(text), "%d , %d",
 			view_box.x - margin.left,
 			view_box.y - margin.top);
-		break;
-	default:
+	} else {
 		wlr_log(WLR_ERROR, "Invalid input mode for indicator update %u",
 			view->server->input_mode);
 		return;


### PR DESCRIPTION
To address:
- https://github.com/labwc/labwc/discussions/2739

For longer cases, factor out the logic to new functions. For very short cases, just move the declaration before the switch.