### PR TITLE
menu: fix use-after-free at exit with sub-menu selected

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1027,6 +1027,10 @@ nullify_item_pointing_to_this_menu(struct menu *menu)
 		if (iter->parent == menu) {
 			iter->parent = NULL;
 		}
+
+		if (iter->selection.menu == menu) {
+			iter->selection.menu = NULL;
+		}
 	}
 }
 


### PR DESCRIPTION
Sequence of events:

- `menu_finish()` frees the sub-menu first
- the `selection.menu` of the parent menu is now dangling
- `menu_finish()` frees the parent menu
- `menu_free()` calls `menu_close_root()` on the parent menu
- `menu_close_root()` tries to close the (freed) sub-menu
- boom

Extending `nullify_item_pointing_to_this_menu()` avoids the crash.

Fixes:
- #2997