### PR TITLE
CLion focus fixes

### DIFF
--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -39,6 +39,7 @@ struct xwayland_unmanaged {
 struct xwayland_view {
 	struct view base;
 	struct wlr_xwayland_surface *xwayland_surface;
+	bool focused_before_map;
 
 	/* Events unique to XWayland views */
 	struct wl_listener associate;

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -46,7 +46,15 @@ void
 view_impl_unmap(struct view *view)
 {
 	struct server *server = view->server;
-	if (view == server->active_view) {
+	/*
+	 * When exiting an xwayland application with multiple views
+	 * mapped, a race condition can occur: after the topmost view
+	 * is unmapped, the next view under it is offered focus, but is
+	 * also unmapped before accepting focus (so server->active_view
+	 * remains NULL). To avoid being left with no active view at
+	 * all, check for that case also.
+	 */
+	if (view == server->active_view || !server->active_view) {
 		desktop_focus_topmost_view(server);
 	}
 }


### PR DESCRIPTION
#2811 fixed an issue with WeChat but unfortunately exposed multiple focus-related bugs, affecting at least JetBrains CLion (probably other apps too).

These bugs were introduced by the addition of `view_offer_focus()` in #1142 but had remained masked due to treating NORMAL and DIALOG type windows as always wanting focus.

The general approach of #1142 still feels right to me, but it introduced some asynchronous behavior (labwc offers focus, client accepts it some time later) which is more of a headache to deal with, and broke some assumptions in the code.

Please see the individual commit messages for details.