### PR TITLE
clients/: add lab-exit to display an exit window with labnag.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,27 +450,38 @@ translation strings under each English string.
 ## Coders
 
 Code contributors may need to update relevant files if their additions
-affect UI elements (at the moment only `src/menu/menu.c` and
-`src/config/rcxml.c`). In this case the `po/labwc.pot` file needs to be
+affect UI elements (at the moment only `src/menu/menu.c`, `src/config/rcxml.c`
+and `clients/lab-exit`). In this case the `po/labwc.pot` file needs to be
 updated so that translators can update their translations. Remember,
 many translators are _not_ coders!
 
 The process is fairly trivial however does involve some manual steps.
 
-1. After adding and testing your code additions to satisfaction, backup
-`po/labwc.pot`. You need the custom header from that file for the newly
-generated .pot file in the next step.
+After adding and testing your code additions to satisfaction, there are
+two commands needed to generate a sane `po/labwc.pot` file. Two commands are
+necessary because we now are using `C` and `Shell` in GUI facing files.
 
-2. From the root of the repository run this:
+1. From the root of the repository run this:
 
 ```
-xgettext --keyword=_ --language=C --add-comments -o po/labwc.pot src/menu/menu.c src/config/rcxml.c
+xgettext --keyword=_ --language=C --add-comments -o po/labwc.pot src/menu/menu.c\
+  src/config/rcxml.c --package-name=labwc --msgid-bugs-address=https://github.com/labwc/labwc/issues\
+  --copyright-holder="2025 labwc team"
 ```
 
 This generates a new pot file at `po/labwc.pot`
 
-3. Copy the header from the original `labwc.pot` to the new one, keeping
-the newly generated dates, check for sanity and commit.
+2. Then next run this:
+```
+xgettext -j --keyword=_ --language=Shell --add-comments -o po/labwc.pot  clients/lab-exit\
+  --package-name=labwc --msgid-bugs-address=https://github.com/labwc/labwc/issues\
+  --copyright-holder="2025 labwc team"
+```
+
+This appends the shell script translatable strings to the `C` code strings
+generated with the first command via the `-j` option to `xgettext`
+
+View the `xgettext` manual for explanation of the other options. 
 
 # Upversion
 

--- a/clients/lab-exit
+++ b/clients/lab-exit
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# logout with labnag
+
+export TEXTDOMAIN=labwc
+export OUTPUT_CHARSET=UTF-8
+alias _='gettext'
+
+QUESTION=$(_ 'Are you sure you want to quit Labwc?')
+YES=$(_ 'Yes')
+NO=$(_ 'No')
+
+labnag \
+ -f "mono 10"\
+ -m "$QUESTION"\
+ -Z " $YES " "labwc -e"\
+ -Z " $NO "\
+ --background 00ffff\
+ --button-background 00ffff\
+ --border 00ccccaa\
+ --text 000000\
+ --button-text 000000\
+ --button-gap 8\
+ --button-margin-right 0\
+ --button-padding 5\
+ --button-border-size 2\
+ -t 60

--- a/clients/meson.build
+++ b/clients/meson.build
@@ -54,3 +54,7 @@ executable(
 	install: true
 )
 
+clients = ['lab-sensible-terminal', 'lab-exit']
+foreach client : clients
+  install_data(client, install_dir: get_option('bindir'))
+endforeach

--- a/meson.build
+++ b/meson.build
@@ -199,10 +199,6 @@ install_data('data/labwc.desktop', install_dir: get_option('datadir') / 'wayland
 
 install_data('data/labwc-portals.conf', install_dir: get_option('datadir') / 'xdg-desktop-portal')
 
-# TODO: move this to clients/meson.build after the labnag PR
-clients = files('clients/lab-sensible-terminal')
-install_data(clients, install_dir: get_option('bindir'))
-
 icons = ['labwc-symbolic.svg', 'labwc.svg']
 foreach icon : icons
   icon_path = join_paths('data', icon)

--- a/po/it.po
+++ b/po/it.po
@@ -1,7 +1,7 @@
 # Labwc pot file
 # Copyright (C) 2022
 # This file is distributed under the same license as the labwc package.
-# Mick Amadio <01micko@gmail.com>, 2022.
+# Mick Amadio <01micko@gmx.com>, 2022.
 #
 msgid ""
 msgstr ""
@@ -19,62 +19,66 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1\n"
 
-#: src/menu/menu.c:1016
+#: src/menu/menu.c:867
+msgid "Always on Visible Workspace"
+msgstr ""
+
+#: src/menu/menu.c:924
 msgid "Go there..."
 msgstr "Vai lì..."
 
-#: src/menu/menu.c:1034
+#: src/menu/menu.c:943
 msgid "Terminal"
 msgstr "Terminale"
 
-#: src/menu/menu.c:1040
+#: src/menu/menu.c:949
 msgid "Reconfigure"
 msgstr "Riconfigura"
 
-#: src/menu/menu.c:1042
+#: src/menu/menu.c:951
 msgid "Exit"
 msgstr "Esci"
 
-#: src/menu/menu.c:1056
+#: src/menu/menu.c:966
 msgid "Minimize"
 msgstr "Minimizza"
 
-#: src/menu/menu.c:1058
+#: src/menu/menu.c:968
 msgid "Maximize"
 msgstr "Massimizza"
 
-#: src/menu/menu.c:1060
+#: src/menu/menu.c:970
 msgid "Fullscreen"
 msgstr "Schermo intero"
 
-#: src/menu/menu.c:1062
+#: src/menu/menu.c:972
 msgid "Roll Up/Down"
 msgstr "Arrotola/srotola"
 
-#: src/menu/menu.c:1064
+#: src/menu/menu.c:974
 msgid "Decorations"
 msgstr "Decorazioni"
 
-#: src/menu/menu.c:1066
+#: src/menu/menu.c:976
 msgid "Always on Top"
 msgstr "Sempre sopra"
 
-#: src/menu/menu.c:1071
-msgid "Move Left"
-msgstr "Sposta a sinistra"
-
-#: src/menu/menu.c:1078
-msgid "Move Right"
-msgstr "Sposta a destra"
-
-#: src/menu/menu.c:1083
-msgid "Always on Visible Workspace"
-msgstr "Sempre sull'area di lavoro visibile"
-
-#: src/menu/menu.c:1086
+#: src/menu/menu.c:980 src/menu/menu.c:999 src/config/rcxml.c:1708
 msgid "Workspace"
 msgstr "Area di lavoro"
 
-#: src/menu/menu.c:1089
+#: src/menu/menu.c:983
 msgid "Close"
 msgstr "Chiudi"
+
+#: clients/lab-exit:9
+msgid "Are you sure you want to quit Labwc?"
+msgstr "Sei sicuro di voler uscire da Labwc?"
+
+#: clients/lab-exit:10
+msgid "Yes"
+msgstr "Si"
+
+#: clients/lab-exit:11
+msgid "No"
+msgstr "No"

--- a/po/labwc.pot
+++ b/po/labwc.pot
@@ -1,5 +1,5 @@
-# Labwc pot file
-# Copyright (C) 2024
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR 2025 labwc team
 # This file is distributed under the same license as the labwc package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: labwc\n"
 "Report-Msgid-Bugs-To: https://github.com/labwc/labwc/issues\n"
-"POT-Creation-Date: 2024-09-19 21:09+1000\n"
+"POT-Creation-Date: 2025-08-30 14:21+1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,62 +17,72 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/menu/menu.c:1016
-msgid "Go there..."
-msgstr ""
-
-#: src/menu/menu.c:1034
-msgid "Terminal"
-msgstr ""
-
-#: src/menu/menu.c:1040
-msgid "Reconfigure"
-msgstr ""
-
-#: src/menu/menu.c:1042
-msgid "Exit"
-msgstr ""
-
-#: src/menu/menu.c:1056
-msgid "Minimize"
-msgstr ""
-
-#: src/menu/menu.c:1058
-msgid "Maximize"
-msgstr ""
-
-#: src/menu/menu.c:1060
-msgid "Fullscreen"
-msgstr ""
-
-#: src/menu/menu.c:1062
-msgid "Roll Up/Down"
-msgstr ""
-
-#: src/menu/menu.c:1064
-msgid "Decorations"
-msgstr ""
-
-#: src/menu/menu.c:1066
-msgid "Always on Top"
-msgstr ""
-
-#: src/menu/menu.c:1071
-msgid "Move Left"
-msgstr ""
-
-#: src/menu/menu.c:1078
-msgid "Move Right"
-msgstr ""
-
-#: src/menu/menu.c:1083
+#: src/menu/menu.c:867
 msgid "Always on Visible Workspace"
 msgstr ""
 
-#: src/menu/menu.c:1086
+#: src/menu/menu.c:924
+msgid "Go there..."
+msgstr ""
+
+#: src/menu/menu.c:943
+msgid "Terminal"
+msgstr ""
+
+#: src/menu/menu.c:949
+msgid "Reconfigure"
+msgstr ""
+
+#: src/menu/menu.c:951
+msgid "Exit"
+msgstr ""
+
+#: src/menu/menu.c:966
+msgid "Minimize"
+msgstr ""
+
+#: src/menu/menu.c:968
+msgid "Maximize"
+msgstr ""
+
+#: src/menu/menu.c:970
+msgid "Fullscreen"
+msgstr ""
+
+#: src/menu/menu.c:972
+msgid "Roll Up/Down"
+msgstr ""
+
+#: src/menu/menu.c:974
+msgid "Decorations"
+msgstr ""
+
+#: src/menu/menu.c:976
+msgid "Always on Top"
+msgstr ""
+
+#. Workspace sub-menu
+#: src/menu/menu.c:980 src/menu/menu.c:999 src/config/rcxml.c:1708
 msgid "Workspace"
 msgstr ""
 
-#: src/menu/menu.c:1089
+#: src/menu/menu.c:983
 msgid "Close"
+msgstr ""
+
+#. Just create placeholder. Contents will be created when launched
+#: src/menu/menu.c:998
+msgid "Windows"
+msgstr ""
+
+#: clients/lab-exit:9
+msgid "Are you sure you want to quit Labwc?"
+msgstr ""
+
+#: clients/lab-exit:10
+msgid "Yes"
+msgstr ""
+
+#: clients/lab-exit:11
+msgid "No"
 msgstr ""

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -949,7 +949,8 @@ init_rootmenu(struct server *server)
 		item = item_create(menu, _("Reconfigure"), NULL, false);
 		item_add_action(item, "Reconfigure");
 		item = item_create(menu, _("Exit"), NULL, false);
-		item_add_action(item, "Exit");
+		struct action *leave = item_add_action(item, "Execute");
+		action_arg_add_str(leave, "command", "lab-exit");
 	}
 }
 


### PR DESCRIPTION
closes #917
Summary follows:
- src/menu/menu.c: add `leave` action to call lab-exit.
- clients/meson.build: add install routine for lab-exit and lab-sensible-terminal.
- meson.build remove lab-sensible-terminal routine re the comment.
- po/labwc.pot: rebuild with new xgettext commands.
- po/it.po: add translations for lab-exit and edit my email.
- CONTRIBUTING.md#translations: modify the instructions for coders as two xgettext commands are needed since we now have two GUI facing languages that have translatable strings.