### PR TITLE
libinput: implement threeFingerDrag feature

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -959,6 +959,7 @@ extending outward from the snapped edge.
     <tapButtonMap></tapButtonMap>
     <tapAndDrag></tapAndDrag>
     <dragLock>sticky</dragLock>
+    <threeFingerDrag></threeFingerDrag>
     <middleEmulation></middleEmulation>
     <disableWhileTyping></disableWhileTyping>
     <clickMethod></clickMethod>
@@ -1032,6 +1033,16 @@ extending outward from the snapped edge.
 	release of a finger during tap-and-dragging. Both *yes* and *sticky* enable
 	drag lock, but if *yes* is set, the drag lock expires after a timeout.
 	Default is *sticky*.
+
+*<libinput><device><threeFingerDrag>* [yes|no|3|4]
+	Enable or disable the three-finger drag feature. When enabled, three
+	fingers down will result in a button down event and subsequent finger
+	motions triggers a drag.
+
+	The available options are:
+	- *no* - Disable three-finger drag.
+	- *yes* | *3* - Enable three-finger drag for 3 fingers.
+	- *4* - Enable three-finger drag for 4 fingers.
 
 *<libinput><device><middleEmulation>* [yes|no]
 	Enable or disable middle button emulation for this category. Middle

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -633,6 +633,7 @@
       <tapButtonMap></tapButtonMap>
       <tapAndDrag></tapAndDrag>
       <dragLock>sticky</dragLock>
+      <threeFingerDrag></threeFingerDrag>
       <middleEmulation></middleEmulation>
       <disableWhileTyping></disableWhileTyping>
       <clickMethod></clickMethod>

--- a/include/config/libinput.h
+++ b/include/config/libinput.h
@@ -25,6 +25,7 @@ struct libinput_category {
 	enum libinput_config_tap_button_map tap_button_map;
 	int tap_and_drag;               /* -1 or libinput_config_drag_state */
 	int drag_lock;                  /* -1 or libinput_config_drag_lock_state */
+	int three_finger_drag;          /* -1 or libinput_config_3fg_drag_state */
 	int accel_profile;              /* -1 or libinput_config_accel_profile */
 	int middle_emu;                 /* -1 or libinput_config_middle_emulation_state */
 	int dwt;                        /* -1 or libinput_config_dwt_state */

--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,7 @@ conf_data.set10('HAVE_RSVG', have_rsvg)
 
 conf_data.set10('HAVE_LIBSFDO', have_libsfdo)
 
-foreach sym : ['LIBINPUT_CONFIG_DRAG_LOCK_ENABLED_STICKY']
+foreach sym : ['LIBINPUT_CONFIG_DRAG_LOCK_ENABLED_STICKY', 'LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG']
 	conf_data.set10('HAVE_' + sym, cc.has_header_symbol('libinput.h', sym, dependencies: input))
 endforeach
 

--- a/src/config/libinput.c
+++ b/src/config/libinput.c
@@ -24,6 +24,7 @@ libinput_category_init(struct libinput_category *l)
 #else
 	l->drag_lock = -1;
 #endif
+	l->three_finger_drag = -1;
 	l->accel_profile = -1;
 	l->middle_emu = -1;
 	l->dwt = -1;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -788,6 +788,27 @@ fill_libinput_category(char *nodename, char *content, struct parser_state *state
 		state->current_libinput_category->drag_lock = ret
 			? LIBINPUT_CONFIG_DRAG_LOCK_ENABLED
 			: LIBINPUT_CONFIG_DRAG_LOCK_DISABLED;
+	} else if (!strcasecmp(nodename, "threeFingerDrag")) {
+#if HAVE_LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG
+		if (!strcmp(content, "3")) {
+			state->current_libinput_category->three_finger_drag =
+				LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG;
+		} else if (!strcmp(content, "4")) {
+			state->current_libinput_category->three_finger_drag =
+				LIBINPUT_CONFIG_3FG_DRAG_ENABLED_4FG;
+		} else {
+			int ret = parse_bool(content, -1);
+			if (ret < 0) {
+				return;
+			}
+			state->current_libinput_category->three_finger_drag = ret
+				? LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG
+				: LIBINPUT_CONFIG_3FG_DRAG_DISABLED;
+		}
+#else
+		wlr_log(WLR_ERROR, "<threeFingerDrag> is only"
+			" supported in libinput >= 1.28");
+#endif
 	} else if (!strcasecmp(nodename, "accelProfile")) {
 		state->current_libinput_category->accel_profile =
 			get_accel_profile(content);

--- a/src/seat.c
+++ b/src/seat.c
@@ -164,6 +164,17 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			libinput_dev, dc->drag_lock);
 	}
 
+#if HAVE_LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG
+	if (libinput_device_config_tap_get_finger_count(libinput_dev) <= 0
+			|| dc->three_finger_drag < 0) {
+		wlr_log(WLR_INFO, "three-finger drag not configured");
+	} else {
+		wlr_log(WLR_INFO, "three-finger drag configured");
+		libinput_device_config_3fg_drag_set_enabled(
+			libinput_dev, dc->three_finger_drag);
+	}
+#endif
+
 	if (libinput_device_config_scroll_has_natural_scroll(libinput_dev) <= 0
 			|| dc->natural_scroll < 0) {
 		wlr_log(WLR_INFO, "natural scroll not configured");


### PR DESCRIPTION
closes #2647.

i took most of the docs directly [from libinput](https://gitlab.freedesktop.org/libinput/libinput/-/blob/49eb6cb8ab2695a4ac8883d2be5148472563b8db/src/libinput.h?page=6#L5071-5074), i hope that's fine.

i tested it locally and it worked fine, but i haven't done extensive testing.