### PR TITLE
ime: fix segfault when IME is killed

### DIFF
--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -304,8 +304,8 @@ handle_keyboard_grab_destroy(struct wl_listener *listener, void *data)
 {
 	struct input_method_relay *relay =
 		wl_container_of(listener, relay, keyboard_grab_destroy);
-	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab =
-		relay->input_method->keyboard_grab;
+	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab = data;
+	assert(keyboard_grab);
 
 	wl_list_remove(&relay->keyboard_grab_destroy.link);
 


### PR DESCRIPTION
Fixes #2978 by partially reverting #2894.

Perhaps we can revert this PR again in wlroots 0.20 by reordering the emitted signals, I'm not sure (ref: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5107#note_3042631)