### PR TITLE
scaled-icon-buffer: fix window icons not loaded after Reconfigure

### DIFF
--- a/src/common/scaled-icon-buffer.c
+++ b/src/common/scaled-icon-buffer.c
@@ -224,13 +224,12 @@ scaled_icon_buffer_set_view(struct scaled_icon_buffer *self, struct view *view)
 		wl_list_remove(&self->on_view.destroy.link);
 	}
 	self->view = view;
-	if (view) {
-		self->on_view.set_icon.notify = handle_view_set_icon;
-		wl_signal_add(&view->events.set_icon, &self->on_view.set_icon);
-		self->on_view.destroy.notify = handle_view_destroy;
-		wl_signal_add(&view->events.destroy, &self->on_view.destroy);
-	}
+	self->on_view.set_icon.notify = handle_view_set_icon;
+	wl_signal_add(&view->events.set_icon, &self->on_view.set_icon);
+	self->on_view.destroy.notify = handle_view_destroy;
+	wl_signal_add(&view->events.destroy, &self->on_view.destroy);
 
+	handle_view_set_icon(&self->on_view.set_icon, NULL);
 	scaled_scene_buffer_request_update(self->scaled_buffer, self->width, self->height);
 }
 


### PR DESCRIPTION
This PR fixes the issue that window icons become the fallback one after Reconfigure, by setting `scaled_icon_buffer->view_{app_id,icon_name,icon_buffers}` in `scaled_icon_buffer_set_view()`.

The reason why the window icons were displayed before Reconfigure is that applications usually enable decorations and then set app_id which fires `handle_view_set_icon()`.

Demonstration of the issue:

https://github.com/user-attachments/assets/7e316a9a-c2a5-4409-a534-56536af89225