### PR TITLE
seat: improve debug logging when configuring input devices

### DIFF
--- a/include/config/libinput.h
+++ b/include/config/libinput.h
@@ -38,6 +38,7 @@ struct libinput_category {
 };
 
 enum lab_libinput_device_type get_device_type(const char *s);
+const char *libinput_device_type_name(enum lab_libinput_device_type type);
 struct libinput_category *libinput_category_create(void);
 struct libinput_category *libinput_category_get_default(void);
 

--- a/src/config/libinput.c
+++ b/src/config/libinput.c
@@ -51,6 +51,25 @@ get_device_type(const char *s)
 	return LAB_LIBINPUT_DEVICE_NONE;
 }
 
+const char *
+libinput_device_type_name(enum lab_libinput_device_type type)
+{
+	switch (type) {
+	case LAB_LIBINPUT_DEVICE_NONE:
+		break;
+	case LAB_LIBINPUT_DEVICE_DEFAULT:
+		return "default";
+	case LAB_LIBINPUT_DEVICE_TOUCH:
+		return "touch";
+	case LAB_LIBINPUT_DEVICE_TOUCHPAD:
+		return "touchpad";
+	case LAB_LIBINPUT_DEVICE_NON_TOUCH:
+		return "non-touch";
+	}
+	/* none/invalid */
+	return "(none)";
+}
+
 struct libinput_category *
 libinput_category_create(void)
 {

--- a/src/seat.c
+++ b/src/seat.c
@@ -149,6 +149,13 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	 */
 	assert(dc);
 
+	wlr_log(WLR_INFO, "configuring input device %s (%s)",
+		libinput_device_get_name(libinput_dev),
+		libinput_device_get_sysname(libinput_dev));
+
+	wlr_log(WLR_INFO, "matched category: %s",
+		dc->name ? dc->name : libinput_device_type_name(dc->type));
+
 	libinput_device_config_tap_set_enabled(libinput_dev,
 		libinput_device_config_tap_get_default_enabled(libinput_dev));
 	libinput_device_config_tap_set_button_map(libinput_dev,
@@ -156,7 +163,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	if (libinput_device_config_tap_get_finger_count(libinput_dev) <= 0) {
 		wlr_log(WLR_INFO, "tap unavailable");
 	} else {
-		wlr_log(WLR_INFO, "tap configured");
+		wlr_log(WLR_INFO, "tap configured (tap=%d, button_map=%d)",
+			dc->tap, dc->tap_button_map);
 		libinput_device_config_tap_set_enabled(libinput_dev, dc->tap);
 		libinput_device_config_tap_set_button_map(libinput_dev,
 			dc->tap_button_map);
@@ -168,7 +176,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			|| dc->tap_and_drag < 0) {
 		wlr_log(WLR_INFO, "tap-and-drag not configured");
 	} else {
-		wlr_log(WLR_INFO, "tap-and-drag configured");
+		wlr_log(WLR_INFO, "tap-and-drag configured (%d)",
+			dc->tap_and_drag);
 		libinput_device_config_tap_set_drag_enabled(
 			libinput_dev, dc->tap_and_drag);
 	}
@@ -179,7 +188,7 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			|| dc->drag_lock < 0) {
 		wlr_log(WLR_INFO, "drag lock not configured");
 	} else {
-		wlr_log(WLR_INFO, "drag lock configured");
+		wlr_log(WLR_INFO, "drag lock configured (%d)", dc->drag_lock);
 		libinput_device_config_tap_set_drag_lock_enabled(
 			libinput_dev, dc->drag_lock);
 	}
@@ -191,7 +200,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			|| dc->three_finger_drag < 0) {
 		wlr_log(WLR_INFO, "three-finger drag not configured");
 	} else {
-		wlr_log(WLR_INFO, "three-finger drag configured");
+		wlr_log(WLR_INFO, "three-finger drag configured (%d)",
+			dc->three_finger_drag);
 		libinput_device_config_3fg_drag_set_enabled(
 			libinput_dev, dc->three_finger_drag);
 	}
@@ -203,7 +213,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			|| dc->natural_scroll < 0) {
 		wlr_log(WLR_INFO, "natural scroll not configured");
 	} else {
-		wlr_log(WLR_INFO, "natural scroll configured");
+		wlr_log(WLR_INFO, "natural scroll configured (%d)",
+			dc->natural_scroll);
 		libinput_device_config_scroll_set_natural_scroll_enabled(
 			libinput_dev, dc->natural_scroll);
 	}
@@ -214,7 +225,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			|| dc->left_handed < 0) {
 		wlr_log(WLR_INFO, "left-handed mode not configured");
 	} else {
-		wlr_log(WLR_INFO, "left-handed mode configured");
+		wlr_log(WLR_INFO, "left-handed mode configured (%d)",
+			dc->left_handed);
 		libinput_device_config_left_handed_set(libinput_dev,
 			dc->left_handed);
 	}
@@ -226,14 +238,24 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 	if (libinput_device_config_accel_is_available(libinput_dev) == 0) {
 		wlr_log(WLR_INFO, "pointer acceleration unavailable");
 	} else {
-		wlr_log(WLR_INFO, "pointer acceleration configured");
 		if (dc->pointer_speed >= -1) {
+			wlr_log(WLR_INFO, "pointer speed configured (%g)",
+				dc->pointer_speed);
 			libinput_device_config_accel_set_speed(libinput_dev,
 				dc->pointer_speed);
+		} else {
+			wlr_log(WLR_INFO, "pointer speed not configured");
 		}
+
 		if (dc->accel_profile > 0) {
+			wlr_log(WLR_INFO,
+				"pointer accel profile configured (%d)",
+				dc->accel_profile);
 			libinput_device_config_accel_set_profile(libinput_dev,
 				dc->accel_profile);
+		} else {
+			wlr_log(WLR_INFO,
+				"pointer accel profile not configured");
 		}
 	}
 
@@ -243,7 +265,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			== 0 || dc->middle_emu < 0)  {
 		wlr_log(WLR_INFO, "middle emulation not configured");
 	} else {
-		wlr_log(WLR_INFO, "middle emulation configured");
+		wlr_log(WLR_INFO, "middle emulation configured (%d)",
+			dc->middle_emu);
 		libinput_device_config_middle_emulation_set_enabled(
 			libinput_dev, dc->middle_emu);
 	}
@@ -254,7 +277,7 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			|| dc->dwt < 0) {
 		wlr_log(WLR_INFO, "dwt not configured");
 	} else {
-		wlr_log(WLR_INFO, "dwt configured");
+		wlr_log(WLR_INFO, "dwt configured (%d)", dc->dwt);
 		libinput_device_config_dwt_set_enabled(libinput_dev, dc->dwt);
 	}
 
@@ -266,7 +289,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			|| dc->click_method < 0) {
 		wlr_log(WLR_INFO, "click method not configured");
 	} else {
-		wlr_log(WLR_INFO, "click method configured");
+		wlr_log(WLR_INFO, "click method configured (%d)",
+			dc->click_method);
 
 		/*
 		 * Note, the documentation claims that:
@@ -289,7 +313,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 				& dc->scroll_method) == 0) {
 		wlr_log(WLR_INFO, "scroll method not supported");
 	} else {
-		wlr_log(WLR_INFO, "scroll method configured");
+		wlr_log(WLR_INFO, "scroll method configured (%d)",
+			dc->scroll_method);
 		libinput_device_config_scroll_set_method(libinput_dev, dc->scroll_method);
 	}
 
@@ -301,7 +326,8 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 			|| dc->send_events_mode < 0) {
 		wlr_log(WLR_INFO, "send events mode not configured");
 	} else {
-		wlr_log(WLR_INFO, "send events mode configured");
+		wlr_log(WLR_INFO, "send events mode configured (%d)",
+			dc->send_events_mode);
 		libinput_device_config_send_events_set_mode(libinput_dev, dc->send_events_mode);
 	}
 
@@ -317,7 +343,7 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		libinput_device_config_calibration_set_matrix(libinput_dev, dc->calibration_matrix);
 	}
 
-	wlr_log(WLR_INFO, "scroll factor configured");
+	wlr_log(WLR_INFO, "scroll factor configured (%g)", dc->scroll_factor);
 	input->scroll_factor = dc->scroll_factor;
 }
 


### PR DESCRIPTION
I needed to debug an input configuration issue and found the debug output not-super-helpful, so I made some improvements:

- Print the name and "sysname" (e.g. event11) of the device being configured. Note that the name alone isn't enough since there can be multiple identically-named devices.

- Print the config category matched for each device.

- Print the config values (if any) being applied. For enums, only the numeric value is printed since I'm lazy.

- Don't print "pointer acceleration configured" if neither a pointer speed nor acceleration profile is configured (it's confusing).