### PR TITLE
output: make autoEnableOutputs=no apply only to drm outputs

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -216,7 +216,7 @@ this is for compatibility with Openbox.
 
 *<core><autoEnableOutputs>* [yes|no]
 	Automatically enable outputs at startup and when new outputs are
-	connected. Default is yes.
+	connected. This option applies only to drm outputs. Default is yes.
 
 	Caution: Disabling this option will make the labwc session unusable
 	unless an external tool such as `wlr-randr` or `kanshi` is used to

--- a/src/output.c
+++ b/src/output.c
@@ -547,7 +547,13 @@ handle_new_output(struct wl_listener *listener, void *data)
 	wlr_scene_node_raise_to_top(&output->osd_tree->node);
 	wlr_scene_node_raise_to_top(&output->session_lock_tree->node);
 
-	if (rc.auto_enable_outputs) {
+	/*
+	 * autoEnableOutputs=no only makes sense for outputs that can be
+	 * hotplugged - currently only drm outputs. With wl/x11/headless
+	 * it would result in no outputs being enabled at all. This check
+	 * might need tweaking if wlroots adds other output backends.
+	 */
+	if (rc.auto_enable_outputs || !wlr_output_is_drm(wlr_output)) {
 		configure_new_output(server, output);
 	}
 


### PR DESCRIPTION
It is not really useful for other output backends and just results in no outputs being enabled at all. (This is mainly an annoyance for developers normally running with drm but occasionally nested.)