### PR TITLE
input: clear SSD hover effects after touch-up

### DIFF
--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -200,6 +200,7 @@ handle_touch_up(struct wl_listener *listener, void *data)
 			} else {
 				cursor_emulate_button(seat, BTN_LEFT,
 					WL_POINTER_BUTTON_STATE_RELEASED, event->time_msec);
+				ssd_update_button_hover(NULL, seat->server->ssd_hover_state);
 			}
 			wl_list_remove(&touch_point->link);
 			zfree(touch_point);


### PR DESCRIPTION
Having a hover effect visible without interaction looks out of place when there is no cursor (the cursor becomes hidden for/after touch interaction until the next mouse or tablet interaction). Just clear the hover effect after touch-up to prevent this. Note that hover effects are still there during touch-move and touch-down.

We can end-up in such a hover-effect-without-cursor situation when using a touch screen and
- opening a labwc root/client window
- tap on an SSD maximize button
- since the tap closes the menu, but doesn't (yet) maximizes, the (invisible) cursor is still on the maximize button and keeps the hover effect alive.

This PR clears the hover effect once the tap is completed (no finger anymore on the touch screen).

I'm not 100% sure if `ssd_update_button_hover()` is meant to be used like this, but it seems to do the job.