### PR TITLE
 menu: allow client-{list-combined,send-to}-menu as submenu of static menu

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -814,13 +814,6 @@ menu_hide_submenu(struct server *server, const char *id)
 	}
 }
 
-static void
-init_client_send_to_menu(struct server *server)
-{
-	/* Just create placeholder. Contents will be created when launched */
-	menu_create(server, NULL, "client-send-to-menu", "");
-}
-
 static struct action *
 item_add_action(struct menuitem *item, const char *action_name)
 {
@@ -864,13 +857,6 @@ update_client_send_to_menu(struct server *server)
 	}
 
 	menu_create_scene(menu);
-}
-
-static void
-init_client_list_combined_menu(struct server *server)
-{
-	/* Just create placeholder. Contents will be created when launched */
-	menu_create(server, NULL, "client-list-combined-menu", "");
 }
 
 /*
@@ -1010,11 +996,14 @@ void
 menu_init(struct server *server)
 {
 	wl_list_init(&server->menus);
+
+	/* Just create placeholder. Contents will be created when launched */
+	menu_create(server, NULL, "client-list-combined-menu", _("Windows"));
+	menu_create(server, NULL, "client-send-to-menu", _("Send to desktop"));
+
 	parse_xml("menu.xml", server);
 	init_rootmenu(server);
 	init_windowmenu(server);
-	init_client_list_combined_menu(server);
-	init_client_send_to_menu(server);
 	validate(server);
 }
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -851,7 +851,7 @@ update_client_send_to_menu(struct server *server)
 			NULL, /*show arrow*/ false);
 
 		struct action *action = item_add_action(item, "SendToDesktop");
-		action_arg_add_str(action, "to", "name");
+		action_arg_add_str(action, "to", workspace->name);
 
 		buf_clear(&buf);
 	}


### PR DESCRIPTION
This PR allows `client-list-combined-menu` and `client-send-to-menu` as submenus of static menus by creating them first.

Their labels are changed to "Windows" and "Send to desktop" which are the same as Openbox.

This PR also fixes my stupid mistake in #2971 that broke `client-send-to-menu`.

Link: #2992