### PR TITLE
input: support tablet tool pressure range configuration (needs wlroots addition)

### DIFF
--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -132,6 +132,8 @@ struct rcxml {
 	struct tablet_tool_config {
 		enum motion motion;
 		double relative_motion_sensitivity;
+		double min_pressure;
+		double max_pressure;
 	} tablet_tool;
 
 	/* libinput */

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1366,6 +1366,12 @@ entry(xmlNode *node, char *nodename, char *content, struct parser_state *state)
 	} else if (!strcasecmp(nodename, "relativeMotionSensitivity.tabletTool")) {
 		rc.tablet_tool.relative_motion_sensitivity =
 			tablet_get_dbl_if_positive(content, "relativeMotionSensitivity");
+	} else if (!strcasecmp(nodename, "minPressure.tabletTool")) {
+		rc.tablet_tool.min_pressure =
+			tablet_get_dbl_if_positive(content, "minPressure");
+	} else if (!strcasecmp(nodename, "maxPressure.tabletTool")) {
+		rc.tablet_tool.max_pressure =
+			tablet_get_dbl_if_positive(content, "maxPressure");
 	} else if (!strcasecmp(nodename, "ignoreButtonReleasePeriod.menu")) {
 		rc.menu_ignore_button_release_period = atoi(content);
 	} else if (!strcasecmp(nodename, "showIcons.menu")) {
@@ -1581,6 +1587,8 @@ rcxml_init(void)
 	tablet_load_default_button_mappings();
 	rc.tablet_tool.motion = LAB_TABLET_MOTION_ABSOLUTE;
 	rc.tablet_tool.relative_motion_sensitivity = 1.0;
+	rc.tablet_tool.min_pressure = 0.0;
+	rc.tablet_tool.max_pressure = 1.0;
 
 	rc.repeat_rate = 25;
 	rc.repeat_delay = 600;

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -2,10 +2,11 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <linux/input-event-codes.h>
+#include "wlr/backend/libinput.h"
 #include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_tool.h>
-#include <wlr/util/log.h>
 #include <wlr/types/wlr_scene.h>
+#include <wlr/util/log.h>
 #include "common/macros.h"
 #include "common/mem.h"
 #include "common/scene-helpers.h"
@@ -332,6 +333,27 @@ handle_tablet_tool_proximity(struct wl_listener *listener, void *data)
 		 * use proximity for creating a `wlr_tablet_v2_tablet_tool`.
 		 */
 		tool = tablet_tool_create(tablet->seat, ev->tool);
+	}
+
+	struct libinput_tablet_tool *libinput_tool =
+		wlr_libinput_get_tablet_tool_handle(tool->tool_v2->wlr_tool);
+
+	/*
+	 * Configure tool pressure range using libinput. Note that a runtime change
+	 * needs two proximity-in events. First one is for applying the pressure range
+	 * here and second one until it is effectively applied, probably because of
+	 * how lininput applies pressure range changes internally.
+	 */
+	if (libinput_tablet_tool_config_pressure_range_is_available(libinput_tool) > 0
+			&& rc.tablet_tool.min_pressure >= 0.0
+			&& rc.tablet_tool.max_pressure <= 1.0) {
+		double min = libinput_tablet_tool_config_pressure_range_get_minimum(libinput_tool);
+		double max = libinput_tablet_tool_config_pressure_range_get_maximum(libinput_tool);
+		if (min != rc.tablet_tool.min_pressure || max != rc.tablet_tool.max_pressure) {
+			wlr_log(WLR_INFO, "tablet tool pressure range configured");
+			libinput_tablet_tool_config_pressure_range_set(libinput_tool,
+				rc.tablet_tool.min_pressure, rc.tablet_tool.max_pressure);
+		}
 	}
 
 	/*


### PR DESCRIPTION
I was curious if pressure range configuration is possible and it is actually and works nicely. That said, a `wlroots` addition is needed so this will likely stay draft for a very long time. 

<details><summary>wlr_libinput_get_tablet_tool_handle.patch</summary>
<p>

```diff
diff --git a/backend/libinput/backend.c b/backend/libinput/backend.c
index 121731b3..05f6f837 100644
--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -230,6 +230,11 @@ struct libinput_device *wlr_libinput_get_device_handle(
 	return dev->handle;
 }
 
+struct libinput_tablet_tool *wlr_libinput_get_tablet_tool_handle(
+		struct wlr_tablet_tool *wlr_tablet_tool) {
+	return device_handle_from_tablet_tool(wlr_tablet_tool);
+}
+
 uint32_t usec_to_msec(uint64_t usec) {
 	return (uint32_t)(usec / 1000);
 }
diff --git a/backend/libinput/tablet_tool.c b/backend/libinput/tablet_tool.c
index eec697c4..4dd212e3 100644
--- a/backend/libinput/tablet_tool.c
+++ b/backend/libinput/tablet_tool.c
@@ -67,6 +67,16 @@ struct wlr_libinput_input_device *device_from_tablet(
 	return dev;
 }
 
+struct libinput_tablet_tool *device_handle_from_tablet_tool(
+		struct wlr_tablet_tool *wlr_tablet_tool) {
+
+	struct tablet_tool *tool =
+		wl_container_of(wlr_tablet_tool, tool, wlr_tool);
+
+	assert(tool);
+	return tool->handle;
+}
+
 static enum wlr_tablet_tool_type wlr_type_from_libinput_type(
 		enum libinput_tablet_tool_type value) {
 	switch (value) {
diff --git a/include/backend/libinput.h b/include/backend/libinput.h
index 874e9aa1..46168049 100644
--- a/include/backend/libinput.h
+++ b/include/backend/libinput.h
@@ -112,6 +112,8 @@ void init_device_tablet(struct wlr_libinput_input_device *dev);
 void finish_device_tablet(struct wlr_libinput_input_device *dev);
 struct wlr_libinput_input_device *device_from_tablet(
 	struct wlr_tablet *tablet);
+struct libinput_tablet_tool *device_handle_from_tablet_tool(
+	struct wlr_tablet_tool *wlr_tablet_tool);
 void handle_tablet_tool_axis(struct libinput_event *event,
 	struct wlr_tablet *tablet);
 void handle_tablet_tool_proximity(struct libinput_event *event,
diff --git a/include/wlr/backend/libinput.h b/include/wlr/backend/libinput.h
index 663f71ac..2a4e1996 100644
--- a/include/wlr/backend/libinput.h
+++ b/include/wlr/backend/libinput.h
@@ -15,6 +15,7 @@
 #include <wlr/backend/session.h>
 
 struct wlr_input_device;
+struct wlr_tablet_tool;
 
 struct wlr_backend *wlr_libinput_backend_create(struct wlr_session *session);
 /**
@@ -22,6 +23,11 @@ struct wlr_backend *wlr_libinput_backend_create(struct wlr_session *session);
  */
 struct libinput_device *wlr_libinput_get_device_handle(
 		struct wlr_input_device *dev);
+/**
+ * Gets the underlying struct libinput_tablet_tool handle for the given tablet tool.
+ */
+struct libinput_tablet_tool *wlr_libinput_get_tablet_tool_handle(
+		struct wlr_tablet_tool *wlr_tablet_tool);
 
 bool wlr_backend_is_libinput(struct wlr_backend *backend);
 bool wlr_input_device_is_libinput(struct wlr_input_device *device);
``` 

</p>
</details> 