### PR TITLE
SIGUSR1 to trigger HideCursor action

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -247,6 +247,7 @@ struct server {
 	struct wlr_compositor *compositor;
 
 	struct wl_event_source *sighup_source;
+	struct wl_event_source *sigusr1_source;
 	struct wl_event_source *sigint_source;
 	struct wl_event_source *sigterm_source;
 	struct wl_event_source *sigchld_source;

--- a/src/server.c
+++ b/src/server.c
@@ -103,6 +103,15 @@ handle_sighup(int signal, void *data)
 }
 
 static int
+handle_sigusr1(int signal, void *data)
+{
+	struct server *server = data;
+
+	cursor_set_visible(&server->seat, false);
+	return 0;
+}
+
+static int
 handle_sigterm(int signal, void *data)
 {
 	struct wl_display *display = data;
@@ -418,6 +427,8 @@ server_init(struct server *server)
 	/* Catch signals */
 	server->sighup_source = wl_event_loop_add_signal(
 		server->wl_event_loop, SIGHUP, handle_sighup, server);
+	server->sigusr1_source = wl_event_loop_add_signal(
+		server->wl_event_loop, SIGUSR1, handle_sigusr1, server);
 	server->sigint_source = wl_event_loop_add_signal(
 		server->wl_event_loop, SIGINT, handle_sigterm, server->wl_display);
 	server->sigterm_source = wl_event_loop_add_signal(
@@ -746,6 +757,7 @@ server_finish(struct server *server)
 	desktop_entry_finish(server);
 #endif
 	wl_event_source_remove(server->sighup_source);
+	wl_event_source_remove(server->sigusr1_source);
 	wl_event_source_remove(server->sigint_source);
 	wl_event_source_remove(server->sigterm_source);
 	wl_event_source_remove(server->sigchld_source);


### PR DESCRIPTION
Not having an equivalent to X's `unclutter` (which hides the cursor after a period of inactivity) is a big pain point for some users. Sway has `seat * hide_cursor 5000` but in labwc there is currently no way to achieve similar functionality without a kluge (see https://github.com/labwc/labwc/issues/2880). I had raised the possibility of configurable signal handlers to Consolatis but, on second thought, I think that would be overkill. An elegant way to achieve this functionality in labwc would be something like `swayidle timeout 5 "pkill -FOO labwc" &` where `FOO` is a signal that triggers the labwc's HideCursor action. labwc uses SIGHUP but SIGUSR1 and SIGUSR2 are both available. I went with SIGUSR1. This is tested and working as expected: `swayidle timeout 5 "pkill -USR1 labwc" &`