### PR TITLE
view.c: free icon name on view destroy

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2595,6 +2595,7 @@ view_destroy(struct view *view)
 	if (view->icon.buffers.data) {
 		view_set_icon(view, NULL, NULL);
 	}
+	zfree(view->icon.name);
 
 	/*
 	 * The layer-shell top-layer is disabled when an application is running


### PR DESCRIPTION
Discovered via `-Db_sanitize=address` with `Ctrl-C` of a nested instance with foot still running.