### PR TITLE
desktop: give focus to a modal dialog rather than its parent

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -156,6 +156,7 @@ struct view_impl {
 	void (*minimize)(struct view *view, bool minimize);
 	struct view *(*get_root)(struct view *self);
 	void (*append_children)(struct view *self, struct wl_array *children);
+	bool (*is_modal_dialog)(struct view *self);
 	struct view_size_hints (*get_size_hints)(struct view *self);
 	/* if not implemented, VIEW_WANTS_FOCUS_ALWAYS is assumed */
 	enum view_wants_focus (*wants_focus)(struct view *self);
@@ -612,6 +613,14 @@ void view_move_to_front(struct view *view);
 void view_move_to_back(struct view *view);
 struct view *view_get_root(struct view *view);
 void view_append_children(struct view *view, struct wl_array *children);
+
+/**
+ * view_get_modal_dialog() - returns any modal dialog found among this
+ * view's children or siblings (or possibly this view itself). Applies
+ * only to xwayland views and always returns NULL for xdg-shell views.
+ */
+struct view *view_get_modal_dialog(struct view *view);
+
 bool view_on_output(struct view *view, struct output *output);
 
 /**

--- a/src/view.c
+++ b/src/view.c
@@ -2343,6 +2343,36 @@ view_append_children(struct view *view, struct wl_array *children)
 	}
 }
 
+struct view *
+view_get_modal_dialog(struct view *view)
+{
+	assert(view);
+	if (!view->impl->is_modal_dialog) {
+		return NULL;
+	}
+	/* check view itself first */
+	if (view->impl->is_modal_dialog(view)) {
+		return view;
+	}
+
+	/* check sibling views */
+	struct view *dialog = NULL;
+	struct view *root = view_get_root(view);
+	struct wl_array children;
+	struct view **child;
+
+	wl_array_init(&children);
+	view_append_children(root, &children);
+	wl_array_for_each(child, &children) {
+		if (view->impl->is_modal_dialog(*child)) {
+			dialog = *child;
+			break;
+		}
+	}
+	wl_array_release(&children);
+	return dialog;
+}
+
 bool
 view_has_strut_partial(struct view *view)
 {

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -933,6 +933,12 @@ xwayland_view_append_children(struct view *self, struct wl_array *children)
 	}
 }
 
+static bool
+xwayland_view_is_modal_dialog(struct view *self)
+{
+	return xwayland_surface_from_view(self)->modal;
+}
+
 static void
 xwayland_view_set_activated(struct view *view, bool activated)
 {
@@ -978,6 +984,7 @@ static const struct view_impl xwayland_view_impl = {
 	.minimize = xwayland_view_minimize,
 	.get_root = xwayland_view_get_root,
 	.append_children = xwayland_view_append_children,
+	.is_modal_dialog = xwayland_view_is_modal_dialog,
 	.get_size_hints = xwayland_view_get_size_hints,
 	.wants_focus = xwayland_view_wants_focus,
 	.offer_focus = xwayland_view_offer_focus,


### PR DESCRIPTION
Fixes: #2722

/cc @tokyo4j 