### PR TITLE
default-bindings.h: focus & raise on border press

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -376,6 +376,10 @@
     </context>
 
     <context name="Border">
+      <mousebind button="Left" action="Press">
+        <action name="Focus" />
+        <action name="Raise" />
+      </mousebind>
       <mousebind button="Left" action="Drag">
         <action name="Resize" />
       </mousebind>

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -145,6 +145,16 @@ static struct mouse_combos {
 } mouse_combos[] = { {
 		.context = "Border",
 		.button = "Left",
+		.event = "Press",
+		.action = "Focus",
+	}, {
+		.context = "Border",
+		.button = "Left",
+		.event = "Press",
+		.action = "Raise",
+	}, {
+		.context = "Border",
+		.button = "Left",
 		.event = "Drag",
 		.action = "Resize",
 	}, {


### PR DESCRIPTION
...because it is probably what most people expect and it makes the behavior consistent with that of Openbox.

Fixes: #3039