### PR TITLE
layers: fix UAF when an output with layer-shell surfaces is destroyed

### DIFF
--- a/include/layers.h
+++ b/include/layers.h
@@ -14,6 +14,8 @@ struct lab_layer_surface {
 	struct server *server;
 
 	bool mapped;
+	/* true only inside handle_unmap() */
+	bool being_unmapped;
 
 	struct wl_listener map;
 	struct wl_listener unmap;

--- a/include/layers.h
+++ b/include/layers.h
@@ -12,8 +12,6 @@ struct lab_layer_surface {
 	struct wlr_layer_surface_v1 *layer_surface;
 	struct wlr_scene_layer_surface_v1 *scene_layer_surface;
 	struct server *server;
-	struct output *output;
-	struct wlr_scene_tree *tree;
 
 	bool mapped;
 

--- a/src/node.c
+++ b/src/node.c
@@ -11,7 +11,7 @@ descriptor_destroy(struct node_descriptor *node_descriptor)
 		return;
 	}
 	wl_list_remove(&node_descriptor->destroy.link);
-	zfree(node_descriptor);
+	free(node_descriptor);
 }
 
 static void


### PR DESCRIPTION
Supersedes #2864.
Fixes #2858.

This PR reverts #1154 and fixes #1153 instead by simply skipping the being-unmapped surface in `arrange_one_layer()`.

Adding `being_unmapped` in `lab_layer_surface` aside from `mapped` doesn't feel very clean, but I think this is simpler than #2864.

I confirmed that destroying an output with layer-shell clients doesn't cause UAF and unmapping an layer-shell client (by running `kitten quick-access-terminal` twice) doesn't terminate the client.