### PR TITLE
keybind: refactor update_keycodes_iter() to reduce nesting

### DIFF
--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -41,5 +41,8 @@ uint32_t parse_modifier(const char *symname);
 
 bool keybind_the_same(struct keybind *a, struct keybind *b);
 
+bool keybind_contains_keycode(struct keybind *keybind, xkb_keycode_t keycode);
+bool keybind_contains_keysym(struct keybind *keybind, xkb_keysym_t keysym);
+
 void keybind_update_keycodes(struct server *server);
 #endif /* LABWC_KEYBIND_H */

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -219,17 +219,14 @@ match_keybinding_for_sym(struct server *server, uint32_t modifiers,
 		}
 		if (sym == XKB_KEY_NoSymbol) {
 			/* Use keycodes */
-			for (size_t i = 0; i < keybind->keycodes_len; i++) {
-				if (keybind->keycodes[i] == xkb_keycode) {
-					return keybind;
-				}
+			if (keybind_contains_keycode(keybind, xkb_keycode)) {
+				return keybind;
 			}
 		} else {
 			/* Use syms */
-			for (size_t i = 0; i < keybind->keysyms_len; i++) {
-				if (xkb_keysym_to_lower(sym) == keybind->keysyms[i]) {
-					return keybind;
-				}
+			if (keybind_contains_keysym(keybind,
+					xkb_keysym_to_lower(sym))) {
+				return keybind;
 			}
 		}
 	}


### PR DESCRIPTION
`update_keycodes_iter()` currently has 4(!) levels of nested loops, which makes the logic (especially the break/continue statements) difficult to understand. The logic also appears to continue looping uselessly after a given keycode has already been added to a keybind.

Refactor by adding some small utility functions:

- `keybind_contains_keycode()`
- `keybind_contains_keysym()`
- `keybind_contains_any_keysym()`

No functional change intended.

/cc @Consolatis 