### PR TITLE
xwayland: always offer focus in Globally Active case

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -75,13 +75,18 @@ enum view_wants_focus {
 	/* View wants focus */
 	VIEW_WANTS_FOCUS_ALWAYS,
 	/*
-	 * View should be offered focus and may accept or decline
-	 * (a.k.a. ICCCM Globally Active input model). Labwc generally
-	 * avoids focusing these views automatically (e.g. when another
-	 * view on top is closed) but they may be focused by user action
-	 * (e.g. mouse click).
+	 * The following values apply only to XWayland views using the
+	 * Globally Active input model per the ICCCM. These views are
+	 * offered focus and will voluntarily accept or decline it.
+	 *
+	 * In some cases, labwc needs to decide in advance whether to
+	 * focus the view. For this purpose, these views are classified
+	 * (by a heuristic) as likely or unlikely to want focus. However,
+	 * it is still ultimately up to the client whether the view gets
+	 * focus or not.
 	 */
-	VIEW_WANTS_FOCUS_OFFER,
+	VIEW_WANTS_FOCUS_LIKELY,
+	VIEW_WANTS_FOCUS_UNLIKELY,
 };
 
 /*

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -84,7 +84,8 @@ desktop_focus_view(struct view *view, bool raise)
 			seat_focus_surface(seat, view->surface);
 		}
 		break;
-	case VIEW_WANTS_FOCUS_OFFER:
+	case VIEW_WANTS_FOCUS_LIKELY:
+	case VIEW_WANTS_FOCUS_UNLIKELY:
 		view_offer_focus(view);
 		break;
 	case VIEW_WANTS_FOCUS_NEVER:

--- a/src/view.c
+++ b/src/view.c
@@ -392,10 +392,14 @@ view_is_focusable(struct view *view)
 	if (!view->surface) {
 		return false;
 	}
-	if (view_wants_focus(view) != VIEW_WANTS_FOCUS_ALWAYS) {
+
+	switch (view_wants_focus(view)) {
+	case VIEW_WANTS_FOCUS_ALWAYS:
+	case VIEW_WANTS_FOCUS_LIKELY:
+		return (view->mapped || view->minimized);
+	default:
 		return false;
 	}
-	return (view->mapped || view->minimized);
 }
 
 void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -116,8 +116,8 @@ xwayland_view_wants_focus(struct view *view)
 	 */
 	case WLR_ICCCM_INPUT_MODEL_GLOBAL:
 		/*
-		 * Assume that NORMAL and DIALOG windows always want
-		 * focus. These window types should show up in the
+		 * Assume that NORMAL and DIALOG windows are likely to
+		 * want focus. These window types should show up in the
 		 * Alt-Tab switcher and be automatically focused when
 		 * they become topmost.
 		 */
@@ -125,7 +125,7 @@ xwayland_view_wants_focus(struct view *view)
 				WLR_XWAYLAND_NET_WM_WINDOW_TYPE_NORMAL)
 			|| wlr_xwayland_surface_has_window_type(xsurface,
 				WLR_XWAYLAND_NET_WM_WINDOW_TYPE_DIALOG)) ?
-			VIEW_WANTS_FOCUS_ALWAYS : VIEW_WANTS_FOCUS_OFFER;
+			VIEW_WANTS_FOCUS_LIKELY : VIEW_WANTS_FOCUS_UNLIKELY;
 
 	/*
 	 * No Input - The client never expects keyboard input.


### PR DESCRIPTION
In 9e3785f8cd7a, a heuristic was added to assume that NORMAL and DIALOG window types were always focusable. (This was before we had the "offer focus" mechanism in place.)

However, we should still call `wlr_xwayland_surface_offer_focus()` for these views, in case they actually don't want focus. (This is uncommon but has recently been seen with WeChat popups, which have both NORMAL and UTILITY type.)

To make this possible, refine `view_wants_focus()` to return either LIKELY or UNLIKELY for Globally Active input windows. This decouples the question of "should we try to focus this view" from the actual mechanism used to do so.