### PR TITLE
Fix header ordering dependencies

### DIFF
--- a/include/common/graphic-helpers.h
+++ b/include/common/graphic-helpers.h
@@ -2,6 +2,8 @@
 #ifndef LABWC_GRAPHIC_HELPERS_H
 #define LABWC_GRAPHIC_HELPERS_H
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <cairo.h>
 
 struct wlr_fbox;

--- a/include/config/touch.h
+++ b/include/config/touch.h
@@ -2,7 +2,7 @@
 #ifndef LABWC_TOUCH_CONFIG_H
 #define LABWC_TOUCH_CONFIG_H
 
-#include <stdint.h>
+#include <stdbool.h>
 #include <wayland-util.h>
 
 struct touch_config_entry {

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -4,6 +4,7 @@
 
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_tablet_v2.h>
+#include "config/tablet-tool.h"
 
 struct seat;
 struct wlr_device;

--- a/src/action.c
+++ b/src/action.c
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "action.h"
 #include <assert.h>
 #include <signal.h>
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
 #include <wlr/util/log.h>
-#include "action.h"
 #include "common/macros.h"
 #include "common/list.h"
 #include "common/mem.h"

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -24,12 +24,12 @@
  * SOFTWARE.
  */
 
+#include "buffer.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <drm_fourcc.h>
 #include <wlr/interfaces/wlr_buffer.h>
 #include <wlr/util/log.h>
-#include "buffer.h"
 #include "common/box.h"
 #include "common/mem.h"
 

--- a/src/common/box.c
+++ b/src/common/box.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
-#include <assert.h>
 #include "common/box.h"
+#include <assert.h>
 #include "common/macros.h"
 
 bool

--- a/src/common/buf.c
+++ b/src/common/buf.c
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "common/buf.h"
 #include <assert.h>
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include "common/buf.h"
 #include "common/macros.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"

--- a/src/common/dir.c
+++ b/src/common/dir.c
@@ -4,13 +4,13 @@
  *
  * Copyright Johan Malm 2020
  */
+#include "common/dir.h"
 #include <assert.h>
 #include <glib.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include "common/dir.h"
 #include "common/buf.h"
 #include "common/list.h"
 #include "common/mem.h"

--- a/src/common/direction.c
+++ b/src/common/direction.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "common/direction.h"
 #include <assert.h>
 #include <wlr/types/wlr_output_layout.h>
-#include "common/direction.h"
 #include "view.h"
 
 enum wlr_direction

--- a/src/common/fd-util.c
+++ b/src/common/fd-util.c
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
 
+#include "common/fd-util.h"
 #include <sys/resource.h>
 #include <wlr/util/log.h>
-
-#include "common/fd-util.h"
 
 static struct rlimit original_nofile_rlimit = {0};
 

--- a/src/common/file-helpers.c
+++ b/src/common/file-helpers.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
-#include <sys/stat.h>
 #include "common/file-helpers.h"
+#include <sys/stat.h>
 
 bool
 file_exists(const char *filename)

--- a/src/common/font.c
+++ b/src/common/font.c
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "common/font.h"
 #include <cairo.h>
 #include <drm_fourcc.h>
 #include <pango/pangocairo.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
-#include "common/font.h"
 #include "common/graphic-helpers.h"
 #include "common/string-helpers.h"
 #include "labwc.h"

--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include "common/graphic-helpers.h"
 #include <cairo.h>
 #include <glib.h> /* g_ascii_strcasecmp */
 #include <wlr/types/wlr_scene.h>
-#include "common/graphic-helpers.h"
 #include "common/macros.h"
 #include "xcolor-table.h"
 

--- a/src/common/lab-scene-rect.c
+++ b/src/common/lab-scene-rect.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "common/lab-scene-rect.h"
 #include <assert.h>
 #include <wlr/types/wlr_scene.h>
-#include "common/lab-scene-rect.h"
 #include "common/mem.h"
 
 struct border_scene {

--- a/src/common/match.c
+++ b/src/common/match.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include <fnmatch.h>
 #include "common/match.h"
+#include <fnmatch.h>
 
 bool
 match_glob(const char *pattern, const char *string)

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "common/mem.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include "common/mem.h"
 
 static void
 die_if_null(void *ptr)

--- a/src/common/nodename.c
+++ b/src/common/nodename.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "common/nodename.h"
 #include <ctype.h>
 #include <string.h>
-#include "common/nodename.h"
 
 char *
 nodename(xmlNode *node, char *buf, int len)

--- a/src/common/parse-bool.c
+++ b/src/common/parse-bool.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "common/parse-bool.h"
 #include <strings.h>
 #include <wlr/util/log.h>
-#include "common/parse-bool.h"
 
 enum three_state
 parse_three_state(const char *str)

--- a/src/common/parse-double.c
+++ b/src/common/parse-double.c
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "common/parse-double.h"
 #include <locale.h>
 #include <stdlib.h>
 #include <string.h>
 #include <wlr/util/log.h>
 #include "common/mem.h"
-#include "common/parse-double.h"
 
 struct dec_separator {
 	int index;

--- a/src/common/scaled-font-buffer.c
+++ b/src/common/scaled-font-buffer.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "common/scaled-font-buffer.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,7 +11,6 @@
 #include "common/graphic-helpers.h"
 #include "common/mem.h"
 #include "common/scaled-scene-buffer.h"
-#include "common/scaled-font-buffer.h"
 #include "common/string-helpers.h"
 
 static struct lab_data_buffer *

--- a/src/common/scaled-icon-buffer.c
+++ b/src/common/scaled-icon-buffer.c
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "common/scaled-icon-buffer.h"
 #include <assert.h>
 #include <string.h>
 #include <wlr/util/log.h>
 #include "buffer.h"
 #include "common/macros.h"
 #include "common/mem.h"
-#include "common/scaled-icon-buffer.h"
 #include "common/scaled-scene-buffer.h"
 #include "common/string-helpers.h"
 #include "config.h"

--- a/src/common/scaled-img-buffer.c
+++ b/src/common/scaled-img-buffer.c
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "common/scaled-img-buffer.h"
 #include <assert.h>
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_scene.h>
 #include "buffer.h"
 #include "common/mem.h"
-#include "common/scaled-img-buffer.h"
 #include "common/scaled-scene-buffer.h"
 #include "img/img.h"
 #include "node.h"

--- a/src/common/scaled-scene-buffer.c
+++ b/src/common/scaled-scene-buffer.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "common/scaled-scene-buffer.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <wayland-server-core.h>
@@ -11,7 +12,6 @@
 #include "common/list.h"
 #include "common/macros.h"
 #include "common/mem.h"
-#include "common/scaled-scene-buffer.h"
 #include "node.h"
 
 /*

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include "common/scene-helpers.h"
 #include <assert.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
 #include <wlr/util/transform.h>
-#include "common/scene-helpers.h"
 #include "labwc.h"
 #include "magnifier.h"
 #include "output-state.h"

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
-#include <wlr/util/log.h>
 #include "common/set.h"
+#include <wlr/util/log.h>
 
 bool
 lab_set_contains(struct lab_set *set, uint32_t value)

--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "common/spawn.h"
 #include <assert.h>
 #include <fcntl.h>
 #include <glib.h>
@@ -9,7 +10,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <wlr/util/log.h>
-#include "common/spawn.h"
 #include "common/fd-util.h"
 
 static void

--- a/src/common/string-helpers.c
+++ b/src/common/string-helpers.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "common/string-helpers.h"
 #include <assert.h>
 #include <ctype.h>
 #include <stdarg.h>
@@ -7,7 +8,6 @@
 #include <string.h>
 #include <strings.h>
 #include "common/mem.h"
-#include "common/string-helpers.h"
 
 enum str_flags {
 	STR_FLAG_NONE = 0,

--- a/src/common/surface-helpers.c
+++ b/src/common/surface-helpers.c
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "common/surface-helpers.h"
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/util/log.h>
-#include "common/surface-helpers.h"
 
 struct wlr_layer_surface_v1 *
 subsurface_parent_layer(struct wlr_surface *wlr_surface)

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "config/keybind.h"
 #include <assert.h>
 #include <glib.h>
 #include <stdio.h>
@@ -8,7 +9,6 @@
 #include <wlr/util/log.h>
 #include "common/list.h"
 #include "common/mem.h"
-#include "config/keybind.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 

--- a/src/config/libinput.c
+++ b/src/config/libinput.c
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "config/libinput.h"
 #include <string.h>
 #include <strings.h>
 #include "common/mem.h"
 #include "common/list.h"
 #include "common/string-helpers.h"
-#include "config/libinput.h"
 #include "config/rcxml.h"
 
 static void

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "config/mousebind.h"
 #include <assert.h>
 #include <linux/input-event-codes.h>
 #include <strings.h>
@@ -7,7 +8,6 @@
 #include <wlr/util/log.h>
 #include "common/list.h"
 #include "common/mem.h"
-#include "config/mousebind.h"
 #include "config/rcxml.h"
 
 uint32_t

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "config/rcxml.h"
 #include <assert.h>
 #include <fcntl.h>
 #include <glib.h>
@@ -29,7 +30,6 @@
 #include "config/libinput.h"
 #include "config/mousebind.h"
 #include "config/tablet.h"
-#include "config/rcxml.h"
 #include "labwc.h"
 #include "osd.h"
 #include "regions.h"

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "config/session.h"
 #include <assert.h>
 #include <dirent.h>
 #include <stdbool.h>
@@ -18,7 +19,6 @@
 #include "common/parse-bool.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"
-#include "config/session.h"
 #include "labwc.h"
 
 static const char *const env_vars[] = {

--- a/src/config/tablet-tool.c
+++ b/src/config/tablet-tool.c
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "config/tablet-tool.h"
 #include <strings.h>
 #include <wlr/util/log.h>
-#include "config/tablet-tool.h"
 
 enum motion
 tablet_parse_motion(const char *name)

--- a/src/config/tablet.c
+++ b/src/config/tablet.c
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "config/tablet.h"
 #include <linux/input-event-codes.h>
 #include <stdint.h>
 #include <strings.h>
 #include <wlr/util/log.h>
 #include "common/parse-double.h"
-#include "config/tablet.h"
 #include "config/rcxml.h"
 #include "input/tablet-pad.h"
 

--- a/src/config/touch.c
+++ b/src/config/touch.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "config/touch.h"
 #include <strings.h>
 #include <wlr/util/log.h>
 #include "common/list.h"

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "debug.h"
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/lab-scene-rect.h"
 #include "common/scene-helpers.h"
 #include "common/string-helpers.h"
-#include "debug.h"
 #include "input/ime.h"
 #include "labwc.h"
 #include "node.h"

--- a/src/desktop-entry.c
+++ b/src/desktop-entry.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "desktop-entry.h"
 #include <sfdo-desktop.h>
 #include <sfdo-icon.h>
 #include <sfdo-basedir.h>
@@ -9,7 +10,6 @@
 #include "common/macros.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"
-#include "desktop-entry.h"
 #include "img/img.h"
 
 #include "labwc.h"

--- a/src/dnd.c
+++ b/src/dnd.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "dnd.h"
 #include <assert.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/log.h>
-#include "dnd.h"
 #include "input/cursor.h"
 #include "labwc.h"  /* for struct seat */
 #include "view.h"

--- a/src/edges.c
+++ b/src/edges.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "edges.h"
 #include <assert.h>
 #include <limits.h>
 #include <pixman.h>
@@ -8,7 +9,6 @@
 #include "common/box.h"
 #include "common/macros.h"
 #include "config/rcxml.h"
-#include "edges.h"
 #include "labwc.h"
 #include "view.h"
 #include "node.h"

--- a/src/idle.c
+++ b/src/idle.c
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include "idle.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include "common/mem.h"
-#include "idle.h"
 
 struct lab_idle_inhibitor {
 	struct wlr_idle_inhibitor_v1 *wlr_inhibitor;

--- a/src/img/img-png.c
+++ b/src/img/img-png.c
@@ -3,6 +3,7 @@
  * Copyright (C) Johan Malm 2023
  */
 #define _POSIX_C_SOURCE 200809L
+#include "img/img-png.h"
 #include <assert.h>
 #include <cairo.h>
 #include <png.h>
@@ -12,7 +13,6 @@
 #include <wlr/util/log.h>
 #include "buffer.h"
 #include "common/string-helpers.h"
-#include "img/img-png.h"
 
 /*
  * cairo_image_surface_create_from_png() does not gracefully handle non-png

--- a/src/img/img-svg.c
+++ b/src/img/img-svg.c
@@ -3,6 +3,7 @@
  * Copyright (C) Johan Malm 2023
  */
 #define _POSIX_C_SOURCE 200809L
+#include "img/img-svg.h"
 #include <cairo.h>
 #include <librsvg/rsvg.h>
 #include <stdbool.h>
@@ -11,7 +12,6 @@
 #include <wlr/util/log.h>
 #include "buffer.h"
 #include "common/string-helpers.h"
-#include "img/img-svg.h"
 #include "labwc.h"
 
 RsvgHandle *

--- a/src/img/img-xbm.c
+++ b/src/img/img-xbm.c
@@ -6,6 +6,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L
+#include "img/img-xbm.h"
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -14,7 +15,6 @@
 #include <string.h>
 #include <drm_fourcc.h>
 #include "img/img.h"
-#include "img/img-xbm.h"
 #include "common/grab-file.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"

--- a/src/img/img-xpm.c
+++ b/src/img/img-xpm.c
@@ -11,6 +11,7 @@
  * Adapted for labwc by John Lindgren, 2024
  */
 
+#include "img/img-xpm.h"
 #include <glib.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,7 +22,6 @@
 #include "common/buf.h"
 #include "common/graphic-helpers.h"
 #include "common/mem.h"
-#include "img/img-xpm.h"
 
 enum buf_op { op_header, op_cmap, op_body };
 

--- a/src/img/img.c
+++ b/src/img/img.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include "img/img.h"
 #include <assert.h>
 #include <wlr/util/log.h>
 #include "buffer.h"
@@ -9,7 +10,6 @@
 #include "common/macros.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"
-#include "img/img.h"
 #include "img/img-png.h"
 #if HAVE_RSVG
 #include "img/img-svg.h"

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "input/cursor.h"
 #include <assert.h>
 #include <linux/input-event-codes.h>
 #include <sys/time.h>

--- a/src/input/gestures.c
+++ b/src/input/gestures.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "input/gestures.h"
 #include <wlr/types/wlr_pointer_gestures_v1.h>
 #include "common/macros.h"
-#include "input/gestures.h"
 #include "labwc.h"
 #include "idle.h"
 

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /* Based on Sway (https://github.com/swaywm/sway) */
 
+#include "input/ime.h"
 #include <assert.h>
 #include "common/mem.h"
-#include "input/ime.h"
 #include "node.h"
 #include "view.h"
 

--- a/src/input/input.c
+++ b/src/input/input.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
-#include "input/cursor.h"
 #include "input/input.h"
+#include "input/cursor.h"
 #include "input/keyboard.h"
 
 void

--- a/src/input/key-state.c
+++ b/src/input/key-state.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "input/key-state.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -6,7 +7,6 @@
 #include <string.h>
 #include <wlr/util/log.h>
 #include "common/set.h"
-#include "input/key-state.h"
 
 static struct lab_set pressed, bound, pressed_sent;
 

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "input/keyboard.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <wlr/backend/multi.h>
@@ -10,7 +11,6 @@
 #include "common/three-state.h"
 #include "idle.h"
 #include "input/ime.h"
-#include "input/keyboard.h"
 #include "input/key-state.h"
 #include "labwc.h"
 #include "menu/menu.h"

--- a/src/input/tablet-pad.c
+++ b/src/input/tablet-pad.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "input/tablet-pad.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <wlr/backend/libinput.h>
@@ -9,7 +10,6 @@
 #include "common/mem.h"
 #include "config/rcxml.h"
 #include "input/cursor.h"
-#include "input/tablet-pad.h"
 #include "input/tablet.h"
 #include "labwc.h"
 

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "input/tablet.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <linux/input-event-codes.h>
@@ -12,7 +13,6 @@
 #include "config/rcxml.h"
 #include "config/mousebind.h"
 #include "input/cursor.h"
-#include "input/tablet.h"
 #include "input/tablet-pad.h"
 #include "labwc.h"
 #include "idle.h"

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "input/touch.h"
 #include <wayland-util.h>
 #include <wlr/types/wlr_touch.h>
 #include <linux/input-event-codes.h>
@@ -6,7 +7,6 @@
 #include "common/mem.h"
 #include "common/scene-helpers.h"
 #include "idle.h"
-#include "input/touch.h"
 #include "labwc.h"
 #include "config/mousebind.h"
 #include "action.h"

--- a/src/layers.c
+++ b/src/layers.c
@@ -6,6 +6,7 @@
  * Copyright (C) 2019 Drew DeVault and Sway developers
  */
 
+#include "layers.h"
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -18,7 +19,6 @@
 #include "common/macros.h"
 #include "common/mem.h"
 #include "config/rcxml.h"
-#include "layers.h"
 #include "labwc.h"
 #include "node.h"
 

--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include "magnifier.h"
 #include <assert.h>
 #include <wlr/render/swapchain.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/util/transform.h>
 #include "common/box.h"
 #include "labwc.h"
-#include "magnifier.h"
 #include "theme.h"
 
 static bool magnify_on;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "menu/menu.h"
 #include <assert.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
@@ -25,7 +26,6 @@
 #include "common/spawn.h"
 #include "common/string-helpers.h"
 #include "labwc.h"
-#include "menu/menu.h"
 #include "workspaces.h"
 #include "view.h"
 #include "node.h"

--- a/src/node.c
+++ b/src/node.c
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "node.h"
 #include <assert.h>
 #include <stdlib.h>
 #include "common/mem.h"
-#include "node.h"
 
 static void
 descriptor_destroy(struct node_descriptor *node_descriptor)

--- a/src/osd.c
+++ b/src/osd.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "osd.h"
 #include <assert.h>
 #include <cairo.h>
 #include <wlr/util/log.h>
@@ -15,7 +16,6 @@
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "node.h"
-#include "osd.h"
 #include "theme.h"
 #include "view.h"
 #include "window-rules.h"

--- a/src/output-state.c
+++ b/src/output-state.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include "output-state.h"
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include "labwc.h"
-#include "output-state.h"
 
 void
 output_state_init(struct output *output)

--- a/src/output-virtual.c
+++ b/src/output-virtual.c
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include "output-virtual.h"
 #include <stdlib.h>
 #include <wlr/backend/headless.h>
 #include <wlr/types/wlr_output.h>
 #include "common/string-helpers.h"
 #include "labwc.h"
-#include "output-virtual.h"
 
 static struct wlr_output *fallback_output = NULL;
 

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "overlay.h"
 #include <assert.h>
 #include "common/lab-scene-rect.h"
 #include "labwc.h"
-#include "overlay.h"
 #include "view.h"
 #include "theme.h"
 

--- a/src/placement.c
+++ b/src/placement.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "placement.h"
 #include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -6,7 +7,6 @@
 #include "common/macros.h"
 #include "common/mem.h"
 #include "labwc.h"
-#include "placement.h"
 #include "ssd.h"
 #include "view.h"
 

--- a/src/protocols/transaction-addon.c
+++ b/src/protocols/transaction-addon.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "protocols/transaction-addon.h"
 #include <assert.h>
 #include <wayland-server-core.h>
 #include "common/list.h"
 #include "common/mem.h"
-#include "protocols/transaction-addon.h"
 
 void
 lab_transaction_op_destroy(struct lab_transaction_op *trans_op)

--- a/src/regions.c
+++ b/src/regions.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #define _POSIX_C_SOURCE 200809L
+#include "regions.h"
 #include <assert.h>
 #include <float.h>
 #include <math.h>
@@ -12,7 +13,6 @@
 #include "common/mem.h"
 #include "input/keyboard.h"
 #include "labwc.h"
-#include "regions.h"
 #include "view.h"
 
 bool

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "resistance.h"
 #include <assert.h>
 #include <limits.h>
 #include "common/border.h"
@@ -6,7 +7,6 @@
 #include "config/rcxml.h"
 #include "edges.h"
 #include "labwc.h"
-#include "resistance.h"
 #include "snap-constraints.h"
 #include "view.h"
 

--- a/src/resize-outlines.c
+++ b/src/resize-outlines.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include "resize-outlines.h"
 #include <wlr/types/wlr_scene.h>
 #include "common/lab-scene-rect.h"
 #include "ssd.h"
-#include "resize-outlines.h"
 #include "labwc.h"
 
 bool

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "session-lock.h"
 #include <assert.h>
 #include "common/mem.h"
 #include "labwc.h"

--- a/src/snap-constraints.c
+++ b/src/snap-constraints.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "snap-constraints.h"
 #include <assert.h>
 #include <wlr/util/box.h>
 #include "common/macros.h"
 #include "labwc.h"
-#include "snap-constraints.h"
 #include "view.h"
 
 /*

--- a/src/snap.c
+++ b/src/snap.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "snap.h"
 #include <assert.h>
 #include <limits.h>
 #include <wlr/util/box.h>
@@ -7,7 +8,6 @@
 #include "edges.h"
 #include "labwc.h"
 #include "snap-constraints.h"
-#include "snap.h"
 #include "view.h"
 
 static void

--- a/src/theme.c
+++ b/src/theme.c
@@ -6,6 +6,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L
+#include "theme.h"
 #include "config.h"
 #include <assert.h>
 #include <cairo.h>
@@ -30,7 +31,6 @@
 #include "config/rcxml.h"
 #include "img/img.h"
 #include "labwc.h"
-#include "theme.h"
 #include "buffer.h"
 #include "ssd.h"
 

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /* view-impl-common.c: common code for shell view->impl functions */
+#include "view-impl-common.h"
 #include <stdio.h>
 #include <strings.h>
 #include "foreign-toplevel.h"
 #include "labwc.h"
 #include "view.h"
-#include "view-impl-common.h"
 #include "window-rules.h"
 
 void

--- a/src/view.c
+++ b/src/view.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
+#include "view.h"
 #include <assert.h>
 #include <stdio.h>
 #include <strings.h>
@@ -25,7 +26,6 @@
 #include "snap-constraints.h"
 #include "snap.h"
 #include "ssd.h"
-#include "view.h"
 #include "window-rules.h"
 #include "wlr/util/log.h"
 #include "workspaces.h"

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "window-rules.h"
 #include <assert.h>
 #include <stdbool.h>
 #include <cairo.h>
@@ -11,7 +12,6 @@
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "view.h"
-#include "window-rules.h"
 
 static bool
 other_instances_exist(struct view *self, struct view_query *query)

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "workspaces.h"
 #include <assert.h>
 #include <cairo.h>
 #include <pango/pangocairo.h>
@@ -18,7 +19,6 @@
 #include "protocols/cosmic-workspaces.h"
 #include "protocols/ext-workspace.h"
 #include "view.h"
-#include "workspaces.h"
 #include "xwayland.h"
 
 #define COSMIC_WORKSPACES_VERSION 1

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
+#include "xwayland.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <wlr/xwayland.h>
@@ -17,7 +18,6 @@
 #include "view-impl-common.h"
 #include "window-rules.h"
 #include "workspaces.h"
-#include "xwayland.h"
 
 enum atoms {
 	ATOM_NET_WM_ICON = 0,


### PR DESCRIPTION
A couple of the headers under `include` do not compile unless other headers are included first. The first commit fixes those.

The second commit implements the common practice of making each C file include its matching header first -- precisely to ensure that header compiles cleanly without implicit dependencies on other headers.

I used a crude bash script to automate the 2nd commit -- ugly enough that I'm not inclined to share it ;)