### PR TITLE
scaled-icon-buffer: fix large client-side icon not being loaded

### DIFF
--- a/src/common/scaled-icon-buffer.c
+++ b/src/common/scaled-icon-buffer.c
@@ -22,7 +22,7 @@
 static struct lab_data_buffer *
 choose_best_icon_buffer(struct scaled_icon_buffer *self, int icon_size, double scale)
 {
-	int best_dist = INT_MIN;
+	int best_dist = -INT_MAX;
 	struct lab_data_buffer *best_buffer = NULL;
 
 	struct lab_data_buffer **buffer;


### PR DESCRIPTION
Fixes https://github.com/labwc/labwc/pull/2981#issuecomment-3238675460.

This commit fixes that client-side icons were not loaded when the rendered icon size is larger than icon sizes from the client. This bug has become more likely to happen due to the new thumnail-style window switcher.

The cause was `abs(INT_MIN)` becomes `INT_MIN` due to integer overflow.