### PR TITLE
RFC: windowswitcher: show 's' as "state" for shaded views

### DIFF
--- a/src/osd-field.c
+++ b/src/osd-field.c
@@ -125,10 +125,12 @@ static void
 field_set_win_state(struct buf *buf, struct view *view, const char *format)
 {
 	/* custom type conversion-specifier: s */
-	if (view->maximized) {
-		buf_add(buf, "M");
-	} else if (view->minimized) {
+	if (view->minimized) {
 		buf_add(buf, "m");
+	} else if (view->shaded) {
+		buf_add(buf, "s");
+	} else if (view->maximized) {
+		buf_add(buf, "M");
 	} else if (view->fullscreen) {
 		buf_add(buf, "F");
 	} else {
@@ -142,7 +144,9 @@ field_set_win_state_all(struct buf *buf, struct view *view, const char *format)
 	/* custom type conversion-specifier: S */
 	buf_add(buf, view->minimized ? "m" : " ");
 	buf_add(buf, view->maximized ? "M" : " ");
-	buf_add(buf, view->fullscreen ? "F" : " ");
+	// XXX WIP -- "s" should be handled separately - consumes space in
+	// XXX custom field -- harder is to choose order...
+	buf_add(buf, view->fullscreen ? "F" : view->shaded ? "s" : " ");
 	/* TODO: add always-on-top and omnipresent ? */
 }
 


### PR DESCRIPTION
While at it sorted the code to show 'm' before 's' and 's' before 'M'
\-- from the least visible to most visible state.

RFC NOTE 1: docs not (yet) updated

RFC NOTE 2: "hacked" the field_set_win_state_all() to show either 'F' or 's', as F and s cannot be (feasibly) be active the same time. This is inconsistent - just used to make 's' seen if one uses only 'S' in custom="..." format and not content="state" at all...