### PR TITLE
ssd: add configurable drop-shadows for tiled windows

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -525,7 +525,10 @@ extending outward from the snapped edge.
 	Should drop-shadows be rendered behind windows. Default is no.
 
 *<theme><dropShadowsOnTiled>* [yes|no]
-	Should drop-shadows be rendered behind tiled windows. Default is no.
+	Should drop-shadows be rendered behind tiled windows. This won't take
+	effect if <core><gap> is smaller than window.active.shadow.size in theme.
+
+	Default is no.
 
 *<theme><font place="">*
 	The font to use for a specific element of a window, menu or OSD.

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -524,6 +524,9 @@ extending outward from the snapped edge.
 *<theme><dropShadows>* [yes|no]
 	Should drop-shadows be rendered behind windows. Default is no.
 
+*<theme><dropShadowsOnTiled>* [yes|no]
+	Should drop-shadows be rendered behind tiled windows. Default is no.
+
 *<theme><font place="">*
 	The font to use for a specific element of a window, menu or OSD.
 	Places can be any of:

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -38,6 +38,7 @@
     <cornerRadius>8</cornerRadius>
     <keepBorder>yes</keepBorder>
     <dropShadows>no</dropShadows>
+    <dropShadowsOnTiled>no</dropShadowsOnTiled>
     <font place="ActiveWindow">
       <name>sans</name>
       <size>10</size>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -92,6 +92,7 @@ struct rcxml {
 	bool title_layout_loaded;
 	bool ssd_keep_border;
 	bool shadows_enabled;
+	bool shadows_on_tiled;
 	struct font font_activewindow;
 	struct font font_inactivewindow;
 	struct font font_menuheader;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1155,6 +1155,8 @@ entry(xmlNode *node, char *nodename, char *content, struct parser_state *state)
 		set_bool(content, &rc.ssd_keep_border);
 	} else if (!strcasecmp(nodename, "dropShadows.theme")) {
 		set_bool(content, &rc.shadows_enabled);
+	} else if (!strcasecmp(nodename, "dropShadowsOnTiled.theme")) {
+		set_bool(content, &rc.shadows_on_tiled);
 	} else if (!strcmp(nodename, "name.font.theme")) {
 		fill_font(nodename, content, font_place);
 	} else if (!strcmp(nodename, "size.font.theme")) {
@@ -1508,6 +1510,7 @@ rcxml_init(void)
 	rc.ssd_keep_border = true;
 	rc.corner_radius = 8;
 	rc.shadows_enabled = false;
+	rc.shadows_on_tiled = false;
 
 	rc.gap = 0;
 	rc.adaptive_sync = LAB_ADAPTIVE_SYNC_DISABLED;

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -293,15 +293,15 @@ ssd_shadow_update(struct ssd *ssd)
 	bool maximized = view->maximized == VIEW_AXIS_BOTH;
 	bool tiled_shadows = false;
 	if (rc.shadows_on_tiled) {
-		if (rc.gap >= theme->window[THEME_ACTIVE].shadow_size &&
-			rc.gap >= theme->window[THEME_INACTIVE].shadow_size) {
+		if (rc.gap >= theme->window[THEME_ACTIVE].shadow_size
+				&& rc.gap >= theme->window[THEME_INACTIVE].shadow_size) {
 			tiled_shadows = true;
 		} else {
 			wlr_log(WLR_INFO, "gap size < shadow_size, ignore rc.shadows_ontiled");
 		}
 	};
-	bool show_shadows = rc.shadows_enabled && !maximized &&
-		(!view_is_tiled(ssd->view) || tiled_shadows);
+	bool show_shadows = rc.shadows_enabled && !maximized
+		&& (!view_is_tiled(ssd->view) || tiled_shadows);
 	wlr_scene_node_set_enabled(&ssd->shadow.tree->node, show_shadows);
 	if (show_shadows) {
 		set_shadow_geometry(ssd);

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -291,7 +291,8 @@ ssd_shadow_update(struct ssd *ssd)
 	struct view *view = ssd->view;
 	bool maximized = view->maximized == VIEW_AXIS_BOTH;
 	bool show_shadows =
-		rc.shadows_enabled && !maximized && !view_is_tiled(ssd->view);
+		rc.shadows_enabled && !maximized &&
+		(!view_is_tiled(ssd->view) || rc.shadows_on_tiled);
 	wlr_scene_node_set_enabled(&ssd->shadow.tree->node, show_shadows);
 	if (show_shadows) {
 		set_shadow_geometry(ssd);

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -289,10 +289,19 @@ ssd_shadow_update(struct ssd *ssd)
 	assert(ssd->shadow.tree);
 
 	struct view *view = ssd->view;
+	struct theme *theme = ssd->view->server->theme;
 	bool maximized = view->maximized == VIEW_AXIS_BOTH;
-	bool show_shadows =
-		rc.shadows_enabled && !maximized &&
-		(!view_is_tiled(ssd->view) || rc.shadows_on_tiled);
+	bool tiled_shadows = false;
+	if (rc.shadows_on_tiled) {
+		if (rc.gap >= theme->window[THEME_ACTIVE].shadow_size &&
+			rc.gap >= theme->window[THEME_INACTIVE].shadow_size) {
+			tiled_shadows = true;
+		} else {
+			wlr_log(WLR_INFO, "gap size < shadow_size, ignore rc.shadows_ontiled");
+		}
+	};
+	bool show_shadows = rc.shadows_enabled && !maximized &&
+		(!view_is_tiled(ssd->view) || tiled_shadows);
 	wlr_scene_node_set_enabled(&ssd->shadow.tree->node, show_shadows);
 	if (show_shadows) {
 		set_shadow_geometry(ssd);


### PR DESCRIPTION
This patch introduces optional drop shadows for tiled windows. The feature is controlled via configuration, allowing users to enable or disable shadows on a per-preference basis.

related issue https://github.com/labwc/labwc/issues/1797