### PR TITLE
node-type: some cleanups

### DIFF
--- a/include/common/node-type.h
+++ b/include/common/node-type.h
@@ -62,7 +62,6 @@ enum lab_node_type {
 
 	/* never returned by get_cursor_context() */
 	LAB_NODE_TREE,
-	LAB_NODE_SCALED_BUFFER,
 };
 
 enum lab_node_type node_type_parse(const char *context);

--- a/include/common/node-type.h
+++ b/include/common/node-type.h
@@ -59,9 +59,6 @@ enum lab_node_type {
 	LAB_NODE_LAYER_POPUP,
 	LAB_NODE_SESSION_LOCK_SURFACE,
 	LAB_NODE_IME_POPUP,
-
-	/* never returned by get_cursor_context() */
-	LAB_NODE_TREE,
 };
 
 enum lab_node_type node_type_parse(const char *context);

--- a/include/common/node-type.h
+++ b/include/common/node-type.h
@@ -59,6 +59,12 @@ enum lab_node_type {
 	LAB_NODE_LAYER_POPUP,
 	LAB_NODE_SESSION_LOCK_SURFACE,
 	LAB_NODE_IME_POPUP,
+
+	/*
+	 * translated to LAB_CORNER_* or LAB_BORDER* by
+	 * ssd_get_resizing_type()
+	 */
+	LAB_NODE_SSD_ROOT,
 };
 
 enum lab_node_type node_type_parse(const char *context);

--- a/include/node.h
+++ b/include/node.h
@@ -60,13 +60,6 @@ struct menuitem *node_menuitem_from_node(
 	struct wlr_scene_node *wlr_scene_node);
 
 /**
- * node_scaled_buffer_from_node - return scaled_buffer from node
- * @wlr_scene_node: wlr_scene_node from which to return data
- */
-struct scaled_buffer *node_scaled_buffer_from_node(
-	struct wlr_scene_node *wlr_scene_node);
-
-/**
  * node_try_ssd_button_from_node - return ssd_button or NULL from node
  * @wlr_scene_node: wlr_scene_node from which to return data
  */

--- a/include/scaled-buffer/scaled-icon-buffer.h
+++ b/include/scaled-buffer/scaled-icon-buffer.h
@@ -48,7 +48,4 @@ void scaled_icon_buffer_set_view(struct scaled_icon_buffer *self,
 void scaled_icon_buffer_set_icon_name(struct scaled_icon_buffer *self,
 	const char *icon_name);
 
-/* Obtain scaled_icon_buffer from wlr_scene_node */
-struct scaled_icon_buffer *scaled_icon_buffer_from_node(struct wlr_scene_node *node);
-
 #endif /* LABWC_SCALED_ICON_BUFFER_H */

--- a/include/scaled-buffer/scaled-img-buffer.h
+++ b/include/scaled-buffer/scaled-img-buffer.h
@@ -64,7 +64,4 @@ struct scaled_img_buffer {
 struct scaled_img_buffer *scaled_img_buffer_create(struct wlr_scene_tree *parent,
 	struct lab_img *img, int width, int height);
 
-/* Obtain scaled_img_buffer from wlr_scene_node */
-struct scaled_img_buffer *scaled_img_buffer_from_node(struct wlr_scene_node *node);
-
 #endif /* LABWC_SCALED_IMG_BUFFER_H */

--- a/include/ssd-internal.h
+++ b/include/ssd-internal.h
@@ -17,7 +17,7 @@ struct ssd_state_title_width {
  * type of each node (enum lab_node_type, stored in the node_descriptor
  * attached to the wlr_scene_node).
  *
- * ssd->tree (LAB_NODE_NONE)
+ * ssd->tree (LAB_NODE_SSD_ROOT)
  * +--titlebar (LAB_NODE_TITLEBAR)
  * |  +--inactive
  * |  |  +--background bar

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -332,7 +332,6 @@ get_cursor_context(struct server *server)
 				ret.type = LAB_NODE_MENUITEM;
 				return ret;
 			case LAB_NODE_TREE:
-			case LAB_NODE_SCALED_BUFFER:
 				/* Continue to parent node */
 				break;
 			default:

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -331,9 +331,6 @@ get_cursor_context(struct server *server)
 				ret.node = node;
 				ret.type = LAB_NODE_MENUITEM;
 				return ret;
-			case LAB_NODE_TREE:
-				/* Continue to parent node */
-				break;
 			default:
 				/*
 				 * All other node descriptors (buttons, title,

--- a/src/node.c
+++ b/src/node.c
@@ -68,15 +68,6 @@ node_menuitem_from_node(struct wlr_scene_node *wlr_scene_node)
 	return (struct menuitem *)node_descriptor->data;
 }
 
-struct scaled_buffer *
-node_scaled_buffer_from_node(struct wlr_scene_node *wlr_scene_node)
-{
-	assert(wlr_scene_node->data);
-	struct node_descriptor *node_descriptor = wlr_scene_node->data;
-	assert(node_descriptor->type == LAB_NODE_SCALED_BUFFER);
-	return (struct scaled_buffer *)node_descriptor->data;
-}
-
 struct ssd_button *
 node_try_ssd_button_from_node(struct wlr_scene_node *wlr_scene_node)
 {

--- a/src/output.c
+++ b/src/output.c
@@ -509,18 +509,10 @@ handle_new_output(struct wl_listener *listener, void *data)
 	for (size_t i = 0; i < ARRAY_SIZE(output->layer_tree); i++) {
 		output->layer_tree[i] =
 			wlr_scene_tree_create(&server->scene->tree);
-		node_descriptor_create(&output->layer_tree[i]->node,
-			LAB_NODE_TREE, /*view*/ NULL, /*data*/ NULL);
 	}
 	output->layer_popup_tree = wlr_scene_tree_create(&server->scene->tree);
-	node_descriptor_create(&output->layer_popup_tree->node,
-		LAB_NODE_TREE, /*view*/ NULL, /*data*/ NULL);
 	output->osd_tree = wlr_scene_tree_create(&server->scene->tree);
-	node_descriptor_create(&output->osd_tree->node,
-		LAB_NODE_TREE, /*view*/ NULL, /*data*/ NULL);
 	output->session_lock_tree = wlr_scene_tree_create(&server->scene->tree);
-	node_descriptor_create(&output->session_lock_tree->node,
-		LAB_NODE_TREE, /*view*/ NULL, /*data*/ NULL);
 
 	/*
 	 * Set the z-positions to achieve the following order (from top to

--- a/src/scaled-buffer/scaled-buffer.c
+++ b/src/scaled-buffer/scaled-buffer.c
@@ -197,8 +197,6 @@ scaled_buffer_create(struct wlr_scene_tree *parent,
 		free(self);
 		return NULL;
 	}
-	node_descriptor_create(&self->scene_buffer->node,
-		LAB_NODE_SCALED_BUFFER, /*view*/ NULL, self);
 
 	self->impl = impl;
 	/*

--- a/src/scaled-buffer/scaled-icon-buffer.c
+++ b/src/scaled-buffer/scaled-icon-buffer.c
@@ -349,12 +349,3 @@ scaled_icon_buffer_set_icon_name(struct scaled_icon_buffer *self,
 	xstrdup_replace(self->icon_name, icon_name);
 	scaled_buffer_request_update(self->scaled_buffer, self->width, self->height);
 }
-
-struct scaled_icon_buffer *
-scaled_icon_buffer_from_node(struct wlr_scene_node *node)
-{
-	struct scaled_buffer *scaled_buffer =
-		node_scaled_buffer_from_node(node);
-	assert(scaled_buffer->impl == &impl);
-	return scaled_buffer->data;
-}

--- a/src/scaled-buffer/scaled-img-buffer.c
+++ b/src/scaled-buffer/scaled-img-buffer.c
@@ -65,12 +65,3 @@ scaled_img_buffer_create(struct wlr_scene_tree *parent, struct lab_img *img,
 
 	return self;
 }
-
-struct scaled_img_buffer *
-scaled_img_buffer_from_node(struct wlr_scene_node *node)
-{
-	struct scaled_buffer *scaled_buffer =
-		node_scaled_buffer_from_node(node);
-	assert(scaled_buffer->impl == &impl);
-	return scaled_buffer->data;
-}

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -146,8 +146,14 @@ ssd_create(struct view *view, bool active)
 
 	ssd->view = view;
 	ssd->tree = wlr_scene_tree_create(view->scene_tree);
+
+	/*
+	 * Attach node_descriptor to the root node so that get_cursor_context()
+	 * detect cursor hovering on borders and extents.
+	 */
 	node_descriptor_create(&ssd->tree->node,
-		LAB_NODE_NONE, view, /*data*/ NULL);
+		LAB_NODE_SSD_ROOT, view, /*data*/ NULL);
+
 	wlr_scene_node_lower_to_bottom(&ssd->tree->node);
 	ssd->titlebar.height = view->server->theme->titlebar_height;
 	ssd_shadow_create(ssd);


### PR DESCRIPTION
This PR shouldn't change any behaviors.

The 1st commit removes `LAB_NODE_SCALED_BUFFER` node type and `scaled_{img,icon}_buffer_from_node()`. I remember those functions were required for updating window icons some time ago, but they are not used anymore.

The 2nd commit removes `LAB_NODE_TREE` node type. It was attached to `output->layer_popup_tree` etc., but I don't think they are needed. CC @johanmalm

The 3nd commit attaches `LAB_NODE_SSD_ROOT` to `ssd->tree` instead of `LAB_NODE_NONE`, as I described in https://github.com/labwc/labwc/pull/3050#discussion_r2328158193. I also updated `get_cursor_context()` to make my intent clearer.