### PR TITLE
overlay: take into account <core><gap> for edge/region overlay

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -429,7 +429,6 @@ void interactive_anchor_to_cursor(struct server *server, struct wlr_box *geo);
 void interactive_begin(struct view *view, enum input_mode mode, uint32_t edges);
 void interactive_finish(struct view *view);
 void interactive_cancel(struct view *view);
-/* Possibly returns VIEW_EDGE_CENTER if <topMaximize> is yes */
 enum view_edge edge_from_cursor(struct seat *seat, struct output **dest_output);
 
 void handle_tearing_new_object(struct wl_listener *listener, void *data);

--- a/include/view.h
+++ b/include/view.h
@@ -501,6 +501,10 @@ bool view_contains_window_type(struct view *view, enum window_type window_type);
  */
 enum view_edge view_edge_invert(enum view_edge edge);
 
+/* If view is NULL, the size of SSD is not considered */
+struct wlr_box view_get_edge_snap_box(struct view *view, struct output *output,
+	enum view_edge edge);
+
 /**
  * view_is_focusable() - Check whether or not a view can be focused
  * @view: view to be checked

--- a/include/view.h
+++ b/include/view.h
@@ -504,6 +504,7 @@ enum view_edge view_edge_invert(enum view_edge edge);
 /* If view is NULL, the size of SSD is not considered */
 struct wlr_box view_get_edge_snap_box(struct view *view, struct output *output,
 	enum view_edge edge);
+struct wlr_box view_get_region_snap_box(struct view *view, struct region *region);
 
 /**
  * view_is_focusable() - Check whether or not a view can be focused

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -195,11 +195,7 @@ edge_from_cursor(struct seat *seat, struct output **dest_output)
 	} else if (cursor_x >= area->x + area->width - snap_range) {
 		return VIEW_EDGE_RIGHT;
 	} else if (cursor_y <= area->y + snap_range) {
-		if (rc.snap_top_maximize) {
-			return VIEW_EDGE_CENTER;
-		} else {
-			return VIEW_EDGE_UP;
-		}
+		return VIEW_EDGE_UP;
 	} else if (cursor_y >= area->y + area->height - snap_range) {
 		return VIEW_EDGE_DOWN;
 	} else {
@@ -223,7 +219,7 @@ snap_to_edge(struct view *view)
 	 * Don't store natural geometry here (it was
 	 * stored already in interactive_begin())
 	 */
-	if (edge == VIEW_EDGE_CENTER) {
+	if (edge == VIEW_EDGE_UP && rc.snap_top_maximize) {
 		/* <topMaximize> */
 		view_maximize(view, VIEW_AXIS_BOTH,
 			/*store_natural_geometry*/ false);

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -111,7 +111,8 @@ show_region_overlay(struct seat *seat, struct region *region)
 	inactivate_overlay(&seat->overlay);
 	seat->overlay.active.region = region;
 
-	show_overlay(seat, &seat->overlay.region_rect, &region->geo);
+	struct wlr_box geo = view_get_region_snap_box(NULL, region);
+	show_overlay(seat, &seat->overlay.region_rect, &geo);
 }
 
 static struct wlr_box get_edge_snap_box(enum view_edge edge, struct output *output)

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -114,31 +114,13 @@ show_region_overlay(struct seat *seat, struct region *region)
 	show_overlay(seat, &seat->overlay.region_rect, &region->geo);
 }
 
-/* TODO: share logic with view_get_edge_snap_box() */
 static struct wlr_box get_edge_snap_box(enum view_edge edge, struct output *output)
 {
-	struct wlr_box box = output_usable_area_in_layout_coords(output);
-	switch (edge) {
-	case VIEW_EDGE_RIGHT:
-		box.x += box.width / 2;
-		/* fallthrough */
-	case VIEW_EDGE_LEFT:
-		box.width /= 2;
-		break;
-	case VIEW_EDGE_DOWN:
-		box.y += box.height / 2;
-		/* fallthrough */
-	case VIEW_EDGE_UP:
-		box.height /= 2;
-		break;
-	case VIEW_EDGE_CENTER:
-		/* <topMaximize> */
-		break;
-	default:
-		/* not reached */
-		assert(false);
+	if (edge == VIEW_EDGE_UP && rc.snap_top_maximize) {
+		return output_usable_area_in_layout_coords(output);
+	} else {
+		return view_get_edge_snap_box(NULL, output, edge);
 	}
-	return box;
 }
 
 static int

--- a/src/view.c
+++ b/src/view.c
@@ -1195,6 +1195,54 @@ view_apply_natural_geometry(struct view *view)
 	view_move_resize(view, geometry);
 }
 
+struct wlr_box
+view_get_region_snap_box(struct view *view, struct region *region)
+{
+	struct wlr_box geo = region->geo;
+
+	/* Adjust for rc.gap */
+	if (rc.gap) {
+		double half_gap = rc.gap / 2.0;
+		struct wlr_fbox offset = {
+			.x = half_gap,
+			.y = half_gap,
+			.width = -rc.gap,
+			.height = -rc.gap
+		};
+		struct wlr_box usable =
+			output_usable_area_in_layout_coords(region->output);
+		if (geo.x == usable.x) {
+			offset.x += half_gap;
+			offset.width -= half_gap;
+		}
+		if (geo.y == usable.y) {
+			offset.y += half_gap;
+			offset.height -= half_gap;
+		}
+		if (geo.x + geo.width == usable.x + usable.width) {
+			offset.width -= half_gap;
+		}
+		if (geo.y + geo.height == usable.y + usable.height) {
+			offset.height -= half_gap;
+		}
+		geo.x += offset.x;
+		geo.y += offset.y;
+		geo.width += offset.width;
+		geo.height += offset.height;
+	}
+
+	/* And adjust for current view */
+	if (view) {
+		struct border margin = ssd_get_margin(view->ssd);
+		geo.x += margin.left;
+		geo.y += margin.top;
+		geo.width -= margin.left + margin.right;
+		geo.height -= margin.top + margin.bottom;
+	}
+
+	return geo;
+}
+
 static void
 view_apply_region_geometry(struct view *view)
 {
@@ -1220,47 +1268,7 @@ view_apply_region_geometry(struct view *view)
 		}
 	}
 
-	/* Create a copy of the original region geometry */
-	struct wlr_box geo = view->tiled_region->geo;
-
-	/* Adjust for rc.gap */
-	if (rc.gap) {
-		double half_gap = rc.gap / 2.0;
-		struct wlr_fbox offset = {
-			.x = half_gap,
-			.y = half_gap,
-			.width = -rc.gap,
-			.height = -rc.gap
-		};
-		struct wlr_box usable =
-			output_usable_area_in_layout_coords(output);
-		if (geo.x == usable.x) {
-			offset.x += half_gap;
-			offset.width -= half_gap;
-		}
-		if (geo.y == usable.y) {
-			offset.y += half_gap;
-			offset.height -= half_gap;
-		}
-		if (geo.x + geo.width == usable.x + usable.width) {
-			offset.width -= half_gap;
-		}
-		if (geo.y + geo.height == usable.y + usable.height) {
-			offset.height -= half_gap;
-		}
-		geo.x += offset.x;
-		geo.y += offset.y;
-		geo.width += offset.width;
-		geo.height += offset.height;
-	}
-
-	/* And adjust for current view */
-	struct border margin = ssd_get_margin(view->ssd);
-	geo.x += margin.left;
-	geo.y += margin.top;
-	geo.width -= margin.left + margin.right;
-	geo.height -= margin.top + margin.bottom;
-
+	struct wlr_box geo = view_get_region_snap_box(view, view->tiled_region);
 	view_move_resize(view, geo);
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -440,7 +440,7 @@ view_edge_invert(enum view_edge edge)
 	}
 }
 
-static struct wlr_box
+struct wlr_box
 view_get_edge_snap_box(struct view *view, struct output *output,
 		enum view_edge edge)
 {
@@ -469,13 +469,20 @@ view_get_edge_snap_box(struct view *view, struct output *output,
 		break;
 	}
 
-	struct border margin = ssd_get_margin(view->ssd);
 	struct wlr_box dst = {
-		.x = x_offset + usable.x + margin.left,
-		.y = y_offset + usable.y + margin.top,
-		.width = base_width - margin.left - margin.right,
-		.height = base_height - margin.top - margin.bottom,
+		.x = x_offset + usable.x,
+		.y = y_offset + usable.y,
+		.width = base_width,
+		.height = base_height,
 	};
+
+	if (view) {
+		struct border margin = ssd_get_margin(view->ssd);
+		dst.x += margin.left;
+		dst.y += margin.top;
+		dst.width -= margin.left + margin.right;
+		dst.height -= margin.top + margin.bottom;
+	}
 
 	return dst;
 }


### PR DESCRIPTION
Preparation for #2885.

The motivation is to deduplicate `get_edge_snap_box()` in `interactive.c` and `view_get_edge_snap_box()` in `view.c`, but I think it's a bit more intuitive for the overlay to indicate the actual window size after snapping.

|Before|After (the overlay is shrunk by `<core><gap>`)|
|-|-|
|<img width="1920" height="1080" alt="20250802_17h59m16s_grim" src="https://github.com/user-attachments/assets/3670a55f-7411-4358-88ef-c9612900bf2b" />|<img width="1920" height="1080" alt="20250802_18h01m21s_grim" src="https://github.com/user-attachments/assets/1a7f3ea0-d81d-4638-a460-6d22bcb5d4d4" />|
