### PR TITLE
Allow dragged views to be moved to other workspaces

### DIFF
--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -443,6 +443,11 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	/* Make sure new views will spawn on the new workspace */
 	server->workspaces.current = target;
 
+	struct view *grabbed_view = server->grabbed_view;
+	if(grabbed_view) {
+		view_move_to_workspace(grabbed_view, target);
+	}
+
 	/*
 	 * Make sure we are focusing what the user sees. Only refocus if
 	 * the focus is not already on an omnipresent or always-on-top view.

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -444,7 +444,7 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	server->workspaces.current = target;
 
 	struct view *grabbed_view = server->grabbed_view;
-	if (grabbed_view) {
+	if (grabbed_view && !view_is_always_on_top(grabbed_view)) {
 		view_move_to_workspace(grabbed_view, target);
 	}
 

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -444,7 +444,7 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	server->workspaces.current = target;
 
 	struct view *grabbed_view = server->grabbed_view;
-	if(grabbed_view) {
+	if (grabbed_view) {
 		view_move_to_workspace(grabbed_view, target);
 	}
 


### PR DESCRIPTION
When configuring labwc for the first time I encountered a - not really a bug but - odd behavior, where if you drag a window and switch workspaces, the window will not carry over. I think that this is an objectively incorrect solution, because you end up dragging a window that you can't even see, and when you switch workspaces while dragging a window, you probably imagined something else to happen.
I initially wanted that behavior because it would allow me to save on the SendToDesktop buttons, which I had to put on an awkward mouse button, because they just didn't fit anywhere else. 
Anyways, I have written a patch, because I'm using Gentoo and I can apply them immediately without needing to do anything besides tell my pkg manager about it. Despite that I think this patch might be useful to others, which is why I'm now trying to upstream it. If there is no desire in merging this then I'll just keep using it locally. I must admit that I'm only semi-positive that there is no way of getting the behavior in mainline labwc, but I searched hard and also didn't find anything in the source code.