### PR TITLE
wlroots.wrap: use branch not tag

### DIFF
--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 0.19.0
+revision = 0.19
 
 [provide]
 dependency_names = wlroots-0.19


### PR DESCRIPTION
Make revision= track the 0.19 branch rather than a specific tag.