### PR TITLE
menu: use client-send-to-menu as 'Workspace' submenu

### DIFF
--- a/docs/menu.xml
+++ b/docs/menu.xml
@@ -25,18 +25,7 @@
     Any menu with the id "workspaces" will be hidden
     if there is only a single workspace available.
   -->
-  <menu id="workspaces" label="Workspace">
-    <item label="Move Left">
-      <action name="SendToDesktop" to="left" />
-    </item>
-    <item label="Move Right">
-      <action name="SendToDesktop" to="right" />
-    </item>
-    <separator />
-    <item label="Always on Visible Workspace">
-      <action name="ToggleOmnipresent" />
-    </item>
-  </menu>
+  <menu id="client-send-to-menu"/>
   <!--
     openbox default workspace selector
     to use replace above workspace menu with the example below

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -844,8 +844,8 @@ update_client_send_to_menu(struct server *server)
 	 * <action name="SendToDesktop"><follow> is true by default so
 	 * GoToDesktop will be called as part of the action.
 	 */
+	struct buf buf = BUF_INIT;
 	wl_list_for_each(workspace, &server->workspaces.all, link) {
-		struct buf buf = BUF_INIT;
 		if (workspace == server->workspaces.current) {
 			buf_add_fmt(&buf, ">%s<", workspace->name);
 		} else {
@@ -859,6 +859,7 @@ update_client_send_to_menu(struct server *server)
 
 		buf_clear(&buf);
 	}
+	buf_reset(&buf);
 
 	separator_create(menu, "");
 	struct menuitem *item = item_create(menu,


### PR DESCRIPTION
...because that is more flexible and how it is in openbox.

I have had in mind that we should do this since the original implementation, and #2994 just jogged my memory.

<img width="476" height="329" alt="20250813_20h41m09s_grim" src="https://github.com/user-attachments/assets/aefe5aa5-370d-4457-bac4-780c7588dd51" />
