### PR TITLE
Unify node + ssd types/descriptors

### DIFF
--- a/include/common/node-type.h
+++ b/include/common/node-type.h
@@ -43,12 +43,23 @@ enum lab_node_type {
 	LAB_NODE_CLIENT,
 	LAB_NODE_FRAME,
 	LAB_NODE_ROOT,
-	LAB_NODE_MENU,
+	LAB_NODE_MENUITEM,
 	LAB_NODE_OSD,
 	LAB_NODE_LAYER_SURFACE,
 	LAB_NODE_LAYER_SUBSURFACE,
 	LAB_NODE_UNMANAGED,
 	LAB_NODE_ALL,
+
+	/* translated to LAB_NODE_CLIENT by get_cursor_context() */
+	LAB_NODE_VIEW,
+	LAB_NODE_XDG_POPUP,
+	LAB_NODE_LAYER_POPUP,
+	LAB_NODE_SESSION_LOCK_SURFACE,
+	LAB_NODE_IME_POPUP,
+
+	/* never returned by get_cursor_context() */
+	LAB_NODE_TREE,
+	LAB_NODE_SCALED_BUFFER,
 };
 
 enum lab_node_type node_type_parse(const char *context);

--- a/include/common/node-type.h
+++ b/include/common/node-type.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_NODE_TYPE_H
+#define LABWC_NODE_TYPE_H
+
+#include "common/edge.h"
+
+/*
+ * In labwc, "node type" indicates the role of a wlr_scene_node in the
+ * overall desktop. It also maps more-or-less to the openbox concept of
+ * "context" (as used when defining mouse bindings).
+ *
+ * Node types are defined in the order they should be processed for press
+ * and hover events. Note that some of their respective interactive areas
+ * overlap, so for example buttons need to come before title.
+ */
+enum lab_node_type {
+	LAB_NODE_NONE = 0,
+
+	LAB_NODE_BUTTON_CLOSE = 1,
+	LAB_NODE_BUTTON_MAXIMIZE,
+	LAB_NODE_BUTTON_ICONIFY,
+	LAB_NODE_BUTTON_WINDOW_ICON,
+	LAB_NODE_BUTTON_WINDOW_MENU,
+	LAB_NODE_BUTTON_SHADE,
+	LAB_NODE_BUTTON_OMNIPRESENT,
+	LAB_NODE_BUTTON_FIRST = LAB_NODE_BUTTON_CLOSE,
+	LAB_NODE_BUTTON_LAST = LAB_NODE_BUTTON_OMNIPRESENT,
+	LAB_NODE_BUTTON,
+
+	LAB_NODE_TITLEBAR,
+	LAB_NODE_TITLE,
+
+	LAB_NODE_CORNER_TOP_LEFT,
+	LAB_NODE_CORNER_TOP_RIGHT,
+	LAB_NODE_CORNER_BOTTOM_RIGHT,
+	LAB_NODE_CORNER_BOTTOM_LEFT,
+	LAB_NODE_BORDER_TOP,
+	LAB_NODE_BORDER_RIGHT,
+	LAB_NODE_BORDER_BOTTOM,
+	LAB_NODE_BORDER_LEFT,
+	LAB_NODE_BORDER,
+
+	LAB_NODE_CLIENT,
+	LAB_NODE_FRAME,
+	LAB_NODE_ROOT,
+	LAB_NODE_MENU,
+	LAB_NODE_OSD,
+	LAB_NODE_LAYER_SURFACE,
+	LAB_NODE_LAYER_SUBSURFACE,
+	LAB_NODE_UNMANAGED,
+	LAB_NODE_ALL,
+};
+
+enum lab_node_type node_type_parse(const char *context);
+
+bool node_type_contains(enum lab_node_type whole, enum lab_node_type part);
+
+enum lab_edge node_type_to_edges(enum lab_node_type type);
+
+#endif /* LABWC_NODE_TYPE_H */

--- a/include/config/mousebind.h
+++ b/include/config/mousebind.h
@@ -2,9 +2,9 @@
 #ifndef LABWC_MOUSEBIND_H
 #define LABWC_MOUSEBIND_H
 
+#include <stdbool.h>
 #include <wayland-util.h>
-#include "ssd.h"
-#include "config/keybind.h"
+#include "common/node-type.h"
 
 enum mouse_event {
 	MOUSE_ACTION_NONE = 0,
@@ -25,7 +25,7 @@ enum direction {
 };
 
 struct mousebind {
-	enum ssd_part_type context;
+	enum lab_node_type context;
 
 	/* ex: BTN_LEFT, BTN_RIGHT from linux/input_event_codes.h */
 	uint32_t button;

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -10,8 +10,8 @@
 #include "common/border.h"
 #include "common/buf.h"
 #include "common/font.h"
+#include "common/node-type.h"
 #include "config/types.h"
-#include "ssd.h"
 
 #define BUTTON_MAP_MAX 16
 
@@ -48,7 +48,7 @@ struct button_map_entry {
 };
 
 struct title_button {
-	enum ssd_part_type type;
+	enum lab_node_type type;
 	struct wl_list link;
 };
 

--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -4,7 +4,7 @@
 
 #include <wlr/types/wlr_cursor.h>
 #include "common/edge.h"
-#include "ssd.h"
+#include "common/node-type.h"
 
 struct view;
 struct seat;
@@ -32,7 +32,7 @@ struct cursor_context {
 	struct view *view;
 	struct wlr_scene_node *node;
 	struct wlr_surface *surface;
-	enum ssd_part_type type;
+	enum lab_node_type type;
 	double sx, sy;
 };
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -225,7 +225,7 @@ struct server {
 	 */
 	struct view *active_view;
 
-	struct ssd_hover_state *ssd_hover_state;
+	struct ssd_part_button *hover_button;
 
 	/* Tree for all non-layer xdg/xwayland-shell surfaces */
 	struct wlr_scene_tree *view_tree;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -225,7 +225,7 @@ struct server {
 	 */
 	struct view *active_view;
 
-	struct ssd_part_button *hover_button;
+	struct ssd_button *hover_button;
 
 	/* Tree for all non-layer xdg/xwayland-shell surfaces */
 	struct wlr_scene_tree *view_tree;

--- a/include/node.h
+++ b/include/node.h
@@ -2,30 +2,11 @@
 #ifndef LABWC_NODE_DESCRIPTOR_H
 #define LABWC_NODE_DESCRIPTOR_H
 #include <wlr/types/wlr_scene.h>
-
-struct view;
-struct lab_layer_surface;
-struct lab_layer_popup;
-struct menuitem;
-struct ssd_part;
-struct scaled_buffer;
-
-enum node_descriptor_type {
-	LAB_NODE_DESC_NODE = 0,
-	LAB_NODE_DESC_VIEW,
-	LAB_NODE_DESC_XDG_POPUP,
-	LAB_NODE_DESC_LAYER_SURFACE,
-	LAB_NODE_DESC_LAYER_POPUP,
-	LAB_NODE_DESC_SESSION_LOCK_SURFACE,
-	LAB_NODE_DESC_IME_POPUP,
-	LAB_NODE_DESC_MENUITEM,
-	LAB_NODE_DESC_TREE,
-	LAB_NODE_DESC_SCALED_BUFFER,
-	LAB_NODE_DESC_SSD_PART,
-};
+#include "common/node-type.h"
 
 struct node_descriptor {
-	enum node_descriptor_type type;
+	enum lab_node_type type;
+	struct view *view;
 	void *data;
 	struct wl_listener destroy;
 };
@@ -38,16 +19,15 @@ struct node_descriptor {
  *
  * @scene_node: wlr_scene_node to attached node_descriptor to
  * @type: node descriptor type
+ * @view: associated view
  * @data: struct to point to as follows:
- *   - LAB_NODE_DESC_VIEW           struct view
- *   - LAB_NODE_DESC_XDG_POPUP      struct view
- *   - LAB_NODE_DESC_LAYER_SURFACE  struct lab_layer_surface
- *   - LAB_NODE_DESC_LAYER_POPUP    struct lab_layer_popup
- *   - LAB_NODE_DESC_MENUITEM       struct menuitem
- *   - LAB_NODE_DESC_SSD_PART       struct ssd_part
+ *   - LAB_NODE_LAYER_SURFACE  struct lab_layer_surface
+ *   - LAB_NODE_LAYER_POPUP    struct lab_layer_popup
+ *   - LAB_NODE_MENUITEM       struct menuitem
+ *   - LAB_NODE_BUTTON_*       struct ssd_button
  */
 void node_descriptor_create(struct wlr_scene_node *scene_node,
-	enum node_descriptor_type type, void *data);
+	enum lab_node_type type, struct view *view, void *data);
 
 /**
  * node_view_from_node - return view struct from node
@@ -77,17 +57,17 @@ struct menuitem *node_menuitem_from_node(
 	struct wlr_scene_node *wlr_scene_node);
 
 /**
- * node_ssd_part_from_node - return ssd_part struct from node
- * @wlr_scene_node: wlr_scene_node from which to return data
- */
-struct ssd_part *node_ssd_part_from_node(
-	struct wlr_scene_node *wlr_scene_node);
-
-/**
  * node_scaled_buffer_from_node - return scaled_buffer from node
  * @wlr_scene_node: wlr_scene_node from which to return data
  */
 struct scaled_buffer *node_scaled_buffer_from_node(
+	struct wlr_scene_node *wlr_scene_node);
+
+/**
+ * node_try_ssd_button_from_node - return ssd_button or NULL from node
+ * @wlr_scene_node: wlr_scene_node from which to return data
+ */
+struct ssd_button *node_try_ssd_button_from_node(
 	struct wlr_scene_node *wlr_scene_node);
 
 #endif /* LABWC_NODE_DESCRIPTOR_H */

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -135,23 +135,10 @@ struct ssd {
 	struct border margin;
 };
 
-/*
- * ssd_part wraps a scene-node with ssd-specific information and can be
- * accessed with node_ssd_part_from_node(wlr_scene_node *).
- * This allows get_cursor_context() in desktop.c to see which SSD part is under
- * the cursor.
- */
-struct ssd_part {
-	enum lab_node_type type;
-	struct view *view;
-
-	/* This part represented in scene graph */
+struct ssd_button {
 	struct wlr_scene_node *node;
-	struct wl_listener node_destroy;
-};
+	enum lab_node_type type;
 
-struct ssd_part_button {
-	struct ssd_part base;
 	/*
 	 * Bitmap of lab_button_state that represents a combination of
 	 * hover/toggled/rounded states.
@@ -177,13 +164,10 @@ struct wlr_buffer;
 struct wlr_scene_tree;
 
 /* SSD internal helpers to create various SSD elements */
-struct ssd_part *attach_ssd_part(enum lab_node_type type, struct view *view,
-	struct wlr_scene_node *node);
-struct ssd_part_button *attach_ssd_part_button(struct wl_list *button_parts,
+struct ssd_button *attach_ssd_button(struct wl_list *button_parts,
 	enum lab_node_type type, struct wlr_scene_tree *parent,
 	struct lab_img *imgs[LAB_BS_ALL + 1], int x, int y,
 	struct view *view);
-struct ssd_part_button *button_try_from_ssd_part(struct ssd_part *part);
 
 /* SSD internal */
 void ssd_titlebar_create(struct ssd *ssd);

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -173,12 +173,6 @@ struct ssd_part_button {
 	struct wl_list link; /* ssd_titlebar_subtree.buttons_{left,right} */
 };
 
-/* FIXME: This structure is redundant as ssd_part contains view */
-struct ssd_hover_state {
-	struct view *view;
-	struct ssd_part_button *button;
-};
-
 struct wlr_buffer;
 struct wlr_scene_tree;
 

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -3,7 +3,7 @@
 #define LABWC_SSD_INTERNAL_H
 
 #include <wlr/util/box.h>
-#include "ssd.h"
+#include "common/border.h"
 #include "theme.h"
 #include "view.h"
 
@@ -142,7 +142,7 @@ struct ssd {
  * the cursor.
  */
 struct ssd_part {
-	enum ssd_part_type type;
+	enum lab_node_type type;
 	struct view *view;
 
 	/* This part represented in scene graph */
@@ -183,10 +183,10 @@ struct wlr_buffer;
 struct wlr_scene_tree;
 
 /* SSD internal helpers to create various SSD elements */
-struct ssd_part *attach_ssd_part(enum ssd_part_type type, struct view *view,
+struct ssd_part *attach_ssd_part(enum lab_node_type type, struct view *view,
 	struct wlr_scene_node *node);
 struct ssd_part_button *attach_ssd_part_button(struct wl_list *button_parts,
-	enum ssd_part_type type, struct wlr_scene_tree *parent,
+	enum lab_node_type type, struct wlr_scene_tree *parent,
 	struct lab_img *imgs[LAB_BS_ALL + 1], int x, int y,
 	struct view *view);
 struct ssd_part_button *button_try_from_ssd_part(struct ssd_part *part);

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -3,7 +3,7 @@
 #define LABWC_SSD_H
 
 #include "common/border.h"
-#include "common/edge.h"
+#include "common/node-type.h"
 #include "config/types.h"
 
 enum ssd_active_state {
@@ -21,51 +21,6 @@ struct wlr_cursor;
  * specifies inset as a multiple of visible shadow size.
  */
 #define SSD_SHADOW_INSET 0.3
-
-/*
- * Sequence these according to the order they should be processed for
- * press and hover events. Bear in mind that some of their respective
- * interactive areas overlap, so for example buttons need to come before title.
- */
-enum ssd_part_type {
-	LAB_SSD_NONE = 0,
-
-	LAB_SSD_BUTTON_CLOSE = 1,
-	LAB_SSD_BUTTON_MAXIMIZE,
-	LAB_SSD_BUTTON_ICONIFY,
-	LAB_SSD_BUTTON_WINDOW_ICON,
-	LAB_SSD_BUTTON_WINDOW_MENU,
-	LAB_SSD_BUTTON_SHADE,
-	LAB_SSD_BUTTON_OMNIPRESENT,
-	/* only for internal use */
-	LAB_SSD_BUTTON_FIRST = LAB_SSD_BUTTON_CLOSE,
-	LAB_SSD_BUTTON_LAST = LAB_SSD_BUTTON_OMNIPRESENT,
-	LAB_SSD_BUTTON,
-
-	LAB_SSD_PART_TITLEBAR,
-	LAB_SSD_PART_TITLE,
-
-	LAB_SSD_PART_CORNER_TOP_LEFT,
-	LAB_SSD_PART_CORNER_TOP_RIGHT,
-	LAB_SSD_PART_CORNER_BOTTOM_RIGHT,
-	LAB_SSD_PART_CORNER_BOTTOM_LEFT,
-	LAB_SSD_PART_TOP,
-	LAB_SSD_PART_RIGHT,
-	LAB_SSD_PART_BOTTOM,
-	LAB_SSD_PART_LEFT,
-	LAB_SSD_PART_BORDER,
-
-	LAB_SSD_CLIENT,
-	LAB_SSD_FRAME,
-	LAB_SSD_ROOT,
-	LAB_SSD_MENU,
-	LAB_SSD_OSD,
-	LAB_SSD_LAYER_SURFACE,
-	LAB_SSD_LAYER_SUBSURFACE,
-	LAB_SSD_UNMANAGED,
-	LAB_SSD_ALL,
-	LAB_SSD_END_MARKER
-};
 
 /* Forward declare arguments */
 struct ssd;
@@ -101,7 +56,7 @@ struct ssd_hover_state *ssd_hover_state_new(void);
 void ssd_update_button_hover(struct wlr_scene_node *node,
 	struct ssd_hover_state *hover_state);
 
-enum ssd_part_type ssd_part_get_type(const struct ssd_part *part);
+enum lab_node_type ssd_part_get_type(const struct ssd_part *part);
 struct view *ssd_part_get_view(const struct ssd_part *part);
 
 /* Public SSD helpers */
@@ -110,10 +65,8 @@ struct view *ssd_part_get_view(const struct ssd_part *part);
  * Returns a part type that represents a mouse context like "Top", "Left" and
  * "TRCorner" when the cursor is on the window border or resizing handle.
  */
-enum ssd_part_type ssd_get_resizing_type(const struct ssd *ssd,
+enum lab_node_type ssd_get_resizing_type(const struct ssd *ssd,
 	struct wlr_cursor *cursor);
-enum lab_edge ssd_resize_edges(enum ssd_part_type type);
-bool ssd_part_contains(enum ssd_part_type whole, enum ssd_part_type candidate);
 enum lab_ssd_mode ssd_mode_parse(const char *mode);
 
 /* TODO: clean up / update */

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -23,8 +23,8 @@ struct wlr_cursor;
 #define SSD_SHADOW_INSET 0.3
 
 /* Forward declare arguments */
+struct server;
 struct ssd;
-struct ssd_hover_state;
 struct ssd_part;
 struct view;
 struct wlr_scene;
@@ -52,9 +52,8 @@ void ssd_set_titlebar(struct ssd *ssd, bool enabled);
 void ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable);
 void ssd_enable_shade(struct ssd *ssd, bool enable);
 
-struct ssd_hover_state *ssd_hover_state_new(void);
-void ssd_update_button_hover(struct wlr_scene_node *node,
-	struct ssd_hover_state *hover_state);
+void ssd_update_button_hover(struct server *server,
+	struct wlr_scene_node *node);
 
 enum lab_node_type ssd_part_get_type(const struct ssd_part *part);
 struct view *ssd_part_get_view(const struct ssd_part *part);

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -25,7 +25,7 @@ struct wlr_cursor;
 /* Forward declare arguments */
 struct server;
 struct ssd;
-struct ssd_part;
+struct ssd_button;
 struct view;
 struct wlr_scene;
 struct wlr_scene_node;
@@ -55,8 +55,7 @@ void ssd_enable_shade(struct ssd *ssd, bool enable);
 void ssd_update_button_hover(struct server *server,
 	struct wlr_scene_node *node);
 
-enum lab_node_type ssd_part_get_type(const struct ssd_part *part);
-struct view *ssd_part_get_view(const struct ssd_part *part);
+void ssd_button_free(struct ssd_button *button);
 
 /* Public SSD helpers */
 

--- a/include/theme.h
+++ b/include/theme.h
@@ -10,7 +10,7 @@
 
 #include <cairo.h>
 #include <wlr/render/wlr_renderer.h>
-#include "ssd.h"
+#include "common/node-type.h"
 
 struct lab_img;
 
@@ -90,7 +90,7 @@ struct theme {
 		struct theme_background title_bg;
 
 		/* TODO: add toggled/hover/pressed/disabled colors for buttons */
-		float button_colors[LAB_SSD_BUTTON_LAST + 1][4];
+		float button_colors[LAB_NODE_BUTTON_LAST + 1][4];
 
 		float border_color[4];
 		float toggled_keybinds_color[4];
@@ -109,7 +109,7 @@ struct theme {
 		 * Elements in buttons[0] are all NULL since LAB_SSD_BUTTON_FIRST is 1.
 		 */
 		struct lab_img *button_imgs
-			[LAB_SSD_BUTTON_LAST + 1][LAB_BS_ALL + 1];
+			[LAB_NODE_BUTTON_LAST + 1][LAB_BS_ALL + 1];
 
 		/*
 		 * The titlebar background is specified as a cairo_pattern

--- a/src/action.c
+++ b/src/action.c
@@ -707,8 +707,8 @@ show_menu(struct server *server, struct view *view, struct cursor_context *ctx,
 		x = extent.x;
 		y = view->current.y;
 		/* Push the client menu underneath the button */
-		if (is_client_menu && ssd_part_contains(
-				LAB_SSD_BUTTON, ctx->type)) {
+		if (is_client_menu && node_type_contains(
+				LAB_NODE_BUTTON, ctx->type)) {
 			assert(ctx->node);
 			int lx, ly;
 			wlr_scene_node_coords(ctx->node, &lx, &ly);

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -12,6 +12,7 @@ labwc_sources += files(
   'match.c',
   'mem.c',
   'nodename.c',
+  'node-type.c',
   'parse-bool.c',
   'parse-double.c',
   'scene-helpers.c',

--- a/src/common/node-type.c
+++ b/src/common/node-type.c
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "common/node-type.h"
+#include <strings.h>
+#include <wlr/util/log.h>
+
+enum lab_node_type
+node_type_parse(const char *context)
+{
+	if (!strcasecmp(context, "Close")) {
+		return LAB_NODE_BUTTON_CLOSE;
+	} else if (!strcasecmp(context, "Maximize")) {
+		return LAB_NODE_BUTTON_MAXIMIZE;
+	} else if (!strcasecmp(context, "Iconify")) {
+		return LAB_NODE_BUTTON_ICONIFY;
+	} else if (!strcasecmp(context, "WindowMenu")) {
+		return LAB_NODE_BUTTON_WINDOW_MENU;
+	} else if (!strcasecmp(context, "Icon")) {
+		return LAB_NODE_BUTTON_WINDOW_ICON;
+	} else if (!strcasecmp(context, "Shade")) {
+		return LAB_NODE_BUTTON_SHADE;
+	} else if (!strcasecmp(context, "AllDesktops")) {
+		return LAB_NODE_BUTTON_OMNIPRESENT;
+	} else if (!strcasecmp(context, "Titlebar")) {
+		return LAB_NODE_TITLEBAR;
+	} else if (!strcasecmp(context, "Title")) {
+		return LAB_NODE_TITLE;
+	} else if (!strcasecmp(context, "TLCorner")) {
+		return LAB_NODE_CORNER_TOP_LEFT;
+	} else if (!strcasecmp(context, "TRCorner")) {
+		return LAB_NODE_CORNER_TOP_RIGHT;
+	} else if (!strcasecmp(context, "BRCorner")) {
+		return LAB_NODE_CORNER_BOTTOM_RIGHT;
+	} else if (!strcasecmp(context, "BLCorner")) {
+		return LAB_NODE_CORNER_BOTTOM_LEFT;
+	} else if (!strcasecmp(context, "Border")) {
+		return LAB_NODE_BORDER;
+	} else if (!strcasecmp(context, "Top")) {
+		return LAB_NODE_BORDER_TOP;
+	} else if (!strcasecmp(context, "Right")) {
+		return LAB_NODE_BORDER_RIGHT;
+	} else if (!strcasecmp(context, "Bottom")) {
+		return LAB_NODE_BORDER_BOTTOM;
+	} else if (!strcasecmp(context, "Left")) {
+		return LAB_NODE_BORDER_LEFT;
+	} else if (!strcasecmp(context, "Frame")) {
+		return LAB_NODE_FRAME;
+	} else if (!strcasecmp(context, "Client")) {
+		return LAB_NODE_CLIENT;
+	} else if (!strcasecmp(context, "Desktop")) {
+		return LAB_NODE_ROOT;
+	} else if (!strcasecmp(context, "Root")) {
+		return LAB_NODE_ROOT;
+	} else if (!strcasecmp(context, "All")) {
+		return LAB_NODE_ALL;
+	}
+	wlr_log(WLR_ERROR, "unknown mouse context (%s)", context);
+	return LAB_NODE_NONE;
+}
+
+bool
+node_type_contains(enum lab_node_type whole, enum lab_node_type part)
+{
+	if (whole == part || whole == LAB_NODE_ALL) {
+		return true;
+	}
+	if (whole == LAB_NODE_BUTTON) {
+		return part >= LAB_NODE_BUTTON_FIRST
+			&& part <= LAB_NODE_BUTTON_LAST;
+	}
+	if (whole == LAB_NODE_TITLEBAR) {
+		return part >= LAB_NODE_BUTTON_FIRST
+			&& part <= LAB_NODE_TITLE;
+	}
+	if (whole == LAB_NODE_TITLE) {
+		/* "Title" includes blank areas of "Titlebar" as well */
+		return part >= LAB_NODE_TITLEBAR
+			&& part <= LAB_NODE_TITLE;
+	}
+	if (whole == LAB_NODE_FRAME) {
+		return part >= LAB_NODE_BUTTON_FIRST
+			&& part <= LAB_NODE_CLIENT;
+	}
+	if (whole == LAB_NODE_BORDER) {
+		return part >= LAB_NODE_CORNER_TOP_LEFT
+			&& part <= LAB_NODE_BORDER_LEFT;
+	}
+	if (whole == LAB_NODE_BORDER_TOP) {
+		return part == LAB_NODE_CORNER_TOP_LEFT
+			|| part == LAB_NODE_CORNER_TOP_RIGHT;
+	}
+	if (whole == LAB_NODE_BORDER_RIGHT) {
+		return part == LAB_NODE_CORNER_TOP_RIGHT
+			|| part == LAB_NODE_CORNER_BOTTOM_RIGHT;
+	}
+	if (whole == LAB_NODE_BORDER_BOTTOM) {
+		return part == LAB_NODE_CORNER_BOTTOM_RIGHT
+			|| part == LAB_NODE_CORNER_BOTTOM_LEFT;
+	}
+	if (whole == LAB_NODE_BORDER_LEFT) {
+		return part == LAB_NODE_CORNER_TOP_LEFT
+			|| part == LAB_NODE_CORNER_BOTTOM_LEFT;
+	}
+	return false;
+}
+
+enum lab_edge
+node_type_to_edges(enum lab_node_type type)
+{
+	switch (type) {
+	case LAB_NODE_BORDER_TOP:
+		return LAB_EDGE_TOP;
+	case LAB_NODE_BORDER_RIGHT:
+		return LAB_EDGE_RIGHT;
+	case LAB_NODE_BORDER_BOTTOM:
+		return LAB_EDGE_BOTTOM;
+	case LAB_NODE_BORDER_LEFT:
+		return LAB_EDGE_LEFT;
+	case LAB_NODE_CORNER_TOP_LEFT:
+		return LAB_EDGES_TOP_LEFT;
+	case LAB_NODE_CORNER_TOP_RIGHT:
+		return LAB_EDGES_TOP_RIGHT;
+	case LAB_NODE_CORNER_BOTTOM_RIGHT:
+		return LAB_EDGES_BOTTOM_RIGHT;
+	case LAB_NODE_CORNER_BOTTOM_LEFT:
+		return LAB_EDGES_BOTTOM_LEFT;
+	default:
+		return LAB_EDGE_NONE;
+	}
+}

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -8,6 +8,7 @@
 #include <wlr/util/log.h>
 #include "common/list.h"
 #include "common/mem.h"
+#include "config/keybind.h"
 #include "config/rcxml.h"
 
 uint32_t
@@ -103,60 +104,6 @@ mousebind_event_from_str(const char *str)
 	return MOUSE_ACTION_NONE;
 }
 
-static enum ssd_part_type
-context_from_str(const char *str)
-{
-	if (!strcasecmp(str, "Close")) {
-		return LAB_SSD_BUTTON_CLOSE;
-	} else if (!strcasecmp(str, "Maximize")) {
-		return LAB_SSD_BUTTON_MAXIMIZE;
-	} else if (!strcasecmp(str, "Iconify")) {
-		return LAB_SSD_BUTTON_ICONIFY;
-	} else if (!strcasecmp(str, "WindowMenu")) {
-		return LAB_SSD_BUTTON_WINDOW_MENU;
-	} else if (!strcasecmp(str, "Icon")) {
-		return LAB_SSD_BUTTON_WINDOW_ICON;
-	} else if (!strcasecmp(str, "Shade")) {
-		return LAB_SSD_BUTTON_SHADE;
-	} else if (!strcasecmp(str, "AllDesktops")) {
-		return LAB_SSD_BUTTON_OMNIPRESENT;
-	} else if (!strcasecmp(str, "Titlebar")) {
-		return LAB_SSD_PART_TITLEBAR;
-	} else if (!strcasecmp(str, "Title")) {
-		return LAB_SSD_PART_TITLE;
-	} else if (!strcasecmp(str, "TLCorner")) {
-		return LAB_SSD_PART_CORNER_TOP_LEFT;
-	} else if (!strcasecmp(str, "TRCorner")) {
-		return LAB_SSD_PART_CORNER_TOP_RIGHT;
-	} else if (!strcasecmp(str, "BRCorner")) {
-		return LAB_SSD_PART_CORNER_BOTTOM_RIGHT;
-	} else if (!strcasecmp(str, "BLCorner")) {
-		return LAB_SSD_PART_CORNER_BOTTOM_LEFT;
-	} else if (!strcasecmp(str, "Border")) {
-		return LAB_SSD_PART_BORDER;
-	} else if (!strcasecmp(str, "Top")) {
-		return LAB_SSD_PART_TOP;
-	} else if (!strcasecmp(str, "Right")) {
-		return LAB_SSD_PART_RIGHT;
-	} else if (!strcasecmp(str, "Bottom")) {
-		return LAB_SSD_PART_BOTTOM;
-	} else if (!strcasecmp(str, "Left")) {
-		return LAB_SSD_PART_LEFT;
-	} else if (!strcasecmp(str, "Frame")) {
-		return LAB_SSD_FRAME;
-	} else if (!strcasecmp(str, "Client")) {
-		return LAB_SSD_CLIENT;
-	} else if (!strcasecmp(str, "Desktop")) {
-		return LAB_SSD_ROOT;
-	} else if (!strcasecmp(str, "Root")) {
-		return LAB_SSD_ROOT;
-	} else if (!strcasecmp(str, "All")) {
-		return LAB_SSD_ALL;
-	}
-	wlr_log(WLR_ERROR, "unknown mouse context (%s)", str);
-	return LAB_SSD_NONE;
-}
-
 bool
 mousebind_the_same(struct mousebind *a, struct mousebind *b)
 {
@@ -176,8 +123,8 @@ mousebind_create(const char *context)
 		return NULL;
 	}
 	struct mousebind *m = znew(*m);
-	m->context = context_from_str(context);
-	if (m->context != LAB_SSD_NONE) {
+	m->context = node_type_parse(context);
+	if (m->context != LAB_NODE_NONE) {
 		wl_list_append(&rc.mousebinds, &m->link);
 	}
 	wl_list_init(&m->actions);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -35,6 +35,7 @@
 #include "labwc.h"
 #include "osd.h"
 #include "regions.h"
+#include "ssd.h"
 #include "view.h"
 #include "window-rules.h"
 #include "workspaces.h"
@@ -126,34 +127,34 @@ fill_section(const char *content, struct wl_list *list, uint32_t *found_buttons)
 		if (string_null_or_empty(identifier)) {
 			continue;
 		}
-		enum ssd_part_type type = LAB_SSD_NONE;
+		enum lab_node_type type = LAB_NODE_NONE;
 		if (!strcmp(identifier, "icon")) {
 #if HAVE_LIBSFDO
-			type = LAB_SSD_BUTTON_WINDOW_ICON;
+			type = LAB_NODE_BUTTON_WINDOW_ICON;
 #else
 			wlr_log(WLR_ERROR, "libsfdo is not linked. "
 				"Replacing 'icon' in titlebar layout with 'menu'.");
 			type = LAB_SSD_BUTTON_WINDOW_MENU;
 #endif
 		} else if (!strcmp(identifier, "menu")) {
-			type = LAB_SSD_BUTTON_WINDOW_MENU;
+			type = LAB_NODE_BUTTON_WINDOW_MENU;
 		} else if (!strcmp(identifier, "iconify")) {
-			type = LAB_SSD_BUTTON_ICONIFY;
+			type = LAB_NODE_BUTTON_ICONIFY;
 		} else if (!strcmp(identifier, "max")) {
-			type = LAB_SSD_BUTTON_MAXIMIZE;
+			type = LAB_NODE_BUTTON_MAXIMIZE;
 		} else if (!strcmp(identifier, "close")) {
-			type = LAB_SSD_BUTTON_CLOSE;
+			type = LAB_NODE_BUTTON_CLOSE;
 		} else if (!strcmp(identifier, "shade")) {
-			type = LAB_SSD_BUTTON_SHADE;
+			type = LAB_NODE_BUTTON_SHADE;
 		} else if (!strcmp(identifier, "desk")) {
-			type = LAB_SSD_BUTTON_OMNIPRESENT;
+			type = LAB_NODE_BUTTON_OMNIPRESENT;
 		} else {
 			wlr_log(WLR_ERROR, "invalid titleLayout identifier '%s'",
 				identifier);
 			continue;
 		}
 
-		assert(type != LAB_SSD_NONE);
+		assert(type != LAB_NODE_NONE);
 
 		/* We no longer need this check, but let's keep it just in case */
 		if (*found_buttons & (1 << type)) {

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -263,7 +263,7 @@ get_surface_from_layer_node(struct wlr_scene_node *node)
 struct cursor_context
 get_cursor_context(struct server *server)
 {
-	struct cursor_context ret = {.type = LAB_SSD_NONE};
+	struct cursor_context ret = {.type = LAB_NODE_NONE};
 	struct wlr_cursor *cursor = server->seat.cursor;
 
 	/* Prevent drag icons to be on top of the hitbox detection */
@@ -281,7 +281,7 @@ get_cursor_context(struct server *server)
 
 	ret.node = node;
 	if (!node) {
-		ret.type = LAB_SSD_ROOT;
+		ret.type = LAB_NODE_ROOT;
 		return ret;
 	}
 
@@ -289,7 +289,7 @@ get_cursor_context(struct server *server)
 	if (node->type == WLR_SCENE_NODE_BUFFER) {
 		struct wlr_surface *surface = lab_wlr_surface_from_node(node);
 		if (node->parent == server->unmanaged_tree) {
-			ret.type = LAB_SSD_UNMANAGED;
+			ret.type = LAB_NODE_UNMANAGED;
 			ret.surface = surface;
 			return ret;
 		}
@@ -304,7 +304,7 @@ get_cursor_context(struct server *server)
 				ret.view = desc->data;
 				if (ret.node->type == WLR_SCENE_NODE_BUFFER
 						&& lab_wlr_surface_from_node(ret.node)) {
-					ret.type = LAB_SSD_CLIENT;
+					ret.type = LAB_NODE_CLIENT;
 					ret.surface = lab_wlr_surface_from_node(ret.node);
 				} else {
 					/* should never be reached */
@@ -318,7 +318,7 @@ get_cursor_context(struct server *server)
 
 				/* Detect mouse contexts like Top, Left and TRCorner */
 				ret.type = ssd_get_resizing_type(ret.view->ssd, cursor);
-				if (ret.type == LAB_SSD_NONE) {
+				if (ret.type == LAB_NODE_NONE) {
 					/*
 					 * Otherwise, detect mouse contexts like
 					 * Title, Titlebar and Iconify
@@ -330,23 +330,23 @@ get_cursor_context(struct server *server)
 			}
 			case LAB_NODE_DESC_LAYER_SURFACE:
 				ret.node = node;
-				ret.type = LAB_SSD_LAYER_SURFACE;
+				ret.type = LAB_NODE_LAYER_SURFACE;
 				ret.surface = get_surface_from_layer_node(node);
 				return ret;
 			case LAB_NODE_DESC_LAYER_POPUP:
 				ret.node = node;
-				ret.type = LAB_SSD_CLIENT;
+				ret.type = LAB_NODE_CLIENT;
 				ret.surface = get_surface_from_layer_node(node);
 				return ret;
 			case LAB_NODE_DESC_SESSION_LOCK_SURFACE: /* fallthrough */
 			case LAB_NODE_DESC_IME_POPUP:
-				ret.type = LAB_SSD_CLIENT;
+				ret.type = LAB_NODE_CLIENT;
 				ret.surface = lab_wlr_surface_from_node(ret.node);
 				return ret;
 			case LAB_NODE_DESC_MENUITEM:
 				/* Always return the top scene node for menu items */
 				ret.node = node;
-				ret.type = LAB_SSD_MENU;
+				ret.type = LAB_NODE_MENU;
 				return ret;
 			case LAB_NODE_DESC_NODE:
 			case LAB_NODE_DESC_TREE:
@@ -373,7 +373,7 @@ get_cursor_context(struct server *server)
 			if (surface && wlr_subsurface_try_from_wlr_surface(surface)
 					&& subsurface_parent_layer(surface)) {
 				ret.surface = surface;
-				ret.type = LAB_SSD_LAYER_SUBSURFACE;
+				ret.type = LAB_NODE_LAYER_SUBSURFACE;
 				return ret;
 			}
 		}

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -247,11 +247,11 @@ get_surface_from_layer_node(struct wlr_scene_node *node)
 {
 	assert(node->data);
 	struct node_descriptor *desc = (struct node_descriptor *)node->data;
-	if (desc->type == LAB_NODE_DESC_LAYER_SURFACE) {
+	if (desc->type == LAB_NODE_LAYER_SURFACE) {
 		struct lab_layer_surface *surface;
 		surface = node_layer_surface_from_node(node);
 		return surface->scene_layer_surface->layer_surface->surface;
-	} else if (desc->type == LAB_NODE_DESC_LAYER_POPUP) {
+	} else if (desc->type == LAB_NODE_LAYER_POPUP) {
 		struct lab_layer_popup *popup;
 		popup = node_layer_popup_from_node(node);
 		return popup->wlr_popup->base->surface;
@@ -299,9 +299,9 @@ get_cursor_context(struct server *server)
 		struct node_descriptor *desc = node->data;
 		if (desc) {
 			switch (desc->type) {
-			case LAB_NODE_DESC_VIEW:
-			case LAB_NODE_DESC_XDG_POPUP:
-				ret.view = desc->data;
+			case LAB_NODE_VIEW:
+			case LAB_NODE_XDG_POPUP:
+				ret.view = desc->view;
 				if (ret.node->type == WLR_SCENE_NODE_BUFFER
 						&& lab_wlr_surface_from_node(ret.node)) {
 					ret.type = LAB_NODE_CLIENT;
@@ -311,10 +311,43 @@ get_cursor_context(struct server *server)
 					wlr_log(WLR_ERROR, "cursor not on client or ssd");
 				}
 				return ret;
-			case LAB_NODE_DESC_SSD_PART: {
-				struct ssd_part *part = node_ssd_part_from_node(node);
+			case LAB_NODE_LAYER_SURFACE:
 				ret.node = node;
-				ret.view = ssd_part_get_view(part);
+				ret.type = LAB_NODE_LAYER_SURFACE;
+				ret.surface = get_surface_from_layer_node(node);
+				return ret;
+			case LAB_NODE_LAYER_POPUP:
+				ret.node = node;
+				ret.type = LAB_NODE_CLIENT;
+				ret.surface = get_surface_from_layer_node(node);
+				return ret;
+			case LAB_NODE_SESSION_LOCK_SURFACE: /* fallthrough */
+			case LAB_NODE_IME_POPUP:
+				ret.type = LAB_NODE_CLIENT;
+				ret.surface = lab_wlr_surface_from_node(ret.node);
+				return ret;
+			case LAB_NODE_MENUITEM:
+				/* Always return the top scene node for menu items */
+				ret.node = node;
+				ret.type = LAB_NODE_MENUITEM;
+				return ret;
+			case LAB_NODE_TREE:
+			case LAB_NODE_SCALED_BUFFER:
+				/* Continue to parent node */
+				break;
+			default:
+				/*
+				 * All other node descriptors (buttons, title,
+				 * frame, etc.) should have an associated view.
+				 */
+				if (!desc->view) {
+					wlr_log(WLR_ERROR, "cursor not on any view "
+						"(node type %d)", desc->type);
+					return ret;
+				}
+
+				ret.node = node;
+				ret.view = desc->view;
 
 				/* Detect mouse contexts like Top, Left and TRCorner */
 				ret.type = ssd_get_resizing_type(ret.view->ssd, cursor);
@@ -323,35 +356,10 @@ get_cursor_context(struct server *server)
 					 * Otherwise, detect mouse contexts like
 					 * Title, Titlebar and Iconify
 					 */
-					ret.type = ssd_part_get_type(part);
+					ret.type = desc->type;
 				}
 
 				return ret;
-			}
-			case LAB_NODE_DESC_LAYER_SURFACE:
-				ret.node = node;
-				ret.type = LAB_NODE_LAYER_SURFACE;
-				ret.surface = get_surface_from_layer_node(node);
-				return ret;
-			case LAB_NODE_DESC_LAYER_POPUP:
-				ret.node = node;
-				ret.type = LAB_NODE_CLIENT;
-				ret.surface = get_surface_from_layer_node(node);
-				return ret;
-			case LAB_NODE_DESC_SESSION_LOCK_SURFACE: /* fallthrough */
-			case LAB_NODE_DESC_IME_POPUP:
-				ret.type = LAB_NODE_CLIENT;
-				ret.surface = lab_wlr_surface_from_node(ret.node);
-				return ret;
-			case LAB_NODE_DESC_MENUITEM:
-				/* Always return the top scene node for menu items */
-				ret.node = node;
-				ret.type = LAB_NODE_MENU;
-				return ret;
-			case LAB_NODE_DESC_NODE:
-			case LAB_NODE_DESC_TREE:
-			case LAB_NODE_DESC_SCALED_BUFFER:
-				break;
 			}
 		}
 

--- a/src/edges.c
+++ b/src/edges.c
@@ -314,7 +314,7 @@ subtract_node_tree(struct wlr_scene_tree *tree, pixman_region32_t *available,
 		}
 
 		node_desc = node->data;
-		if (node_desc && node_desc->type == LAB_NODE_DESC_VIEW) {
+		if (node_desc && node_desc->type == LAB_NODE_VIEW) {
 			view = node_view_from_node(node);
 			if (view != ignored_view) {
 				subtract_view_from_space(view, available);

--- a/src/edges.c
+++ b/src/edges.c
@@ -10,9 +10,10 @@
 #include "common/macros.h"
 #include "config/rcxml.h"
 #include "labwc.h"
-#include "output.h"
-#include "view.h"
 #include "node.h"
+#include "output.h"
+#include "ssd.h"
+#include "view.h"
 
 static void
 edges_for_target_geometry(struct border *edges, struct view *view,

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -609,7 +609,7 @@ cursor_process_motion(struct server *server, uint32_t time, double *sx, double *
 	struct cursor_context ctx = get_cursor_context(server);
 	struct seat *seat = &server->seat;
 
-	if (ctx.type == LAB_NODE_MENU) {
+	if (ctx.type == LAB_NODE_MENUITEM) {
 		menu_process_cursor_motion(ctx.node);
 		cursor_set(&server->seat, LAB_CURSOR_DEFAULT);
 		return false;
@@ -1173,7 +1173,7 @@ cursor_process_button_release(struct seat *seat, uint32_t button,
 	if (server->input_mode == LAB_INPUT_STATE_MENU) {
 		/* TODO: take into account overflow of time_msec */
 		if (time_msec - press_msec > rc.menu_ignore_button_release_period) {
-			if (ctx.type == LAB_NODE_MENU) {
+			if (ctx.type == LAB_NODE_MENUITEM) {
 				menu_call_selected_actions(server);
 			} else {
 				menu_close_root(server);

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -515,7 +515,7 @@ cursor_update_common(struct server *server, struct cursor_context *ctx,
 	struct seat *seat = &server->seat;
 	struct wlr_seat *wlr_seat = seat->seat;
 
-	ssd_update_button_hover(ctx->node, server->ssd_hover_state);
+	ssd_update_button_hover(server, ctx->node);
 
 	if (server->input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
 		/*

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -393,7 +393,8 @@ handle_input_method_new_popup_surface(struct wl_listener *listener, void *data)
 
 	popup->tree = wlr_scene_subsurface_tree_create(
 		relay->popup_tree, popup->popup_surface->surface);
-	node_descriptor_create(&popup->tree->node, LAB_NODE_DESC_IME_POPUP, NULL);
+	node_descriptor_create(&popup->tree->node, LAB_NODE_IME_POPUP,
+		/*view*/ NULL, /*data*/ NULL);
 
 	wl_list_insert(&relay->popups, &popup->link);
 

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -666,7 +666,7 @@ handle_tablet_tool_button(struct wl_listener *listener, void *data)
 			wl_list_for_each(mousebind, &rc.mousebinds, link) {
 				if (mousebind->mouse_event == MOUSE_ACTION_PRESS
 						&& mousebind->button == button
-						&& mousebind->context == LAB_SSD_CLIENT) {
+						&& mousebind->context == LAB_NODE_CLIENT) {
 					actions_run(view, tool->seat->server,
 						&mousebind->actions, NULL);
 				}

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -167,7 +167,7 @@ handle_touch_down(struct wl_listener *listener, void *data)
 		wl_list_for_each(mousebind, &rc.mousebinds, link) {
 			if (mousebind->mouse_event == MOUSE_ACTION_PRESS
 					&& mousebind->button == BTN_LEFT
-					&& mousebind->context == LAB_SSD_CLIENT) {
+					&& mousebind->context == LAB_NODE_CLIENT) {
 				actions_run(view, seat->server, &mousebind->actions, NULL);
 			}
 		}

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -206,7 +206,7 @@ handle_touch_up(struct wl_listener *listener, void *data)
 			} else {
 				cursor_emulate_button(seat, BTN_LEFT,
 					WL_POINTER_BUTTON_STATE_RELEASED, event->time_msec);
-				ssd_update_button_hover(NULL, seat->server->ssd_hover_state);
+				ssd_update_button_hover(seat->server, NULL);
 			}
 			wl_list_remove(&touch_point->link);
 			zfree(touch_point);

--- a/src/layers.c
+++ b/src/layers.c
@@ -473,7 +473,7 @@ create_popup(struct server *server, struct wlr_xdg_popup *wlr_popup,
 	wlr_popup->base->surface->data = popup->scene_tree;
 
 	node_descriptor_create(&popup->scene_tree->node,
-		LAB_NODE_DESC_LAYER_POPUP, popup);
+		LAB_NODE_LAYER_POPUP, /*view*/ NULL, popup);
 
 	popup->destroy.notify = handle_popup_destroy;
 	wl_signal_add(&wlr_popup->events.destroy, &popup->destroy);
@@ -624,7 +624,7 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 	layer_surface->surface->data = surface->scene_layer_surface->tree;
 
 	node_descriptor_create(&surface->scene_layer_surface->tree->node,
-		LAB_NODE_DESC_LAYER_SURFACE, surface);
+		LAB_NODE_LAYER_SURFACE, /*view*/ NULL, surface);
 
 	surface->server = server;
 	surface->scene_layer_surface->layer_surface = layer_surface;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -246,8 +246,8 @@ item_create_scene(struct menuitem *menuitem, int *item_y)
 
 	/* Menu item root node */
 	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
-	node_descriptor_create(&menuitem->tree->node,
-		LAB_NODE_DESC_MENUITEM, menuitem);
+	node_descriptor_create(&menuitem->tree->node, LAB_NODE_MENUITEM,
+		/*view*/ NULL, menuitem);
 
 	/* Create scenes for unselected/selected states */
 	menuitem->normal_tree = item_create_scene_for_state(menuitem,
@@ -295,8 +295,8 @@ separator_create_scene(struct menuitem *menuitem, int *item_y)
 
 	/* Menu item root node */
 	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
-	node_descriptor_create(&menuitem->tree->node,
-		LAB_NODE_DESC_MENUITEM, menuitem);
+	node_descriptor_create(&menuitem->tree->node, LAB_NODE_MENUITEM,
+		/*view*/ NULL, menuitem);
 
 	/* Tree to hold background and line buffer */
 	menuitem->normal_tree = wlr_scene_tree_create(menuitem->tree);
@@ -343,8 +343,8 @@ title_create_scene(struct menuitem *menuitem, int *item_y)
 
 	/* Menu item root node */
 	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
-	node_descriptor_create(&menuitem->tree->node,
-		LAB_NODE_DESC_MENUITEM, menuitem);
+	node_descriptor_create(&menuitem->tree->node, LAB_NODE_MENUITEM,
+		/*view*/ NULL, menuitem);
 
 	/* Tree to hold background and text buffer */
 	menuitem->normal_tree = wlr_scene_tree_create(menuitem->tree);

--- a/src/node.c
+++ b/src/node.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include "common/mem.h"
+#include "ssd.h"
 
 static void
 descriptor_destroy(struct node_descriptor *node_descriptor)
@@ -10,6 +11,12 @@ descriptor_destroy(struct node_descriptor *node_descriptor)
 	if (!node_descriptor) {
 		return;
 	}
+
+	if (node_descriptor->type >= LAB_NODE_BUTTON_FIRST
+			&& node_descriptor->type <= LAB_NODE_BUTTON_LAST) {
+		ssd_button_free(node_descriptor->data);
+	}
+
 	wl_list_remove(&node_descriptor->destroy.link);
 	free(node_descriptor);
 }
@@ -24,10 +31,11 @@ handle_node_destroy(struct wl_listener *listener, void *data)
 
 void
 node_descriptor_create(struct wlr_scene_node *scene_node,
-		enum node_descriptor_type type, void *data)
+		enum lab_node_type type, struct view *view, void *data)
 {
 	struct node_descriptor *node_descriptor = znew(*node_descriptor);
 	node_descriptor->type = type;
+	node_descriptor->view = view;
 	node_descriptor->data = data;
 	node_descriptor->destroy.notify = handle_node_destroy;
 	wl_signal_add(&scene_node->events.destroy, &node_descriptor->destroy);
@@ -39,9 +47,7 @@ node_view_from_node(struct wlr_scene_node *wlr_scene_node)
 {
 	assert(wlr_scene_node->data);
 	struct node_descriptor *node_descriptor = wlr_scene_node->data;
-	assert(node_descriptor->type == LAB_NODE_DESC_VIEW
-		|| node_descriptor->type == LAB_NODE_DESC_XDG_POPUP);
-	return (struct view *)node_descriptor->data;
+	return node_descriptor->view;
 }
 
 struct lab_layer_surface *
@@ -49,7 +55,7 @@ node_layer_surface_from_node(struct wlr_scene_node *wlr_scene_node)
 {
 	assert(wlr_scene_node->data);
 	struct node_descriptor *node_descriptor = wlr_scene_node->data;
-	assert(node_descriptor->type == LAB_NODE_DESC_LAYER_SURFACE);
+	assert(node_descriptor->type == LAB_NODE_LAYER_SURFACE);
 	return (struct lab_layer_surface *)node_descriptor->data;
 }
 
@@ -58,7 +64,7 @@ node_layer_popup_from_node(struct wlr_scene_node *wlr_scene_node)
 {
 	assert(wlr_scene_node->data);
 	struct node_descriptor *node_descriptor = wlr_scene_node->data;
-	assert(node_descriptor->type == LAB_NODE_DESC_LAYER_POPUP);
+	assert(node_descriptor->type == LAB_NODE_LAYER_POPUP);
 	return (struct lab_layer_popup *)node_descriptor->data;
 }
 
@@ -67,17 +73,8 @@ node_menuitem_from_node(struct wlr_scene_node *wlr_scene_node)
 {
 	assert(wlr_scene_node->data);
 	struct node_descriptor *node_descriptor = wlr_scene_node->data;
-	assert(node_descriptor->type == LAB_NODE_DESC_MENUITEM);
+	assert(node_descriptor->type == LAB_NODE_MENUITEM);
 	return (struct menuitem *)node_descriptor->data;
-}
-
-struct ssd_part *
-node_ssd_part_from_node(struct wlr_scene_node *wlr_scene_node)
-{
-	assert(wlr_scene_node->data);
-	struct node_descriptor *node_descriptor = wlr_scene_node->data;
-	assert(node_descriptor->type == LAB_NODE_DESC_SSD_PART);
-	return (struct ssd_part *)node_descriptor->data;
 }
 
 struct scaled_buffer *
@@ -85,6 +82,20 @@ node_scaled_buffer_from_node(struct wlr_scene_node *wlr_scene_node)
 {
 	assert(wlr_scene_node->data);
 	struct node_descriptor *node_descriptor = wlr_scene_node->data;
-	assert(node_descriptor->type == LAB_NODE_DESC_SCALED_BUFFER);
+	assert(node_descriptor->type == LAB_NODE_SCALED_BUFFER);
 	return (struct scaled_buffer *)node_descriptor->data;
+}
+
+struct ssd_button *
+node_try_ssd_button_from_node(struct wlr_scene_node *wlr_scene_node)
+{
+	assert(wlr_scene_node->data);
+	struct node_descriptor *node_descriptor = wlr_scene_node->data;
+
+	if (node_descriptor->type >= LAB_NODE_BUTTON_FIRST
+			&& node_descriptor->type <= LAB_NODE_BUTTON_LAST) {
+		return (struct ssd_button *)node_descriptor->data;
+	}
+
+	return NULL;
 }

--- a/src/osd/osd.c
+++ b/src/osd/osd.c
@@ -13,6 +13,7 @@
 #include "output.h"
 #include "scaled-buffer/scaled-font-buffer.h"
 #include "scaled-buffer/scaled-icon-buffer.h"
+#include "ssd.h"
 #include "theme.h"
 #include "view.h"
 #include "window-rules.h"

--- a/src/output.c
+++ b/src/output.c
@@ -511,17 +511,17 @@ handle_new_output(struct wl_listener *listener, void *data)
 		output->layer_tree[i] =
 			wlr_scene_tree_create(&server->scene->tree);
 		node_descriptor_create(&output->layer_tree[i]->node,
-			LAB_NODE_DESC_TREE, NULL);
+			LAB_NODE_TREE, /*view*/ NULL, /*data*/ NULL);
 	}
 	output->layer_popup_tree = wlr_scene_tree_create(&server->scene->tree);
 	node_descriptor_create(&output->layer_popup_tree->node,
-		LAB_NODE_DESC_TREE, NULL);
+		LAB_NODE_TREE, /*view*/ NULL, /*data*/ NULL);
 	output->osd_tree = wlr_scene_tree_create(&server->scene->tree);
 	node_descriptor_create(&output->osd_tree->node,
-		LAB_NODE_DESC_TREE, NULL);
+		LAB_NODE_TREE, /*view*/ NULL, /*data*/ NULL);
 	output->session_lock_tree = wlr_scene_tree_create(&server->scene->tree);
 	node_descriptor_create(&output->session_lock_tree->node,
-		LAB_NODE_DESC_TREE, NULL);
+		LAB_NODE_TREE, /*view*/ NULL, /*data*/ NULL);
 
 	/*
 	 * Set the z-positions to achieve the following order (from top to

--- a/src/scaled-buffer/scaled-buffer.c
+++ b/src/scaled-buffer/scaled-buffer.c
@@ -198,7 +198,7 @@ scaled_buffer_create(struct wlr_scene_tree *parent,
 		return NULL;
 	}
 	node_descriptor_create(&self->scene_buffer->node,
-		LAB_NODE_DESC_SCALED_BUFFER, self);
+		LAB_NODE_SCALED_BUFFER, /*view*/ NULL, self);
 
 	self->impl = impl;
 	/*

--- a/src/server.c
+++ b/src/server.c
@@ -549,8 +549,6 @@ server_init(struct server *server)
 	wl_list_init(&server->views);
 	wl_list_init(&server->unmanaged_surfaces);
 
-	server->ssd_hover_state = ssd_hover_state_new();
-
 	server->scene = wlr_scene_create();
 	if (!server->scene) {
 		wlr_log(WLR_ERROR, "unable to create scene");
@@ -795,5 +793,4 @@ server_finish(struct server *server)
 	wlr_scene_node_destroy(&server->scene->tree.node);
 
 	wl_display_destroy(server->wl_display);
-	free(server->ssd_hover_state);
 }

--- a/src/server.c
+++ b/src/server.c
@@ -65,6 +65,7 @@
 #include "resize-indicator.h"
 #include "scaled-buffer/scaled-buffer.h"
 #include "session-lock.h"
+#include "ssd.h"
 #include "theme.h"
 #include "view.h"
 #include "workspaces.h"

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -135,7 +135,7 @@ handle_new_surface(struct wl_listener *listener, void *data)
 	struct wlr_scene_tree *surface_tree =
 		wlr_scene_subsurface_tree_create(lock_output->tree, lock_surface->surface);
 	node_descriptor_create(&surface_tree->node,
-		LAB_NODE_DESC_SESSION_LOCK_SURFACE, NULL);
+		LAB_NODE_SESSION_LOCK_SURFACE, /*view*/ NULL, /*data*/ NULL);
 
 	lock_output->surface_destroy.notify = handle_surface_destroy;
 	wl_signal_add(&lock_surface->events.destroy, &lock_output->surface_destroy);

--- a/src/snap.c
+++ b/src/snap.c
@@ -2,12 +2,13 @@
 #include "snap.h"
 #include <assert.h>
 #include <wlr/util/box.h>
+#include <wlr/util/log.h>
 #include "common/border.h"
 #include "config/rcxml.h"
 #include "edges.h"
-#include "labwc.h"
 #include "output.h"
 #include "snap-constraints.h"
+#include "ssd.h"
 #include "view.h"
 
 static void

--- a/src/ssd/meson.build
+++ b/src/ssd/meson.build
@@ -1,7 +1,7 @@
 labwc_sources += files(
   'resize-indicator.c',
   'ssd.c',
-  'ssd-part.c',
+  'ssd-button.c',
   'ssd-titlebar.c',
   'ssd-border.c',
   'ssd-extents.c',

--- a/src/ssd/resize-indicator.c
+++ b/src/ssd/resize-indicator.c
@@ -3,12 +3,12 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
-#include "common/macros.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "resize-indicator.h"
 #include "resize-outlines.h"
 #include "scaled-buffer/scaled-font-buffer.h"
+#include "ssd.h"
 #include "theme.h"
 #include "view.h"
 

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -5,6 +5,7 @@
 #include "common/macros.h"
 #include "common/scene-helpers.h"
 #include "labwc.h"
+#include "ssd.h"
 #include "ssd-internal.h"
 #include "theme.h"
 #include "view.h"

--- a/src/ssd/ssd-part.c
+++ b/src/ssd/ssd-part.c
@@ -32,7 +32,7 @@ handle_node_destroy(struct wl_listener *listener, void *data)
  * to is destroyed.
  */
 static void
-init_ssd_part(struct ssd_part *part, enum ssd_part_type type,
+init_ssd_part(struct ssd_part *part, enum lab_node_type type,
 		struct view *view, struct wlr_scene_node *node)
 {
 	part->type = type;
@@ -45,17 +45,17 @@ init_ssd_part(struct ssd_part *part, enum ssd_part_type type,
 }
 
 struct ssd_part *
-attach_ssd_part(enum ssd_part_type type, struct view *view,
+attach_ssd_part(enum lab_node_type type, struct view *view,
 		struct wlr_scene_node *node)
 {
-	assert(!ssd_part_contains(LAB_SSD_BUTTON, type));
+	assert(!node_type_contains(LAB_NODE_BUTTON, type));
 	struct ssd_part *part = znew(*part);
 	init_ssd_part(part, type, view, node);
 	return part;
 }
 
 struct ssd_part_button *
-attach_ssd_part_button(struct wl_list *button_parts, enum ssd_part_type type,
+attach_ssd_part_button(struct wl_list *button_parts, enum lab_node_type type,
 		struct wlr_scene_tree *parent,
 		struct lab_img *imgs[LAB_BS_ALL + 1],
 		int x, int y, struct view *view)
@@ -63,7 +63,7 @@ attach_ssd_part_button(struct wl_list *button_parts, enum ssd_part_type type,
 	struct wlr_scene_tree *root = wlr_scene_tree_create(parent);
 	wlr_scene_node_set_position(&root->node, x, y);
 
-	assert(ssd_part_contains(LAB_SSD_BUTTON, type));
+	assert(node_type_contains(LAB_NODE_BUTTON, type));
 	struct ssd_part_button *button = znew(*button);
 	init_ssd_part(&button->base, type, view, &root->node);
 	wl_list_append(button_parts, &button->link);
@@ -86,7 +86,7 @@ attach_ssd_part_button(struct wl_list *button_parts, enum ssd_part_type type,
 	 */
 	int icon_padding = button_width / 10;
 
-	if (type == LAB_SSD_BUTTON_WINDOW_ICON) {
+	if (type == LAB_NODE_BUTTON_WINDOW_ICON) {
 		struct scaled_icon_buffer *icon_buffer =
 			scaled_icon_buffer_create(root, view->server,
 				button_width - 2 * icon_padding, button_height);
@@ -120,7 +120,7 @@ attach_ssd_part_button(struct wl_list *button_parts, enum ssd_part_type type,
 struct ssd_part_button *
 button_try_from_ssd_part(struct ssd_part *part)
 {
-	if (ssd_part_contains(LAB_SSD_BUTTON, part->type)) {
+	if (node_type_contains(LAB_NODE_BUTTON, part->type)) {
 		return (struct ssd_part_button *)part;
 	}
 	return NULL;

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -6,6 +6,7 @@
 #include "buffer.h"
 #include "config/rcxml.h"
 #include "labwc.h"
+#include "ssd.h"
 #include "ssd-internal.h"
 #include "theme.h"
 #include "view.h"

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -16,12 +16,13 @@
 #include "scaled-buffer/scaled-font-buffer.h"
 #include "scaled-buffer/scaled-icon-buffer.h"
 #include "scaled-buffer/scaled-img-buffer.h"
+#include "ssd.h"
 #include "ssd-internal.h"
 #include "theme.h"
 #include "view.h"
 
 static void set_squared_corners(struct ssd *ssd, bool enable);
-static void set_alt_button_icon(struct ssd *ssd, enum ssd_part_type type, bool enable);
+static void set_alt_button_icon(struct ssd *ssd, enum lab_node_type type, bool enable);
 static void update_visible_buttons(struct ssd *ssd);
 
 void
@@ -33,7 +34,7 @@ ssd_titlebar_create(struct ssd *ssd)
 	int corner_width = ssd_get_corner_width();
 
 	ssd->titlebar.tree = wlr_scene_tree_create(ssd->tree);
-	attach_ssd_part(LAB_SSD_PART_TITLEBAR, view, &ssd->tree->node);
+	attach_ssd_part(LAB_NODE_TITLEBAR, view, &ssd->tree->node);
 
 	enum ssd_active_state active;
 	FOR_EACH_ACTIVE_STATE(active) {
@@ -77,7 +78,7 @@ ssd_titlebar_create(struct ssd *ssd)
 			subtree->tree, theme->titlebar_height,
 			theme->window[active].titlebar_pattern);
 		assert(subtree->title);
-		attach_ssd_part(LAB_SSD_PART_TITLE,
+		attach_ssd_part(LAB_NODE_TITLE,
 			view, &subtree->title->scene_buffer->node);
 
 		/* Buttons */
@@ -115,7 +116,7 @@ ssd_titlebar_create(struct ssd *ssd)
 	bool maximized = view->maximized == VIEW_AXIS_BOTH;
 	bool squared = ssd_should_be_squared(ssd);
 	if (maximized) {
-		set_alt_button_icon(ssd, LAB_SSD_BUTTON_MAXIMIZE, true);
+		set_alt_button_icon(ssd, LAB_NODE_BUTTON_MAXIMIZE, true);
 		ssd->state.was_maximized = true;
 	}
 	if (squared) {
@@ -124,11 +125,11 @@ ssd_titlebar_create(struct ssd *ssd)
 	set_squared_corners(ssd, maximized || squared);
 
 	if (view->shaded) {
-		set_alt_button_icon(ssd, LAB_SSD_BUTTON_SHADE, true);
+		set_alt_button_icon(ssd, LAB_NODE_BUTTON_SHADE, true);
 	}
 
 	if (view->visible_on_all_workspaces) {
-		set_alt_button_icon(ssd, LAB_SSD_BUTTON_OMNIPRESENT, true);
+		set_alt_button_icon(ssd, LAB_NODE_BUTTON_OMNIPRESENT, true);
 	}
 }
 
@@ -189,7 +190,7 @@ set_squared_corners(struct ssd *ssd, bool enable)
 }
 
 static void
-set_alt_button_icon(struct ssd *ssd, enum ssd_part_type type, bool enable)
+set_alt_button_icon(struct ssd *ssd, enum lab_node_type type, bool enable)
 {
 	enum ssd_active_state active;
 	FOR_EACH_ACTIVE_STATE(active) {
@@ -281,19 +282,19 @@ ssd_titlebar_update(struct ssd *ssd)
 			|| ssd->state.was_squared != squared) {
 		set_squared_corners(ssd, maximized || squared);
 		if (ssd->state.was_maximized != maximized) {
-			set_alt_button_icon(ssd, LAB_SSD_BUTTON_MAXIMIZE, maximized);
+			set_alt_button_icon(ssd, LAB_NODE_BUTTON_MAXIMIZE, maximized);
 		}
 		ssd->state.was_maximized = maximized;
 		ssd->state.was_squared = squared;
 	}
 
 	if (ssd->state.was_shaded != view->shaded) {
-		set_alt_button_icon(ssd, LAB_SSD_BUTTON_SHADE, view->shaded);
+		set_alt_button_icon(ssd, LAB_NODE_BUTTON_SHADE, view->shaded);
 		ssd->state.was_shaded = view->shaded;
 	}
 
 	if (ssd->state.was_omnipresent != view->visible_on_all_workspaces) {
-		set_alt_button_icon(ssd, LAB_SSD_BUTTON_OMNIPRESENT,
+		set_alt_button_icon(ssd, LAB_NODE_BUTTON_OMNIPRESENT,
 			view->visible_on_all_workspaces);
 		ssd->state.was_omnipresent = view->visible_on_all_workspaces;
 	}

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -492,8 +492,7 @@ ssd_update_title(struct ssd *ssd)
 }
 
 void
-ssd_update_button_hover(struct wlr_scene_node *node,
-		struct ssd_hover_state *hover_state)
+ssd_update_button_hover(struct server *server, struct wlr_scene_node *node)
 {
 	struct ssd_part_button *button = NULL;
 
@@ -502,7 +501,7 @@ ssd_update_button_hover(struct wlr_scene_node *node,
 		if (desc->type == LAB_NODE_DESC_SSD_PART) {
 			button = button_try_from_ssd_part(
 					node_ssd_part_from_node(node));
-			if (button == hover_state->button) {
+			if (button == server->hover_button) {
 				/* Cursor is still on the same button */
 				return;
 			}
@@ -510,15 +509,12 @@ ssd_update_button_hover(struct wlr_scene_node *node,
 	}
 
 	/* Disable old hover */
-	if (hover_state->button) {
-		update_button_state(hover_state->button, LAB_BS_HOVERD, false);
-		hover_state->view = NULL;
-		hover_state->button = NULL;
+	if (server->hover_button) {
+		update_button_state(server->hover_button, LAB_BS_HOVERD, false);
 	}
+	server->hover_button = button;
 	if (button) {
 		update_button_state(button, LAB_BS_HOVERD, true);
-		hover_state->view = button->base.view;
-		hover_state->button = button;
 	}
 }
 

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -34,7 +34,8 @@ ssd_titlebar_create(struct ssd *ssd)
 	int corner_width = ssd_get_corner_width();
 
 	ssd->titlebar.tree = wlr_scene_tree_create(ssd->tree);
-	attach_ssd_part(LAB_NODE_TITLEBAR, view, &ssd->tree->node);
+	node_descriptor_create(&ssd->tree->node,
+		LAB_NODE_TITLEBAR, view, /*data*/ NULL);
 
 	enum ssd_active_state active;
 	FOR_EACH_ACTIVE_STATE(active) {
@@ -78,8 +79,8 @@ ssd_titlebar_create(struct ssd *ssd)
 			subtree->tree, theme->titlebar_height,
 			theme->window[active].titlebar_pattern);
 		assert(subtree->title);
-		attach_ssd_part(LAB_NODE_TITLE,
-			view, &subtree->title->scene_buffer->node);
+		node_descriptor_create(&subtree->title->scene_buffer->node,
+			LAB_NODE_TITLE, view, /*data*/ NULL);
 
 		/* Buttons */
 		struct title_button *b;
@@ -94,7 +95,7 @@ ssd_titlebar_create(struct ssd *ssd)
 		wl_list_for_each(b, &rc.title_buttons_left, link) {
 			struct lab_img **imgs =
 				theme->window[active].button_imgs[b->type];
-			attach_ssd_part_button(&subtree->buttons_left, b->type, parent,
+			attach_ssd_button(&subtree->buttons_left, b->type, parent,
 				imgs, x, y, view);
 			x += theme->window_button_width + theme->window_button_spacing;
 		}
@@ -104,7 +105,7 @@ ssd_titlebar_create(struct ssd *ssd)
 			x -= theme->window_button_width + theme->window_button_spacing;
 			struct lab_img **imgs =
 				theme->window[active].button_imgs[b->type];
-			attach_ssd_part_button(&subtree->buttons_right, b->type, parent,
+			attach_ssd_button(&subtree->buttons_right, b->type, parent,
 				imgs, x, y, view);
 		}
 	}
@@ -134,7 +135,7 @@ ssd_titlebar_create(struct ssd *ssd)
 }
 
 static void
-update_button_state(struct ssd_part_button *button, enum lab_button_state state,
+update_button_state(struct ssd_button *button, enum lab_button_state state,
 		bool enable)
 {
 	if (enable) {
@@ -177,7 +178,7 @@ set_squared_corners(struct ssd *ssd, bool enable)
 		wlr_scene_node_set_enabled(&subtree->corner_right->node, !enable);
 
 		/* (Un)round the corner buttons */
-		struct ssd_part_button *button;
+		struct ssd_button *button;
 		wl_list_for_each(button, &subtree->buttons_left, link) {
 			update_button_state(button, LAB_BS_ROUNDED, !enable);
 			break;
@@ -196,15 +197,15 @@ set_alt_button_icon(struct ssd *ssd, enum lab_node_type type, bool enable)
 	FOR_EACH_ACTIVE_STATE(active) {
 		struct ssd_titlebar_subtree *subtree = &ssd->titlebar.subtrees[active];
 
-		struct ssd_part_button *button;
+		struct ssd_button *button;
 		wl_list_for_each(button, &subtree->buttons_left, link) {
-			if (button->base.type == type) {
+			if (button->type == type) {
 				update_button_state(button,
 					LAB_BS_TOGGLED, enable);
 			}
 		}
 		wl_list_for_each(button, &subtree->buttons_right, link) {
-			if (button->base.type == type) {
+			if (button->type == type) {
 				update_button_state(button,
 					LAB_BS_TOGGLED, enable);
 			}
@@ -251,16 +252,16 @@ update_visible_buttons(struct ssd *ssd)
 		struct ssd_titlebar_subtree *subtree = &ssd->titlebar.subtrees[active];
 		int button_count = 0;
 
-		struct ssd_part_button *button;
+		struct ssd_button *button;
 		wl_list_for_each(button, &subtree->buttons_left, link) {
-			wlr_scene_node_set_enabled(button->base.node,
+			wlr_scene_node_set_enabled(button->node,
 				button_count < button_count_left);
 			button_count++;
 		}
 
 		button_count = 0;
 		wl_list_for_each(button, &subtree->buttons_right, link) {
-			wlr_scene_node_set_enabled(button->base.node,
+			wlr_scene_node_set_enabled(button->node,
 				button_count < button_count_right);
 			button_count++;
 		}
@@ -317,9 +318,9 @@ ssd_titlebar_update(struct ssd *ssd)
 			MAX(width - bg_offset * 2, 0), theme->titlebar_height);
 
 		x = theme->window_titlebar_padding_width;
-		struct ssd_part_button *button;
+		struct ssd_button *button;
 		wl_list_for_each(button, &subtree->buttons_left, link) {
-			wlr_scene_node_set_position(button->base.node, x, y);
+			wlr_scene_node_set_position(button->node, x, y);
 			x += theme->window_button_width + theme->window_button_spacing;
 		}
 
@@ -330,7 +331,7 @@ ssd_titlebar_update(struct ssd *ssd)
 		x = width - theme->window_titlebar_padding_width + theme->window_button_spacing;
 		wl_list_for_each(button, &subtree->buttons_right, link) {
 			x -= theme->window_button_width + theme->window_button_spacing;
-			wlr_scene_node_set_position(button->base.node, x, y);
+			wlr_scene_node_set_position(button->node, x, y);
 		}
 	}
 
@@ -419,14 +420,14 @@ get_title_offsets(struct ssd *ssd, int *offset_left, int *offset_right)
 	*offset_left = padding_width;
 	*offset_right = padding_width;
 
-	struct ssd_part_button *button;
+	struct ssd_button *button;
 	wl_list_for_each(button, &subtree->buttons_left, link) {
-		if (button->base.node->enabled) {
+		if (button->node->enabled) {
 			*offset_left += button_width + button_spacing;
 		}
 	}
 	wl_list_for_each(button, &subtree->buttons_right, link) {
-		if (button->base.node->enabled) {
+		if (button->node->enabled) {
 			*offset_right += button_width + button_spacing;
 		}
 	}
@@ -494,17 +495,13 @@ ssd_update_title(struct ssd *ssd)
 void
 ssd_update_button_hover(struct server *server, struct wlr_scene_node *node)
 {
-	struct ssd_part_button *button = NULL;
+	struct ssd_button *button = NULL;
 
 	if (node && node->data) {
-		struct node_descriptor *desc = node->data;
-		if (desc->type == LAB_NODE_DESC_SSD_PART) {
-			button = button_try_from_ssd_part(
-					node_ssd_part_from_node(node));
-			if (button == server->hover_button) {
-				/* Cursor is still on the same button */
-				return;
-			}
+		button = node_try_ssd_button_from_node(node);
+		if (button == server->hover_button) {
+			/* Cursor is still on the same button */
+			return;
 		}
 	}
 

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -14,6 +14,7 @@
 #include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
+#include "node.h"
 #include "ssd-internal.h"
 #include "theme.h"
 #include "view.h"
@@ -145,7 +146,8 @@ ssd_create(struct view *view, bool active)
 
 	ssd->view = view;
 	ssd->tree = wlr_scene_tree_create(view->scene_tree);
-	attach_ssd_part(LAB_NODE_NONE, view, &ssd->tree->node);
+	node_descriptor_create(&ssd->tree->node,
+		LAB_NODE_NONE, view, /*data*/ NULL);
 	wlr_scene_node_lower_to_bottom(&ssd->tree->node);
 	ssd->titlebar.height = view->server->theme->titlebar_height;
 	ssd_shadow_create(ssd);
@@ -265,7 +267,8 @@ ssd_destroy(struct ssd *ssd)
 	/* Maybe reset hover view */
 	struct view *view = ssd->view;
 	struct server *server = view->server;
-	if (server->hover_button && server->hover_button->base.view == view) {
+	if (server->hover_button && node_view_from_node(
+			server->hover_button->node) == view) {
 		server->hover_button = NULL;
 	}
 
@@ -341,18 +344,6 @@ ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable)
 		? rc.theme->window_toggled_keybinds_color
 		: rc.theme->window[THEME_ACTIVE].border_color;
 	wlr_scene_rect_set_color(ssd->border.subtrees[SSD_ACTIVE].top, color);
-}
-
-enum lab_node_type
-ssd_part_get_type(const struct ssd_part *part)
-{
-	return part ? part->type : LAB_NODE_NONE;
-}
-
-struct view *
-ssd_part_get_view(const struct ssd_part *part)
-{
-	return part ? part->view : NULL;
 }
 
 bool

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -264,11 +264,9 @@ ssd_destroy(struct ssd *ssd)
 
 	/* Maybe reset hover view */
 	struct view *view = ssd->view;
-	struct ssd_hover_state *hover_state;
-	hover_state = view->server->ssd_hover_state;
-	if (hover_state->view == view) {
-		hover_state->view = NULL;
-		hover_state->button = NULL;
+	struct server *server = view->server;
+	if (server->hover_button && server->hover_button->base.view == view) {
+		server->hover_button = NULL;
 	}
 
 	/* Destroy subcomponents */
@@ -343,12 +341,6 @@ ssd_enable_keybind_inhibit_indicator(struct ssd *ssd, bool enable)
 		? rc.theme->window_toggled_keybinds_color
 		: rc.theme->window[THEME_ACTIVE].border_color;
 	wlr_scene_rect_set_color(ssd->border.subtrees[SSD_ACTIVE].top, color);
-}
-
-struct ssd_hover_state *
-ssd_hover_state_new(void)
-{
-	return znew(struct ssd_hover_state);
 }
 
 enum lab_node_type

--- a/src/theme.c
+++ b/src/theme.c
@@ -39,7 +39,7 @@ struct button {
 	const char *name;
 	const char *alt_name;
 	const char *fallback_button;  /* built-in 6x6 button */
-	enum ssd_part_type type;
+	enum lab_node_type type;
 	uint8_t state_set;
 };
 
@@ -290,94 +290,94 @@ load_buttons(struct theme *theme)
 	struct button buttons[] = { {
 		.name = "menu",
 		.fallback_button = (const char[]){ 0x00, 0x21, 0x33, 0x1E, 0x0C, 0x00 },
-		.type = LAB_SSD_BUTTON_WINDOW_MENU,
+		.type = LAB_NODE_BUTTON_WINDOW_MENU,
 		.state_set = 0,
 	}, {
 		.name = "iconify",
 		.fallback_button = (const char[]){ 0x00, 0x00, 0x00, 0x00, 0x3f, 0x3f },
-		.type = LAB_SSD_BUTTON_ICONIFY,
+		.type = LAB_NODE_BUTTON_ICONIFY,
 		.state_set = 0,
 	}, {
 		.name = "max",
 		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x21, 0x21, 0x21, 0x3f },
-		.type = LAB_SSD_BUTTON_MAXIMIZE,
+		.type = LAB_NODE_BUTTON_MAXIMIZE,
 		.state_set = 0,
 	}, {
 		.name = "max_toggled",
 		.fallback_button = (const char[]){ 0x3e, 0x22, 0x2f, 0x29, 0x39, 0x0f },
-		.type = LAB_SSD_BUTTON_MAXIMIZE,
+		.type = LAB_NODE_BUTTON_MAXIMIZE,
 		.state_set = LAB_BS_TOGGLED,
 	}, {
 		.name = "shade",
 		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x00, 0x0c, 0x1e, 0x3f },
-		.type = LAB_SSD_BUTTON_SHADE,
+		.type = LAB_NODE_BUTTON_SHADE,
 		.state_set = 0,
 	}, {
 		.name = "shade_toggled",
 		.fallback_button = (const char[]){ 0x3f, 0x3f, 0x00, 0x3f, 0x1e, 0x0c },
-		.type = LAB_SSD_BUTTON_SHADE,
+		.type = LAB_NODE_BUTTON_SHADE,
 		.state_set = LAB_BS_TOGGLED,
 	}, {
 		.name = "desk",
 		.fallback_button = (const char[]){ 0x33, 0x33, 0x00, 0x00, 0x33, 0x33 },
-		.type = LAB_SSD_BUTTON_OMNIPRESENT,
+		.type = LAB_NODE_BUTTON_OMNIPRESENT,
 		.state_set = 0,
 	}, {
 		.name = "desk_toggled",
 		.fallback_button = (const char[]){ 0x00, 0x1e, 0x1a, 0x16, 0x1e, 0x00 },
-		.type = LAB_SSD_BUTTON_OMNIPRESENT,
+		.type = LAB_NODE_BUTTON_OMNIPRESENT,
 		.state_set = LAB_BS_TOGGLED,
 	}, {
 		.name = "close",
 		.fallback_button = (const char[]){ 0x33, 0x3f, 0x1e, 0x1e, 0x3f, 0x33 },
-		.type = LAB_SSD_BUTTON_CLOSE,
+		.type = LAB_NODE_BUTTON_CLOSE,
 		.state_set = 0,
 	}, {
 		.name = "menu_hover",
-		.type = LAB_SSD_BUTTON_WINDOW_MENU,
+		.type = LAB_NODE_BUTTON_WINDOW_MENU,
 		.state_set = LAB_BS_HOVERD,
 		/* no fallback (non-hover variant is used instead) */
 	}, {
 		.name = "iconify_hover",
-		.type = LAB_SSD_BUTTON_ICONIFY,
+		.type = LAB_NODE_BUTTON_ICONIFY,
 		.state_set = LAB_BS_HOVERD,
 		/* no fallback (non-hover variant is used instead) */
 	}, {
 		.name = "max_hover",
-		.type = LAB_SSD_BUTTON_MAXIMIZE,
+		.type = LAB_NODE_BUTTON_MAXIMIZE,
 		.state_set = LAB_BS_HOVERD,
 		/* no fallback (non-hover variant is used instead) */
 	}, {
 		.name = "max_toggled_hover",
 		.alt_name = "max_hover_toggled",
-		.type = LAB_SSD_BUTTON_MAXIMIZE,
+		.type = LAB_NODE_BUTTON_MAXIMIZE,
 		.state_set = LAB_BS_TOGGLED | LAB_BS_HOVERD,
 		/* no fallback (non-hover variant is used instead) */
 	}, {
 		.name = "shade_hover",
-		.type = LAB_SSD_BUTTON_SHADE,
+		.type = LAB_NODE_BUTTON_SHADE,
 		.state_set = LAB_BS_HOVERD,
 		/* no fallback (non-hover variant is used instead) */
 	}, {
 		.name = "shade_toggled_hover",
 		.alt_name = "shade_hover_toggled",
-		.type = LAB_SSD_BUTTON_SHADE,
+		.type = LAB_NODE_BUTTON_SHADE,
 		.state_set = LAB_BS_TOGGLED | LAB_BS_HOVERD,
 		/* no fallback (non-hover variant is used instead) */
 	}, {
 		.name = "desk_hover",
 		/* no fallback (non-hover variant is used instead) */
-		.type = LAB_SSD_BUTTON_OMNIPRESENT,
+		.type = LAB_NODE_BUTTON_OMNIPRESENT,
 		.state_set = LAB_BS_HOVERD,
 	}, {
 		.name = "desk_toggled_hover",
 		.alt_name = "desk_hover_toggled",
-		.type = LAB_SSD_BUTTON_OMNIPRESENT,
+		.type = LAB_NODE_BUTTON_OMNIPRESENT,
 		.state_set = LAB_BS_TOGGLED | LAB_BS_HOVERD,
 		/* no fallback (non-hover variant is used instead) */
 	}, {
 		.name = "close_hover",
-		.type = LAB_SSD_BUTTON_CLOSE,
+		.type = LAB_NODE_BUTTON_CLOSE,
 		.state_set = LAB_BS_HOVERD,
 		/* no fallback (non-hover variant is used instead) */
 	}, };
@@ -572,8 +572,8 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->window_button_spacing = 0;
 	theme->window_button_hover_bg_corner_radius = 0;
 
-	for (enum ssd_part_type type = LAB_SSD_BUTTON_FIRST;
-			type <= LAB_SSD_BUTTON_LAST; type++) {
+	for (enum lab_node_type type = LAB_NODE_BUTTON_FIRST;
+			type <= LAB_NODE_BUTTON_LAST; type++) {
 		parse_hexstr("#000000",
 			theme->window[THEME_INACTIVE].button_colors[type]);
 		parse_hexstr("#000000",
@@ -802,15 +802,15 @@ entry(struct theme *theme, const char *key, const char *value)
 
 	/* universal button */
 	if (match_glob(key, "window.active.button.unpressed.image.color")) {
-		for (enum ssd_part_type type = LAB_SSD_BUTTON_FIRST;
-				type <= LAB_SSD_BUTTON_LAST; type++) {
+		for (enum lab_node_type type = LAB_NODE_BUTTON_FIRST;
+				type <= LAB_NODE_BUTTON_LAST; type++) {
 			parse_color(value,
 				theme->window[THEME_ACTIVE].button_colors[type]);
 		}
 	}
 	if (match_glob(key, "window.inactive.button.unpressed.image.color")) {
-		for (enum ssd_part_type type = LAB_SSD_BUTTON_FIRST;
-				type <= LAB_SSD_BUTTON_LAST; type++) {
+		for (enum lab_node_type type = LAB_NODE_BUTTON_FIRST;
+				type <= LAB_NODE_BUTTON_LAST; type++) {
 			parse_color(value,
 				theme->window[THEME_INACTIVE].button_colors[type]);
 		}
@@ -819,55 +819,55 @@ entry(struct theme *theme, const char *key, const char *value)
 	/* individual buttons */
 	if (match_glob(key, "window.active.button.menu.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_ACTIVE]
-			.button_colors[LAB_SSD_BUTTON_WINDOW_MENU]);
+			.button_colors[LAB_NODE_BUTTON_WINDOW_MENU]);
 		parse_color(value, theme->window[THEME_ACTIVE]
-			.button_colors[LAB_SSD_BUTTON_WINDOW_ICON]);
+			.button_colors[LAB_NODE_BUTTON_WINDOW_ICON]);
 	}
 	if (match_glob(key, "window.active.button.iconify.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_ACTIVE]
-			.button_colors[LAB_SSD_BUTTON_ICONIFY]);
+			.button_colors[LAB_NODE_BUTTON_ICONIFY]);
 	}
 	if (match_glob(key, "window.active.button.max.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_ACTIVE]
-			.button_colors[LAB_SSD_BUTTON_MAXIMIZE]);
+			.button_colors[LAB_NODE_BUTTON_MAXIMIZE]);
 	}
 	if (match_glob(key, "window.active.button.shade.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_ACTIVE]
-			.button_colors[LAB_SSD_BUTTON_SHADE]);
+			.button_colors[LAB_NODE_BUTTON_SHADE]);
 	}
 	if (match_glob(key, "window.active.button.desk.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_ACTIVE]
-			.button_colors[LAB_SSD_BUTTON_OMNIPRESENT]);
+			.button_colors[LAB_NODE_BUTTON_OMNIPRESENT]);
 	}
 	if (match_glob(key, "window.active.button.close.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_ACTIVE]
-			.button_colors[LAB_SSD_BUTTON_CLOSE]);
+			.button_colors[LAB_NODE_BUTTON_CLOSE]);
 	}
 	if (match_glob(key, "window.inactive.button.menu.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_INACTIVE]
-			.button_colors[LAB_SSD_BUTTON_WINDOW_MENU]);
+			.button_colors[LAB_NODE_BUTTON_WINDOW_MENU]);
 		parse_color(value, theme->window[THEME_INACTIVE]
-			.button_colors[LAB_SSD_BUTTON_WINDOW_ICON]);
+			.button_colors[LAB_NODE_BUTTON_WINDOW_ICON]);
 	}
 	if (match_glob(key, "window.inactive.button.iconify.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_INACTIVE]
-			.button_colors[LAB_SSD_BUTTON_ICONIFY]);
+			.button_colors[LAB_NODE_BUTTON_ICONIFY]);
 	}
 	if (match_glob(key, "window.inactive.button.max.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_INACTIVE]
-			.button_colors[LAB_SSD_BUTTON_MAXIMIZE]);
+			.button_colors[LAB_NODE_BUTTON_MAXIMIZE]);
 	}
 	if (match_glob(key, "window.inactive.button.shade.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_INACTIVE]
-			.button_colors[LAB_SSD_BUTTON_SHADE]);
+			.button_colors[LAB_NODE_BUTTON_SHADE]);
 	}
 	if (match_glob(key, "window.inactive.button.desk.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_INACTIVE]
-			.button_colors[LAB_SSD_BUTTON_OMNIPRESENT]);
+			.button_colors[LAB_NODE_BUTTON_OMNIPRESENT]);
 	}
 	if (match_glob(key, "window.inactive.button.close.unpressed.image.color")) {
 		parse_color(value, theme->window[THEME_INACTIVE]
-			.button_colors[LAB_SSD_BUTTON_CLOSE]);
+			.button_colors[LAB_NODE_BUTTON_CLOSE]);
 	}
 
 	/* window drop-shadows */
@@ -1811,8 +1811,8 @@ static void destroy_img(struct lab_img **img)
 void
 theme_finish(struct theme *theme)
 {
-	for (enum ssd_part_type type = LAB_SSD_BUTTON_FIRST;
-			type <= LAB_SSD_BUTTON_LAST; type++) {
+	for (enum lab_node_type type = LAB_NODE_BUTTON_FIRST;
+			type <= LAB_NODE_BUTTON_LAST; type++) {
 		for (uint8_t state_set = LAB_BS_DEFAULT;
 				state_set <= LAB_BS_ALL; state_set++) {
 			destroy_img(&theme->window[THEME_INACTIVE]

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -164,5 +164,5 @@ xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup)
 	wlr_popup->base->surface->data =
 		wlr_scene_xdg_surface_create(parent_tree, wlr_popup->base);
 	node_descriptor_create(wlr_popup->base->surface->data,
-		LAB_NODE_DESC_XDG_POPUP, view);
+		LAB_NODE_XDG_POPUP, view, /*data*/ NULL);
 }

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -1023,7 +1023,7 @@ handle_new_xdg_toplevel(struct wl_listener *listener, void *data)
 	}
 	view->content_tree = tree;
 	node_descriptor_create(&view->scene_tree->node,
-		LAB_NODE_DESC_VIEW, view);
+		LAB_NODE_VIEW, view, /*data*/ NULL);
 
 	/*
 	 * The xdg_toplevel_decoration and kde_server_decoration protocols

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -17,7 +17,6 @@
 #include "labwc.h"
 #include "node.h"
 #include "output.h"
-#include "ssd.h"
 #include "view.h"
 #include "view-impl-common.h"
 #include "window-rules.h"

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -1090,7 +1090,8 @@ xwayland_view_create(struct server *server,
 
 	view->workspace = server->workspaces.current;
 	view->scene_tree = wlr_scene_tree_create(view->workspace->tree);
-	node_descriptor_create(&view->scene_tree->node, LAB_NODE_DESC_VIEW, view);
+	node_descriptor_create(&view->scene_tree->node,
+		LAB_NODE_VIEW, view, /*data*/ NULL);
 
 	CONNECT_SIGNAL(xsurface, view, destroy);
 	CONNECT_SIGNAL(xsurface, view, request_minimize);


### PR DESCRIPTION
First of all, as noted in https://github.com/labwc/labwc/pull/2999#issuecomment-3191581771, `enum ssd_part_type` contains several node types that are not actually part of server-side decorations (ROOT, MENU, OSD, etc.) So rename it to `lab_node_type` and move it to a common location `common/node-type.c/h`, along with some related conversion/comparison functions.

Second, eliminate `struct ssd_hover_state` (addressing a FIXME) and just store a pointer to the button instead. The view pointer can be fetched indirectly from that.

Finally, I noticed that `struct ssd_part` and `struct node_descriptor` seem to have essentially the same purpose: tag a `wlr_scene_node` with some extra data indicating what we're using it for. And as with `enum ssd_part_type` (now `lab_node_type`), `ssd_part` is used for several types of nodes that are not part of SSD.

So instead of the current chaining (`node_descriptor` -> `ssd_part`), let's flatten/unify the two structs.

In detail:

- First, merge `enum node_descriptor_type` into `enum lab_node_type`.
- Add a separate view pointer in `node_descriptor`, since in the case of SSD buttons we need separate view and button data pointers.
- Rename `ssd_part_button` to simply `ssd_button`. It no longer contains an `ssd_part` as base.
- Add `node_try_ssd_button_from_node()` which replaces `node_ssd_part_from_node()` + `button_try_from_ssd_part()`.
- Factor out `ssd_button_free()` to be called in node descriptor destroy.
- Finish up by slightly reorganizing `get_cursor_context()` to handle the unified structs.

Overall, this simplifies the code a bit, and in my opinion makes it easier to understand. No functional change intended.

This builds heavily on:
- #2993 

So if @tokyo4j has time to review this, it would be appreciated.