### PR TITLE
Rename some handler functions to be more consistent

### DIFF
--- a/src/layers.c
+++ b/src/layers.c
@@ -357,7 +357,7 @@ handle_map(struct wl_listener *listener, void *data)
 }
 
 static void
-popup_handle_destroy(struct wl_listener *listener, void *data)
+handle_popup_destroy(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_popup *popup =
 		wl_container_of(listener, popup, destroy);
@@ -376,7 +376,7 @@ popup_handle_destroy(struct wl_listener *listener, void *data)
 }
 
 static void
-popup_handle_commit(struct wl_listener *listener, void *data)
+handle_popup_commit(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_popup *popup =
 		wl_container_of(listener, popup, commit);
@@ -392,7 +392,7 @@ popup_handle_commit(struct wl_listener *listener, void *data)
 }
 
 static void
-popup_handle_reposition(struct wl_listener *listener, void *data)
+handle_popup_reposition(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_popup *popup =
 		wl_container_of(listener, popup, reposition);
@@ -400,7 +400,7 @@ popup_handle_reposition(struct wl_listener *listener, void *data)
 		&popup->output_toplevel_sx_box);
 }
 
-static void popup_handle_new_popup(struct wl_listener *listener, void *data);
+static void handle_popup_new_popup(struct wl_listener *listener, void *data);
 
 static struct lab_layer_popup *
 create_popup(struct server *server, struct wlr_xdg_popup *wlr_popup,
@@ -422,16 +422,16 @@ create_popup(struct server *server, struct wlr_xdg_popup *wlr_popup,
 	node_descriptor_create(&popup->scene_tree->node,
 		LAB_NODE_DESC_LAYER_POPUP, popup);
 
-	popup->destroy.notify = popup_handle_destroy;
+	popup->destroy.notify = handle_popup_destroy;
 	wl_signal_add(&wlr_popup->events.destroy, &popup->destroy);
 
-	popup->new_popup.notify = popup_handle_new_popup;
+	popup->new_popup.notify = handle_popup_new_popup;
 	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);
 
-	popup->commit.notify = popup_handle_commit;
+	popup->commit.notify = handle_popup_commit;
 	wl_signal_add(&wlr_popup->base->surface->events.commit, &popup->commit);
 
-	popup->reposition.notify = popup_handle_reposition;
+	popup->reposition.notify = handle_popup_reposition;
 	wl_signal_add(&wlr_popup->events.reposition, &popup->reposition);
 
 	return popup;
@@ -439,7 +439,7 @@ create_popup(struct server *server, struct wlr_xdg_popup *wlr_popup,
 
 /* This popup's parent is a layer popup */
 static void
-popup_handle_new_popup(struct wl_listener *listener, void *data)
+handle_popup_new_popup(struct wl_listener *listener, void *data)
 {
 	struct lab_layer_popup *lab_layer_popup =
 		wl_container_of(listener, lab_layer_popup, new_popup);

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -70,7 +70,7 @@ popup_unconstrain(struct xdg_popup *popup)
 }
 
 static void
-handle_xdg_popup_destroy(struct wl_listener *listener, void *data)
+handle_destroy(struct wl_listener *listener, void *data)
 {
 	struct xdg_popup *popup = wl_container_of(listener, popup, destroy);
 	wl_list_remove(&popup->destroy.link);
@@ -88,7 +88,7 @@ handle_xdg_popup_destroy(struct wl_listener *listener, void *data)
 }
 
 static void
-handle_xdg_popup_commit(struct wl_listener *listener, void *data)
+handle_commit(struct wl_listener *listener, void *data)
 {
 	struct xdg_popup *popup = wl_container_of(listener, popup, commit);
 
@@ -102,14 +102,14 @@ handle_xdg_popup_commit(struct wl_listener *listener, void *data)
 }
 
 static void
-handle_xdg_popup_reposition(struct wl_listener *listener, void *data)
+handle_reposition(struct wl_listener *listener, void *data)
 {
 	struct xdg_popup *popup = wl_container_of(listener, popup, reposition);
 	popup_unconstrain(popup);
 }
 
 static void
-popup_handle_new_xdg_popup(struct wl_listener *listener, void *data)
+handle_new_popup(struct wl_listener *listener, void *data)
 {
 	struct xdg_popup *popup = wl_container_of(listener, popup, new_popup);
 	struct wlr_xdg_popup *wlr_popup = data;
@@ -130,17 +130,10 @@ xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup)
 	popup->parent_view = view;
 	popup->wlr_popup = wlr_popup;
 
-	popup->destroy.notify = handle_xdg_popup_destroy;
-	wl_signal_add(&wlr_popup->events.destroy, &popup->destroy);
-
-	popup->new_popup.notify = popup_handle_new_xdg_popup;
-	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);
-
-	popup->commit.notify = handle_xdg_popup_commit;
-	wl_signal_add(&wlr_popup->base->surface->events.commit, &popup->commit);
-
-	popup->reposition.notify = handle_xdg_popup_reposition;
-	wl_signal_add(&wlr_popup->events.reposition, &popup->reposition);
+	CONNECT_SIGNAL(wlr_popup, popup, destroy);
+	CONNECT_SIGNAL(wlr_popup->base, popup, new_popup);
+	CONNECT_SIGNAL(wlr_popup->base->surface, popup, commit);
+	CONNECT_SIGNAL(wlr_popup, popup, reposition);
 
 	/*
 	 * We must add xdg popups to the scene graph so they get rendered. The

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -809,7 +809,7 @@ struct token_data {
 };
 
 static void
-xdg_activation_handle_token_destroy(struct wl_listener *listener, void *data)
+handle_xdg_activation_token_destroy(struct wl_listener *listener, void *data)
 {
 	struct token_data *token_data = wl_container_of(listener, token_data, destroy);
 	wl_list_remove(&token_data->destroy.link);
@@ -817,7 +817,7 @@ xdg_activation_handle_token_destroy(struct wl_listener *listener, void *data)
 }
 
 static void
-xdg_activation_handle_new_token(struct wl_listener *listener, void *data)
+handle_xdg_activation_new_token(struct wl_listener *listener, void *data)
 {
 	struct wlr_xdg_activation_token_v1 *token = data;
 	struct token_data *token_data = znew(*token_data);
@@ -825,12 +825,12 @@ xdg_activation_handle_new_token(struct wl_listener *listener, void *data)
 	token_data->had_valid_seat = !!token->seat;
 	token->data = token_data;
 
-	token_data->destroy.notify = xdg_activation_handle_token_destroy;
+	token_data->destroy.notify = handle_xdg_activation_token_destroy;
 	wl_signal_add(&token->events.destroy, &token_data->destroy);
 }
 
 static void
-xdg_activation_handle_request(struct wl_listener *listener, void *data)
+handle_xdg_activation_request(struct wl_listener *listener, void *data)
 {
 	const struct wlr_xdg_activation_v1_request_activate_event *event = data;
 	struct token_data *token_data = event->token->data;
@@ -998,11 +998,11 @@ xdg_shell_init(struct server *server)
 		exit(EXIT_FAILURE);
 	}
 
-	server->xdg_activation_request.notify = xdg_activation_handle_request;
+	server->xdg_activation_request.notify = handle_xdg_activation_request;
 	wl_signal_add(&server->xdg_activation->events.request_activate,
 		&server->xdg_activation_request);
 
-	server->xdg_activation_new_token.notify = xdg_activation_handle_new_token;
+	server->xdg_activation_new_token.notify = handle_xdg_activation_new_token;
 	wl_signal_add(&server->xdg_activation->events.new_token,
 		&server->xdg_activation_new_token);
 }


### PR DESCRIPTION
Our documentation (https://github.com/labwc/labwc/blob/master/CONTRIBUTING.md#naming-conventions) states that handlers should have prefix `handle_`.