### PR TITLE
Miscellaneous cleanups of discouraged/obscure C language features

### DIFF
--- a/include/common/string-helpers.h
+++ b/include/common/string-helpers.h
@@ -59,8 +59,7 @@ char *strdup_printf(const char *fmt, ...);
  * The separator is arbitrary. When the separator is NULL, a single space will
  * be used.
  */
-char *str_join(const char *const parts[],
-	const char *restrict fmt, const char *restrict sep);
+char *str_join(const char *const parts[], const char *fmt, const char *sep);
 
 /**
  * str_endswith - indicate whether a string ends with a given suffix

--- a/include/foreign-toplevel-internal.h
+++ b/include/foreign-toplevel-internal.h
@@ -6,62 +6,63 @@
 #include <wayland-server-core.h>
 #include "foreign-toplevel.h"
 
+struct wlr_foreign_toplevel {
+	struct wlr_foreign_toplevel_handle_v1 *handle;
+
+	/* Client side events */
+	struct {
+		struct wl_listener request_maximize;
+		struct wl_listener request_minimize;
+		struct wl_listener request_fullscreen;
+		struct wl_listener request_activate;
+		struct wl_listener request_close;
+		struct wl_listener handle_destroy;
+	} on;
+
+	/* Compositor side state updates */
+	struct {
+		struct wl_listener new_app_id;
+		struct wl_listener new_title;
+		struct wl_listener new_outputs;
+		struct wl_listener maximized;
+		struct wl_listener minimized;
+		struct wl_listener fullscreened;
+		struct wl_listener activated;
+	} on_view;
+
+	/* Internal signals */
+	struct {
+		struct wl_listener toplevel_parent;
+		struct wl_listener toplevel_destroy;
+	} on_foreign_toplevel;
+};
+
+struct ext_foreign_toplevel {
+	struct wlr_ext_foreign_toplevel_handle_v1 *handle;
+
+	/* Client side events */
+	struct {
+		struct wl_listener handle_destroy;
+	} on;
+
+	/* Compositor side state updates */
+	struct {
+		struct wl_listener new_app_id;
+		struct wl_listener new_title;
+	} on_view;
+
+	/* Internal signals */
+	struct {
+		struct wl_listener toplevel_destroy;
+	} on_foreign_toplevel;
+};
+
 struct foreign_toplevel {
 	struct view *view;
 
 	/* *-toplevel implementations */
-	struct wlr_foreign_toplevel {
-		struct wlr_foreign_toplevel_handle_v1 *handle;
-
-		/* Client side events */
-		struct {
-			struct wl_listener request_maximize;
-			struct wl_listener request_minimize;
-			struct wl_listener request_fullscreen;
-			struct wl_listener request_activate;
-			struct wl_listener request_close;
-			struct wl_listener handle_destroy;
-		} on;
-
-		/* Compositor side state updates */
-		struct {
-			struct wl_listener new_app_id;
-			struct wl_listener new_title;
-			struct wl_listener new_outputs;
-			struct wl_listener maximized;
-			struct wl_listener minimized;
-			struct wl_listener fullscreened;
-			struct wl_listener activated;
-		} on_view;
-
-		/* Internal signals */
-		struct {
-			struct wl_listener toplevel_parent;
-			struct wl_listener toplevel_destroy;
-		} on_foreign_toplevel;
-
-	} wlr_toplevel;
-
-	struct ext_foreign_toplevel {
-		struct wlr_ext_foreign_toplevel_handle_v1 *handle;
-
-		/* Client side events */
-		struct {
-			struct wl_listener handle_destroy;
-		} on;
-
-		/* Compositor side state updates */
-		struct {
-			struct wl_listener new_app_id;
-			struct wl_listener new_title;
-		} on_view;
-
-		/* Internal signals */
-		struct {
-			struct wl_listener toplevel_destroy;
-		} on_foreign_toplevel;
-
-	} ext_toplevel;
+	struct wlr_foreign_toplevel wlr_toplevel;
+	struct ext_foreign_toplevel ext_toplevel;
 
 	/* TODO: add struct xdg_x11_mapped_toplevel at some point */
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -233,6 +233,15 @@ enum lab_cycle_dir {
 	LAB_CYCLE_DIR_BACKWARD,
 };
 
+struct osd_state {
+	struct view *cycle_view;
+	bool preview_was_enabled;
+	struct wlr_scene_node *preview_node;
+	struct wlr_scene_tree *preview_parent;
+	struct wlr_scene_node *preview_anchor;
+	struct lab_scene_rect *preview_outline;
+};
+
 struct server {
 	struct wl_display *wl_display;
 	struct wl_event_loop *wl_event_loop;  /* Can be used for timer events */
@@ -386,14 +395,7 @@ struct server {
 	struct wlr_security_context_manager_v1 *security_context_manager_v1;
 
 	/* Set when in cycle (alt-tab) mode */
-	struct osd_state {
-		struct view *cycle_view;
-		bool preview_was_enabled;
-		struct wlr_scene_node *preview_node;
-		struct wlr_scene_tree *preview_parent;
-		struct wlr_scene_node *preview_anchor;
-		struct lab_scene_rect *preview_outline;
-	} osd_state;
+	struct osd_state osd_state;
 
 	struct theme *theme;
 

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -48,6 +48,12 @@ struct ssd_state_title_width {
 	bool truncated;
 };
 
+struct ssd_state_title {
+	char *text;
+	struct ssd_state_title_width active;
+	struct ssd_state_title_width inactive;
+};
+
 struct ssd {
 	struct view *view;
 	struct wlr_scene_tree *tree;
@@ -78,11 +84,7 @@ struct ssd {
 		bool was_squared;
 
 		struct wlr_box geometry;
-		struct ssd_state_title {
-			char *text;
-			struct ssd_state_title_width active;
-			struct ssd_state_title_width inactive;
-		} title;
+		struct ssd_state_title title;
 	} state;
 
 	/* An invisible area around the view which allows resizing */

--- a/include/view.h
+++ b/include/view.h
@@ -170,6 +170,19 @@ struct view_impl {
 	pid_t (*get_pid)(struct view *view);
 };
 
+struct resize_indicator {
+	int width, height;
+	struct wlr_scene_tree *tree;
+	struct wlr_scene_rect *border;
+	struct wlr_scene_rect *background;
+	struct scaled_font_buffer *text;
+};
+
+struct resize_outlines {
+	struct wlr_box view_geo;
+	struct lab_scene_rect *rect;
+};
+
 struct view {
 	struct server *server;
 	enum view_type type;
@@ -261,17 +274,8 @@ struct view {
 	struct wl_event_source *pending_configure_timeout;
 
 	struct ssd *ssd;
-	struct resize_indicator {
-		int width, height;
-		struct wlr_scene_tree *tree;
-		struct wlr_scene_rect *border;
-		struct wlr_scene_rect *background;
-		struct scaled_font_buffer *text;
-	} resize_indicator;
-	struct resize_outlines {
-		struct wlr_box view_geo;
-		struct lab_scene_rect *rect;
-	} resize_outlines;
+	struct resize_indicator resize_indicator;
+	struct resize_outlines resize_outlines;
 
 	struct mappable mappable;
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -33,14 +33,8 @@
 #include "common/box.h"
 #include "common/mem.h"
 
-static const struct wlr_buffer_impl data_buffer_impl;
-
-static struct lab_data_buffer *
-data_buffer_from_buffer(struct wlr_buffer *buffer)
-{
-	assert(buffer->impl == &data_buffer_impl);
-	return (struct lab_data_buffer *)buffer;
-}
+static struct lab_data_buffer *data_buffer_from_buffer(
+	struct wlr_buffer *buffer);
 
 static void
 data_buffer_destroy(struct wlr_buffer *wlr_buffer)
@@ -79,6 +73,13 @@ static const struct wlr_buffer_impl data_buffer_impl = {
 	.begin_data_ptr_access = data_buffer_begin_data_ptr_access,
 	.end_data_ptr_access = data_buffer_end_data_ptr_access,
 };
+
+static struct lab_data_buffer *
+data_buffer_from_buffer(struct wlr_buffer *buffer)
+{
+	assert(buffer->impl == &data_buffer_impl);
+	return (struct lab_data_buffer *)buffer;
+}
 
 struct lab_data_buffer *
 buffer_adopt_cairo_surface(cairo_surface_t *surface)

--- a/src/common/buf.c
+++ b/src/common/buf.c
@@ -13,15 +13,15 @@
 void
 buf_expand_tilde(struct buf *s)
 {
-	struct buf new = BUF_INIT;
+	struct buf tmp = BUF_INIT;
 	for (int i = 0 ; i < s->len ; i++) {
 		if (s->data[i] == '~') {
-			buf_add(&new, getenv("HOME"));
+			buf_add(&tmp, getenv("HOME"));
 		} else {
-			buf_add_char(&new, s->data[i]);
+			buf_add_char(&tmp, s->data[i]);
 		}
 	}
-	buf_move(s, &new);
+	buf_move(s, &tmp);
 }
 
 static void
@@ -45,7 +45,7 @@ isvalid(char p)
 void
 buf_expand_shell_variables(struct buf *s)
 {
-	struct buf new = BUF_INIT;
+	struct buf tmp = BUF_INIT;
 	struct buf environment_variable = BUF_INIT;
 
 	for (int i = 0 ; i < s->len ; i++) {
@@ -62,14 +62,14 @@ buf_expand_shell_variables(struct buf *s)
 			strip_curly_braces(environment_variable.data);
 			p = getenv(environment_variable.data);
 			if (p) {
-				buf_add(&new, p);
+				buf_add(&tmp, p);
 			}
 		} else {
-			buf_add_char(&new, s->data[i]);
+			buf_add_char(&tmp, s->data[i]);
 		}
 	}
 	buf_reset(&environment_variable);
-	buf_move(s, &new);
+	buf_move(s, &tmp);
 }
 
 static void

--- a/src/common/string-helpers.c
+++ b/src/common/string-helpers.c
@@ -93,8 +93,7 @@ strdup_printf(const char *fmt, ...)
 }
 
 char *
-str_join(const char *const parts[],
-		const char *restrict fmt, const char *restrict sep)
+str_join(const char *const parts[], const char *fmt, const char *sep)
 {
 	assert(parts);
 

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -123,7 +123,7 @@ keybind_create(const char *keybind)
 	xkb_keysym_t keysyms[MAX_KEYSYMS];
 	gchar **symnames = g_strsplit(keybind, "-", -1);
 	for (size_t i = 0; symnames[i]; i++) {
-		char *symname = symnames[i];
+		const char *symname = symnames[i];
 		/*
 		 * Since "-" is used as a separator, a keybind string like "W--"
 		 * becomes "W", "", "". This means that it is impossible to bind

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1556,7 +1556,7 @@ rcxml_init(void)
 
 	rc.gap = 0;
 	rc.adaptive_sync = LAB_ADAPTIVE_SYNC_DISABLED;
-	rc.allow_tearing = false;
+	rc.allow_tearing = LAB_TEARING_DISABLED;
 	rc.auto_enable_outputs = true;
 	rc.reuse_output_mode = false;
 	rc.xwayland_persistence = false;

--- a/src/edges.c
+++ b/src/edges.c
@@ -283,8 +283,8 @@ subtract_view_from_space(struct view *view, pixman_region32_t *available)
 	struct wlr_box view_size = ssd_max_extents(view);
 	pixman_box32_t view_rect = {
 		.x1 = view_size.x,
-		.x2 = view_size.x + view_size.width,
 		.y1 = view_size.y,
+		.x2 = view_size.x + view_size.width,
 		.y2 = view_size.y + view_size.height
 	};
 
@@ -431,10 +431,10 @@ edges_find_neighbors(struct border *nearest_edges, struct view *view,
 
 		struct border win_edges = {
 			.top = v->current.y - border.top,
-			.left = v->current.x - border.left,
+			.right = v->current.x + v->current.width + border.right,
 			.bottom = v->current.y + border.bottom
 				+ view_effective_height(v, /* use_pending */ false),
-			.right = v->current.x + v->current.width + border.right,
+			.left = v->current.x - border.left,
 		};
 
 		validate_edges(nearest_edges, view_edges,

--- a/src/img/img-xbm.c
+++ b/src/img/img-xbm.c
@@ -141,12 +141,13 @@ tokenize_xbm(char *buffer)
 			add_token(&ctx, TOKEN_IDENT);
 			get_identifier_token(&ctx);
 			continue;
-		case '0' ... '9':
+		case '0' ... '9': {
 			add_token(&ctx, TOKEN_INT);
 			get_number_token(&ctx);
 			struct token *token = ctx.tokens + ctx.nr_tokens - 1;
 			token->value = (int)strtol(token->name, NULL, 0);
 			continue;
+		}
 		case '{':
 			add_token(&ctx, TOKEN_SPECIAL);
 			get_special_char_token(&ctx);

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -224,13 +224,13 @@ update_popup_position(struct input_method_popup *popup)
 		.anchor_rect = cursor_rect,
 		.anchor = XDG_POSITIONER_ANCHOR_BOTTOM_LEFT,
 		.gravity = XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT,
+		.constraint_adjustment =
+			XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y
+			| XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X,
 		.size = {
 			.width = popup->popup_surface->surface->current.width,
 			.height = popup->popup_surface->surface->current.height,
 		},
-		.constraint_adjustment =
-			XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y
-			| XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X,
 	};
 
 	struct wlr_box popup_box;

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -387,7 +387,7 @@ get_keyinfo(struct wlr_keyboard *wlr_keyboard, uint32_t evdev_keycode)
 	return keyinfo;
 }
 
-static bool
+static enum lab_key_handled
 handle_key_release(struct server *server, uint32_t evdev_keycode)
 {
 	/*
@@ -395,7 +395,7 @@ handle_key_release(struct server *server, uint32_t evdev_keycode)
 	 * forwarded to clients to avoid stuck keys.
 	 */
 	if (!key_state_corresponding_press_event_was_bound(evdev_keycode)) {
-		return false;
+		return LAB_KEY_HANDLED_FALSE;
 	}
 
 	/*
@@ -416,7 +416,7 @@ handle_key_release(struct server *server, uint32_t evdev_keycode)
 	 * not forward the corresponding release event to clients.
 	 */
 	key_state_bound_key_remove(evdev_keycode);
-	return true;
+	return LAB_KEY_HANDLED_TRUE;
 }
 
 static bool
@@ -518,10 +518,10 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 			key_state_bound_key_remove(event->keycode);
 			if (locked && !cur_keybind->allow_when_locked) {
 				cur_keybind = NULL;
-				return true;
+				return LAB_KEY_HANDLED_TRUE;
 			}
 			actions_run(NULL, server, &cur_keybind->actions, NULL);
-			return true;
+			return LAB_KEY_HANDLED_TRUE;
 		} else {
 			return handle_key_release(server, event->keycode);
 		}
@@ -542,11 +542,11 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 		if (server->input_mode == LAB_INPUT_STATE_MENU) {
 			key_state_store_pressed_key_as_bound(event->keycode);
 			handle_menu_keys(server, &keyinfo.translated);
-			return true;
+			return LAB_KEY_HANDLED_TRUE;
 		} else if (server->input_mode == LAB_INPUT_STATE_WINDOW_SWITCHER) {
 			if (handle_cycle_view_key(server, &keyinfo)) {
 				key_state_store_pressed_key_as_bound(event->keycode);
-				return true;
+				return LAB_KEY_HANDLED_TRUE;
 			}
 		}
 	}
@@ -565,10 +565,10 @@ handle_compositor_keybindings(struct keyboard *keyboard,
 		if (!cur_keybind->on_release) {
 			actions_run(NULL, server, &cur_keybind->actions, NULL);
 		}
-		return true;
+		return LAB_KEY_HANDLED_TRUE;
 	}
 
-	return false;
+	return LAB_KEY_HANDLED_FALSE;
 }
 
 static int

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -265,23 +265,21 @@ static struct keybind *
 match_keybinding(struct server *server, struct keyinfo *keyinfo,
 		bool is_virtual)
 {
-	if (is_virtual) {
-		goto process_syms;
+	if (!is_virtual) {
+		/* First try keycodes */
+		struct keybind *keybind = match_keybinding_for_sym(server,
+			keyinfo->modifiers, XKB_KEY_NoSymbol, keyinfo->xkb_keycode);
+		if (keybind) {
+			wlr_log(WLR_DEBUG, "keycode matched");
+			return keybind;
+		}
 	}
 
-	/* First try keycodes */
-	struct keybind *keybind = match_keybinding_for_sym(server,
-		keyinfo->modifiers, XKB_KEY_NoSymbol, keyinfo->xkb_keycode);
-	if (keybind) {
-		wlr_log(WLR_DEBUG, "keycode matched");
-		return keybind;
-	}
-
-process_syms:
 	/* Then fall back to keysyms */
 	for (int i = 0; i < keyinfo->translated.nr_syms; i++) {
-		keybind = match_keybinding_for_sym(server, keyinfo->modifiers,
-			keyinfo->translated.syms[i], keyinfo->xkb_keycode);
+		struct keybind *keybind =
+			match_keybinding_for_sym(server, keyinfo->modifiers,
+				keyinfo->translated.syms[i], keyinfo->xkb_keycode);
 		if (keybind) {
 			wlr_log(WLR_DEBUG, "translated keysym matched");
 			return keybind;
@@ -290,8 +288,9 @@ process_syms:
 
 	/* And finally test for keysyms without modifier */
 	for (int i = 0; i < keyinfo->raw.nr_syms; i++) {
-		keybind = match_keybinding_for_sym(server, keyinfo->modifiers,
-			keyinfo->raw.syms[i], keyinfo->xkb_keycode);
+		struct keybind *keybind =
+			match_keybinding_for_sym(server, keyinfo->modifiers,
+				keyinfo->raw.syms[i], keyinfo->xkb_keycode);
 		if (keybind) {
 			wlr_log(WLR_DEBUG, "raw keysym matched");
 			return keybind;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -467,13 +467,14 @@ menu_create_scene(struct menu *menu)
  * </item>
  */
 static void
-fill_item(char *nodename, char *content)
+fill_item(const char *nodename_, const char *content)
 {
 	/*
 	 * Nodenames for most menu-items end with '.item.menu' but top-level
 	 * pipemenu items do not have the associated <menu> element so merely
 	 * end with a '.item'
 	 */
+	char *nodename = xstrdup(nodename_);
 	string_truncate_at_pattern(nodename, ".item.menu");
 	string_truncate_at_pattern(nodename, ".item");
 
@@ -503,6 +504,8 @@ fill_item(char *nodename, char *content)
 	} else {
 		action_arg_from_xml_node(current_item_action, nodename, content);
 	}
+
+	free(nodename);
 }
 
 static void

--- a/src/osd-field.c
+++ b/src/osd-field.c
@@ -21,8 +21,6 @@ struct field_converter {
 	field_conversion_type *fn;
 };
 
-static const struct field_converter field_converter[];
-
 /* Internal helpers */
 
 static const char *
@@ -200,6 +198,27 @@ field_set_title_short(struct buf *buf, struct view *view, const char *format)
 	buf_add(buf, get_title_if_different(view));
 }
 
+static void field_set_custom(struct buf *buf, struct view *view,
+	const char *format);
+
+static const struct field_converter field_converter[LAB_FIELD_COUNT] = {
+	[LAB_FIELD_TYPE]               = { 'B', field_set_type },
+	[LAB_FIELD_TYPE_SHORT]         = { 'b', field_set_type_short },
+	[LAB_FIELD_WIN_STATE_ALL]      = { 'S', field_set_win_state_all },
+	[LAB_FIELD_WIN_STATE]          = { 's', field_set_win_state },
+	[LAB_FIELD_IDENTIFIER]         = { 'I', field_set_identifier },
+	[LAB_FIELD_TRIMMED_IDENTIFIER] = { 'i', field_set_identifier_trimmed },
+	[LAB_FIELD_DESKTOP_ENTRY_NAME] = { 'n', field_set_desktop_entry_name},
+	[LAB_FIELD_WORKSPACE]          = { 'W', field_set_workspace },
+	[LAB_FIELD_WORKSPACE_SHORT]    = { 'w', field_set_workspace_short },
+	[LAB_FIELD_OUTPUT]             = { 'O', field_set_output },
+	[LAB_FIELD_OUTPUT_SHORT]       = { 'o', field_set_output_short },
+	[LAB_FIELD_TITLE]              = { 'T', field_set_title },
+	[LAB_FIELD_TITLE_SHORT]        = { 't', field_set_title_short },
+	/* fmt_char can never be matched so prevents LAB_FIELD_CUSTOM recursion */
+	[LAB_FIELD_CUSTOM]             = { '\0', field_set_custom },
+};
+
 static void
 field_set_custom(struct buf *buf, struct view *view, const char *format)
 {
@@ -277,24 +296,6 @@ reset_format:
 	}
 	buf_reset(&field_result);
 }
-
-static const struct field_converter field_converter[LAB_FIELD_COUNT] = {
-	[LAB_FIELD_TYPE]               = { 'B', field_set_type },
-	[LAB_FIELD_TYPE_SHORT]         = { 'b', field_set_type_short },
-	[LAB_FIELD_WIN_STATE_ALL]      = { 'S', field_set_win_state_all },
-	[LAB_FIELD_WIN_STATE]          = { 's', field_set_win_state },
-	[LAB_FIELD_IDENTIFIER]         = { 'I', field_set_identifier },
-	[LAB_FIELD_TRIMMED_IDENTIFIER] = { 'i', field_set_identifier_trimmed },
-	[LAB_FIELD_DESKTOP_ENTRY_NAME] = { 'n', field_set_desktop_entry_name},
-	[LAB_FIELD_WORKSPACE]          = { 'W', field_set_workspace },
-	[LAB_FIELD_WORKSPACE_SHORT]    = { 'w', field_set_workspace_short },
-	[LAB_FIELD_OUTPUT]             = { 'O', field_set_output },
-	[LAB_FIELD_OUTPUT_SHORT]       = { 'o', field_set_output_short },
-	[LAB_FIELD_TITLE]              = { 'T', field_set_title },
-	[LAB_FIELD_TITLE_SHORT]        = { 't', field_set_title_short },
-	/* fmt_char can never be matched so prevents LAB_FIELD_CUSTOM recursion */
-	[LAB_FIELD_CUSTOM]             = { '\0', field_set_custom },
-};
 
 struct window_switcher_field *
 osd_field_create(void)

--- a/src/protocols/cosmic_workspaces/cosmic-workspaces.c
+++ b/src/protocols/cosmic_workspaces/cosmic-workspaces.c
@@ -323,11 +323,12 @@ manager_handle_commit(struct wl_client *client, struct wl_resource *resource)
 	struct lab_transaction_op *trans_op, *trans_op_tmp;
 	lab_transaction_for_each_safe(trans_op, trans_op_tmp, addon->ctx) {
 		switch (trans_op->change) {
-		case CW_PENDING_WS_CREATE:
+		case CW_PENDING_WS_CREATE: {
 			group = trans_op->src;
 			struct ws_create_workspace_event *ev = trans_op->data;
 			wl_signal_emit_mutable(&group->events.create_workspace, ev->name);
 			break;
+		}
 		case CW_PENDING_WS_ACTIVATE:
 			workspace = trans_op->src;
 			wl_signal_emit_mutable(&workspace->events.activate, NULL);

--- a/src/protocols/ext-workspace/ext-workspace.c
+++ b/src/protocols/ext-workspace/ext-workspace.c
@@ -295,11 +295,12 @@ manager_handle_commit(struct wl_client *client, struct wl_resource *resource)
 	struct lab_transaction_op *trans_op, *trans_op_tmp;
 	lab_transaction_for_each_safe(trans_op, trans_op_tmp, addon->ctx) {
 		switch (trans_op->change) {
-		case WS_PENDING_WS_CREATE:
+		case WS_PENDING_WS_CREATE: {
 			group = trans_op->src;
 			struct ws_create_workspace_event *ev = trans_op->data;
 			wl_signal_emit_mutable(&group->events.create_workspace, ev->name);
 			break;
+		}
 		case WS_PENDING_WS_ACTIVATE:
 			workspace = trans_op->src;
 			wl_signal_emit_mutable(&workspace->events.activate, NULL);

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -216,7 +216,7 @@ session_lock_output_create(struct session_lock_manager *manager, struct output *
 	 * all outputs with an opaque color such that their normal content is
 	 * fully hidden
 	 */
-	float *black = (float[4]) { 0.f, 0.f, 0.f, 1.f };
+	float black[4] = { 0.f, 0.f, 0.f, 1.f };
 	struct wlr_scene_rect *background = wlr_scene_rect_create(tree, 0, 0, black);
 	if (!background) {
 		wlr_log(WLR_ERROR, "session-lock: wlr_scene_rect_create()");

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -543,20 +543,18 @@ ssd_update_button_hover(struct wlr_scene_node *node,
 		struct ssd_hover_state *hover_state)
 {
 	struct ssd_button *button = NULL;
-	if (!node || !node->data) {
-		goto disable_old_hover;
-	}
 
-	struct node_descriptor *desc = node->data;
-	if (desc->type == LAB_NODE_DESC_SSD_BUTTON) {
-		button = node_ssd_button_from_node(node);
-		if (button == hover_state->button) {
-			/* Cursor is still on the same button */
-			return;
+	if (node && node->data) {
+		struct node_descriptor *desc = node->data;
+		if (desc->type == LAB_NODE_DESC_SSD_BUTTON) {
+			button = node_ssd_button_from_node(node);
+			if (button == hover_state->button) {
+				/* Cursor is still on the same button */
+				return;
+			}
 		}
 	}
 
-disable_old_hover:
 	if (hover_state->button) {
 		update_button_state(hover_state->button, LAB_BS_HOVERD, false);
 		hover_state->view = NULL;

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -46,9 +46,9 @@ ssd_thickness(struct view *view)
 
 	struct border thickness = {
 		.top = theme->titlebar_height + theme->border_width,
+		.right = theme->border_width,
 		.bottom = theme->border_width,
 		.left = theme->border_width,
-		.right = theme->border_width,
 	};
 
 	if (view->ssd_titlebar_hidden) {

--- a/src/theme.c
+++ b/src/theme.c
@@ -289,49 +289,49 @@ load_buttons(struct theme *theme)
 {
 	struct button buttons[] = { {
 		.name = "menu",
+		.fallback_button = (const char[]){ 0x00, 0x21, 0x33, 0x1E, 0x0C, 0x00 },
 		.type = LAB_SSD_BUTTON_WINDOW_MENU,
 		.state_set = 0,
-		.fallback_button = (const char[]){ 0x00, 0x21, 0x33, 0x1E, 0x0C, 0x00 },
 	}, {
 		.name = "iconify",
+		.fallback_button = (const char[]){ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
 		.type = LAB_SSD_BUTTON_ICONIFY,
 		.state_set = 0,
-		.fallback_button = (const char[]){ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
 	}, {
 		.name = "max",
+		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
 		.type = LAB_SSD_BUTTON_MAXIMIZE,
 		.state_set = 0,
-		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
 	}, {
 		.name = "max_toggled",
+		.fallback_button = (const char[]){ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
 		.type = LAB_SSD_BUTTON_MAXIMIZE,
 		.state_set = LAB_BS_TOGGLED,
-		.fallback_button = (const char[]){ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
 	}, {
 		.name = "shade",
+		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x00, 0x0c, 0x1e, 0x3f },
 		.type = LAB_SSD_BUTTON_SHADE,
 		.state_set = 0,
-		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x00, 0x0c, 0x1e, 0x3f },
 	}, {
 		.name = "shade_toggled",
+		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x00, 0x3f, 0x1e, 0x0c },
 		.type = LAB_SSD_BUTTON_SHADE,
 		.state_set = LAB_BS_TOGGLED,
-		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x00, 0x3f, 0x1e, 0x0c },
 	}, {
 		.name = "desk",
+		.fallback_button = (const char[]){ 0x33, 0x33, 0x00, 0x00, 0x33, 0x33 },
 		.type = LAB_SSD_BUTTON_OMNIPRESENT,
 		.state_set = 0,
-		.fallback_button = (const char[]){ 0x33, 0x33, 0x00, 0x00, 0x33, 0x33 },
 	}, {
 		.name = "desk_toggled",
+		.fallback_button = (const char[]){ 0x00, 0x1e, 0x1a, 0x16, 0x1e, 0x00 },
 		.type = LAB_SSD_BUTTON_OMNIPRESENT,
 		.state_set = LAB_BS_TOGGLED,
-		.fallback_button = (const char[]){ 0x00, 0x1e, 0x1a, 0x16, 0x1e, 0x00 },
 	}, {
 		.name = "close",
+		.fallback_button = (const char[]){ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
 		.type = LAB_SSD_BUTTON_CLOSE,
 		.state_set = 0,
-		.fallback_button = (const char[]){ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
 	}, {
 		.name = "menu_hover",
 		.type = LAB_SSD_BUTTON_WINDOW_MENU,


### PR DESCRIPTION
Background: I was doing an experiment compiling labwc as C++. (I know we've discussed this before, and I'm not pushing a transition -- it's just a personal experiment.) But in the process, I found some usages of discouraged/obscure C language features, which are forbidden and produce errors in C++.

Some of the fixes seemed like they would be good cleanups even in C, so I cherry-picked those to this branch. Roughly in order of most- to least-important (in my judgment).

Please feel free to take or leave any of them. Or take some now and leave the others till after the release, if that makes sense.