### PR TITLE
docs: update package maintainer list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,7 @@ to analyse keyboard events
 Some distributions carry labwc in their repositories or user repositories.
 
 - @ptrcnull (Alpine)
-- @narrat (Arch)
-- @artist-artix (Artix)
+- @ptr1337 (Arch)
 - @b1rger (Debian)
 - @jbeich (FreeBSD)
 - @epsilon-0 (Gentoo)


### PR DESCRIPTION
The Arch package is now an official Arch package with a new maintainer.

The Github account of the Artix Linux maintainer has been deleted.