### PR TITLE
rcxml: allow empty values in <libinput>

### DIFF
--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -723,6 +723,9 @@ fill_libinput_category(xmlNode *node)
 	xmlNode *child;
 	char *key, *content;
 	LAB_XML_FOR_EACH(node, child, key, content) {
+		if (string_null_or_empty(content)) {
+			continue;
+		}
 		if (!strcmp(key, "category")) {
 			/*
 			 * First we try to get a type based on a number of

--- a/src/seat.c
+++ b/src/seat.c
@@ -146,6 +146,10 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	 */
 	assert(dc);
 
+	libinput_device_config_tap_set_enabled(libinput_dev,
+		libinput_device_config_tap_get_default_enabled(libinput_dev));
+	libinput_device_config_tap_set_button_map(libinput_dev,
+		libinput_device_config_tap_get_default_button_map(libinput_dev));
 	if (libinput_device_config_tap_get_finger_count(libinput_dev) <= 0) {
 		wlr_log(WLR_INFO, "tap unavailable");
 	} else {
@@ -155,6 +159,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			dc->tap_button_map);
 	}
 
+	libinput_device_config_tap_set_drag_enabled(libinput_dev,
+		libinput_device_config_tap_get_default_drag_enabled(libinput_dev));
 	if (libinput_device_config_tap_get_finger_count(libinput_dev) <= 0
 			|| dc->tap_and_drag < 0) {
 		wlr_log(WLR_INFO, "tap-and-drag not configured");
@@ -164,6 +170,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			libinput_dev, dc->tap_and_drag);
 	}
 
+	libinput_device_config_tap_set_drag_lock_enabled(libinput_dev,
+		libinput_device_config_tap_get_default_drag_lock_enabled(libinput_dev));
 	if (libinput_device_config_tap_get_finger_count(libinput_dev) <= 0
 			|| dc->drag_lock < 0) {
 		wlr_log(WLR_INFO, "drag lock not configured");
@@ -174,6 +182,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	}
 
 #if HAVE_LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG
+	libinput_device_config_3fg_drag_set_enabled(libinput_dev,
+		libinput_device_config_3fg_drag_get_default_enabled(libinput_dev));
 	if (libinput_device_config_tap_get_finger_count(libinput_dev) <= 0
 			|| dc->three_finger_drag < 0) {
 		wlr_log(WLR_INFO, "three-finger drag not configured");
@@ -184,6 +194,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	}
 #endif
 
+	libinput_device_config_scroll_set_natural_scroll_enabled(libinput_dev,
+		libinput_device_config_scroll_get_default_natural_scroll_enabled(libinput_dev));
 	if (libinput_device_config_scroll_has_natural_scroll(libinput_dev) <= 0
 			|| dc->natural_scroll < 0) {
 		wlr_log(WLR_INFO, "natural scroll not configured");
@@ -193,6 +205,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			libinput_dev, dc->natural_scroll);
 	}
 
+	libinput_device_config_left_handed_set(libinput_dev,
+		libinput_device_config_left_handed_get_default(libinput_dev));
 	if (libinput_device_config_left_handed_is_available(libinput_dev) <= 0
 			|| dc->left_handed < 0) {
 		wlr_log(WLR_INFO, "left-handed mode not configured");
@@ -202,6 +216,10 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			dc->left_handed);
 	}
 
+	libinput_device_config_accel_set_speed(libinput_dev,
+		libinput_device_config_accel_get_default_speed(libinput_dev));
+	libinput_device_config_accel_set_profile(libinput_dev,
+		libinput_device_config_accel_get_default_profile(libinput_dev));
 	if (libinput_device_config_accel_is_available(libinput_dev) == 0) {
 		wlr_log(WLR_INFO, "pointer acceleration unavailable");
 	} else {
@@ -216,6 +234,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		}
 	}
 
+	libinput_device_config_middle_emulation_set_enabled(libinput_dev,
+		libinput_device_config_middle_emulation_get_default_enabled(libinput_dev));
 	if (libinput_device_config_middle_emulation_is_available(libinput_dev)
 			== 0 || dc->middle_emu < 0)  {
 		wlr_log(WLR_INFO, "middle emulation not configured");
@@ -225,6 +245,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			libinput_dev, dc->middle_emu);
 	}
 
+	libinput_device_config_dwt_set_enabled(libinput_dev,
+		libinput_device_config_dwt_get_default_enabled(libinput_dev));
 	if (libinput_device_config_dwt_is_available(libinput_dev) == 0
 			|| dc->dwt < 0) {
 		wlr_log(WLR_INFO, "dwt not configured");
@@ -233,6 +255,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		libinput_device_config_dwt_set_enabled(libinput_dev, dc->dwt);
 	}
 
+	libinput_device_config_click_set_method(libinput_dev,
+		libinput_device_config_click_get_default_method(libinput_dev));
 	if ((dc->click_method != LIBINPUT_CONFIG_CLICK_METHOD_NONE
 			&& (libinput_device_config_click_get_methods(libinput_dev)
 				& dc->click_method) == 0)
@@ -253,6 +277,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		libinput_device_config_click_set_method(libinput_dev, dc->click_method);
 	}
 
+	libinput_device_config_scroll_set_method(libinput_dev,
+		libinput_device_config_scroll_get_default_method(libinput_dev));
 	if (dc->scroll_method < 0) {
 		wlr_log(WLR_INFO, "scroll method not configured");
 	} else if (dc->scroll_method != LIBINPUT_CONFIG_SCROLL_NO_SCROLL
@@ -264,6 +290,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		libinput_device_config_scroll_set_method(libinput_dev, dc->scroll_method);
 	}
 
+	libinput_device_config_send_events_set_mode(libinput_dev,
+		libinput_device_config_send_events_get_default_mode(libinput_dev));
 	if ((dc->send_events_mode != LIBINPUT_CONFIG_SEND_EVENTS_ENABLED
 			&& (libinput_device_config_send_events_get_modes(libinput_dev)
 				& dc->send_events_mode) == 0)
@@ -274,6 +302,9 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		libinput_device_config_send_events_set_mode(libinput_dev, dc->send_events_mode);
 	}
 
+	float default_matrix[6];
+	libinput_device_config_calibration_get_default_matrix(libinput_dev, default_matrix);
+	libinput_device_config_calibration_set_matrix(libinput_dev, default_matrix);
 	/* Non-zero if the device can be calibrated, zero otherwise. */
 	if (libinput_device_config_calibration_has_matrix(libinput_dev) == 0
 			|| !dc->have_calibration_matrix) {


### PR DESCRIPTION
The first commit restores the old behavior prior to #2667 that empty values in `<libinput>` are ignored.

The second commit implements what I proposed as "future plan" in https://github.com/labwc/labwc/issues/3006#issuecomment-3197033177. Reconfiguring a libinput device with empty values now restores its default values, rather than leaving its old configuration before Reconfigure. This makes `rc.xml` more declarative.

I wonder whether we should allow empty values in other places (e.g. `<margin top="" />`). They were allowed before #2667, but I don't find empty values useful outside of `<libinput>`. If we allow empty values in all the configurations, we will need add `if (string_null_or_empty(identifier)) { continue; }` in `fill_region()`, `fill_window_rule()` etc., or we can skip nodes with an empty value in `LAB_XML_FOR_EACH()` (with additional `skip_empty_node` argument?).