### PR TITLE
Wayland protocols: support alpha modifier and ext_data_control_manager

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6,6 +6,7 @@
 #include <sys/wait.h>
 #include <wlr/backend/headless.h>
 #include <wlr/backend/multi.h>
+#include <wlr/types/wlr_alpha_modifier_v1.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_drm.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
@@ -270,12 +271,13 @@ allow_for_sandbox(const struct wlr_security_context_v1_state *security_state,
 		"zxdg_importer_v2",
 		"xdg_toplevel_icon_manager_v1",
 		/* plus */
+		"wp_alpha_modifier_v1",
+		"wp_linux_drm_syncobj_manager_v1",
 		"zxdg_exporter_v1",
 		"zxdg_exporter_v2",
 		"zwp_idle_inhibit_manager_v1",
 		"zwp_pointer_constraints_v1",
 		"zxdg_output_manager_v1",
-		"wp_linux_drm_syncobj_manager_v1",
 	};
 
 	for (size_t i = 0; i < ARRAY_SIZE(allowed_protocols); i++) {
@@ -678,6 +680,8 @@ server_init(struct server *server)
 	server->foreign_toplevel_list =
 		wlr_ext_foreign_toplevel_list_v1_create(
 			server->wl_display, LAB_EXT_FOREIGN_TOPLEVEL_LIST_VERSION);
+
+	wlr_alpha_modifier_v1_create(server->wl_display);
 
 	session_lock_init(server);
 

--- a/src/server.c
+++ b/src/server.c
@@ -8,6 +8,7 @@
 #include <wlr/backend/multi.h>
 #include <wlr/types/wlr_alpha_modifier_v1.h>
 #include <wlr/types/wlr_data_control_v1.h>
+#include <wlr/types/wlr_ext_data_control_v1.h>
 #include <wlr/types/wlr_drm.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>
@@ -55,6 +56,7 @@
 #include "workspaces.h"
 #include "xwayland.h"
 
+#define LAB_EXT_DATA_CONTROL_VERSION 1
 #define LAB_EXT_FOREIGN_TOPLEVEL_LIST_VERSION 1
 #define LAB_WLR_COMPOSITOR_VERSION 6
 #define LAB_WLR_FRACTIONAL_SCALE_V1_VERSION 1
@@ -212,6 +214,7 @@ protocol_is_privileged(const struct wl_interface *iface)
 		"zwp_virtual_keyboard_manager_v1",
 		"zwlr_export_dmabuf_manager_v1",
 		"zwlr_screencopy_manager_v1",
+		"ext_data_control_manager_v1",
 		"zwlr_data_control_manager_v1",
 		"wp_security_context_manager_v1",
 		"ext_idle_notifier_v1",
@@ -656,6 +659,8 @@ server_init(struct server *server)
 	wlr_ext_image_copy_capture_manager_v1_create(server->wl_display, 1);
 	wlr_ext_output_image_capture_source_manager_v1_create(server->wl_display, 1);
 	wlr_data_control_manager_v1_create(server->wl_display);
+	wlr_ext_data_control_manager_v1_create(server->wl_display,
+		LAB_EXT_DATA_CONTROL_VERSION);
 	server->security_context_manager_v1 =
 		wlr_security_context_manager_v1_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);

--- a/src/server.c
+++ b/src/server.c
@@ -54,10 +54,10 @@
 #include "workspaces.h"
 #include "xwayland.h"
 
+#define LAB_EXT_FOREIGN_TOPLEVEL_LIST_VERSION 1
 #define LAB_WLR_COMPOSITOR_VERSION 6
 #define LAB_WLR_FRACTIONAL_SCALE_V1_VERSION 1
 #define LAB_WLR_LINUX_DMABUF_VERSION 4
-#define EXT_FOREIGN_TOPLEVEL_LIST_VERSION 1
 #define LAB_WLR_PRESENTATION_TIME_VERSION 2
 
 static void
@@ -677,7 +677,7 @@ server_init(struct server *server)
 
 	server->foreign_toplevel_list =
 		wlr_ext_foreign_toplevel_list_v1_create(
-			server->wl_display, EXT_FOREIGN_TOPLEVEL_LIST_VERSION);
+			server->wl_display, LAB_EXT_FOREIGN_TOPLEVEL_LIST_VERSION);
 
 	session_lock_init(server);
 


### PR DESCRIPTION
With that we mostly caught up with sway 1.11. Still missing are:
- `ext_transient_seat_manager_v1` which I don't think we need
- `wp_content_type_manager_v1` which is pretty useless right now
- `zwp_keyboard_shortcuts_inhibit_manager_v1` which sounds like a really bad idea, we do have `ToggleKeybinds` for that which is under the control of the user and not some random web app
- `xdg_wm_base` (#2814)

The [fixup commit](https://github.com/swaywm/sway/commit/9a9be01ad4130e4e19b437fd064f90982974971f) for alpha modifier isn't relevant to us from what I can see because we don't have a SetOpacity action and thus don't overwrite the opacity of any scene nodes.