### PR TITLE
Remaximize after fullscreen move

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -222,6 +222,7 @@ struct view {
 	enum ssd_preference ssd_preference;
 	bool shaded;
 	bool minimized;
+	bool remaximize;
 	enum view_axis maximized;
 	bool fullscreen;
 	bool tearing_hint;

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -295,6 +295,8 @@ process_cursor_move(struct server *server, uint32_t time)
 		};
 		interactive_anchor_to_cursor(server, &new_geo);
 		/* Shaded clients will not process resize events until unshaded */
+		if (view->maximized == VIEW_AXIS_BOTH)
+			view->remaximize = true;
 		view_set_shade(view, false);
 		view_set_untiled(view);
 		view_restore_to(view, new_geo);

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -152,6 +152,8 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 		interactive_anchor_to_cursor(server, &natural_geo);
 		/* Shaded clients will not process resize events until unshaded */
 		view_set_shade(view, false);
+		if (view->maximized == VIEW_AXIS_BOTH)
+			view->remaximize = true;
 		view_set_untiled(view);
 		view_restore_to(view, natural_geo);
 	}
@@ -263,6 +265,11 @@ interactive_finish(struct view *view)
 		if (!snap_to_region(view)) {
 			snap_to_edge(view);
 		}
+	}
+
+	if (view->remaximize) {
+		view_maximize(view, VIEW_AXIS_BOTH, true);
+		view->remaximize = false;
 	}
 
 	interactive_cancel(view);


### PR DESCRIPTION
I quite like the behavior of openbox that it allows moving of full screen windows by keeping them maximized and snapping them from one output to the next. This is very useful when you have a lot of outputs and most window movements consist of shoving maximized windows around. The current behavior requires you to manually remaximize the windows after every move, which is tedious.


This pr implements similar behavior by remembering if a window started a move maximized, and re maximizing it when the move is finished if it was. Its a draft, as at the very least we probably want this behavior to be optional