### PR TITLE
Fix xdg-shell views moving between outputs due to configure timeout

### DIFF
--- a/src/xdg.c
+++ b/src/xdg.c
@@ -288,6 +288,14 @@ handle_configure_timeout(void *data)
 	view->pending_configure_serial = 0;
 	view->pending_configure_timeout = NULL;
 
+	/*
+	 * No need to do anything else if the view is just being slow to
+	 * map - the map handler will take care of the positioning.
+	 */
+	if (!view->mapped) {
+		return 0; /* ignored per wl_event_loop docs */
+	}
+
 	bool empty_pending = wlr_box_empty(&view->pending);
 	if (empty_pending || view->pending.x != view->current.x
 			|| view->pending.y != view->current.y) {

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -322,6 +322,13 @@ handle_configure_timeout(void *data)
 			wlr_log(WLR_INFO, "using fallback position");
 			view->pending.x = VIEW_FALLBACK_X;
 			view->pending.y = VIEW_FALLBACK_Y;
+			/* At least try to keep it on the same output */
+			if (output_is_usable(view->output)) {
+				struct wlr_box box =
+					output_usable_area_in_layout_coords(view->output);
+				view->pending.x += box.x;
+				view->pending.y += box.y;
+			}
 		}
 		view->current.x = view->pending.x;
 		view->current.y = view->pending.y;


### PR DESCRIPTION
Fixes: #2938

Either commit will actually fix the issue with mousepad, but I think we should do both:

- We shouldn't be setting a fallback position at all for views that aren't mapped yet. Just let the map handler take care of it.
- In the corner case where we really do need a fallback position (the initially-maximized case), we can still make the fallback position relative to the view's current output to reduce the surprise factor.