### PR TITLE
Added information about idle screen inhibitor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Suggested apps to use with Labwc:
 - Output managers: [wlopm], [kanshi], [wlr-randr]
 - Screen locker: [swaylock]
 - Gamma adjustment: [gammastep]
+- Idle screen inhibitor: [sway-audio-idle-inhibit]
 
 See [integration] for further details.
 
@@ -303,3 +304,4 @@ The default window bar menu can be translated on the [weblate platform](https://
 [wlr-randr]: https://sr.ht/~emersion/wlr-randr/
 [swaylock]: https://github.com/swaywm/swaylock
 [gammastep]: https://gitlab.com/chinstrap/gammastep
+[sway-audio-idle-inhibit]: https://github.com/ErikReider/SwayAudioIdleInhibit


### PR DESCRIPTION
I would like you to add this mention about sway-audio-idle-inhibit, it is an idle screen inhibitor that prevents the screen from turning off based on audio, I tested it on Labwc and it worked very well.