### PR TITLE
tree-wide: use enum types/constants where appropriate

### DIFF
--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -173,7 +173,7 @@ struct rcxml {
 		bool show;
 		bool preview;
 		bool outlines;
-		uint32_t criteria;
+		enum lab_view_criteria criteria;
 		struct wl_list fields;  /* struct window_switcher_field.link */
 	} window_switcher;
 

--- a/include/config/types.h
+++ b/include/config/types.h
@@ -48,7 +48,16 @@ enum lab_tristate {
 	LAB_STATE_DISABLED
 };
 
-/* All criteria is applied in AND logic */
+/*
+ * This enum type is a set of bit flags where each set bit makes the
+ * criteria more restrictive. For example:
+ *
+ * (LAB_VIEW_CRITERIA_FULLSCREEN | LAB_VIEW_CRITERIA_CURRENT_WORKSPACE)
+ * matches only fullscreen views on the current workspace, while
+ *
+ * (LAB_VIEW_CRITERIA_ALWAYS_ON_TOP | LAB_VIEW_CRITERIA_NO_ALWAYS_ON_TOP)
+ * would be contradictory and match nothing at all.
+ */
 enum lab_view_criteria {
 	/* No filter -> all focusable views */
 	LAB_VIEW_CRITERIA_NONE = 0,
@@ -79,6 +88,7 @@ enum lab_view_criteria {
  * to make them available even in builds with xwayland support disabled.
  */
 enum lab_window_type {
+	LAB_WINDOW_TYPE_INVALID = -1,
 	LAB_WINDOW_TYPE_DESKTOP = 0,
 	LAB_WINDOW_TYPE_DOCK,
 	LAB_WINDOW_TYPE_TOOLBAR,

--- a/include/osd.h
+++ b/include/osd.h
@@ -43,7 +43,6 @@ struct window_switcher_field {
 struct buf;
 struct view;
 struct server;
-enum lab_cycle_dir;
 
 /* Begin window switcher */
 void osd_begin(struct server *server, enum lab_cycle_dir direction);

--- a/include/output.h
+++ b/include/output.h
@@ -3,8 +3,7 @@
 #define LABWC_OUTPUT_H
 
 #include <wlr/types/wlr_output.h>
-
-enum lab_edge;
+#include "common/edge.h"
 
 #define LAB_NR_LAYERS (4)
 

--- a/include/view.h
+++ b/include/view.h
@@ -274,7 +274,7 @@ struct view_query {
 	struct wl_list link;
 	char *identifier;
 	char *title;
-	int window_type;
+	enum lab_window_type window_type;
 	char *sandbox_engine;
 	char *sandbox_app_id;
 	enum lab_tristate shaded;

--- a/include/window-rules.h
+++ b/include/window-rules.h
@@ -4,6 +4,7 @@
 
 #include <stdbool.h>
 #include <wayland-util.h>
+#include "config/types.h"
 
 enum window_rule_event {
 	LAB_WINDOW_RULE_EVENT_ON_FIRST_MAP = 0,
@@ -24,7 +25,7 @@ enum property {
 struct window_rule {
 	char *identifier;
 	char *title;
-	int window_type;
+	enum lab_window_type window_type;
 	char *sandbox_engine;
 	char *sandbox_app_id;
 	bool match_once;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -56,11 +56,11 @@ enum font_place {
 static void load_default_key_bindings(void);
 static void load_default_mouse_bindings(void);
 
-static int
+static enum lab_window_type
 parse_window_type(const char *type)
 {
 	if (!type) {
-		return -1;
+		return LAB_WINDOW_TYPE_INVALID;
 	}
 	if (!strcasecmp(type, "desktop")) {
 		return LAB_WINDOW_TYPE_DESKTOP;
@@ -91,7 +91,7 @@ parse_window_type(const char *type)
 	} else if (!strcasecmp(type, "normal")) {
 		return LAB_WINDOW_TYPE_NORMAL;
 	} else {
-		return -1;
+		return LAB_WINDOW_TYPE_INVALID;
 	}
 }
 
@@ -258,7 +258,7 @@ static void
 fill_window_rule(xmlNode *node)
 {
 	struct window_rule *window_rule = znew(*window_rule);
-	window_rule->window_type = -1; // Window types are >= 0
+	window_rule->window_type = LAB_WINDOW_TYPE_INVALID;
 	wl_list_append(&rc.window_rules, &window_rule->link);
 	wl_list_init(&window_rule->actions);
 
@@ -1406,7 +1406,7 @@ rcxml_init(void)
 
 	rc.tablet.force_mouse_emulation = false;
 	rc.tablet.output_name = NULL;
-	rc.tablet.rotation = 0;
+	rc.tablet.rotation = LAB_ROTATE_NONE;
 	rc.tablet.box = (struct wlr_fbox){0};
 	tablet_load_default_button_mappings();
 	rc.tablet_tool.motion = LAB_MOTION_ABSOLUTE;

--- a/src/img/img-xbm.c
+++ b/src/img/img-xbm.c
@@ -251,7 +251,7 @@ parse_xbm_builtin(const char *button, int size, uint32_t color)
 		t[i].value = button[i];
 		t[i].type = TOKEN_INT;
 	}
-	t[size].type = 0;
+	t[size].type = TOKEN_NONE;
 	process_bytes(&pixmap, t, color);
 	return pixmap;
 }

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -882,7 +882,7 @@ handle_motion(struct wl_listener *listener, void *data)
 	cursor_set_visible(seat, /* visible */ true);
 
 	if (seat->cursor_scroll_wheel_emulation) {
-		uint32_t orientation;
+		enum wl_pointer_axis orientation;
 		double delta;
 		if (fabs(event->delta_x) > fabs(event->delta_y)) {
 			orientation = WL_POINTER_AXIS_HORIZONTAL_SCROLL;
@@ -1014,7 +1014,7 @@ is_double_click(long double_click_speed, uint32_t button,
 		 */
 		last_button = 0;
 		last_view = NULL;
-		last_type = 0;
+		last_type = LAB_SSD_NONE;
 		return true;
 	}
 	return false;

--- a/src/view.c
+++ b/src/view.c
@@ -79,7 +79,7 @@ view_query_create(void)
 {
 	struct view_query *query = znew(*query);
 	/* Must be synced with view_matches_criteria() in window-rules.c */
-	query->window_type = -1;
+	query->window_type = LAB_WINDOW_TYPE_INVALID;
 	query->maximized = VIEW_AXIS_INVALID;
 	query->decoration = LAB_SSD_MODE_INVALID;
 	return query;
@@ -132,7 +132,8 @@ view_matches_query(struct view *view, struct view_query *query)
 		return false;
 	}
 
-	if (query->window_type >= 0 && !view_contains_window_type(view, query->window_type)) {
+	if (query->window_type != LAB_WINDOW_TYPE_INVALID
+			&& !view_contains_window_type(view, query->window_type)) {
 		return false;
 	}
 


### PR DESCRIPTION
- add `LAB_WINDOW_TYPE_INVALID` in place of literal `-1`
- document more clearly that `enum lab_view_criteria` is a bitset
- other one-off replacements of integer values/types for consistency

Note: variables of type `enum lab_view_criteria` are already used extensively throughout the code to contain combinations of the declared enum values. I am not introducing any new usage here, just changing the single `uint32_t` to be consistent with all the other usages.