### PR TITLE
 Update for wlroots 0.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
           apt-get install -y git gcc clang gdb xwayland
           apt-get build-dep -y labwc
           apt-get build-dep -y libwlroots-0.18-dev
+          apt-get build-dep -y libxkbcommon-dev
 
       - name: Install FreeBSD dependencies
         if: matrix.name == 'FreeBSD'
@@ -118,7 +119,7 @@ jobs:
           xbps-install -y git meson gcc clang pkg-config scdoc \
             cairo-devel glib-devel libpng-devel librsvg-devel libxml2-devel \
             pango-devel wlroots0.19-devel gdb bash xorg-server-xwayland \
-            dejavu-fonts-ttf libsfdo-devel foot
+            dejavu-fonts-ttf libsfdo-devel foot hwids
 
       # These builds are executed on all runners
       - name: Build with gcc

--- a/meson.build
+++ b/meson.build
@@ -51,9 +51,9 @@ endif
 add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 
 wlroots = dependency(
-  'wlroots-0.19',
+  'wlroots-0.20',
   default_options: ['default_library=static', 'examples=false'],
-  version: ['>=0.19.0', '<0.20.0'],
+  version: ['>=0.20.0', '<0.21.0'],
 )
 
 wlroots_has_xwayland = wlroots.get_variable('have_xwayland') == 'true'

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -572,7 +572,7 @@ input_method_relay_create(struct seat *seat)
 	relay->popup_tree = wlr_scene_tree_create(&seat->server->scene->tree);
 
 	relay->new_text_input.notify = handle_new_text_input;
-	wl_signal_add(&seat->server->text_input_manager->events.text_input,
+	wl_signal_add(&seat->server->text_input_manager->events.new_text_input,
 		&relay->new_text_input);
 
 	relay->new_input_method.notify = handle_new_input_method;

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -263,6 +263,7 @@ update_popups_position(struct input_method_relay *relay)
 static void
 handle_input_method_commit(struct wl_listener *listener, void *data)
 {
+	// FIXME: data argument is now NULL for enable, commit, disable and destroy
 	struct input_method_relay *relay =
 		wl_container_of(listener, relay, input_method_commit);
 	struct wlr_input_method_v2 *input_method = data;

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 2d5492c73770c9de420527df1098fefabe43d689
+revision = master
 
 [provide]
 dependency_names = wlroots-0.20

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 0.19
+revision = f04ef79f619983bfb4a7c9908bdae62e0d0d5ba7
 
 [provide]
-dependency_names = wlroots-0.19
-wlroots-0.19=wlroots
+dependency_names = wlroots-0.20
+wlroots-0.20=wlroots

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = f04ef79f619983bfb4a7c9908bdae62e0d0d5ba7
+revision = 536100488fc4c64528786801860f96cfa1a55765
 
 [provide]
 dependency_names = wlroots-0.20

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 536100488fc4c64528786801860f96cfa1a55765
+revision = 2d5492c73770c9de420527df1098fefabe43d689
 
 [provide]
 dependency_names = wlroots-0.20


### PR DESCRIPTION
Replaced by
- #2956

---

You know the drill, not intended to be merged anytime soon.
Mainly to ease incremental chase updates so we don't end up with a giant pile of work when we start tracking 0.20.

Not suggested to use as daily driver but pointing out issues in this PR is obviously welcome. The last commit always tracks the wlroots master branch so issues are expected when wlroots breaks API. List of breaking changes from wlroots is [here](https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3977).

This PR may also serve as a base for other PRs to test new wlroots things like toplevel capture.

Known defects as of today:
- [ ] remove erroneous IME commit, I mixed up the `input_method` with the `text_input`.

Push policy: feel free to push commits to this PR but please don't force-push, I'll handle the rebasing.