### PR TITLE
Ensure the view signals are initialized early

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -921,6 +921,8 @@ xdg_toplevel_new(struct wl_listener *listener, void *data)
 	view->server = server;
 	view->type = LAB_XDG_SHELL_VIEW;
 	view->impl = &xdg_toplevel_view_impl;
+	view_init(view);
+
 	xdg_toplevel_view->xdg_surface = xdg_surface;
 
 	/*
@@ -997,7 +999,6 @@ xdg_toplevel_new(struct wl_listener *listener, void *data)
 	CONNECT_SIGNAL(toplevel, xdg_toplevel_view, request_show_window_menu);
 	CONNECT_SIGNAL(xdg_surface, xdg_toplevel_view, new_popup);
 
-	view_init(view);
 	wl_list_insert(&server->views, &view->link);
 }
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -965,6 +965,7 @@ xwayland_view_create(struct server *server,
 	view->server = server;
 	view->type = LAB_XWAYLAND_VIEW;
 	view->impl = &xwayland_view_impl;
+	view_init(view);
 
 	/*
 	 * Set two-way view <-> xsurface association.  Usually the association
@@ -1001,7 +1002,6 @@ xwayland_view_create(struct server *server,
 	CONNECT_SIGNAL(xsurface, xwayland_view, focus_in);
 	CONNECT_SIGNAL(xsurface, xwayland_view, map_request);
 
-	view_init(view);
 	wl_list_insert(&view->server->views, &view->link);
 
 	if (xsurface->surface) {


### PR DESCRIPTION
This prevents a crash observed by the scaled-icon-buffer listening to the `view->events.set_icons` signal before it is initialized. For this to happen, the application needs to use the kde decoration protocol and set it on the xdg_surface before creating the xdg_toplevel.

Fixes:
- #2798