### PR TITLE
server: some minor fixes

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -244,6 +244,12 @@ struct server {
 	} headless;
 	struct wlr_session *session;
 	struct wlr_linux_dmabuf_v1 *linux_dmabuf;
+	struct wlr_compositor *compositor;
+
+	struct wl_event_source *sighup_source;
+	struct wl_event_source *sigint_source;
+	struct wl_event_source *sigterm_source;
+	struct wl_event_source *sigchld_source;
 
 	struct wlr_xdg_shell *xdg_shell;
 	struct wlr_layer_shell_v1 *layer_shell;

--- a/src/server.c
+++ b/src/server.c
@@ -760,9 +760,11 @@ server_finish(struct server *server)
 #if HAVE_LIBSFDO
 	desktop_entry_finish(server);
 #endif
-	if (server->sighup_source) {
-		wl_event_source_remove(server->sighup_source);
-	}
+	wl_event_source_remove(server->sighup_source);
+	wl_event_source_remove(server->sigint_source);
+	wl_event_source_remove(server->sigterm_source);
+	wl_event_source_remove(server->sigchld_source);
+
 	wl_display_destroy_clients(server->wl_display);
 
 	seat_finish(server);


### PR DESCRIPTION
- Move global variables (`compositor`, `sig{hup,int,term,chld}_source`) into `struct server`
- Remove `sig{int,term,chld}_source` in `server_finish()`