### PR TITLE
scaled-icon-buffer: prevent accidental downcasting of scale

### DIFF
--- a/src/common/scaled-icon-buffer.c
+++ b/src/common/scaled-icon-buffer.c
@@ -45,7 +45,7 @@ choose_best_icon_buffer(struct scaled_icon_buffer *self, int icon_size, double s
 }
 
 static struct lab_data_buffer *
-img_to_buffer(struct lab_img *img, int width, int height, int scale)
+img_to_buffer(struct lab_img *img, int width, int height, double scale)
 {
 	struct lab_data_buffer *buffer = lab_img_render(img, width, height, scale);
 	lab_img_destroy(img);


### PR DESCRIPTION
This causes blurry icons on non-integer scales and triggers an assert within cairo when using a output scale < 1.

Fixes:
- #2983