### PR TITLE
desktop.c: don't print errors when cursor is on resize-indicator

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -303,13 +303,12 @@ get_cursor_context(struct server *server)
 			case LAB_NODE_VIEW:
 			case LAB_NODE_XDG_POPUP:
 				ret.view = desc->view;
-				if (ret.node->type == WLR_SCENE_NODE_BUFFER
-						&& lab_wlr_surface_from_node(ret.node)) {
+				ret.surface = lab_wlr_surface_from_node(ret.node);
+				if (ret.surface) {
 					ret.type = LAB_NODE_CLIENT;
-					ret.surface = lab_wlr_surface_from_node(ret.node);
 				} else {
-					/* should never be reached */
-					wlr_log(WLR_ERROR, "cursor not on client or ssd");
+					/* e.g. when cursor is on resize-indicator */
+					ret.type = LAB_NODE_NONE;
 				}
 				return ret;
 			case LAB_NODE_LAYER_SURFACE:


### PR DESCRIPTION
Removes log spams when the cursor is on resize-indicator:

https://github.com/user-attachments/assets/27fdb17a-0fee-4966-9d4b-8604d79b3356

In #2993, I thought there are only window contents and SSD under `view->scene_tree` and forgot about the resize-indicator.

I also refactored the logic around it:
- Remove `ret.node->type == WLR_SCENE_NODE_BUFFER` check since it's already done by `lab_wlr_surface_from_node()`
- Eliminate duplicated call to `lab_wlr_surface_from_node()`