### PR TITLE
actions: added query tiled=any comparison for rc.xml simplification

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -474,7 +474,7 @@ Actions that execute other actions. Used in keyboard/mouse bindings.
 			The "left" , "right", "left-occupied" and
 			"right-occupied" directions will not wrap.
 
-		*tiled* [up|right|down|left|center]
+		*tiled* [up|right|down|left|center|any]
 			Whether the client is tiled (snapped) along the the
 			indicated screen edge.
 

--- a/include/view.h
+++ b/include/view.h
@@ -62,11 +62,14 @@ enum view_axis {
 enum view_edge {
 	VIEW_EDGE_INVALID = 0,
 
-	VIEW_EDGE_LEFT,
-	VIEW_EDGE_RIGHT,
-	VIEW_EDGE_UP,
-	VIEW_EDGE_DOWN,
-	VIEW_EDGE_CENTER,
+	VIEW_EDGE_LEFT = (1 << 0),
+	VIEW_EDGE_RIGHT = (1 << 1),
+	VIEW_EDGE_UP = (1 << 2),
+	VIEW_EDGE_DOWN = (1 << 3),
+	VIEW_EDGE_CENTER = (1 << 4),
+
+	VIEW_EDGE_ALL = (VIEW_EDGE_LEFT | VIEW_EDGE_RIGHT |
+		VIEW_EDGE_UP | VIEW_EDGE_DOWN | VIEW_EDGE_CENTER),
 };
 
 enum view_wants_focus {

--- a/include/view.h
+++ b/include/view.h
@@ -28,7 +28,6 @@
  * In labwc, a view is a container for surfaces which can be moved around by
  * the user. In practice this means XDG toplevel and XWayland windows.
  */
-
 enum view_type {
 	LAB_XDG_SHELL_VIEW,
 #if HAVE_XWAYLAND
@@ -59,6 +58,12 @@ enum view_axis {
 	VIEW_AXIS_INVALID = (1 << 2),
 };
 
+/**
+ * Edges to which a view can be snapped to. "All" is used as
+ * a catchall for every valid edge in order to simplify certain
+ * types of conditionals, but it is only valid for a selection
+ * of options in rc.xml.
+ */
 enum view_edge {
 	VIEW_EDGE_INVALID = 0,
 

--- a/src/action.c
+++ b/src/action.c
@@ -344,7 +344,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			bool allow_center = action->type == ACTION_TYPE_TOGGLE_SNAP_TO_EDGE
 				|| action->type == ACTION_TYPE_SNAP_TO_EDGE;
 			if ((edge == VIEW_EDGE_CENTER && !allow_center)
-					|| edge == VIEW_EDGE_INVALID) {
+					|| edge == VIEW_EDGE_INVALID || edge == VIEW_EDGE_ALL) {
 				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {
@@ -452,7 +452,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 		}
 		if (!strcmp(argument, "direction")) {
 			enum view_edge edge = view_edge_parse(content);
-			if (edge == VIEW_EDGE_CENTER) {
+			if (edge == VIEW_EDGE_CENTER || edge == VIEW_EDGE_ALL) {
 				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {

--- a/src/view.c
+++ b/src/view.c
@@ -166,7 +166,7 @@ view_matches_query(struct view *view, struct view_query *query)
 		return false;
 	}
 
-	if (query->tiled != VIEW_EDGE_INVALID && query->tiled != view->tiled) {
+	if (query->tiled != VIEW_EDGE_INVALID && !(query->tiled & view->tiled)) {
 		return false;
 	}
 
@@ -2116,6 +2116,8 @@ view_edge_parse(const char *direction)
 		return VIEW_EDGE_DOWN;
 	} else if (!strcasecmp(direction, "center")) {
 		return VIEW_EDGE_CENTER;
+	} else if (!strcasecmp(direction, "any")) {
+		return VIEW_EDGE_ALL;
 	} else {
 		return VIEW_EDGE_INVALID;
 	}


### PR DESCRIPTION
Following up from discussion #2869, this converts the view_edge enum to bitfields (similar to view_axis enum above), and adds a VIEW_EDGE_ANY value which combines all valid options.

This allows the user to query for any snap directions without using multiple query statements, ie:

```xml
<keybind key="W-Down">
  <action name="If">
    <query tiled="any" />
    <then>
      <action name="UnSnap" />
    </then>
    <else>
      <action name="Iconify" />
    </else>
  </action>
</keybind>
```

This has been compiled and tested locally with no issues or aberrant behaviour.