### PR TITLE
theme: change builtin menu fallback button to arrow

### DIFF
--- a/src/theme.c
+++ b/src/theme.c
@@ -292,7 +292,7 @@ load_buttons(struct theme *theme)
 		.name = "menu",
 		.type = LAB_SSD_BUTTON_WINDOW_MENU,
 		.state_set = 0,
-		.fallback_button = (const char[]){ 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x00 },
+		.fallback_button = (const char[]){ 0x00, 0x21, 0x33, 0x1E, 0x0C, 0x00 },
 	}, {
 		.name = "iconify",
 		.type = LAB_SSD_BUTTON_ICONIFY,


### PR DESCRIPTION
What do you think of changing the default menu button from this:

![menu xml current](https://github.com/user-attachments/assets/5ffbbc17-f406-4b4f-ac70-fecc0b72ca45)

to this:

![menu xml new](https://github.com/user-attachments/assets/be5c280c-01a4-4bfa-98c2-3427a398317b)

With `icon` being the default, I don't suspect most users would notice it.

I feel the downward arrow just looks nicer.