### PR TITLE
input: support tablet tool mouse buttons

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -895,13 +895,15 @@ extending outward from the snapped edge.
 	available mouse	buttons. If not specified otherwise, the tip is
 	mapped to left mouse click, the first pen button (Stylus) is mapped
 	to right mouse button click and the second pen button (Stylus2)
-	emulates a middle mouse	button click.
+	emulates a middle mouse	button click. Buttons of a tablet tool mouse
+	are by default mapped to their (regular) mouse counterparts.
 
 	Supported map *buttons* for mouse emulation are:
 	- Tip
 	- Stylus
 	- Stylus2
 	- Stylus3
+	- Left..Task
 	- Pad
 	- Pad2..Pad9
 

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -14,7 +14,6 @@ struct drawing_tablet {
 	struct seat *seat;
 	struct wlr_tablet *tablet;
 	struct wlr_tablet_v2_tablet *tablet_v2;
-	enum motion motion_mode;
 	double x, y, dx, dy;
 	double distance;
 	double pressure;

--- a/src/config/tablet.c
+++ b/src/config/tablet.c
@@ -103,7 +103,10 @@ void
 tablet_load_default_button_mappings(void)
 {
 	rc.tablet.button_map_count = 0;
-	tablet_button_mapping_add(BTN_TOOL_PEN, BTN_LEFT); /* Used for the pen tip */
+
+	/* used for the pen tip */
+	tablet_button_mapping_add(BTN_TOOL_PEN, BTN_LEFT);
+
 	tablet_button_mapping_add(BTN_STYLUS, BTN_RIGHT);
 	tablet_button_mapping_add(BTN_STYLUS2, BTN_MIDDLE);
 }

--- a/src/config/tablet.c
+++ b/src/config/tablet.c
@@ -51,6 +51,22 @@ tablet_button_from_str(const char *button)
 		return BTN_STYLUS2;
 	} else if (!strcasecmp(button, "Stylus3")) {
 		return BTN_STYLUS3;
+	} else if (!strcasecmp(button, "Left")) {
+		return BTN_LEFT;
+	} else if (!strcasecmp(button, "Right")) {
+		return BTN_RIGHT;
+	} else if (!strcasecmp(button, "Middle")) {
+		return BTN_MIDDLE;
+	} else if (!strcasecmp(button, "Side")) {
+		return BTN_SIDE;
+	} else if (!strcasecmp(button, "Extra")) {
+		return BTN_EXTRA;
+	} else if (!strcasecmp(button, "Forward")) {
+		return BTN_FORWARD;
+	} else if (!strcasecmp(button, "Back")) {
+		return BTN_BACK;
+	} else if (!strcasecmp(button, "Task")) {
+		return BTN_TASK;
 	} else if (!strcasecmp(button, "Pad")) {
 		return LAB_BTN_PAD;
 	} else if (!strcasecmp(button, "Pad2")) {
@@ -109,6 +125,16 @@ tablet_load_default_button_mappings(void)
 
 	tablet_button_mapping_add(BTN_STYLUS, BTN_RIGHT);
 	tablet_button_mapping_add(BTN_STYLUS2, BTN_MIDDLE);
+
+	/* pass-through buttons of a tablet tool mouse */
+	tablet_button_mapping_add(BTN_LEFT, BTN_LEFT);
+	tablet_button_mapping_add(BTN_RIGHT, BTN_RIGHT);
+	tablet_button_mapping_add(BTN_MIDDLE, BTN_MIDDLE);
+	tablet_button_mapping_add(BTN_SIDE, BTN_SIDE);
+	tablet_button_mapping_add(BTN_EXTRA, BTN_EXTRA);
+	tablet_button_mapping_add(BTN_FORWARD, BTN_FORWARD);
+	tablet_button_mapping_add(BTN_BACK, BTN_BACK);
+	tablet_button_mapping_add(BTN_TASK, BTN_TASK);
 }
 
 uint32_t

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -273,8 +273,13 @@ handle_tablet_tool_proximity(struct wl_listener *listener, void *data)
 	 * enforced. Not having a tool or tablet capable surface will trigger
 	 * the fallback to cursor move/button emulation in the tablet signal
 	 * handlers.
+	 * Also stick to mouse emulation when the current tool is a tablet mouse.
+	 * Client support for tablet mouses in tablet mode is often incomplete
+	 * and no functionality is lost since those device do not support tool
+	 * specific axis like pressure or distance.
 	 */
 	if (!rc.tablet.force_mouse_emulation
+			&& ev->tool->type != WLR_TABLET_TOOL_TYPE_MOUSE
 			&& tablet->seat->server->tablet_manager && !tool) {
 		/*
 		 * Unfortunately `wlr_tool` is only present in the events, so

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -439,6 +439,21 @@ handle_tablet_tool_axis(struct wl_listener *listener, void *data)
 				break;
 			}
 		}
+		if (ev->updated_axes & WLR_TABLET_TOOL_AXIS_WHEEL) {
+			/*
+			 * libinput reports delta_discrete for tablet tool mouses,
+			 * but unfortunately wlroots doesn't expose it. That said,
+			 * based on the libinput source (tablet_device_has_axis()),
+			 * we only have to deal with non-high-res mouses here, so
+			 * it is relatively safe to set a fixed value.
+			 */
+			int delta_discrete = tablet->wheel_delta >= 0 ? 1 : -1;
+			cursor_emulate_axis(tablet->seat, &ev->tablet->base,
+				WL_POINTER_AXIS_VERTICAL_SCROLL,
+				tablet->wheel_delta,
+				WLR_POINTER_AXIS_DISCRETE_STEP * delta_discrete,
+				WL_POINTER_AXIS_SOURCE_WHEEL, ev->time_msec);
+		}
 	}
 }
 

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -417,7 +417,7 @@ handle_tablet_tool_axis(struct wl_listener *listener, void *data)
 		}
 	} else {
 		if (ev->updated_axes & (WLR_TABLET_TOOL_AXIS_X | WLR_TABLET_TOOL_AXIS_Y)) {
-			if (tool && tool->tool_v2->focused_surface) {
+			if (tool && tool->tool_v2 && tool->tool_v2->focused_surface) {
 				wlr_tablet_v2_tablet_tool_notify_proximity_out(
 					tool->tool_v2);
 			}


### PR DESCRIPTION
Those are regular mouse buttons, but attached to a tablet tool (which looks like a mouse).
Not tested since I don't have such a device.

Closes #2775 