### PR TITLE
window-rules: fix window rules not being applied

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -78,6 +78,7 @@ struct view_query *
 view_query_create(void)
 {
 	struct view_query *query = znew(*query);
+	/* Must be synced with view_matches_criteria() in window-rules.c */
 	query->window_type = -1;
 	query->maximized = VIEW_AXIS_INVALID;
 	query->decoration = LAB_SSD_MODE_INVALID;

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -36,7 +36,9 @@ view_matches_criteria(struct window_rule *rule, struct view *view)
 		.window_type = rule->window_type,
 		.sandbox_engine = rule->sandbox_engine,
 		.sandbox_app_id = rule->sandbox_app_id,
+		/* Must be synced with view_query_create() */
 		.maximized = VIEW_AXIS_INVALID,
+		.decoration = LAB_SSD_MODE_INVALID,
 	};
 
 	if (rule->match_once && other_instances_exist(view, &query)) {


### PR DESCRIPTION
In 943f5751, I initialized heap-allocated `view_query` used for `If` actions with `decoration=LAB_SSD_MODE_INVALID`, but I forgot to do that for stack-allocated `view_query` used for window rules.