### PR TITLE
view: respect client-initiated resize of non-maximized axis

### DIFF
--- a/src/interactive.c
+++ b/src/interactive.c
@@ -90,9 +90,9 @@ interactive_begin(struct view *view, enum input_mode mode, uint32_t edges)
 			return;
 		}
 
+		/* Store natural geometry at start of move */
+		view_store_natural_geometry(view);
 		if (view_is_floating(view)) {
-			/* Store natural geometry at start of move */
-			view_store_natural_geometry(view);
 			view_invalidate_last_layout_geometry(view);
 		}
 


### PR DESCRIPTION
When implementing single-axis maximize some time ago, I made the simplifying assumption that a view couldn't be resized while maximized (even in only one axis). And indeed for compositor-initiated resize, we always unmaximize the view first.

However, I didn't account for the client resizing the non-maximized axis, which we can't (and shouldn't) prevent. When this happens, we should also update the natural geometry of that single axis so that we don't undo the resize when un-maximizing.

P.S. xdg-shell clients resizing the *maximized* axis is still an unsolved problem, exacerbated by the fact that xdg-shell protocol doesn't allow clients to even know about single-axis maximize. That's the problem at the root of:
- #3018

P.P.S. the view_invalidate_last_layout_geometry() logic may need similar updates, I'm not sure.