### PR TITLE
src/output.c: restore drm lease include

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -13,6 +13,7 @@
 #include <wlr/backend/drm.h>
 #include <wlr/backend/wayland.h>
 #include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_management_v1.h>


### PR DESCRIPTION
Introduced in #3062.

Its usage is guarded by a wlroots version check
which prevented the CI to detect the issue.

When compiled with a wlroots version > 0.19.0
(like the chase 0.20 PR) the error shows up.