### PR TITLE
[proof-of-concept] icon priority

### DIFF
--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -38,6 +38,7 @@ struct window_rule {
 	enum property ignore_focus_request;
 	enum property ignore_configure_request;
 	enum property fixed_position;
+	enum property icon_prefer_server;
 
 	struct wl_list link; /* struct rcxml.window_rules */
 };

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -328,6 +328,15 @@ fill_window_rule(char *nodename, char *content, struct parser_state *state)
 	/* Properties */
 	} else if (!strcasecmp(nodename, "serverDecoration")) {
 		set_property(content, &state->current_window_rule->server_decoration);
+	} else if (!strcasecmp(nodename, "iconPriority")) {
+		if (!strcasecmp(content, "client")) {
+			state->current_window_rule->icon_prefer_server = LAB_PROP_FALSE;
+		} else if (!strcasecmp(content, "server")) {
+			state->current_window_rule->icon_prefer_server = LAB_PROP_TRUE;
+		} else {
+			wlr_log(WLR_ERROR,
+				"Invalid value for window rule property 'iconPriority'");
+		}
 	} else if (!strcasecmp(nodename, "skipTaskbar")) {
 		set_property(content, &state->current_window_rule->skip_taskbar);
 	} else if (!strcasecmp(nodename, "skipWindowSwitcher")) {

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -108,6 +108,10 @@ window_rules_get_property(struct view *view, const char *property)
 					&& !strcasecmp(property, "fixedPosition")) {
 				return rule->fixed_position;
 			}
+			if (rule->icon_prefer_server
+					&& !strcasecmp(property, "iconPreferServer")) {
+				return rule->icon_prefer_server;
+			}
 		}
 	}
 	return LAB_PROP_UNSPECIFIED;


### PR DESCRIPTION
My try at implementing a icon lookup priority via window rules.

Can be tested with
```xml
</windowRules>
	<windowRule identifier="*" iconPriority="server" />
</windowRules>
```

Notable:

- This introduces a subtle change in behavior for `scaled_icon_buffer_set_icon_name()` (only used for menu icons right now): if the icon isn't found it will now fall back to the configured app-id fallback.
- The user facing window rule attribute is called `iconPriority` but the internal property is called `iconPreferServer` to make it work with `enum property` so we don't need to add an additional enum and API for that config.

Missing:
- [ ] docs
- [ ] remove some log spam (especially "Trying to load ..", but maybe also "loaded icon by .."?)