### PR TITLE
osd-field: fix odd behaviors with `title` and `output` fields

### DIFF
--- a/src/osd-field.c
+++ b/src/osd-field.c
@@ -324,8 +324,7 @@ osd_field_arg_from_xml_node(struct window_switcher_field *field,
 		} else if (!strcmp(content, "desktop_entry_name")) {
 			field->content = LAB_FIELD_DESKTOP_ENTRY_NAME;
 		} else if (!strcmp(content, "title")) {
-			/* Keep old defaults */
-			field->content = LAB_FIELD_TITLE_SHORT;
+			field->content = LAB_FIELD_TITLE;
 		} else if (!strcmp(content, "workspace")) {
 			field->content = LAB_FIELD_WORKSPACE;
 		} else if (!strcmp(content, "state")) {

--- a/src/osd-field.c
+++ b/src/osd-field.c
@@ -330,8 +330,7 @@ osd_field_arg_from_xml_node(struct window_switcher_field *field,
 		} else if (!strcmp(content, "state")) {
 			field->content = LAB_FIELD_WIN_STATE;
 		} else if (!strcmp(content, "output")) {
-			/* Keep old defaults */
-			field->content = LAB_FIELD_OUTPUT_SHORT;
+			field->content = LAB_FIELD_OUTPUT;
 		} else if (!strcmp(content, "custom")) {
 			field->content = LAB_FIELD_CUSTOM;
 		} else {


### PR DESCRIPTION
Fixes #2764