### PR TITLE
[No wlroots change required] xwayland: support _NET_WM_ICON

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,7 @@ wayland_server = dependency('wayland-server', version: '>=1.19.0')
 wayland_protos = dependency('wayland-protocols', version: '>=1.39')
 xkbcommon = dependency('xkbcommon')
 xcb = dependency('xcb', required: get_option('xwayland'))
+xcb_ewmh = dependency('xcb-ewmh', required: get_option('xwayland'))
 xcb_icccm = dependency('xcb-icccm', required: get_option('xwayland'))
 drm_full = dependency('libdrm')
 drm = drm_full.partial_dependency(compile_args: true, includes: true)
@@ -136,6 +137,7 @@ labwc_deps = [
   wayland_server,
   wlroots,
   xkbcommon,
+	xcb_ewmh,
   xcb_icccm,
   xml2,
   glib,

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -1043,6 +1043,7 @@ handle_xdg_toplevel_icon_set_icon(struct wl_listener *listener, void *data)
 		}
 	}
 
+	/* view takes ownership of the buffers */
 	view_set_icon(view, icon_name, &buffers);
 	wl_array_release(&buffers);
 }


### PR DESCRIPTION
Support `_NET_WM_ICON` property without waiting for [wlroots MR](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5079)

Just copied from https://github.com/consolatis/labwc/tree/feature/x11_icons