### PR TITLE
desktop-entry: fix partial string matching

### DIFF
--- a/src/desktop-entry.c
+++ b/src/desktop-entry.c
@@ -268,7 +268,7 @@ get_db_entry_by_id_fuzzy(struct sfdo_desktop_db *db, const char *app_id)
 		int alen = strlen(app_id);
 		int dlen = strlen(desktop_id_base);
 
-		if (!strncasecmp(app_id, desktop_id, alen > dlen ? dlen : alen)) {
+		if (!strncasecmp(app_id, desktop_id_base, alen > dlen ? dlen : alen)) {
 			return entry;
 		}
 	}


### PR DESCRIPTION
Use the base instead of the full string for the comparison.

The desktop_id_base is currently basically unused.

---

I noticed that something was weird when Godot would show the Zeal icon.

Debugging session:

<img width="2370" height="1184" alt="image" src="https://github.com/user-attachments/assets/5df4f849-8f85-4e20-8a6a-16712a3ba7e3" />

---

I think the partial match search could be improved.
The id of the desktop file is: `org.godotengine.Godot4.4`. So there are various difficulties with it finding the correct icon ;).

But I am already pretty happy with it no longer showing a wrong icon, and instead showing the labwc icon (default.)