### PR TITLE
osd: add null-check for output->osd_scene.tree

### DIFF
--- a/src/osd.c
+++ b/src/osd.c
@@ -33,9 +33,10 @@ destroy_osd_scenes(struct server *server)
 {
 	struct output *output;
 	wl_list_for_each(output, &server->outputs, link) {
-		wlr_scene_node_destroy(&output->osd_scene.tree->node);
-		output->osd_scene.tree = NULL;
-
+		if (output->osd_scene.tree) {
+			wlr_scene_node_destroy(&output->osd_scene.tree->node);
+			output->osd_scene.tree = NULL;
+		}
 		wl_array_release(&output->osd_scene.items);
 		wl_array_init(&output->osd_scene.items);
 	}


### PR DESCRIPTION
`wlr_scene_node_destroy(&output->osd_scene.tree->node);` does nothing for null pointer, but ASAN is unhappy about accessing `(NULL)->node`, saying: `runtime error: member access within null pointer of type 'struct wlr_scene_tree'`.