### PR TITLE
Fix some warnings from clang-tidy

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -823,8 +823,9 @@ get_target_output(struct output *output, struct server *server,
 }
 
 static void
-warp_cursor(struct view *view, struct output *output, const char *to, const char *x, const char *y)
+warp_cursor(struct server *server, struct view *view, const char *to, const char *x, const char *y)
 {
+	struct output *output = output_nearest_to_cursor(server);
 	struct wlr_box target_area = {0};
 	int goto_x;
 	int goto_y;
@@ -855,8 +856,8 @@ warp_cursor(struct view *view, struct output *output, const char *to, const char
 			target_area.y + target_area.height + offset_y;
 	}
 
-	wlr_cursor_warp(output->server->seat.cursor, NULL, goto_x, goto_y);
-	cursor_update_focus(output->server);
+	wlr_cursor_warp(server->seat.cursor, NULL, goto_x, goto_y);
+	cursor_update_focus(server);
 }
 
 void
@@ -1352,9 +1353,7 @@ actions_run(struct view *activator, struct server *server,
 			const char *to = action_get_str(action, "to", "output");
 			const char *x = action_get_str(action, "x", "center");
 			const char *y = action_get_str(action, "y", "center");
-			struct output *output = output_nearest_to_cursor(server);
-
-			warp_cursor(view, output, to, x, y);
+			warp_cursor(server, view, to, x, y);
 			break;
 		}
 		case ACTION_TYPE_HIDE_CURSOR:

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -302,6 +302,7 @@ process_cursor_resize(struct server *server, uint32_t time)
 	static uint32_t last_resize_time = 0;
 	static struct view *last_resize_view = NULL;
 
+	assert(server->grabbed_view);
 	if (server->grabbed_view == last_resize_view) {
 		int32_t refresh = 0;
 		if (output_is_usable(last_resize_view->output)) {

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -1024,9 +1024,6 @@ static void
 handle_xdg_toplevel_icon_set_icon(struct wl_listener *listener, void *data)
 {
 	struct wlr_xdg_toplevel_icon_manager_v1_set_icon_event *event = data;
-
-	struct server *server =
-		wl_container_of(listener, server, xdg_toplevel_icon_set_icon);
 	struct wlr_xdg_surface *xdg_surface = event->toplevel->base;
 	struct view *view = xdg_surface->data;
 	assert(view);


### PR DESCRIPTION
Notably this fixes a possible null pointer dereference in `warp_cursor()` when `output_nearest_to_cursor()` returns null.