### PR TITLE
Header cleanups

### DIFF
--- a/clients/labnag.c
+++ b/clients/labnag.c
@@ -16,17 +16,14 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <strings.h>
 #ifdef __FreeBSD__
 #include <sys/event.h> /* For signalfd() */
 #endif
 #include <sys/signalfd.h>
-#include <sys/stat.h>
 #include <sys/timerfd.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-client.h>
 #include <wayland-cursor.h>
 #include <wlr/util/log.h>
 #include "action-prompt-codes.h"
@@ -61,8 +58,6 @@ struct conf {
 	ssize_t button_margin_right;
 	ssize_t button_padding;
 };
-
-struct nag;
 
 struct pointer {
 	struct wl_pointer *pointer;

--- a/clients/pool-buffer.c
+++ b/clients/pool-buffer.c
@@ -5,18 +5,14 @@
  * Copyright (C) 2016-2017 Drew DeVault
  */
 #define _POSIX_C_SOURCE 200809L
-#include <assert.h>
 #include <cairo.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pango/pangocairo.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/mman.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-client.h>
 #include "pool-buffer.h"
 
 static int anonymous_shm_open(void)

--- a/include/common/nodename.h
+++ b/include/common/nodename.h
@@ -4,7 +4,6 @@
 
 #include <libxml/parser.h>
 #include <libxml/tree.h>
-#include <stdio.h>
 
 /**
  * nodename - give xml node an ascii name

--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -2,7 +2,8 @@
 #ifndef LABWC_KEYBIND_H
 #define LABWC_KEYBIND_H
 
-#include <wlr/types/wlr_keyboard.h>
+#include <stdbool.h>
+#include <wayland-util.h>
 #include <xkbcommon/xkbcommon.h>
 
 #define MAX_KEYSYMS 32

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -8,7 +8,6 @@
 #include <libxml/tree.h>
 
 #include "common/border.h"
-#include "common/buf.h"
 #include "common/font.h"
 #include "common/node-type.h"
 #include "config/types.h"
@@ -41,6 +40,8 @@ enum tiling_events_mode {
 	LAB_TILING_EVENTS_ALWAYS =
 		(LAB_TILING_EVENTS_REGION | LAB_TILING_EVENTS_EDGE),
 };
+
+struct buf;
 
 struct button_map_entry {
 	uint32_t from;

--- a/include/img/img.h
+++ b/include/img/img.h
@@ -4,7 +4,6 @@
 
 #include <cairo.h>
 #include <stdbool.h>
-#include <stdint.h>
 #include <wayland-util.h>
 
 enum lab_img_type {

--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -2,13 +2,15 @@
 #ifndef LABWC_CURSOR_H
 #define LABWC_CURSOR_H
 
-#include <wlr/types/wlr_cursor.h>
+#include <wayland-server-protocol.h>
 #include "common/edge.h"
 #include "common/node-type.h"
 
 struct view;
 struct seat;
 struct server;
+struct wlr_input_device;
+struct wlr_cursor;
 struct wlr_surface;
 struct wlr_scene_node;
 

--- a/include/input/ime.h
+++ b/include/input/ime.h
@@ -3,10 +3,10 @@
 #ifndef LABWC_IME_H
 #define LABWC_IME_H
 
-#include <wlr/types/wlr_text_input_v3.h>
-#include <wlr/types/wlr_input_method_v2.h>
+#include <wayland-server-core.h>
 
 struct keyboard;
+struct wlr_keyboard_key_event;
 
 /*
  * The relay structure manages the relationship between text-inputs and

--- a/include/input/ime.h
+++ b/include/input/ime.h
@@ -5,7 +5,6 @@
 
 #include <wlr/types/wlr_text_input_v3.h>
 #include <wlr/types/wlr_input_method_v2.h>
-#include "labwc.h"
 
 struct keyboard;
 

--- a/include/input/tablet-pad.h
+++ b/include/input/tablet-pad.h
@@ -3,7 +3,6 @@
 #define LABWC_TABLET_PAD_H
 
 #include <wayland-server-core.h>
-#include <wlr/types/wlr_tablet_v2.h>
 
 struct seat;
 struct wlr_device;

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -3,7 +3,6 @@
 #define LABWC_TABLET_H
 
 #include <wayland-server-core.h>
-#include <wlr/types/wlr_tablet_v2.h>
 #include "config/types.h"
 
 struct seat;

--- a/include/input/tablet.h
+++ b/include/input/tablet.h
@@ -4,7 +4,7 @@
 
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_tablet_v2.h>
-#include "config/tablet-tool.h"
+#include "config/types.h"
 
 struct seat;
 struct wlr_device;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -2,6 +2,7 @@
 #ifndef LABWC_H
 #define LABWC_H
 #include "config.h"
+#include <wlr/util/box.h>
 #include <wlr/util/log.h>
 #include "common/set.h"
 #include "input/cursor.h"

--- a/include/layers.h
+++ b/include/layers.h
@@ -1,8 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 #ifndef LABWC_LAYERS_H
 #define LABWC_LAYERS_H
-#include <wayland-server.h>
-#include <wlr/types/wlr_layer_shell_v1.h>
+
+#include <wayland-server-core.h>
+#include <wlr/util/box.h>
 
 struct server;
 struct output;

--- a/include/node.h
+++ b/include/node.h
@@ -1,8 +1,11 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 #ifndef LABWC_NODE_DESCRIPTOR_H
 #define LABWC_NODE_DESCRIPTOR_H
-#include <wlr/types/wlr_scene.h>
+
+#include <wayland-server-core.h>
 #include "common/node-type.h"
+
+struct wlr_scene_node;
 
 struct node_descriptor {
 	enum lab_node_type type;

--- a/include/placement.h
+++ b/include/placement.h
@@ -4,7 +4,8 @@
 
 #include <stdbool.h>
 #include <wlr/util/box.h>
-#include "view.h"
+
+struct view;
 
 bool placement_find_best(struct view *view, struct wlr_box *geometry);
 

--- a/include/resistance.h
+++ b/include/resistance.h
@@ -1,7 +1,11 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 #ifndef LABWC_RESISTANCE_H
 #define LABWC_RESISTANCE_H
-#include "labwc.h"
+
+#include <stdbool.h>
+#include <wlr/util/box.h>
+
+struct view;
 
 /**
  * resistance_unsnap_apply() - Apply resistance when dragging a

--- a/include/scaled-buffer/scaled-img-buffer.h
+++ b/include/scaled-buffer/scaled-img-buffer.h
@@ -2,8 +2,6 @@
 #ifndef LABWC_SCALED_IMG_BUFFER_H
 #define LABWC_SCALED_IMG_BUFFER_H
 
-#include <stdbool.h>
-
 struct wlr_scene_tree;
 struct wlr_scene_node;
 struct wlr_scene_buffer;

--- a/include/session-lock.h
+++ b/include/session-lock.h
@@ -2,7 +2,7 @@
 #ifndef LABWC_SESSION_LOCK_H
 #define LABWC_SESSION_LOCK_H
 
-#include <wlr/types/wlr_session_lock_v1.h>
+#include <wayland-server-core.h>
 
 struct output;
 struct server;

--- a/include/snap.h
+++ b/include/snap.h
@@ -2,9 +2,9 @@
 #ifndef LABWC_SNAP_H
 #define LABWC_SNAP_H
 
-#include "common/border.h"
-#include "view.h"
+#include "common/edge.h"
 
+struct view;
 struct wlr_box;
 
 void snap_move_to_edge(struct view *view,

--- a/include/ssd.h
+++ b/include/ssd.h
@@ -2,7 +2,6 @@
 #ifndef LABWC_SSD_H
 #define LABWC_SSD_H
 
-#include "common/border.h"
 #include "common/node-type.h"
 #include "config/types.h"
 

--- a/include/theme.h
+++ b/include/theme.h
@@ -9,7 +9,7 @@
 #define LABWC_THEME_H
 
 #include <cairo.h>
-#include <wlr/render/wlr_renderer.h>
+#include <stdbool.h>
 #include "common/node-type.h"
 
 struct lab_img;

--- a/src/action.c
+++ b/src/action.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/log.h>
 #include "action-prompt-codes.h"

--- a/src/action.c
+++ b/src/action.c
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/log.h>
 #include "action-prompt-codes.h"
+#include "common/buf.h"
 #include "common/macros.h"
 #include "common/list.h"
 #include "common/mem.h"

--- a/src/common/box.c
+++ b/src/common/box.c
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "common/box.h"
-#include <assert.h>
 #include "common/macros.h"
 
 bool

--- a/src/common/dir.c
+++ b/src/common/dir.c
@@ -7,16 +7,13 @@
 #include "common/dir.h"
 #include <assert.h>
 #include <glib.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/stat.h>
 #include "common/buf.h"
 #include "common/list.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"
 #include "config/rcxml.h"
-#include "labwc.h"
 
 struct dir {
 	const char *prefix;

--- a/src/common/font.c
+++ b/src/common/font.c
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "common/font.h"
 #include <cairo.h>
-#include <drm_fourcc.h>
 #include <pango/pangocairo.h>
-#include <wlr/render/wlr_renderer.h>
-#include <wlr/util/box.h>
 #include <wlr/util/log.h>
 #include "common/graphic-helpers.h"
 #include "common/string-helpers.h"
-#include "labwc.h"
 #include "buffer.h"
 
 PangoFontDescription *

--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -3,7 +3,7 @@
 #include "common/graphic-helpers.h"
 #include <cairo.h>
 #include <glib.h> /* g_ascii_strcasecmp */
-#include <wlr/types/wlr_scene.h>
+#include <wlr/util/box.h>
 #include "common/macros.h"
 #include "xcolor-table.h"
 

--- a/src/common/parse-double.c
+++ b/src/common/parse-double.c
@@ -2,7 +2,6 @@
 #include "common/parse-double.h"
 #include <locale.h>
 #include <stdlib.h>
-#include <string.h>
 #include <wlr/util/log.h>
 #include "common/mem.h"
 

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -5,12 +5,8 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/log.h>
-#include <wlr/util/region.h>
-#include <wlr/util/transform.h>
-#include "labwc.h"
 #include "magnifier.h"
 #include "output.h"
-#include "output-state.h"
 
 struct wlr_surface *
 lab_wlr_surface_from_node(struct wlr_scene_node *node)

--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -6,7 +6,6 @@
 #include <glib.h>
 #include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <wlr/util/log.h>

--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -3,7 +3,6 @@
 #include "config/keybind.h"
 #include <assert.h>
 #include <glib.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <wlr/types/wlr_keyboard_group.h>

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -4,7 +4,6 @@
 #include <assert.h>
 #include <linux/input-event-codes.h>
 #include <strings.h>
-#include <unistd.h>
 #include <wlr/util/log.h>
 #include "common/list.h"
 #include "common/mem.h"

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -2,17 +2,13 @@
 #define _POSIX_C_SOURCE 200809L
 #include "config/rcxml.h"
 #include <assert.h>
-#include <fcntl.h>
 #include <glib.h>
 #include <libxml/parser.h>
-#include <libxml/tree.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <unistd.h>
-#include <wayland-server-core.h>
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
 #include "action.h"

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -16,6 +16,7 @@
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
 #include "action.h"
+#include "common/buf.h"
 #include "common/dir.h"
 #include "common/list.h"
 #include "common/macros.h"

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -8,14 +8,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <wlr/backend/drm.h>
 #include <wlr/backend/multi.h>
 #include <wlr/util/log.h>
 #include "common/buf.h"
 #include "common/dir.h"
 #include "common/file-helpers.h"
-#include "common/mem.h"
 #include "common/parse-bool.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"

--- a/src/config/touch.c
+++ b/src/config/touch.c
@@ -3,7 +3,6 @@
 #include "config/touch.h"
 #include <strings.h>
 #include <wlr/util/log.h>
-#include "common/list.h"
 #include "config/rcxml.h"
 
 static struct touch_config_entry *

--- a/src/desktop-entry.c
+++ b/src/desktop-entry.c
@@ -7,12 +7,10 @@
 #include <string.h>
 #include <strings.h>
 #include <wlr/util/log.h>
-#include "common/macros.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"
 #include "config/rcxml.h"
 #include "img/img.h"
-
 #include "labwc.h"
 
 static const char *debug_libsfdo;

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "config.h"
 #include <assert.h>
+#include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_xdg_shell.h>

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -10,13 +10,10 @@
 #include "labwc.h"
 #include "layers.h"
 #include "node.h"
-#include "osd.h"
 #include "output.h"
 #include "ssd.h"
 #include "view.h"
-#include "window-rules.h"
 #include "workspaces.h"
-#include "xwayland.h"
 
 #if HAVE_XWAYLAND
 #include <wlr/xwayland.h>

--- a/src/edges.c
+++ b/src/edges.c
@@ -3,7 +3,6 @@
 #include <assert.h>
 #include <limits.h>
 #include <pixman.h>
-#include <wlr/util/edges.h>
 #include <wlr/util/box.h>
 #include "common/border.h"
 #include "common/box.h"

--- a/src/edges.c
+++ b/src/edges.c
@@ -3,6 +3,8 @@
 #include <assert.h>
 #include <limits.h>
 #include <pixman.h>
+#include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
 #include "common/border.h"
 #include "common/box.h"

--- a/src/img/img-png.c
+++ b/src/img/img-png.c
@@ -4,12 +4,10 @@
  */
 #define _POSIX_C_SOURCE 200809L
 #include "img/img-png.h"
-#include <assert.h>
 #include <cairo.h>
 #include <png.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <wlr/util/log.h>
 #include "buffer.h"
 #include "common/string-helpers.h"

--- a/src/img/img-svg.c
+++ b/src/img/img-svg.c
@@ -6,13 +6,10 @@
 #include "img/img-svg.h"
 #include <cairo.h>
 #include <librsvg/rsvg.h>
-#include <stdbool.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <wlr/util/log.h>
 #include "buffer.h"
 #include "common/string-helpers.h"
-#include "labwc.h"
 
 RsvgHandle *
 img_svg_load(const char *filename)

--- a/src/img/img-xbm.c
+++ b/src/img/img-xbm.c
@@ -8,13 +8,10 @@
 #define _POSIX_C_SOURCE 200809L
 #include "img/img-xbm.h"
 #include <assert.h>
-#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <drm_fourcc.h>
-#include "img/img.h"
 #include "common/grab-file.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"

--- a/src/img/img.c
+++ b/src/img/img.c
@@ -2,7 +2,6 @@
 
 #include "img/img.h"
 #include <assert.h>
-#include <wlr/util/log.h>
 #include "buffer.h"
 #include "config.h"
 #include "common/box.h"

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -4,8 +4,10 @@
 #include <assert.h>
 #include <time.h>
 #include <wlr/backend/libinput.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_cursor_shape_v1.h>
 #include <wlr/types/wlr_data_device.h>
+#include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_primary_selection.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -2,8 +2,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "input/cursor.h"
 #include <assert.h>
-#include <linux/input-event-codes.h>
-#include <sys/time.h>
 #include <time.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/types/wlr_cursor_shape_v1.h>
@@ -19,7 +17,6 @@
 #include "action.h"
 #include "common/macros.h"
 #include "common/mem.h"
-#include "common/scene-helpers.h"
 #include "common/surface-helpers.h"
 #include "config/mousebind.h"
 #include "config/rcxml.h"
@@ -33,7 +30,6 @@
 #include "layers.h"
 #include "menu/menu.h"
 #include "output.h"
-#include "regions.h"
 #include "resistance.h"
 #include "resize-outlines.h"
 #include "ssd.h"

--- a/src/input/gestures.c
+++ b/src/input/gestures.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "input/gestures.h"
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_pointer_gestures_v1.h>
 #include "common/macros.h"
 #include "labwc.h"

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -11,7 +11,6 @@
 #include "labwc.h"
 #include "node.h"
 #include "output.h"
-#include "view.h"
 
 #define SAME_CLIENT(wlr_obj1, wlr_obj2) \
 	(wl_resource_get_client((wlr_obj1)->resource) \

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -3,7 +3,12 @@
 
 #include "input/ime.h"
 #include <assert.h>
+#include <wlr/types/wlr_input_method_v2.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_scene.h>
+#include <wlr/types/wlr_seat.h>
+#include <wlr/types/wlr_text_input_v3.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include "common/mem.h"

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include "common/mem.h"
 #include "input/keyboard.h"
+#include "labwc.h"
 #include "node.h"
 #include "output.h"
 #include "view.h"

--- a/src/input/key-state.c
+++ b/src/input/key-state.c
@@ -4,8 +4,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <wlr/util/log.h>
 #include "common/set.h"
 
 static struct lab_set pressed, bound, pressed_sent;

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -6,6 +6,7 @@
 #include <wlr/backend/session.h>
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/types/wlr_keyboard_group.h>
+#include <wlr/types/wlr_seat.h>
 #include "action.h"
 #include "common/macros.h"
 #include "config/keybind.h"

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -3,7 +3,6 @@
 #include "input/keyboard.h"
 #include <assert.h>
 #include <stdlib.h>
-#include <wlr/backend/multi.h>
 #include <wlr/backend/session.h>
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/types/wlr_keyboard_group.h>
@@ -17,7 +16,6 @@
 #include "labwc.h"
 #include "menu/menu.h"
 #include "osd.h"
-#include "regions.h"
 #include "session-lock.h"
 #include "view.h"
 #include "workspaces.h"

--- a/src/input/tablet-pad.c
+++ b/src/input/tablet-pad.c
@@ -4,6 +4,7 @@
 #include <wlr/backend/libinput.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 #include "common/macros.h"
 #include "common/mem.h"

--- a/src/input/tablet-pad.c
+++ b/src/input/tablet-pad.c
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "input/tablet-pad.h"
-#include <assert.h>
 #include <stdlib.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_tablet_pad.h>
-#include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/util/log.h>
 #include "common/macros.h"
 #include "common/mem.h"

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "input/tablet.h"
-#include <assert.h>
 #include <stdlib.h>
 #include <linux/input-event-codes.h>
-#include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/util/log.h>
 #include <wlr/types/wlr_scene.h>

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -2,7 +2,9 @@
 #include "input/tablet.h"
 #include <stdlib.h>
 #include <linux/input-event-codes.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/macros.h"

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "input/touch.h"
 #include <wayland-util.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_touch.h>

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -7,7 +7,6 @@
 #include "output.h"
 #include "regions.h"
 #include "resize-indicator.h"
-#include "snap.h"
 #include "view.h"
 #include "window-rules.h"
 

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <assert.h>
+#include <wlr/types/wlr_cursor.h>
 #include "config/rcxml.h"
 #include "edges.h"
 #include "input/keyboard.h"

--- a/src/layers.c
+++ b/src/layers.c
@@ -10,9 +10,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <string.h>
 #include <strings.h>
-#include <wayland-server.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>

--- a/src/layers.c
+++ b/src/layers.c
@@ -11,8 +11,10 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include "common/macros.h"

--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <wlr/render/allocator.h>
 #include <wlr/render/swapchain.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/transform.h>

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -3,7 +3,6 @@
 #include "menu/menu.h"
 #include <assert.h>
 #include <libxml/parser.h>
-#include <libxml/tree.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -20,7 +19,6 @@
 #include "common/lab-scene-rect.h"
 #include "common/list.h"
 #include "common/mem.h"
-#include "common/scene-helpers.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"
 #include "common/xml.h"

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
-#include <wayland-server-core.h>
+#include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include "action.h"

--- a/src/node.c
+++ b/src/node.c
@@ -2,6 +2,7 @@
 #include "node.h"
 #include <assert.h>
 #include <stdlib.h>
+#include <wlr/types/wlr_scene.h>
 #include "common/mem.h"
 #include "ssd.h"
 

--- a/src/osd/osd-classic.c
+++ b/src/osd/osd-classic.c
@@ -1,24 +1,20 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <assert.h>
-#include <cairo.h>
-#include <wlr/util/log.h>
+#include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
+#include <wlr/util/log.h>
 #include "common/array.h"
 #include "common/buf.h"
 #include "common/font.h"
 #include "common/lab-scene-rect.h"
-#include "common/scene-helpers.h"
 #include "common/string-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
-#include "node.h"
 #include "osd.h"
 #include "output.h"
 #include "scaled-buffer/scaled-font-buffer.h"
 #include "scaled-buffer/scaled-icon-buffer.h"
 #include "theme.h"
-#include "view.h"
-#include "window-rules.h"
 #include "workspaces.h"
 
 struct osd_classic_scene_item {

--- a/src/osd/osd-field.c
+++ b/src/osd/osd-field.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <wlr/util/log.h>
+#include "common/buf.h"
 #include "common/mem.h"
 #include "config/rcxml.h"
 #include "view.h"

--- a/src/osd/osd-thumbnail.c
+++ b/src/osd/osd-thumbnail.c
@@ -2,7 +2,6 @@
 #include <assert.h>
 #include <wlr/render/swapchain.h>
 #include <wlr/types/wlr_scene.h>
-#include <wlr/types/wlr_compositor.h>
 #include <wlr/render/allocator.h>
 #include "config/rcxml.h"
 #include "common/array.h"

--- a/src/osd/osd.c
+++ b/src/osd/osd.c
@@ -1,23 +1,19 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "osd.h"
 #include <assert.h>
-#include <cairo.h>
-#include <wlr/util/log.h>
+#include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
 #include "common/array.h"
 #include "common/lab-scene-rect.h"
 #include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
-#include "node.h"
 #include "output.h"
 #include "scaled-buffer/scaled-font-buffer.h"
 #include "scaled-buffer/scaled-icon-buffer.h"
 #include "ssd.h"
 #include "theme.h"
 #include "view.h"
-#include "window-rules.h"
-#include "workspaces.h"
 
 static void update_osd(struct server *server);
 

--- a/src/osd/osd.c
+++ b/src/osd/osd.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
+#include <wlr/util/log.h>
 #include "common/array.h"
 #include "common/lab-scene-rect.h"
 #include "common/scene-helpers.h"

--- a/src/output-virtual.c
+++ b/src/output-virtual.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <wlr/backend/headless.h>
 #include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_output_layout.h>
 #include "common/string-helpers.h"
 #include "labwc.h"
 #include "output.h"

--- a/src/output.c
+++ b/src/output.c
@@ -12,8 +12,6 @@
 #include <strings.h>
 #include <wlr/backend/drm.h>
 #include <wlr/backend/wayland.h>
-#include <wlr/types/wlr_buffer.h>
-#include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_management_v1.h>
@@ -21,7 +19,6 @@
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
 #include <wlr/types/wlr_scene.h>
-#include <wlr/util/region.h>
 #include <wlr/util/log.h>
 #include "common/macros.h"
 #include "common/mem.h"

--- a/src/output.c
+++ b/src/output.c
@@ -12,6 +12,7 @@
 #include <strings.h>
 #include <wlr/backend/drm.h>
 #include <wlr/backend/wayland.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_management_v1.h>

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "overlay.h"
 #include <assert.h>
+#include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/lab-scene-rect.h"
 #include "config/rcxml.h"

--- a/src/protocols/cosmic_workspaces/cosmic-workspaces.c
+++ b/src/protocols/cosmic_workspaces/cosmic-workspaces.c
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <assert.h>
-#include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
 #include "common/array.h"
 #include "common/mem.h"

--- a/src/protocols/ext-workspace/ext-workspace.c
+++ b/src/protocols/ext-workspace/ext-workspace.c
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <assert.h>
-#include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
-#include "common/array.h"
 #include "common/mem.h"
 #include "common/list.h"
 #include "ext-workspace-v1-protocol.h"

--- a/src/regions.c
+++ b/src/regions.c
@@ -6,6 +6,7 @@
 #include <float.h>
 #include <math.h>
 #include <string.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/util/box.h>
 #include "common/list.h"
 #include "common/mem.h"

--- a/src/regions.c
+++ b/src/regions.c
@@ -6,9 +6,7 @@
 #include <float.h>
 #include <math.h>
 #include <string.h>
-#include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
-#include <wlr/util/log.h>
 #include "common/list.h"
 #include "common/mem.h"
 #include "config/rcxml.h"

--- a/src/resistance.c
+++ b/src/resistance.c
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "resistance.h"
 #include <assert.h>
-#include <limits.h>
 #include "common/border.h"
-#include "common/macros.h"
 #include "config/rcxml.h"
 #include "edges.h"
 #include "labwc.h"

--- a/src/resize-outlines.c
+++ b/src/resize-outlines.c
@@ -2,6 +2,7 @@
 
 #include "resize-outlines.h"
 #include <wlr/types/wlr_scene.h>
+#include "common/border.h"
 #include "common/lab-scene-rect.h"
 #include "labwc.h"
 #include "resize-indicator.h"

--- a/src/scaled-buffer/scaled-font-buffer.c
+++ b/src/scaled-buffer/scaled-font-buffer.c
@@ -4,9 +4,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server-core.h>
 #include <wlr/util/log.h>
-#include "buffer.h"
 #include "common/font.h"
 #include "common/graphic-helpers.h"
 #include "common/mem.h"

--- a/src/scaled-buffer/scaled-icon-buffer.c
+++ b/src/scaled-buffer/scaled-icon-buffer.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <wlr/util/log.h>
 #include "buffer.h"
-#include "common/macros.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"
 #include "config.h"

--- a/src/scaled-buffer/scaled-img-buffer.c
+++ b/src/scaled-buffer/scaled-img-buffer.c
@@ -2,9 +2,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "scaled-buffer/scaled-img-buffer.h"
 #include <assert.h>
-#include <wayland-server-core.h>
-#include <wlr/types/wlr_scene.h>
-#include "buffer.h"
 #include "common/mem.h"
 #include "img/img.h"
 #include "node.h"

--- a/src/seat.c
+++ b/src/seat.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <strings.h>
 #include <wlr/backend/libinput.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_keyboard_group.h>

--- a/src/server.c
+++ b/src/server.c
@@ -19,7 +19,6 @@
 #include <wlr/types/wlr_ext_image_copy_capture_v1.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
-#include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_input_method_v2.h>
 #include <wlr/types/wlr_linux_drm_syncobj_v1.h>
 #include <wlr/types/wlr_output_power_management_v1.h>
@@ -45,7 +44,6 @@
 #include "xwayland-shell-v1-protocol.h"
 #endif
 
-#include "drm-lease-v1-protocol.h"
 #include "action.h"
 #include "common/macros.h"
 #include "config/rcxml.h"
@@ -59,7 +57,6 @@
 #include "magnifier.h"
 #include "menu/menu.h"
 #include "output.h"
-#include "output-state.h"
 #include "output-virtual.h"
 #include "regions.h"
 #include "resize-indicator.h"

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -2,6 +2,9 @@
 #define _POSIX_C_SOURCE 200809L
 #include "session-lock.h"
 #include <assert.h>
+#include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_scene.h>
+#include <wlr/types/wlr_session_lock_v1.h>
 #include "common/mem.h"
 #include "labwc.h"
 #include "node.h"

--- a/src/snap-constraints.c
+++ b/src/snap-constraints.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "snap-constraints.h"
 #include <assert.h>
+#include <string.h>
 #include <wlr/util/box.h>
 #include "common/macros.h"
-#include "labwc.h"
 #include "view.h"
 
 /*

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -3,7 +3,6 @@
 #include <assert.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/macros.h"
-#include "common/scene-helpers.h"
 #include "labwc.h"
 #include "ssd.h"
 #include "ssd-internal.h"

--- a/src/ssd/ssd-button.c
+++ b/src/ssd/ssd-button.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <assert.h>
+#include <wlr/types/wlr_scene.h>
 #include "config/rcxml.h"
 #include "common/list.h"
 #include "common/mem.h"

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include <assert.h>
 #include <pixman.h>
 #include <wlr/types/wlr_scene.h>
-#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "output.h"

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <assert.h>
-#include <cairo.h>
 #include <wlr/types/wlr_scene.h>
 #include "buffer.h"
 #include "config/rcxml.h"

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <string.h>
 #include <wlr/render/pixman.h>
+#include <wlr/types/wlr_scene.h>
 #include "buffer.h"
 #include "common/mem.h"
 #include "common/string-helpers.h"

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -6,11 +6,8 @@
 #include <wlr/render/pixman.h>
 #include "buffer.h"
 #include "common/mem.h"
-#include "common/scene-helpers.h"
 #include "common/string-helpers.h"
 #include "config/rcxml.h"
-#include "desktop-entry.h"
-#include "img/img.h"
 #include "labwc.h"
 #include "node.h"
 #include "scaled-buffer/scaled-font-buffer.h"

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -11,7 +11,6 @@
 #include <strings.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/mem.h"
-#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "node.h"

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -9,6 +9,7 @@
 #include "ssd.h"
 #include <assert.h>
 #include <strings.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/mem.h"
 #include "config/rcxml.h"

--- a/src/theme.c
+++ b/src/theme.c
@@ -7,7 +7,6 @@
 
 #define _POSIX_C_SOURCE 200809L
 #include "theme.h"
-#include "config.h"
 #include <assert.h>
 #include <cairo.h>
 #include <drm_fourcc.h>

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /* view-impl-common.c: common code for shell view->impl functions */
 #include "view-impl-common.h"
-#include <strings.h>
 #include "foreign-toplevel/foreign.h"
 #include "labwc.h"
 #include "view.h"

--- a/src/view.c
+++ b/src/view.c
@@ -2,6 +2,7 @@
 #include "view.h"
 #include <assert.h>
 #include <strings.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_keyboard_group.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_scene.h>

--- a/src/view.c
+++ b/src/view.c
@@ -13,7 +13,6 @@
 #include "common/list.h"
 #include "common/match.h"
 #include "common/mem.h"
-#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "foreign-toplevel/foreign.h"
 #include "input/keyboard.h"
@@ -33,7 +32,6 @@
 #include "window-rules.h"
 #include "wlr/util/log.h"
 #include "workspaces.h"
-#include "xwayland.h"
 
 #if HAVE_XWAYLAND
 #include <wlr/xwayland.h>

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -3,12 +3,8 @@
 #include "window-rules.h"
 #include <assert.h>
 #include <stdbool.h>
-#include <cairo.h>
-#include <glib.h>
 #include <strings.h>
-#include <wlr/util/log.h>
 #include "action.h"
-#include "common/match.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "view.h"

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_scene.h>
 #include "buffer.h"
 #include "common/font.h"

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -7,6 +7,7 @@
  *	- keeping non-layer-shell xdg-popups outside the layers.c code
  */
 
+#include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include "common/macros.h"
 #include "common/mem.h"

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <assert.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
+#include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_xdg_activation_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_xdg_toplevel_icon_v1.h>

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -4,6 +4,8 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <wlr/types/wlr_compositor.h>
+#include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/xwayland.h>


### PR DESCRIPTION
- Remove unused #includes
- Make use of forward declarations to reduce indirect #includes (one
  header including another) where it seems appropriate

Really this is just cosmetic as the extra #includes do no harm, but I had these cleanups in a local branch for a while, so submitting them in case they're of interest.