### PR TITLE
cursor: also toggle mousebinds with `ToggleKeybinds`

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -227,10 +227,10 @@ Actions are used in menus and keyboard/mouse bindings.
 	window.
 
 *<action name="ToggleKeybinds" />*
-	Stop handling keybinds other than ToggleKeybinds itself.
-	This can be used to allow A-Tab and similar keybinds to be delivered
-	to Virtual Machines, VNC clients or nested compositors.
-	A second call will restore all original keybinds.
+	Stop handling keybinds/mousebinds other than ToggleKeybinds itself.
+	This can be used to allow A-Tab and similar keybinds/mousebinds to be
+	delivered to Virtual Machines, VNC clients or nested compositors.
+	A second call will restore all original keybinds/mousebinds.
 
 	This action will only affect the window that had keyboard focus when
 	the binding was executed. Thus when switching to another window, all

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -128,9 +128,6 @@ struct seat {
 
 	struct wlr_pointer_constraint_v1 *current_constraint;
 
-	/* In support for ToggleKeybinds */
-	uint32_t nr_inhibited_keybind_views;
-
 	/* Used to hide the workspace OSD after switching workspaces */
 	struct wl_event_source *workspace_osd_timer;
 	bool workspace_osd_shown_by_modifier;

--- a/include/view.h
+++ b/include/view.h
@@ -229,7 +229,7 @@ struct view {
 	bool visible_on_all_workspaces;
 	enum view_edge tiled;
 	uint32_t edges_visible;  /* enum wlr_edges bitset */
-	bool inhibits_keybinds;
+	bool inhibits_keybinds; /* also inhibits mousebinds */
 	xkb_layout_index_t keyboard_layout;
 
 	/* Pointer to an output owned struct region, may be NULL */
@@ -526,6 +526,7 @@ void mappable_connect(struct mappable *mappable, struct wlr_surface *surface,
 void mappable_disconnect(struct mappable *mappable);
 
 void view_toggle_keybinds(struct view *view);
+bool view_inhibits_actions(struct view *view, struct wl_list *actions);
 
 void view_set_activated(struct view *view, bool activated);
 void view_set_output(struct view *view, struct output *output);

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -610,6 +610,10 @@ cursor_process_motion(struct server *server, uint32_t time, double *sx, double *
 
 	struct mousebind *mousebind;
 	wl_list_for_each(mousebind, &rc.mousebinds, link) {
+		if (ctx.type == LAB_SSD_CLIENT
+				&& view_inhibits_actions(ctx.view, &mousebind->actions)) {
+			continue;
+		}
 		if (mousebind->mouse_event == MOUSE_ACTION_DRAG
 				&& mousebind->pressed_in_context) {
 			/*
@@ -949,6 +953,10 @@ process_release_mousebinding(struct server *server,
 	uint32_t modifiers = keyboard_get_all_modifiers(&server->seat);
 
 	wl_list_for_each(mousebind, &rc.mousebinds, link) {
+		if (ctx->type == LAB_SSD_CLIENT
+				&& view_inhibits_actions(ctx->view, &mousebind->actions)) {
+			continue;
+		}
 		if (ssd_part_contains(mousebind->context, ctx->type)
 				&& mousebind->button == button
 				&& modifiers == mousebind->modifiers) {
@@ -1016,6 +1024,10 @@ process_press_mousebinding(struct server *server, struct cursor_context *ctx,
 	uint32_t modifiers = keyboard_get_all_modifiers(&server->seat);
 
 	wl_list_for_each(mousebind, &rc.mousebinds, link) {
+		if (ctx->type == LAB_SSD_CLIENT
+				&& view_inhibits_actions(ctx->view, &mousebind->actions)) {
+			continue;
+		}
 		if (ssd_part_contains(mousebind->context, ctx->type)
 				&& mousebind->button == button
 				&& modifiers == mousebind->modifiers) {

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -211,9 +211,7 @@ match_keybinding_for_sym(struct server *server, uint32_t modifiers,
 		if (modifiers ^ keybind->modifiers) {
 			continue;
 		}
-		if (server->active_view
-				&& server->active_view->inhibits_keybinds
-				&& !actions_contain_toggle_keybinds(&keybind->actions)) {
+		if (view_inhibits_actions(server->active_view, &keybind->actions)) {
 			continue;
 		}
 		if (sym == XKB_KEY_NoSymbol) {

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -211,8 +211,7 @@ match_keybinding_for_sym(struct server *server, uint32_t modifiers,
 		if (modifiers ^ keybind->modifiers) {
 			continue;
 		}
-		if (server->seat.nr_inhibited_keybind_views
-				&& server->active_view
+		if (server->active_view
 				&& server->active_view->inhibits_keybinds
 				&& !actions_contain_toggle_keybinds(&keybind->actions)) {
 			continue;

--- a/src/view.c
+++ b/src/view.c
@@ -4,6 +4,7 @@
 #include <strings.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_security_context_v1.h>
+#include "action.h"
 #include "buffer.h"
 #include "common/box.h"
 #include "common/list.h"
@@ -2444,6 +2445,12 @@ view_toggle_keybinds(struct view *view)
 	}
 }
 
+bool
+view_inhibits_actions(struct view *view, struct wl_list *actions)
+{
+	return view && view->inhibits_keybinds && !actions_contain_toggle_keybinds(actions);
+}
+
 void
 mappable_connect(struct mappable *mappable, struct wlr_surface *surface,
 		wl_notify_func_t notify_map, wl_notify_func_t notify_unmap)
@@ -2612,10 +2619,6 @@ view_destroy(struct view *view)
 
 	if (view->tiled_region_evacuate) {
 		zfree(view->tiled_region_evacuate);
-	}
-
-	if (view->inhibits_keybinds) {
-		view->inhibits_keybinds = false;
 	}
 
 	osd_on_view_destroy(view);

--- a/src/view.c
+++ b/src/view.c
@@ -2437,11 +2437,6 @@ view_toggle_keybinds(struct view *view)
 {
 	assert(view);
 	view->inhibits_keybinds = !view->inhibits_keybinds;
-	if (view->inhibits_keybinds) {
-		view->server->seat.nr_inhibited_keybind_views++;
-	} else {
-		view->server->seat.nr_inhibited_keybind_views--;
-	}
 
 	if (view->ssd_enabled) {
 		ssd_enable_keybind_inhibit_indicator(view->ssd,
@@ -2621,7 +2616,6 @@ view_destroy(struct view *view)
 
 	if (view->inhibits_keybinds) {
 		view->inhibits_keybinds = false;
-		server->seat.nr_inhibited_keybind_views--;
 	}
 
 	osd_on_view_destroy(view);


### PR DESCRIPTION
Closes #1536.

Mousebinds can still be applied when the cursor is over window decoration.

The first commit removes `seat->nr_inhibited_keybind_views` as I don't think it's needed.