### PR TITLE
menu: allow overwriting submenu icon

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -613,7 +613,7 @@ fill_menu(struct server *server, struct menu *parent, xmlNode *n)
 		}
 
 		struct menuitem *item = item_create(parent, menu->label,
-			parent->icon_name, true);
+			icon_name ? icon_name : menu->icon_name, true);
 		item->submenu = menu;
 	}
 error:


### PR DESCRIPTION
This PR allows overwriting the icon of item linking to another menu like below (the icon for `krita` instead of `mpv` should be shown):

```xml
<openbox_menu>
  <menu id="static-menu" label="Static Menu" icon="mpv" />
  <menu id="root-menu" label="Root">
    <menu id="static-menu" icon="krita" />
  </menu>
</openbox_menu>
```

For comparison, Openbox seems to ignore `icon` property in toplevel menu definition in the first place and always follows `icon` property inside the `<menu>` that links to a static menu. So when we have following `menu.xml`:

```xml
<openbox_menu>
  <menu id="static-menu" label="Static Menu"
    icon="/usr/share/icons/hicolor/32x32/apps/mpv.png" />
  <menu id="root-menu" label="Root">
    <menu id="static-menu"
      icon="/usr/share/icons/hicolor/22x22/apps/krita.png" />
    <menu id="inline-menu" label="Inline Menu"
      icon="/usr/share/icons/hicolor/32x32/apps/chromium.png" />
  </menu>
</openbox_menu>
```

|Openbox|labwc 0.9.0|This PR|
|-|-|-|
| <img width="121" height="52" alt="20250815_02h59m17s_grim" src="https://github.com/user-attachments/assets/fb6e3857-2351-4185-bafb-d7e2cdb72ba0" /> | <img width="137" height="64" alt="20250815_03h06m42s_grim" src="https://github.com/user-attachments/assets/38fdcf66-4dea-4562-abf3-466c571ff592" /> | <img width="136" height="65" alt="20250815_03h11m59s_grim" src="https://github.com/user-attachments/assets/de70f10d-14d1-4b53-b781-8a08b393c2ee" /> |

So I think this PR enhances compatibility to Openbox.

This PR also fixes my mistake in #2971 (`s/parent->icon/menu->icon/`) that showed incorrect icon in an item linking to another menu.

Link: https://github.com/labwc/labwc/discussions/2992#discussioncomment-14101404