### PR TITLE
cursor: prevent hi-res mice triggering scroll actions too often

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -111,9 +111,10 @@ struct seat {
 	bool cursor_visible;
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;
-	struct {
-		double x, y;
-	} smooth_scroll_offset;
+	struct accumulated_scroll {
+		double delta;
+		double delta_discrete;
+	} accumulated_scrolls[2]; /* indexed by wl_pointer_axis */
 	bool cursor_scroll_wheel_emulation;
 
 	/*


### PR DESCRIPTION
Fixes #1068

Hi-res mice produces mulitple scroll events with `delta_discrete` != 0 during a single "click". This patch makes them trigger `Scroll` actions only when the accumulated `delta_discrete` exceeds 120 (= 1 click).

See https://lists.freedesktop.org/archives/wayland-devel/2019-April/040377.html for how hi-res scroll events are reported.