### PR TITLE
Enable content-type-v1 protocol

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -18,6 +18,7 @@ server_protocols = [
 	wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
 	wl_protocol_dir / 'stable/tablet/tablet-v2.xml',
 	wl_protocol_dir / 'staging/cursor-shape/cursor-shape-v1.xml',
+	wl_protocol_dir / 'staging/content-type/content-type-v1.xml',
 	wl_protocol_dir / 'staging/drm-lease/drm-lease-v1.xml',
 	wl_protocol_dir / 'staging/xwayland-shell/xwayland-shell-v1.xml',
 	wl_protocol_dir / 'staging/tearing-control/tearing-control-v1.xml',

--- a/src/server.c
+++ b/src/server.c
@@ -8,6 +8,7 @@
 #include <wlr/backend/multi.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_drm.h>
+#include <wlr/types/wlr_content_type_v1.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
@@ -664,6 +665,7 @@ server_init(struct server *server)
 		wlr_security_context_manager_v1_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);
 	wlr_single_pixel_buffer_manager_v1_create(server->wl_display);
+	wlr_content_type_manager_v1_create(server->wl_display, 1);
 	wlr_fractional_scale_manager_v1_create(server->wl_display,
 		LAB_WLR_FRACTIONAL_SCALE_V1_VERSION);
 


### PR DESCRIPTION
The [content-type-v1](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/content-type/content-type-v1.xml?ref_type=heads) protocol allows clients to send compositor a hint about the type of content being displayed on its surface so it could potentially make some sort of optimization. The protocol itself exposes 4 different types of content: none, photo, video, and game.  Tested on RetroArch (always set `game` type) and MPV (set `video` type by default)

https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3599