### PR TITLE
resistance: refactor snap constraints, use in interactive resistance

### DIFF
--- a/include/snap-constraints.h
+++ b/include/snap-constraints.h
@@ -2,19 +2,21 @@
 #ifndef LABWC_SNAP_CONSTRAINTS_H
 #define LABWC_SNAP_CONSTRAINTS_H
 
+#include <wlr/util/edges.h>
+
 #include "common/border.h"
 #include "view.h"
 
 struct wlr_box;
 
 void snap_constraints_set(struct view *view,
-	enum view_edge direction, struct wlr_box geom);
+	enum wlr_edges direction, struct wlr_box geom);
 
 void snap_constraints_invalidate(struct view *view);
 
 void snap_constraints_update(struct view *view);
 
 struct wlr_box snap_constraints_effective(struct view *view,
-	enum view_edge direction);
+	enum wlr_edges direction, bool use_pending);
 
 #endif /* LABWC_SNAP_CONSTRAINTS_H */

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -185,7 +185,7 @@ resistance_resize_apply(struct view *view, struct wlr_box *new_geom)
 
 	/* If any "best" edges were encountered during this move, snap motion */
 	edges_adjust_resize_geom(view, next_edges,
-		view->server->resize_edges, new_geom, /* use_pending */ false);
+		resize_edges, new_geom, /* use_pending */ false);
 
 	/*
 	 * Record effective geometry after snapping in case the client opts to

--- a/src/snap-constraints.c
+++ b/src/snap-constraints.c
@@ -152,8 +152,12 @@ snap_constraints_update(struct view *view)
 		return;
 	}
 
-	/* Only update constraints when view geometry matches expectation */
-	if (!wlr_box_equal(&view->pending, &last_snap_hit.geom)) {
+	/* Only update constraints when pending view dimensions match expectation */
+	if (view->pending.width != last_snap_hit.geom.width) {
+		return;
+	}
+
+	if (view->pending.height != last_snap_hit.geom.height) {
 		return;
 	}
 

--- a/src/snap.c
+++ b/src/snap.c
@@ -195,7 +195,8 @@ snap_grow_to_next_edge(struct view *view,
 	edges_initialize(&next_edges);
 
 	/* Use a constrained, effective geometry for snapping if appropriate */
-	struct wlr_box origin = snap_constraints_effective(view, direction);
+	struct wlr_box origin =
+		snap_constraints_effective(view, resize_edges, /* use_pending */ true);
 
 	/* Limit motion to any intervening edge of other views on this output */
 	edges_find_neighbors(&next_edges, view, origin, *geo,
@@ -208,7 +209,7 @@ snap_grow_to_next_edge(struct view *view,
 	 * Record effective geometry after snapping in case the client opts to
 	 * ignore or modify the configured geometry
 	 */
-	snap_constraints_set(view, direction, *geo);
+	snap_constraints_set(view, resize_edges, *geo);
 }
 
 void
@@ -261,7 +262,8 @@ snap_shrink_to_next_edge(struct view *view,
 	edges_initialize(&next_edges);
 
 	/* Use a constrained, effective geometry for snapping if appropriate */
-	struct wlr_box origin = snap_constraints_effective(view, direction);
+	struct wlr_box origin =
+		snap_constraints_effective(view, resize_edges, /* use_pending */ true);
 
 	/* Snap to output edges if the moving edge started off-screen */
 	edges_find_outputs(&next_edges, view,
@@ -278,5 +280,5 @@ snap_shrink_to_next_edge(struct view *view,
 	 * Record effective geometry after snapping in case the client opts to
 	 * ignore or modify the configured geometry
 	 */
-	snap_constraints_set(view, direction, *geo);
+	snap_constraints_set(view, resize_edges, *geo);
 }


### PR DESCRIPTION
With negative screen or window resistance (attraction), snapping can cause "flickering" in clients (like `foot`) that enforce constraints on sizes. As labwc tries to snap a window to an edge, the client may substitute its own size that does not quite reach the edge; this can leave the cursor in a position that, when it moves slightly, will cause the client to bounce rapidly between a size that puts its resize edge near the cursor and one that puts its resize edge near the snapping edge.

A similar issue appeared earlier with "grow to edge" or "shrink to edge" operations, which was handled by caching the "desired" size set by labwc and using that for subsequent edge checks. When the client overrules a configure request with a different size, we still remember our "intended" size, and use that for subsequent edge checks.

The same cache and logic can be applied to interactive resizes. However, because interactive resizes can act on both a horizontal and a vertical edge, the cache has been extended to apply to either orientation or both simultaneously.

I have tested these changes briefly, but we will need more extensive validation that existing (grow or shrink)-to-edge operations have not been broken, and that both positive and negative resistance values behave intuitively for interactive resizes.