### PR TITLE
config: deprecate some key- and mousebinds

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -689,7 +689,6 @@ extending outward from the snapped edge.
   A-Tab - next window
   A-S-Tab - previous window
   W-Return - alacritty
-  A-F3 - run bemenu
   A-F4 - close window
   W-a - toggle maximize
   W-<arrow> - resize window to fill half the output

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -796,14 +796,14 @@ extending outward from the snapped edge.
 </labwc_config>
 ```
 
-	Example to un-bind the default alt + left-button-press to move window:
+	Example to un-bind the default Super + left-button-press to move window:
 
 ```
 <mouse>
   <default/>
   <context name="Frame">
-    <mousebind button="A-Left" action="Press"/>
-    <mousebind button="A-Left" action="Drag"/>
+    <mousebind button="W-Left" action="Press"/>
+    <mousebind button="W-Left" action="Drag"/>
   </context>
 </mouse>
 ```

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -692,7 +692,6 @@ extending outward from the snapped edge.
   A-F3 - run bemenu
   A-F4 - close window
   W-a - toggle maximize
-  A-<arrow> - move window to edge
   W-<arrow> - resize window to fill half the output
   A-Space - show window menu
 ```

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -354,18 +354,18 @@
     <doubleClickTime>500</doubleClickTime>
 
     <context name="Frame">
-      <mousebind button="A-Left" action="Press">
+      <mousebind button="W-Left" action="Press">
         <action name="Focus" />
         <action name="Raise" />
       </mousebind>
-      <mousebind button="A-Left" action="Drag">
+      <mousebind button="W-Left" action="Drag">
         <action name="Move" />
       </mousebind>
-      <mousebind button="A-Right" action="Press">
+      <mousebind button="W-Right" action="Press">
         <action name="Focus" />
         <action name="Raise" />
       </mousebind>
-      <mousebind button="A-Right" action="Drag">
+      <mousebind button="W-Right" action="Drag">
         <action name="Resize" />
       </mousebind>
     </context>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -268,18 +268,6 @@
     <keybind key="W-a">
       <action name="ToggleMaximize" />
     </keybind>
-    <keybind key="A-Left">
-      <action name="MoveToEdge" direction="left" />
-    </keybind>
-    <keybind key="A-Right">
-      <action name="MoveToEdge" direction="right" />
-    </keybind>
-    <keybind key="A-Up">
-      <action name="MoveToEdge" direction="up" />
-    </keybind>
-    <keybind key="A-Down">
-      <action name="MoveToEdge" direction="down" />
-    </keybind>
     <keybind key="W-Left">
       <action name="SnapToEdge" direction="left" />
     </keybind>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -259,9 +259,6 @@
     <keybind key="W-Return">
       <action name="Execute" command="alacritty" />
     </keybind>
-    <keybind key="A-F3">
-      <action name="Execute" command="bemenu-run" />
-    </keybind>
     <keybind key="A-F4">
       <action name="Close" />
     </keybind>

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -36,34 +36,6 @@ static struct key_combos {
 		.binding = "W-a",
 		.action = "ToggleMaximize",
 	}, {
-		.binding = "A-Left",
-		.action = "MoveToEdge",
-		.attributes[0] = {
-			.name = "direction",
-			.value = "left",
-		},
-	}, {
-		.binding = "A-Right",
-		.action = "MoveToEdge",
-		.attributes[0] = {
-			.name = "direction",
-			.value = "right",
-		},
-	}, {
-		.binding = "A-Up",
-		.action = "MoveToEdge",
-		.attributes[0] = {
-			.name = "direction",
-			.value = "up",
-		},
-	}, {
-		.binding = "A-Down",
-		.action = "MoveToEdge",
-		.attributes[0] = {
-			.name = "direction",
-			.value = "down",
-		},
-	}, {
 		.binding = "W-Left",
 		.action = "SnapToEdge",
 		.attributes[0] = {

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -184,32 +184,32 @@ static struct mouse_combos {
 		.action = "Resize",
 	}, {
 		.context = "Frame",
-		.button = "A-Left",
+		.button = "W-Left",
 		.event = "Press",
 		.action = "Focus",
 	}, {
 		.context = "Frame",
-		.button = "A-Left",
+		.button = "W-Left",
 		.event = "Press",
 		.action = "Raise",
 	}, {
 		.context = "Frame",
-		.button = "A-Left",
+		.button = "W-Left",
 		.event = "Drag",
 		.action = "Move",
 	}, {
 		.context = "Frame",
-		.button = "A-Right",
+		.button = "W-Right",
 		.event = "Press",
 		.action = "Focus",
 	}, {
 		.context = "Frame",
-		.button = "A-Right",
+		.button = "W-Right",
 		.event = "Press",
 		.action = "Raise",
 	}, {
 		.context = "Frame",
-		.button = "A-Right",
+		.button = "W-Right",
 		.event = "Drag",
 		.action = "Resize",
 	}, {

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -23,13 +23,6 @@ static struct key_combos {
 			.value = "alacritty",
 		},
 	}, {
-		.binding = "A-F3",
-		.action = "Execute",
-		.attributes[0] = {
-			.name = "command",
-			.value = "bemenu-run",
-		},
-	}, {
 		.binding = "A-F4",
 		.action = "Close",
 	}, {


### PR DESCRIPTION
...because Alt- keybinds should be for clients to use and the A-<arrow> default combination is a frequent user complaint because it prevents some common usage patterns like alt-left/right in web browers.

#2825