### PR TITLE
meson.build: move lab-sensible-terminal install routine.

### DIFF
--- a/clients/meson.build
+++ b/clients/meson.build
@@ -54,3 +54,5 @@ executable(
 	install: true
 )
 
+clients = files('lab-sensible-terminal')
+install_data(clients, install_dir: get_option('bindir'))

--- a/meson.build
+++ b/meson.build
@@ -199,10 +199,6 @@ install_data('data/labwc.desktop', install_dir: get_option('datadir') / 'wayland
 
 install_data('data/labwc-portals.conf', install_dir: get_option('datadir') / 'xdg-desktop-portal')
 
-# TODO: move this to clients/meson.build after the labnag PR
-clients = files('clients/lab-sensible-terminal')
-install_data(clients, install_dir: get_option('bindir'))
-
 icons = ['labwc-symbolic.svg', 'labwc.svg']
 foreach icon : icons
   icon_path = join_paths('data', icon)


### PR DESCRIPTION
Moved to clients/meson.build as per the comment in meson.build.