### PR TITLE
overlay: refactor

### DIFF
--- a/include/overlay.h
+++ b/include/overlay.h
@@ -2,10 +2,9 @@
 #ifndef LABWC_OVERLAY_H
 #define LABWC_OVERLAY_H
 
-#include <wlr/util/box.h>
-#include "common/graphic-helpers.h"
-#include "regions.h"
-#include "view.h"
+#include "common/edge.h"
+
+struct seat;
 
 /* TODO: replace this with single lab_scene_rect */
 struct overlay_rect {

--- a/include/overlay.h
+++ b/include/overlay.h
@@ -6,19 +6,8 @@
 
 struct seat;
 
-/* TODO: replace this with single lab_scene_rect */
-struct overlay_rect {
-	struct wlr_scene_tree *tree;
-
-	bool bg_enabled;
-	struct wlr_scene_rect *bg_rect;
-
-	bool border_enabled;
-	struct lab_scene_rect *border_rect;
-};
-
 struct overlay {
-	struct overlay_rect region_rect, edge_rect;
+	struct lab_scene_rect *rect;
 
 	/* Represents currently shown or delayed overlay */
 	struct {
@@ -34,15 +23,13 @@ struct overlay {
 	struct wl_event_source *timer;
 };
 
-void overlay_reconfigure(struct seat *seat);
-
-/* Calls overlay_hide() internally if there's no overlay to show */
+/*
+ * Shows or updates an overlay when the grabbed window can be snapped to
+ * a region or an output edge. Calls overlay_finish() otherwise.
+ */
 void overlay_update(struct seat *seat);
 
-/* This function must be called when server->grabbed_view is destroyed */
-void overlay_hide(struct seat *seat);
-
-/* This function is called to clean up the timer on exit */
+/* Destroys the overlay if it exists */
 void overlay_finish(struct seat *seat);
 
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -22,7 +22,7 @@
 #define IGNORE_SSD true
 #define IGNORE_MENU true
 #define IGNORE_OSD_PREVIEW_OUTLINE true
-#define IGNORE_SNAPPING_PREVIEW_OUTLINE true
+#define IGNORE_SNAPPING_OVERLAY true
 
 static struct view *last_view;
 
@@ -141,15 +141,10 @@ get_special(struct server *server, struct wlr_scene_node *node)
 	if (node == &server->seat.drag.icons->node) {
 		return "seat->drag.icons";
 	}
-	if (server->seat.overlay.region_rect.tree
-			&& node == &server->seat.overlay.region_rect.tree->node) {
+	if (server->seat.overlay.rect
+			&& node == &server->seat.overlay.rect->tree->node) {
 		/* Created on-demand */
-		return "seat->overlay.region_rect";
-	}
-	if (server->seat.overlay.edge_rect.tree
-			&& node == &server->seat.overlay.edge_rect.tree->node) {
-		/* Created on-demand */
-		return "seat->overlay.edge_rect";
+		return "seat->overlay.rect";
 	}
 	if (server->seat.input_method_relay->popup_tree
 			&& node == &server->seat.input_method_relay->popup_tree->node) {
@@ -224,21 +219,13 @@ dump_tree(struct server *server, struct wlr_scene_node *node,
 
 	struct lab_scene_rect *osd_preview_outline =
 		server->osd_state.preview_outline;
-	struct lab_scene_rect *region_snapping_overlay_outline =
-		server->seat.overlay.region_rect.border_rect;
-	struct lab_scene_rect *edge_snapping_overlay_outline =
-		server->seat.overlay.edge_rect.border_rect;
 	if ((IGNORE_MENU && node == &server->menu_tree->node)
 			|| (IGNORE_SSD && last_view
 				&& ssd_debug_is_root_node(last_view->ssd, node))
 			|| (IGNORE_OSD_PREVIEW_OUTLINE && osd_preview_outline
 				&& node == &osd_preview_outline->tree->node)
-			|| (IGNORE_SNAPPING_PREVIEW_OUTLINE
-				&& region_snapping_overlay_outline
-				&& node == &region_snapping_overlay_outline->tree->node)
-			|| (IGNORE_SNAPPING_PREVIEW_OUTLINE
-				&& edge_snapping_overlay_outline
-				&& node == &edge_snapping_overlay_outline->tree->node)) {
+			|| (IGNORE_SNAPPING_OVERLAY && server->seat.overlay.rect
+				&& node == &server->seat.overlay.rect->tree->node)) {
 		printf("%*c%s\n", pos + 4 + INDENT_SIZE, ' ', "<skipping children>");
 		return;
 	}

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -18,6 +18,7 @@
 #include "labwc.h"
 #include "idle.h"
 #include "action.h"
+#include "view.h"
 
 bool
 tablet_tool_has_focused_surface(struct seat *seat)

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -15,6 +15,7 @@
 #include "idle.h"
 #include "labwc.h"
 #include "ssd.h"
+#include "view.h"
 
 /* Holds layout -> surface offsets to report motion events in relative coords */
 struct touch_point {

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -303,7 +303,7 @@ interactive_cancel(struct view *view)
 		return;
 	}
 
-	overlay_hide(&view->server->seat);
+	overlay_finish(&view->server->seat);
 
 	resize_indicator_hide(view);
 

--- a/src/osd/osd-thumbnail.c
+++ b/src/osd/osd-thumbnail.c
@@ -5,7 +5,6 @@
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/render/allocator.h>
 #include "config/rcxml.h"
-#include "config/types.h"
 #include "common/array.h"
 #include "common/box.h"
 #include "common/lab-scene-rect.h"
@@ -15,6 +14,7 @@
 #include "osd.h"
 #include "output.h"
 #include "theme.h"
+#include "view.h"
 
 struct osd_thumbnail_scene_item {
 	struct view *view;

--- a/src/output.c
+++ b/src/output.c
@@ -171,7 +171,7 @@ handle_output_destroy(struct wl_listener *listener, void *data)
 	regions_evacuate_output(output);
 	regions_destroy(seat, &output->regions);
 	if (seat->overlay.active.output == output) {
-		overlay_hide(seat);
+		overlay_finish(seat);
 	}
 	wl_list_remove(&output->link);
 	wl_list_remove(&output->frame.link);

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -6,8 +6,9 @@
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "output.h"
-#include "view.h"
+#include "regions.h"
 #include "theme.h"
+#include "view.h"
 
 static void
 create_overlay_rect(struct seat *seat, struct overlay_rect *rect,

--- a/src/regions.c
+++ b/src/regions.c
@@ -166,7 +166,7 @@ regions_destroy(struct seat *seat, struct wl_list *regions)
 	wl_list_for_each_safe(region, region_tmp, regions, link) {
 		wl_list_remove(&region->link);
 		if (seat && seat->overlay.active.region == region) {
-			overlay_hide(seat);
+			overlay_finish(seat);
 		}
 		zfree(region->name);
 		zfree(region);

--- a/src/resize-outlines.c
+++ b/src/resize-outlines.c
@@ -7,6 +7,7 @@
 #include "resize-indicator.h"
 #include "ssd.h"
 #include "theme.h"
+#include "view.h"
 
 bool
 resize_outlines_enabled(struct view *view)

--- a/src/seat.c
+++ b/src/seat.c
@@ -731,7 +731,7 @@ seat_reconfigure(struct server *server)
 	struct seat *seat = &server->seat;
 	struct input *input;
 	cursor_reload(seat);
-	overlay_reconfigure(seat);
+	overlay_finish(seat);
 	keyboard_reset_current_keybind();
 	wl_list_for_each(input, &seat->inputs, link) {
 		switch (input->wlr_input_device->type) {

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -602,7 +602,7 @@ workspaces_reconfigure(struct server *server)
 	}
 
 	/* # of configured workspaces decreased */
-	overlay_hide(&server->seat);
+	overlay_finish(&server->seat);
 	struct workspace *first_workspace =
 		wl_container_of(server->workspaces.all.next, first_workspace, link);
 


### PR DESCRIPTION
- Use a single `lab_scene_rect` for both overlay background and outlines, like I described in the TODO comment in #2809.
- Simplify the resource management by destroying the overlay tree when it's hidden. I think its overhead is pretty minimal.
- Share a single `lab_scene_rect` for both region/edge overlays.