### PR TITLE
scaled-icon-buffer: don't render twice in scaled_icon_buffer_set_view()

### DIFF
--- a/src/common/scaled-icon-buffer.c
+++ b/src/common/scaled-icon-buffer.c
@@ -230,7 +230,6 @@ scaled_icon_buffer_set_view(struct scaled_icon_buffer *self, struct view *view)
 	wl_signal_add(&view->events.destroy, &self->on_view.destroy);
 
 	handle_view_set_icon(&self->on_view.set_icon, NULL);
-	scaled_scene_buffer_request_update(self->scaled_buffer, self->width, self->height);
 }
 
 void


### PR DESCRIPTION
`handle_view_set_icon()` calls `scaled_scene_buffer_request_update()` internally.