### PR TITLE
cursor: omit pointer cursor shape for tablet tool

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -224,6 +224,16 @@ handle_request_set_shape(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	/*
+	 * Omit cursor notifications from a pointer when a tablet
+	 * tool (stylus/pen) is in proximity.
+	 */
+	if (tablet_tool_has_focused_surface(seat)
+			&& event->device_type
+				!= WLR_CURSOR_SHAPE_MANAGER_V1_DEVICE_TYPE_TABLET_TOOL) {
+		return;
+	}
+
 	wlr_log(WLR_DEBUG, "set xcursor to shape %s", shape_name);
 	wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager, shape_name);
 }


### PR DESCRIPTION
Omit cursor notifications from a pointer when a tablet tool (stylus/pen) is in proximity. This is equivalent to `handle_request_set_cursor()` and prevents a resize cursor for out-of-surface scrolling with a tablet tool in recent GTK4 (which uses the cursor shape protocol).

This fixes this issue:

https://github.com/user-attachments/assets/de763a4e-a8d2-4022-ab63-b98dc803a622

(the cursor is from a tablet tool)

This is not a GTK4 issue since this works in Gnome, so really up to us to fix this. 
