### PR TITLE
interactive: un-maximize only axes that are being resized

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -513,7 +513,7 @@ void view_place_by_policy(struct view *view, bool allow_cursor,
 	enum lab_placement_policy policy);
 void view_constrain_size_to_that_of_usable_area(struct view *view);
 
-void view_restore_to(struct view *view, struct wlr_box geometry);
+void view_set_maximized(struct view *view, enum view_axis maximized);
 void view_set_untiled(struct view *view);
 void view_maximize(struct view *view, enum view_axis axis,
 	bool store_natural_geometry);

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -291,8 +291,9 @@ process_cursor_move(struct server *server, uint32_t time)
 		interactive_anchor_to_cursor(server, &new_geo);
 		/* Shaded clients will not process resize events until unshaded */
 		view_set_shade(view, false);
+		view_set_maximized(view, VIEW_AXIS_NONE);
 		view_set_untiled(view);
-		view_restore_to(view, new_geo);
+		view_move_resize(view, new_geo);
 		x = new_geo.x;
 		y = new_geo.y;
 	}

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -122,8 +122,8 @@ interactive_begin(struct view *view, enum input_mode mode, enum lab_edge edges)
 		 * maximized/tiled state but keep the same geometry as
 		 * the starting point for the resize.
 		 */
+		view_set_maximized(view, VIEW_AXIS_NONE);
 		view_set_untiled(view);
-		view_restore_to(view, view->pending);
 		cursor_shape = cursor_get_from_edge(edges);
 		break;
 	default:
@@ -153,8 +153,9 @@ interactive_begin(struct view *view, enum input_mode mode, enum lab_edge edges)
 		interactive_anchor_to_cursor(server, &natural_geo);
 		/* Shaded clients will not process resize events until unshaded */
 		view_set_shade(view, false);
+		view_set_maximized(view, VIEW_AXIS_NONE);
 		view_set_untiled(view);
-		view_restore_to(view, natural_geo);
+		view_move_resize(view, natural_geo);
 	}
 
 	if (rc.resize_indicator) {

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -119,10 +119,17 @@ interactive_begin(struct view *view, enum input_mode mode, enum lab_edge edges)
 
 		/*
 		 * If tiled or maximized in only one direction, reset
-		 * maximized/tiled state but keep the same geometry as
-		 * the starting point for the resize.
+		 * tiled state and un-maximize the relevant axes, but
+		 * keep the same geometry as the starting point.
 		 */
-		view_set_maximized(view, VIEW_AXIS_NONE);
+		enum view_axis maximized = view->maximized;
+		if (edges & LAB_EDGES_LEFT_RIGHT) {
+			maximized &= ~VIEW_AXIS_HORIZONTAL;
+		}
+		if (edges & LAB_EDGES_TOP_BOTTOM) {
+			maximized &= ~VIEW_AXIS_VERTICAL;
+		}
+		view_set_maximized(view, maximized);
 		view_set_untiled(view);
 		cursor_shape = cursor_get_from_edge(edges);
 		break;

--- a/src/view.c
+++ b/src/view.c
@@ -660,7 +660,7 @@ view_move_relative(struct view *view, int x, int y)
 	view_maximize(view, VIEW_AXIS_NONE, /*store_natural_geometry*/ false);
 	if (view_is_tiled(view)) {
 		view_set_untiled(view);
-		view_restore_to(view, view->natural_geometry);
+		view_move_resize(view, view->natural_geometry);
 	}
 	view_move(view, view->pending.x + x, view->pending.y + y);
 }
@@ -678,7 +678,7 @@ view_move_to_cursor(struct view *view)
 	view_maximize(view, VIEW_AXIS_NONE, /*store_natural_geometry*/ false);
 	if (view_is_tiled(view)) {
 		view_set_untiled(view);
-		view_restore_to(view, view->natural_geometry);
+		view_move_resize(view, view->natural_geometry);
 	}
 
 	struct border margin = ssd_thickness(view);
@@ -1371,10 +1371,18 @@ view_apply_special_geometry(struct view *view)
 	}
 }
 
-/* For internal use only. Does not update geometry. */
-static void
-set_maximized(struct view *view, enum view_axis maximized)
+/*
+ * Sets maximized state without updating geometry. Used in interactive
+ * move/resize. In most other cases, use view_maximize() instead.
+ */
+void
+view_set_maximized(struct view *view, enum view_axis maximized)
 {
+	assert(view);
+	if (view->maximized == maximized) {
+		return;
+	}
+
 	if (view->impl->maximize) {
 		view->impl->maximize(view, maximized);
 	}
@@ -1388,23 +1396,6 @@ set_maximized(struct view *view, enum view_axis maximized)
 	 * up using an outdated ssd->margin to calculate offsets.
 	 */
 	ssd_update_margin(view->ssd);
-}
-
-/*
- * Un-maximize view and move it to specific geometry. Does not reset
- * tiled state (use view_set_untiled() if you want that).
- */
-void
-view_restore_to(struct view *view, struct wlr_box geometry)
-{
-	assert(view);
-	if (view->fullscreen) {
-		return;
-	}
-	if (view->maximized != VIEW_AXIS_NONE) {
-		set_maximized(view, VIEW_AXIS_NONE);
-	}
-	view_move_resize(view, geometry);
 }
 
 bool
@@ -1509,7 +1500,7 @@ view_maximize(struct view *view, enum view_axis axis,
 		view_set_fallback_natural_geometry(view);
 	}
 
-	set_maximized(view, axis);
+	view_set_maximized(view, axis);
 	if (view_is_floating(view)) {
 		view_apply_natural_geometry(view);
 	} else {


### PR DESCRIPTION
When resizing in only one axis (horizontal/vertical), there's no reason to un-maximize the other axis.

Most of the supporting logic was landed already in:
- #3020

However, that PR fixed only the client-initiated case. Let's do the same for interactive resize.

The first commit is prep work, eliminating `view_restore_to()` and exposing `view_set_maximized()` instead.
Then all that remains is to make a small change in `interactive_begin()` (second commit).