### PR TITLE
action: add toggle for GoToDesktop

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -278,7 +278,7 @@ Actions are used in menus and keyboard/mouse bindings.
 	Resizes active window size to width and height of the output when the
 	window size exceeds the output size.
 
-*<action name="GoToDesktop" to="value" wrap="yes" />*
+*<action name="GoToDesktop" to="value" wrap="yes" toggle="no" />*
 	Switch to workspace.
 
 	*to* The workspace to switch to. Supported values are "current", "last",
@@ -287,6 +287,9 @@ Actions are used in menus and keyboard/mouse bindings.
 
 	*wrap* [yes|no] Wrap around from last desktop to first, and vice
 	versa. Default yes.
+
+	*toggle* [yes|no] Toggle to “last” if already on the workspace that
+	would be the actual destination. Default no.
 
 *<action name="SendToDesktop" to="value" follow="yes" wrap="yes" />*
 	Send active window to workspace.

--- a/src/action.c
+++ b/src/action.c
@@ -440,6 +440,11 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			action_arg_add_bool(action, argument, parse_bool(content, true));
 			goto cleanup;
 		}
+		if (!strcmp(argument, "toggle")) {
+			action_arg_add_bool(
+				action, argument, parse_bool(content, false));
+			goto cleanup;
+		}
 		break;
 	case ACTION_TYPE_TOGGLE_SNAP_TO_REGION:
 	case ACTION_TYPE_SNAP_TO_REGION:
@@ -1228,6 +1233,13 @@ run_action(struct view *view, struct server *server, struct action *action,
 		 */
 		struct workspace *target_workspace = workspaces_find(
 			server->workspaces.current, to, wrap);
+		if (action->type == ACTION_TYPE_GO_TO_DESKTOP) {
+			bool toggle = action_get_bool(action, "toggle", false);
+			if (target_workspace == server->workspaces.current
+				&& toggle) {
+				target_workspace = server->workspaces.last;
+			}
+		}
 		if (!target_workspace) {
 			break;
 		}


### PR DESCRIPTION
Adds an option "toogle" to GoToDesktop.
In case the target equals current, we go back to the last desktop instead if configured.

This is inspired by the tweak available in xfwm4, see https://docs.xfce.org/xfce/xfwm4/wmtweaks:
"Remember and recall previous workspace when switching via keyboard shortcuts".

Example of rc.xml

```xml
<keybind key="C-F1">
  <action name="GoToDesktop">
    <to>1</to>
    <toggle>true</toggle>
  </action>
</keybind>
```

I like this option a lot because I have, e.g., my browser on Desktop 1 and code on another one. Quickly pressing Ctrl-F1 brings me to the browser to read up sth and pressing again Ctrl-F1 allows to be back in code.

If you like the contribution, I'd be happy to contribute also documentation and other parts if needed. First, wanted to understand if you are interested in this small patch.