### PR TITLE
docs/menu.xml: adjust labnag example

### DIFF
--- a/docs/menu.xml
+++ b/docs/menu.xml
@@ -68,11 +68,12 @@
   <!--
   # A prompt can be used as follows:
   <item label="Exit">
-    <action name="If"/>
+    <action name="If">
       <prompt message="Do you really want to exit the compositor?"/>
       <then>
         <action name="Exit"/>
       </then>
+    </action>
   </item>
   -->
 </menu>


### PR DESCRIPTION
It was missing the respective closing tag
____________________
Something I noticed when I tried to use the example for `labnag` in the menu.
Unless this syntax should also work?