### PR TITLE
Support <snapping><cornerRange>

### DIFF
--- a/include/common/direction.h
+++ b/include/common/direction.h
@@ -2,9 +2,10 @@
 #ifndef LABWC_DIRECTION_H
 #define LABWC_DIRECTION_H
 
+#include <wlr/types/wlr_output_layout.h>
 #include "view.h"
 
-enum wlr_direction direction_from_view_edge(enum view_edge edge);
+bool direction_from_view_edge(enum view_edge edge, enum wlr_direction *dir);
 enum wlr_direction direction_get_opposite(enum wlr_direction direction);
 
 #endif /* LABWC_DIRECTION_H */

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -145,6 +145,7 @@ struct rcxml {
 
 	/* window snapping */
 	int snap_edge_range;
+	int snap_edge_corner_range;
 	bool snap_overlay_enabled;
 	int snap_overlay_delay_inner;
 	int snap_overlay_delay_outer;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -548,8 +548,16 @@ void interactive_anchor_to_cursor(struct server *server, struct wlr_box *geo);
 void interactive_begin(struct view *view, enum input_mode mode, uint32_t edges);
 void interactive_finish(struct view *view);
 void interactive_cancel(struct view *view);
-/* Possibly returns VIEW_EDGE_CENTER if <topMaximize> is yes */
-enum view_edge edge_from_cursor(struct seat *seat, struct output **dest_output);
+
+/**
+ * Returns the edge to snap a window to.
+ * For example, if the output-relative cursor position (x,y) fulfills
+ * x <= (<snapping><cornerRange>) and y <= (<snapping><range>),
+ * then edge1=VIEW_EDGE_UP and edge2=VIEW_EDGE_LEFT.
+ * The value of (edge1|edge2) can be passed to view_snap_to_edge().
+ */
+bool edge_from_cursor(struct seat *seat, struct output **dest_output,
+	enum view_edge *edge1, enum view_edge *edge2);
 
 void output_init(struct server *server);
 void output_finish(struct server *server);

--- a/include/view.h
+++ b/include/view.h
@@ -62,11 +62,15 @@ enum view_axis {
 enum view_edge {
 	VIEW_EDGE_INVALID = 0,
 
-	VIEW_EDGE_LEFT,
-	VIEW_EDGE_RIGHT,
-	VIEW_EDGE_UP,
-	VIEW_EDGE_DOWN,
-	VIEW_EDGE_CENTER,
+	VIEW_EDGE_LEFT = 1 << 0,
+	VIEW_EDGE_RIGHT = 1 << 1,
+	VIEW_EDGE_UP = 1 << 2,
+	VIEW_EDGE_DOWN = 1 << 3,
+	VIEW_EDGE_CENTER = 1 << 4,
+	VIEW_EDGE_UPLEFT = VIEW_EDGE_UP | VIEW_EDGE_LEFT,
+	VIEW_EDGE_UPRIGHT = VIEW_EDGE_UP | VIEW_EDGE_RIGHT,
+	VIEW_EDGE_DOWNLEFT = VIEW_EDGE_DOWN | VIEW_EDGE_LEFT,
+	VIEW_EDGE_DOWNRIGHT = VIEW_EDGE_DOWN | VIEW_EDGE_RIGHT,
 };
 
 enum view_wants_focus {
@@ -513,6 +517,9 @@ bool view_is_focusable(struct view *view);
  */
 void view_offer_focus(struct view *view);
 
+struct wlr_box view_get_edge_snap_box(struct view *view, struct output *output,
+	enum view_edge edge);
+
 void mappable_connect(struct mappable *mappable, struct wlr_surface *surface,
 	wl_notify_func_t notify_map, wl_notify_func_t notify_unmap);
 void mappable_disconnect(struct mappable *mappable);
@@ -654,7 +661,7 @@ void view_init(struct view *view);
 void view_destroy(struct view *view);
 
 enum view_axis view_axis_parse(const char *direction);
-enum view_edge view_edge_parse(const char *direction);
+enum view_edge view_edge_parse(const char *direction, bool tiling);
 enum view_placement_policy view_placement_parse(const char *policy);
 
 /* xdg.c */

--- a/src/action.c
+++ b/src/action.c
@@ -340,11 +340,10 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 	case ACTION_TYPE_GROW_TO_EDGE:
 	case ACTION_TYPE_SHRINK_TO_EDGE:
 		if (!strcmp(argument, "direction")) {
-			enum view_edge edge = view_edge_parse(content);
-			bool allow_center = action->type == ACTION_TYPE_TOGGLE_SNAP_TO_EDGE
-				|| action->type == ACTION_TYPE_SNAP_TO_EDGE;
-			if ((edge == VIEW_EDGE_CENTER && !allow_center)
-					|| edge == VIEW_EDGE_INVALID) {
+			bool tiling = (action->type == ACTION_TYPE_TOGGLE_SNAP_TO_EDGE
+					|| action->type == ACTION_TYPE_SNAP_TO_EDGE);
+			enum view_edge edge = view_edge_parse(content, tiling);
+			if (edge == VIEW_EDGE_INVALID) {
 				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {
@@ -451,8 +450,8 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			goto cleanup;
 		}
 		if (!strcmp(argument, "direction")) {
-			enum view_edge edge = view_edge_parse(content);
-			if (edge == VIEW_EDGE_CENTER) {
+			enum view_edge edge = view_edge_parse(content, /*tiling*/ false);
+			if (edge == VIEW_EDGE_INVALID) {
 				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {

--- a/src/common/direction.c
+++ b/src/common/direction.c
@@ -4,22 +4,24 @@
 #include "common/direction.h"
 #include "view.h"
 
-enum wlr_direction
-direction_from_view_edge(enum view_edge edge)
+bool
+direction_from_view_edge(enum view_edge edge, enum wlr_direction *dir)
 {
 	switch (edge) {
 	case VIEW_EDGE_LEFT:
-		return WLR_DIRECTION_LEFT;
+		*dir = WLR_DIRECTION_LEFT;
+		return true;
 	case VIEW_EDGE_RIGHT:
-		return WLR_DIRECTION_RIGHT;
+		*dir = WLR_DIRECTION_RIGHT;
+		return true;
 	case VIEW_EDGE_UP:
-		return WLR_DIRECTION_UP;
+		*dir = WLR_DIRECTION_UP;
+		return true;
 	case VIEW_EDGE_DOWN:
-		return WLR_DIRECTION_DOWN;
-	case VIEW_EDGE_CENTER:
-	case VIEW_EDGE_INVALID:
+		*dir = WLR_DIRECTION_DOWN;
+		return true;
 	default:
-		return WLR_DIRECTION_UP;
+		return false;
 	}
 }
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -482,7 +482,7 @@ fill_action_query(char *nodename, char *content, struct action *action, struct p
 	} else if (!strcasecmp(nodename, "omnipresent")) {
 		state->current_view_query->omnipresent = parse_three_state(content);
 	} else if (!strcasecmp(nodename, "tiled")) {
-		state->current_view_query->tiled = view_edge_parse(content);
+		state->current_view_query->tiled = view_edge_parse(content, /*tiling*/ true);
 	} else if (!strcasecmp(nodename, "tiled_region")) {
 		xstrdup_replace(state->current_view_query->tiled_region, content);
 	} else if (!strcasecmp(nodename, "desktop")) {
@@ -1252,6 +1252,8 @@ entry(xmlNode *node, char *nodename, char *content, struct parser_state *state)
 		rc.unmaximize_threshold = atoi(content);
 	} else if (!strcasecmp(nodename, "range.snapping")) {
 		rc.snap_edge_range = atoi(content);
+	} else if (!strcasecmp(nodename, "cornerRange.snapping")) {
+		rc.snap_edge_corner_range = atoi(content);
 	} else if (!strcasecmp(nodename, "enabled.overlay.snapping")) {
 		set_bool(content, &rc.snap_overlay_enabled);
 	} else if (!strcasecmp(nodename, "inner.delay.overlay.snapping")) {
@@ -1592,6 +1594,7 @@ rcxml_init(void)
 	rc.unmaximize_threshold = 150;
 
 	rc.snap_edge_range = 10;
+	rc.snap_edge_corner_range = 30;
 	rc.snap_overlay_enabled = true;
 	rc.snap_overlay_delay_inner = 500;
 	rc.snap_overlay_delay_outer = 500;

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -163,22 +163,26 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 	}
 }
 
-enum view_edge
-edge_from_cursor(struct seat *seat, struct output **dest_output)
+bool
+edge_from_cursor(struct seat *seat, struct output **dest_output,
+		enum view_edge *edge1, enum view_edge *edge2)
 {
+	*dest_output = NULL;
+	*edge1 = VIEW_EDGE_INVALID;
+	*edge2 = VIEW_EDGE_INVALID;
+
 	if (!view_is_floating(seat->server->grabbed_view)) {
-		return VIEW_EDGE_INVALID;
+		return false;
 	}
 
-	int snap_range = rc.snap_edge_range;
-	if (!snap_range) {
-		return VIEW_EDGE_INVALID;
+	if (rc.snap_edge_range == 0) {
+		return false;
 	}
 
 	struct output *output = output_nearest_to_cursor(seat->server);
 	if (!output_is_usable(output)) {
 		wlr_log(WLR_ERROR, "output at cursor is unusable");
-		return VIEW_EDGE_INVALID;
+		return false;
 	}
 	*dest_output = output;
 
@@ -189,22 +193,39 @@ edge_from_cursor(struct seat *seat, struct output **dest_output)
 		output->wlr_output, &cursor_x, &cursor_y);
 
 	struct wlr_box *area = &output->usable_area;
-	if (cursor_x <= area->x + snap_range) {
-		return VIEW_EDGE_LEFT;
-	} else if (cursor_x >= area->x + area->width - snap_range) {
-		return VIEW_EDGE_RIGHT;
-	} else if (cursor_y <= area->y + snap_range) {
-		if (rc.snap_top_maximize) {
-			return VIEW_EDGE_CENTER;
-		} else {
-			return VIEW_EDGE_UP;
-		}
-	} else if (cursor_y >= area->y + area->height - snap_range) {
-		return VIEW_EDGE_DOWN;
+
+	int top = cursor_y - area->y;
+	int bottom = area->y + area->height - cursor_y;
+	int left = cursor_x - area->x;
+	int right = area->x + area->width - cursor_x;
+
+	if (top < rc.snap_edge_range) {
+		*edge1 = VIEW_EDGE_UP;
+	} else if (bottom < rc.snap_edge_range) {
+		*edge1 = VIEW_EDGE_DOWN;
+	} else if (left < rc.snap_edge_range) {
+		*edge1 = VIEW_EDGE_LEFT;
+	} else if (right < rc.snap_edge_range) {
+		*edge1 = VIEW_EDGE_RIGHT;
 	} else {
-		/* Not close to any edge */
-		return VIEW_EDGE_INVALID;
+		return false;
 	}
+
+	if (*edge1 & (VIEW_EDGE_UP | VIEW_EDGE_DOWN)) {
+		if (left < rc.snap_edge_corner_range) {
+			*edge2 = VIEW_EDGE_LEFT;
+		} else if (right < rc.snap_edge_corner_range) {
+			*edge2 = VIEW_EDGE_RIGHT;
+		}
+	} else if (*edge1 & (VIEW_EDGE_LEFT | VIEW_EDGE_RIGHT)) {
+		if (top < rc.snap_edge_corner_range) {
+			*edge2 = VIEW_EDGE_UP;
+		} else if (bottom < rc.snap_edge_corner_range) {
+			*edge2 = VIEW_EDGE_DOWN;
+		}
+	}
+
+	return true;
 }
 
 /* Returns true if view was snapped to any edge */
@@ -212,8 +233,8 @@ static bool
 snap_to_edge(struct view *view)
 {
 	struct output *output;
-	enum view_edge edge = edge_from_cursor(&view->server->seat, &output);
-	if (edge == VIEW_EDGE_INVALID) {
+	enum view_edge edge1, edge2;
+	if (!edge_from_cursor(&view->server->seat, &output, &edge1, &edge2)) {
 		return false;
 	}
 
@@ -222,12 +243,11 @@ snap_to_edge(struct view *view)
 	 * Don't store natural geometry here (it was
 	 * stored already in interactive_begin())
 	 */
-	if (edge == VIEW_EDGE_CENTER) {
-		/* <topMaximize> */
+	if (edge1 == VIEW_EDGE_UP && rc.snap_top_maximize) {
 		view_maximize(view, VIEW_AXIS_BOTH,
 			/*store_natural_geometry*/ false);
 	} else {
-		view_snap_to_edge(view, edge,
+		view_snap_to_edge(view, edge1 | edge2,
 			/*across_outputs*/ false,
 			/*store_natural_geometry*/ false);
 	}

--- a/src/output.c
+++ b/src/output.c
@@ -964,6 +964,11 @@ output_get_adjacent(struct output *output, enum view_edge edge, bool wrap)
 		return NULL;
 	}
 
+	enum wlr_direction direction;
+	if (!direction_from_view_edge(edge, &direction)) {
+		return NULL;
+	}
+
 	struct wlr_box box = output_usable_area_in_layout_coords(output);
 	int lx = box.x + box.width / 2;
 	int ly = box.y + box.height / 2;
@@ -972,7 +977,6 @@ output_get_adjacent(struct output *output, enum view_edge edge, bool wrap)
 	struct wlr_output *new_output = NULL;
 	struct wlr_output *current_output = output->wlr_output;
 	struct wlr_output_layout *layout = output->server->output_layout;
-	enum wlr_direction direction = direction_from_view_edge(edge);
 	new_output = wlr_output_layout_adjacent_output(layout, direction,
 		current_output, lx, ly);
 

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <assert.h>
+#include "common/direction.h"
 #include "common/lab-scene-rect.h"
 #include "labwc.h"
 #include "overlay.h"
@@ -112,31 +113,15 @@ show_region_overlay(struct seat *seat, struct region *region)
 	show_overlay(seat, &seat->overlay.region_rect, &region->geo);
 }
 
-/* TODO: share logic with view_get_edge_snap_box() */
-static struct wlr_box get_edge_snap_box(enum view_edge edge, struct output *output)
+static struct wlr_box
+get_edge_snap_box(struct seat *seat)
 {
-	struct wlr_box box = output_usable_area_in_layout_coords(output);
-	switch (edge) {
-	case VIEW_EDGE_RIGHT:
-		box.x += box.width / 2;
-		/* fallthrough */
-	case VIEW_EDGE_LEFT:
-		box.width /= 2;
-		break;
-	case VIEW_EDGE_DOWN:
-		box.y += box.height / 2;
-		/* fallthrough */
-	case VIEW_EDGE_UP:
-		box.height /= 2;
-		break;
-	case VIEW_EDGE_CENTER:
-		/* <topMaximize> */
-		break;
-	default:
-		/* not reached */
-		assert(false);
+	struct output *output = seat->overlay.active.output;
+	if (rc.snap_top_maximize && seat->overlay.active.edge == VIEW_EDGE_UP) {
+		return output_usable_area_in_layout_coords(output);
+	} else {
+		return view_get_edge_snap_box(NULL, output, seat->overlay.active.edge);
 	}
-	return box;
 }
 
 static int
@@ -145,48 +130,32 @@ handle_edge_overlay_timeout(void *data)
 	struct seat *seat = data;
 	assert(seat->overlay.active.edge != VIEW_EDGE_INVALID
 		&& seat->overlay.active.output);
-	struct wlr_box box = get_edge_snap_box(seat->overlay.active.edge,
-		seat->overlay.active.output);
+	struct wlr_box box = get_edge_snap_box(seat);
 	show_overlay(seat, &seat->overlay.edge_rect, &box);
 	return 0;
-}
-
-static enum wlr_direction
-get_wlr_direction(enum view_edge edge)
-{
-	switch (edge) {
-	case VIEW_EDGE_LEFT:
-		return WLR_DIRECTION_LEFT;
-	case VIEW_EDGE_RIGHT:
-		return WLR_DIRECTION_RIGHT;
-	case VIEW_EDGE_UP:
-	case VIEW_EDGE_CENTER:
-		return WLR_DIRECTION_UP;
-	case VIEW_EDGE_DOWN:
-		return WLR_DIRECTION_DOWN;
-	default:
-		/* not reached */
-		assert(false);
-		return 0;
-	}
 }
 
 static bool
 edge_has_adjacent_output_from_cursor(struct seat *seat, struct output *output,
 		enum view_edge edge)
 {
+	enum wlr_direction dir;
+	if (!direction_from_view_edge(edge, &dir)) {
+		return false;
+	}
 	return wlr_output_layout_adjacent_output(
-		seat->server->output_layout, get_wlr_direction(edge),
+		seat->server->output_layout, dir,
 		output->wlr_output, seat->cursor->x, seat->cursor->y);
 }
 
 static void
-show_edge_overlay(struct seat *seat, enum view_edge edge,
+show_edge_overlay(struct seat *seat, enum view_edge edge1, enum view_edge edge2,
 		struct output *output)
 {
 	if (!rc.snap_overlay_enabled) {
 		return;
 	}
+	uint32_t edge = edge1 | edge2;
 	if (seat->overlay.active.edge == edge
 			&& seat->overlay.active.output == output) {
 		return;
@@ -196,7 +165,7 @@ show_edge_overlay(struct seat *seat, enum view_edge edge,
 	seat->overlay.active.output = output;
 
 	int delay;
-	if (edge_has_adjacent_output_from_cursor(seat, output, edge)) {
+	if (edge_has_adjacent_output_from_cursor(seat, output, edge1)) {
 		delay = rc.snap_overlay_delay_inner;
 	} else {
 		delay = rc.snap_overlay_delay_outer;
@@ -212,8 +181,7 @@ show_edge_overlay(struct seat *seat, enum view_edge edge,
 		wl_event_source_timer_update(seat->overlay.timer, delay);
 	} else {
 		/* Show overlay now */
-		struct wlr_box box = get_edge_snap_box(seat->overlay.active.edge,
-			seat->overlay.active.output);
+		struct wlr_box box = get_edge_snap_box(seat);
 		show_overlay(seat, &seat->overlay.edge_rect, &box);
 	}
 }
@@ -234,9 +202,9 @@ overlay_update(struct seat *seat)
 
 	/* Edge-snapping overlay */
 	struct output *output;
-	enum view_edge edge = edge_from_cursor(seat, &output);
-	if (edge != VIEW_EDGE_INVALID) {
-		show_edge_overlay(seat, edge, output);
+	enum view_edge edge1, edge2;
+	if (edge_from_cursor(seat, &output, &edge1, &edge2)) {
+		show_edge_overlay(seat, edge1, edge2, output);
 		return;
 	}
 

--- a/src/view.c
+++ b/src/view.c
@@ -437,42 +437,42 @@ view_edge_invert(enum view_edge edge)
 	}
 }
 
-static struct wlr_box
+struct wlr_box
 view_get_edge_snap_box(struct view *view, struct output *output,
 		enum view_edge edge)
 {
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
-	int x_offset = edge == VIEW_EDGE_RIGHT
-		? (usable.width + rc.gap) / 2 : rc.gap;
-	int y_offset = edge == VIEW_EDGE_DOWN
-		? (usable.height + rc.gap) / 2 : rc.gap;
 
-	int base_width, base_height;
-	switch (edge) {
-	case VIEW_EDGE_LEFT:
-	case VIEW_EDGE_RIGHT:
-		base_width = (usable.width - 3 * rc.gap) / 2;
-		base_height = usable.height - 2 * rc.gap;
-		break;
-	case VIEW_EDGE_UP:
-	case VIEW_EDGE_DOWN:
-		base_width = usable.width - 2 * rc.gap;
-		base_height = (usable.height - 3 * rc.gap) / 2;
-		break;
-	default:
-	case VIEW_EDGE_CENTER:
-		base_width = usable.width - 2 * rc.gap;
-		base_height = usable.height - 2 * rc.gap;
-		break;
+	int x1 = rc.gap;
+	int y1 = rc.gap;
+	int x2 = usable.width - rc.gap;
+	int y2 = usable.height - rc.gap;
+	if (edge & VIEW_EDGE_RIGHT) {
+		x1 = (usable.width + rc.gap) / 2;
+	}
+	if (edge & VIEW_EDGE_LEFT) {
+		x2 = (usable.width - rc.gap) / 2;
+	}
+	if (edge & VIEW_EDGE_DOWN) {
+		y1 = (usable.height + rc.gap) / 2;
+	}
+	if (edge & VIEW_EDGE_UP) {
+		y2 = (usable.height - rc.gap) / 2;
 	}
 
-	struct border margin = ssd_get_margin(view->ssd);
 	struct wlr_box dst = {
-		.x = x_offset + usable.x + margin.left,
-		.y = y_offset + usable.y + margin.top,
-		.width = base_width - margin.left - margin.right,
-		.height = base_height - margin.top - margin.bottom,
+		.x = x1 + usable.x,
+		.y = y1 + usable.y,
+		.width = x2 - x1,
+		.height = y2 - y1,
 	};
+	if (view) {
+		struct border margin = ssd_get_margin(view->ssd);
+		dst.x += margin.left;
+		dst.y += margin.top;
+		dst.width -= margin.left + margin.right;
+		dst.height -= margin.top + margin.bottom;
+	}
 
 	return dst;
 }
@@ -2101,7 +2101,7 @@ view_axis_parse(const char *direction)
 }
 
 enum view_edge
-view_edge_parse(const char *direction)
+view_edge_parse(const char *direction, bool tiling)
 {
 	if (!direction) {
 		return VIEW_EDGE_INVALID;
@@ -2114,11 +2114,23 @@ view_edge_parse(const char *direction)
 		return VIEW_EDGE_RIGHT;
 	} else if (!strcasecmp(direction, "down")) {
 		return VIEW_EDGE_DOWN;
-	} else if (!strcasecmp(direction, "center")) {
-		return VIEW_EDGE_CENTER;
-	} else {
-		return VIEW_EDGE_INVALID;
 	}
+
+	if (tiling) {
+		if (!strcasecmp(direction, "center")) {
+			return VIEW_EDGE_CENTER;
+		} else if (!strcasecmp(direction, "up-left")) {
+			return VIEW_EDGE_UPLEFT;
+		} else if (!strcasecmp(direction, "up-right")) {
+			return VIEW_EDGE_UPRIGHT;
+		} else if (!strcasecmp(direction, "down-left")) {
+			return VIEW_EDGE_DOWNLEFT;
+		} else if (!strcasecmp(direction, "down-right")) {
+			return VIEW_EDGE_DOWNRIGHT;
+		}
+	}
+
+	return VIEW_EDGE_INVALID;
 }
 
 enum view_placement_policy
@@ -2143,7 +2155,7 @@ view_placement_parse(const char *policy)
 
 void
 view_snap_to_edge(struct view *view, enum view_edge edge,
-			bool across_outputs, bool store_natural_geometry)
+		bool across_outputs, bool store_natural_geometry)
 {
 	assert(view);
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -604,7 +604,7 @@ xdg_toplevel_view_notify_tiled(struct view *view)
 		return;
 	}
 
-	enum wlr_edges edge = WLR_EDGE_NONE;
+	uint32_t edge = WLR_EDGE_NONE;
 
 	bool want_edge = rc.snap_tiling_events_mode & LAB_TILING_EVENTS_EDGE;
 	bool want_region = rc.snap_tiling_events_mode & LAB_TILING_EVENTS_REGION;
@@ -627,8 +627,21 @@ xdg_toplevel_view_notify_tiled(struct view *view)
 		case VIEW_EDGE_DOWN:
 			edge = WLR_EDGE_BOTTOM | WLR_EDGE_LEFT | WLR_EDGE_RIGHT;
 			break;
+		case VIEW_EDGE_UPLEFT:
+			edge = WLR_EDGE_TOP | WLR_EDGE_LEFT;
+			break;
+		case VIEW_EDGE_UPRIGHT:
+			edge = WLR_EDGE_TOP | WLR_EDGE_RIGHT;
+			break;
+		case VIEW_EDGE_DOWNLEFT:
+			edge = WLR_EDGE_BOTTOM | WLR_EDGE_LEFT;
+			break;
+		case VIEW_EDGE_DOWNRIGHT:
+			edge = WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT;
+			break;
 		default:
 			edge = WLR_EDGE_NONE;
+			break;
 		}
 	}
 


### PR DESCRIPTION
Closes #1758.

By default, `<snapping><cornerRange>` is set to 50(px).

`up-left`/`up-right`/`bottom-left`/`bottom-right` are added for `direction` argument of `SnapToEdge`/`ToggleSnapToEdge` actions.

Additionally, this PR changes the edge-snapping overlay to take into account `<core><gap>`, as a result of deduplicating `get_edge_snap_box()` in `interactive.c` and `view_get_edge_snap_box()` in `view.c`. But as this makes the region/edge snapping overlays inconsistent, I'm planning to open another sub-PR to both snapping overlays to take into account `<core><gap>`.

Documentation is also lacking.