### PR TITLE
view: use fixed default window width 

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -11,6 +11,11 @@
 #include "config.h"
 #include "config/types.h"
 
+/*
+ * Default minimal window size. Clients can explicitly set smaller values via
+ * e.g. xdg_toplevel::set_min_size.
+ */
+#define LAB_MIN_VIEW_WIDTH 100
 #define LAB_MIN_VIEW_HEIGHT 60
 
 /*
@@ -573,7 +578,6 @@ const char *view_get_string_prop(struct view *view, const char *prop);
 void view_update_title(struct view *view);
 void view_update_app_id(struct view *view);
 void view_reload_ssd(struct view *view);
-int view_get_min_width(void);
 
 void view_set_shade(struct view *view, bool shaded);
 

--- a/src/snap.c
+++ b/src/snap.c
@@ -221,7 +221,6 @@ snap_shrink_to_next_edge(struct view *view,
 
 	*geo = view->pending;
 	enum lab_edge resize_edges;
-	int min_width = view_get_min_width();
 
 	/*
 	 * First shrink the view along the relevant edge. The maximum shrink
@@ -230,12 +229,12 @@ snap_shrink_to_next_edge(struct view *view,
 	 */
 	switch (direction) {
 	case LAB_EDGE_RIGHT:
-		geo->width = MAX(geo->width / 2, min_width);
+		geo->width = MAX(geo->width / 2, LAB_MIN_VIEW_WIDTH);
 		geo->x = view->pending.x + view->pending.width - geo->width;
 		resize_edges = LAB_EDGE_LEFT;
 		break;
 	case LAB_EDGE_LEFT:
-		geo->width = MAX(geo->width / 2, min_width);
+		geo->width = MAX(geo->width / 2, LAB_MIN_VIEW_WIDTH);
 		resize_edges = LAB_EDGE_RIGHT;
 		break;
 	case LAB_EDGE_BOTTOM:

--- a/src/view.c
+++ b/src/view.c
@@ -744,7 +744,6 @@ view_adjust_size(struct view *view, int *w, int *h)
 {
 	assert(view);
 	struct view_size_hints hints = view_get_size_hints(view);
-	int min_width = view_get_min_width();
 
 	/*
 	 * "If a base size is not provided, the minimum size is to be
@@ -764,7 +763,7 @@ view_adjust_size(struct view *view, int *w, int *h)
 
 	/* If a minimum width/height was not set, then use default */
 	if (hints.min_width < 1) {
-		hints.min_width = min_width;
+		hints.min_width = LAB_MIN_VIEW_WIDTH;
 	}
 	if (hints.min_height < 1) {
 		hints.min_height = LAB_MIN_VIEW_HEIGHT;
@@ -2410,17 +2409,6 @@ view_reload_ssd(struct view *view)
 		undecorate(view);
 		decorate(view);
 	}
-}
-
-int
-view_get_min_width(void)
-{
-	int button_count_left = wl_list_length(&rc.title_buttons_left);
-	int button_count_right =  wl_list_length(&rc.title_buttons_right);
-	return (rc.theme->window_button_width * (button_count_left + button_count_right)) +
-		(rc.theme->window_button_spacing * MAX((button_count_right - 1), 0)) +
-		(rc.theme->window_button_spacing * MAX((button_count_left - 1), 0)) +
-		(2 * rc.theme->window_titlebar_padding_width);
 }
 
 void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -748,15 +748,13 @@ handle_map_request(struct wl_listener *listener, void *data)
 static void
 check_natural_geometry(struct view *view)
 {
-	int min_width = view_get_min_width();
-
 	/*
 	 * Some applications (example: Thonny) don't set a reasonable
 	 * un-maximized size when started maximized. Try to detect this
 	 * and set a fallback size.
 	 */
 	if (!view_is_floating(view)
-			&& (view->natural_geometry.width < min_width
+			&& (view->natural_geometry.width < LAB_MIN_VIEW_WIDTH
 			|| view->natural_geometry.height < LAB_MIN_VIEW_HEIGHT)) {
 		view_set_fallback_natural_geometry(view);
 	}


### PR DESCRIPTION
Now it's not very reasonable to determine the default window width based on the titlebar geometry, as the titlebar can be shrunk to 1px.

Let's use the fixed value of 100px for simplification.