### PR TITLE
Add a way to replicate KDE Window Control Setups

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -186,6 +186,11 @@ this is for compatibility with Openbox.
 	that it is not always possible to turn off client side decorations.
 	Default is server.
 
+*<core><disableMaximizedServerDecor>*
+	Hide server side decoration when a window is maximized.
+	Useful for trying to replicate a KDE window controls setup where window controls
+	merge with the top panel
+
 *<core><gap>*
 	The distance in pixels between windows and output edges when using
 	movement actions, for example MoveToEdge. Default is 0.

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -70,6 +70,7 @@ struct rcxml {
 	enum adaptive_sync_mode adaptive_sync;
 	enum tearing_mode allow_tearing;
 	bool auto_enable_outputs;
+	bool disable_maximized_ssd_decor;
 	bool reuse_output_mode;
 	enum view_placement_policy placement_policy;
 	bool xwayland_persistence;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1162,6 +1162,8 @@ entry(xmlNode *node, char *nodename, char *content, struct parser_state *state)
 		rc.gap = atoi(content);
 	} else if (!strcasecmp(nodename, "adaptiveSync.core")) {
 		set_adaptive_sync_mode(content, &rc.adaptive_sync);
+	} else if (!strcasecmp(nodename, "disableMaximizedServerDecor.core")) {
+		set_bool(content, &rc.disable_maximized_ssd_decor);
 	} else if (!strcasecmp(nodename, "allowTearing.core")) {
 		set_tearing_mode(content, &rc.allow_tearing);
 	} else if (!strcasecmp(nodename, "autoEnableOutputs.core")) {

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -30,7 +30,7 @@ ssd_thickness(struct view *view)
 	 * in border-only deco mode as view->ssd would only be set
 	 * after ssd_create() returns.
 	 */
-	if (!view->ssd_enabled || view->fullscreen) {
+	if (!view->ssd_enabled || view->fullscreen || (view->maximized && rc.disable_maximized_ssd_decor)) {
 		return (struct border){ 0 };
 	}
 
@@ -87,7 +87,7 @@ static enum ssd_part_type
 get_resizing_type(const struct ssd *ssd, struct wlr_cursor *cursor)
 {
 	struct view *view = ssd ? ssd->view : NULL;
-	if (!view || !cursor || !view->ssd_enabled || view->fullscreen) {
+	if (!view || !cursor || !view->ssd_enabled || view->fullscreen || (view->maximized && rc.disable_maximized_ssd_decor)) {
 		return LAB_SSD_NONE;
 	}
 


### PR DESCRIPTION
In KDE you can use KDE Window Control to hide SSDs and merge the window controls in the top panel, i think it works like this in MacOS too, i added a simple change to allow doing this in labwc