### PR TITLE
[v0.20] [proof-of-concept] allow toplevel capture

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -192,6 +192,13 @@ struct server {
 	struct wlr_xdg_toplevel_icon_manager_v1 *xdg_toplevel_icon_manager;
 	struct wl_listener xdg_toplevel_icon_set_icon;
 
+	struct {
+		struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *manager;
+		struct {
+			struct wl_listener new_request;
+		} on;
+	} toplevel_capture;
+
 	/* front to back order */
 	struct wl_list views;
 	uint64_t next_view_creation_id;

--- a/include/view.h
+++ b/include/view.h
@@ -177,6 +177,12 @@ struct view {
 	char *title;
 	char *app_id; /* WM_CLASS for xwayland windows */
 
+	struct {
+		struct wlr_scene *scene;
+		struct wlr_ext_image_capture_source_v1 *source;
+		struct wl_listener on_capture_source_destroy;
+	} capture;
+
 	bool mapped;
 	bool been_mapped;
 	uint64_t creation_id;
@@ -319,6 +325,7 @@ struct xdg_toplevel_view {
 	/* Events unique to xdg-toplevel views */
 	struct wl_listener set_app_id;
 	struct wl_listener request_show_window_menu;
+	struct wl_listener set_parent;
 	struct wl_listener new_popup;
 };
 

--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,7 @@ add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 wlroots = dependency(
   'wlroots-0.20',
   default_options: ['default_library=static', 'examples=false'],
-  version: ['>=0.20.0', '<0.21.0'],
+  version: ['>=0.20.1', '<0.21.0'],
 )
 
 wlroots_has_xwayland = wlroots.get_variable('have_xwayland') == 'true'

--- a/src/foreign-toplevel/ext-foreign.c
+++ b/src/foreign-toplevel/ext-foreign.c
@@ -75,6 +75,9 @@ ext_foreign_toplevel_init(struct ext_foreign_toplevel *ext_toplevel,
 		return;
 	}
 
+	/* In support for ext-toplevel-capture */
+	ext_toplevel->handle->data = view;
+
 	/* Client side requests */
 	ext_toplevel->on.handle_destroy.notify = handle_handle_destroy;
 	wl_signal_add(&ext_toplevel->handle->events.destroy, &ext_toplevel->on.handle_destroy);

--- a/src/server.c
+++ b/src/server.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
 #include "config.h"
+#include <assert.h>
 #include <signal.h>
 #include <string.h>
 #include <sys/wait.h>
@@ -410,6 +411,39 @@ handle_renderer_lost(struct wl_listener *listener, void *data)
 	wlr_renderer_destroy(old_renderer);
 }
 
+static void
+handle_toplevel_capture_source_destroy(struct wl_listener *listener, void *data)
+{
+	struct view *view = wl_container_of(listener, view, capture.on_capture_source_destroy);
+	assert(view->capture.source);
+	view->capture.source = NULL;
+	wl_list_remove(&listener->link);
+	wl_list_init(&listener->link);
+}
+
+static void
+handle_toplevel_capture_request(struct wl_listener *listener, void *data)
+{
+	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request = data;
+	struct view *view = request->toplevel_handle->data;
+	assert(view);
+	wlr_log(WLR_INFO, "Capturing toplevel %s", view->app_id);
+
+	if (!view->capture.source) {
+		view->capture.source = wlr_ext_image_capture_source_v1_create_with_scene_node(
+			&view->capture.scene->tree.node, server.wl_event_loop,
+			server.allocator, server.renderer);
+		assert(view->capture.source);
+
+		view->capture.on_capture_source_destroy.notify =
+			handle_toplevel_capture_source_destroy;
+		wl_signal_add(&view->capture.source->events.destroy,
+			&view->capture.on_capture_source_destroy);
+	}
+	wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request_accept(
+		request, view->capture.source);
+}
+
 void
 server_init(void)
 {
@@ -689,6 +723,19 @@ server_init(void)
 	wlr_screencopy_manager_v1_create(server.wl_display);
 	wlr_ext_image_copy_capture_manager_v1_create(server.wl_display, 1);
 	wlr_ext_output_image_capture_source_manager_v1_create(server.wl_display, 1);
+
+	server.toplevel_capture.manager =
+		wlr_ext_foreign_toplevel_image_capture_source_manager_v1_create(
+			server.wl_display, 1);
+	if (server.toplevel_capture.manager) {
+		server.toplevel_capture.on.new_request.notify = handle_toplevel_capture_request;
+		wl_signal_add(&server.toplevel_capture.manager->events.new_request,
+			&server.toplevel_capture.on.new_request);
+	} else {
+		/* Allow safe removal on shutdown */
+		wl_list_init(&server.toplevel_capture.on.new_request.link);
+	}
+
 	wlr_data_control_manager_v1_create(server.wl_display);
 	wlr_ext_data_control_manager_v1_create(server.wl_display,
 		LAB_EXT_DATA_CONTROL_VERSION);
@@ -822,6 +869,8 @@ server_finish(void)
 		wl_list_remove(&server.drm_lease_request.link);
 		server.drm_lease_request.notify = NULL;
 	}
+
+	wl_list_remove(&server.toplevel_capture.on.new_request.link);
 
 	wlr_backend_destroy(server.backend);
 	wlr_allocator_destroy(server.allocator);

--- a/src/view.c
+++ b/src/view.c
@@ -2482,6 +2482,10 @@ view_init(struct view *view)
 
 	view->title = xstrdup("");
 	view->app_id = xstrdup("");
+
+	view->capture.scene = wlr_scene_create();
+	view->capture.scene->restack_xwayland_surfaces = false;
+	wl_list_init(&view->capture.on_capture_source_destroy.link);
 }
 
 void
@@ -2503,6 +2507,9 @@ view_destroy(struct view *view)
 	wl_list_remove(&view->request_fullscreen.link);
 	wl_list_remove(&view->set_title.link);
 	wl_list_remove(&view->destroy.link);
+	wl_list_remove(&view->capture.on_capture_source_destroy.link);
+
+	wlr_scene_node_destroy(&view->capture.scene->tree.node);
 
 	if (view->foreign_toplevel) {
 		foreign_toplevel_destroy(view->foreign_toplevel);

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -169,4 +169,6 @@ xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup)
 
 	node_descriptor_create(wlr_popup->base->surface->data,
 		LAB_NODE_XDG_POPUP, view, /*data*/ NULL);
+
+	wlr_scene_xdg_surface_create(&view->capture.scene->tree, wlr_popup->base);
 }

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -30,6 +30,8 @@
 #define LAB_XDG_SHELL_VERSION 6
 #define CONFIGURE_TIMEOUT_MS 100
 
+static struct view *xdg_toplevel_view_get_root(struct view *view);
+
 static struct xdg_toplevel_view *
 xdg_toplevel_view_from_view(struct view *view)
 {
@@ -462,6 +464,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 	/* Remove xdg-shell view specific listeners */
 	wl_list_remove(&xdg_toplevel_view->set_app_id.link);
 	wl_list_remove(&xdg_toplevel_view->request_show_window_menu.link);
+	wl_list_remove(&xdg_toplevel_view->set_parent.link);
 	wl_list_remove(&xdg_toplevel_view->new_popup.link);
 	wl_list_remove(&view->commit.link);
 
@@ -563,6 +566,23 @@ handle_request_show_window_menu(struct wl_listener *listener, void *data)
 
 	struct wlr_cursor *cursor = server.seat.cursor;
 	menu_open_root(menu, cursor->x, cursor->y);
+}
+
+static void
+handle_set_parent(struct wl_listener *listener, void *data)
+{
+	struct xdg_toplevel_view *xdg_toplevel_view = wl_container_of(
+		listener, xdg_toplevel_view, set_parent);
+	struct view *view = &xdg_toplevel_view->base;
+	struct view *view_root = xdg_toplevel_view_get_root(view);
+	if (view_root == view) {
+		return;
+	}
+	struct wlr_scene_node *node, *tmp;
+	wl_list_for_each_safe(node, tmp, &view->capture.scene->tree.children, link) {
+		wlr_log(WLR_DEBUG, "moving capture scene node to view_root");
+		wlr_scene_node_reparent(node, &view_root->capture.scene->tree);
+	}
 }
 
 static void
@@ -1046,6 +1066,9 @@ handle_new_xdg_toplevel(struct wl_listener *listener, void *data)
 	mappable_connect(&view->mappable, xdg_surface->surface,
 		handle_map, handle_unmap);
 
+	struct view *root_view = xdg_toplevel_view_get_root(view);
+	wlr_scene_xdg_surface_create(&root_view->capture.scene->tree, xdg_surface);
+
 	struct wlr_xdg_toplevel *toplevel = xdg_surface->toplevel;
 	CONNECT_SIGNAL(toplevel, view, destroy);
 	CONNECT_SIGNAL(toplevel, view, request_move);
@@ -1059,6 +1082,7 @@ handle_new_xdg_toplevel(struct wl_listener *listener, void *data)
 	/* Events specific to XDG toplevel views */
 	CONNECT_SIGNAL(toplevel, xdg_toplevel_view, set_app_id);
 	CONNECT_SIGNAL(toplevel, xdg_toplevel_view, request_show_window_menu);
+	CONNECT_SIGNAL(toplevel, xdg_toplevel_view, set_parent);
 	CONNECT_SIGNAL(xdg_surface, xdg_toplevel_view, new_popup);
 
 	wl_list_insert(&server.views, &view->link);

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -783,6 +783,7 @@ handle_map(struct wl_listener *listener, void *data)
 		view->content_tree = wlr_scene_subsurface_tree_create(
 			view->scene_tree, view->surface);
 		die_if_null(view->content_tree);
+		wlr_scene_subsurface_tree_create(&view->capture.scene->tree, view->surface);
 	}
 
 	wlr_scene_node_set_enabled(&view->content_tree->node, !view->shaded);


### PR DESCRIPTION
Just to experiment.

Missing:
- [x] disable capture scene xwayland restacking via [restack_xwayland_surfaces](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5108)
- [ ] xwayland child windows
- [ ] xwayland unmanaged windows, e.g. popups / menus / ...
- [ ] xdg child window positioning
- [ ] xdg subsurfaces (test-case: mate-terminal settings listboxes)
- [ ] xdg popup positioning