### PR TITLE
Trivial cleanups

### DIFF
--- a/include/common/array.h
+++ b/include/common/array.h
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 #ifndef LABWC_ARRAY_H
 #define LABWC_ARRAY_H
-#include <stdio.h>
-#include <stdlib.h>
+
 #include <wayland-server-core.h>
+#include "common/mem.h"
 
 /*
  * Wayland's wl_array API is a bit sparse consisting only of
@@ -66,10 +66,7 @@ wl_array_len(struct wl_array *array)
 #define array_add(_arr, _val) do {                           \
 		__typeof__(_val) *_entry = wl_array_add(     \
 			(_arr), sizeof(__typeof__(_val)));   \
-		if (!_entry) {                               \
-			perror("Failed to allocate memory"); \
-			exit(EXIT_FAILURE);                  \
-		}                                            \
+		die_if_null(_entry);                         \
 		*_entry = (_val);                            \
 	} while (0)
 

--- a/include/common/mem.h
+++ b/include/common/mem.h
@@ -5,6 +5,12 @@
 #include <stdlib.h>
 
 /*
+ * If ptr is NULL, prints an error (based on errno) and exits.
+ * Suitable for checking the return value of malloc() etc.
+ */
+void die_if_null(void *ptr);
+
+/*
  * As defined in busybox, weston, etc.
  * Allocates zero-filled memory; calls exit() on error.
  * Returns NULL only if (size == 0).

--- a/include/idle.h
+++ b/include/idle.h
@@ -5,7 +5,7 @@
 struct wl_display;
 struct wlr_seat;
 
-void idle_manager_create(struct wl_display *display, struct wlr_seat *wlr_seat);
+void idle_manager_create(struct wl_display *display);
 void idle_manager_notify_activity(struct wlr_seat *seat);
 
 #endif /* LABWC_IDLE_H */

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 
-static void
+void
 die_if_null(void *ptr)
 {
 	if (!ptr) {

--- a/src/idle.c
+++ b/src/idle.c
@@ -19,7 +19,6 @@ struct lab_idle_manager {
 		struct wl_listener on_new_inhibitor;
 		struct wl_listener on_destroy;
 	} inhibitor;
-	struct wlr_seat *wlr_seat;
 };
 
 static struct lab_idle_manager *manager;
@@ -67,11 +66,10 @@ handle_inhibitor_manager_destroy(struct wl_listener *listener, void *data)
 }
 
 void
-idle_manager_create(struct wl_display *display, struct wlr_seat *wlr_seat)
+idle_manager_create(struct wl_display *display)
 {
 	assert(!manager);
 	manager = znew(*manager);
-	manager->wlr_seat = wlr_seat;
 
 	manager->ext = wlr_idle_notifier_v1_create(display);
 

--- a/src/server.c
+++ b/src/server.c
@@ -661,7 +661,7 @@ server_init(struct server *server)
 	wlr_fractional_scale_manager_v1_create(server->wl_display,
 		LAB_WLR_FRACTIONAL_SCALE_V1_VERSION);
 
-	idle_manager_create(server->wl_display, server->seat.seat);
+	idle_manager_create(server->wl_display);
 
 	server->relative_pointer_manager = wlr_relative_pointer_manager_v1_create(
 		server->wl_display);


### PR DESCRIPTION
A couple of trivial cleanups:

- Remove an unused parameter & struct member
- Make use of a function that exists already, rather than repeating it