### PR TITLE
img: fix apparent double-free in img_svg_render() failure path

### DIFF
--- a/src/img/img-svg.c
+++ b/src/img/img-svg.c
@@ -65,6 +65,5 @@ img_svg_render(RsvgHandle *svg, int w, int h, double scale)
 error:
 	wlr_buffer_drop(&buffer->base);
 	cairo_destroy(cr);
-	g_object_unref(svg);
 	return NULL;
 }


### PR DESCRIPTION
img_svg_render() calls g_object_unref() on the RsvgHandle in its error path, but the handle is owned by the shared lab_img_data struct and will be double-freed later by lab_img_destroy().

The double-free was introduced when img_svg_load() was split from img_svg_render(). The g_object_unref() should have been removed from img_svg_render() but was missed.

Fixes: 16dbdc64e58d66011bbf319b92de844dab0ca8d9
("ssd: rework titlebar button rendering")

cc @tokyo4j 