### PR TITLE
More small cleanups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,14 +12,21 @@ UseTab: Always
 IndentWidth: 8
 ContinuationIndentWidth: 8
 AlignAfterOpenBracket: DontAlign
+AlignOperands: false
 AlwaysBreakAfterDefinitionReturnType: true
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Linux
 IndentCaseLabels: false
+PenaltyBreakOpenParenthesis: 100
+PenaltyReturnTypeOnItsOwnLine: 500
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 ForEachMacros: ['for_each_view',
+                'for_each_view_reverse',
                 'wl_array_for_each',
                 'wl_list_for_each',
                 'wl_list_for_each_reverse',
                 'wl_list_for_each_reverse_safe',
                 'wl_list_for_each_safe']
+IncludeCategories:
+  - Regex: '<.*>'
+  - Regex: '.*'

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -14,6 +14,9 @@
 
 #define BUTTON_MAP_MAX 16
 
+/* max of one button of each type (no repeats) */
+#define TITLE_BUTTONS_MAX ((LAB_NODE_BUTTON_LAST + 1) - LAB_NODE_BUTTON_FIRST)
+
 enum adaptive_sync_mode {
 	LAB_ADAPTIVE_SYNC_DISABLED,
 	LAB_ADAPTIVE_SYNC_ENABLED,
@@ -46,11 +49,6 @@ struct buf;
 struct button_map_entry {
 	uint32_t from;
 	uint32_t to;
-};
-
-struct title_button {
-	enum lab_node_type type;
-	struct wl_list link;
 };
 
 struct usable_area_override {
@@ -88,8 +86,12 @@ struct rcxml {
 	char *theme_name;
 	char *icon_theme_name;
 	char *fallback_app_icon_name;
-	struct wl_list title_buttons_left;
-	struct wl_list title_buttons_right;
+
+	enum lab_node_type title_buttons_left[TITLE_BUTTONS_MAX];
+	int nr_title_buttons_left;
+	enum lab_node_type title_buttons_right[TITLE_BUTTONS_MAX];
+	int nr_title_buttons_right;
+
 	int corner_radius;
 	bool show_title;
 	bool title_layout_loaded;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -178,7 +178,7 @@ clear_title_layout(void)
 }
 
 static void
-fill_title_layout(char *content)
+fill_title_layout(const char *content)
 {
 	clear_title_layout();
 

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -101,7 +101,7 @@ interactive_begin(struct view *view, enum input_mode mode, enum lab_edge edges)
 
 		cursor_shape = LAB_CURSOR_GRAB;
 		break;
-	case LAB_INPUT_STATE_RESIZE:
+	case LAB_INPUT_STATE_RESIZE: {
 		if (view->shaded || view->fullscreen ||
 				view->maximized == VIEW_AXIS_BOTH) {
 			/*
@@ -133,6 +133,7 @@ interactive_begin(struct view *view, enum input_mode mode, enum lab_edge edges)
 		view_set_untiled(view);
 		cursor_shape = cursor_get_from_edge(edges);
 		break;
+	}
 	default:
 		/* Should not be reached */
 		return;

--- a/src/osd/osd-thumbnail.c
+++ b/src/osd/osd-thumbnail.c
@@ -130,12 +130,12 @@ create_item_scene(struct wlr_scene_tree *parent, struct view *view,
 
 	/* background for selected item */
 	struct lab_scene_rect_options opts = {
+		.border_colors = (float *[1]) { switcher_theme->item_active_border_color },
+		.nr_borders = 1,
+		.border_width = switcher_theme->item_active_border_width,
+		.bg_color = switcher_theme->item_active_bg_color,
 		.width = switcher_theme->item_width,
 		.height = switcher_theme->item_height,
-		.bg_color = switcher_theme->item_active_bg_color,
-		.nr_borders = 1,
-		.border_colors = (float *[1]) { switcher_theme->item_active_border_color },
-		.border_width = switcher_theme->item_active_border_width,
 	};
 	item->active_bg = lab_scene_rect_create(item->tree, &opts);
 
@@ -241,12 +241,12 @@ osd_thumbnail_create(struct output *output, struct wl_array *views)
 
 	/* background */
 	struct lab_scene_rect_options bg_opts = {
-		.width = nr_cols * switcher_theme->item_width + 2 * padding,
-		.height = nr_rows * switcher_theme->item_height + 2 * padding,
-		.bg_color = theme->osd_bg_color,
+		.border_colors = (float *[1]) { theme->osd_border_color },
 		.nr_borders = 1,
 		.border_width = theme->osd_border_width,
-		.border_colors = (float *[1]) { theme->osd_border_color },
+		.bg_color = theme->osd_bg_color,
+		.width = nr_cols * switcher_theme->item_width + 2 * padding,
+		.height = nr_rows * switcher_theme->item_height + 2 * padding,
 	};
 	struct lab_scene_rect *bg =
 		lab_scene_rect_create(output->osd_scene.tree, &bg_opts);

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -81,7 +81,6 @@ ssd_titlebar_create(struct ssd *ssd)
 			LAB_NODE_TITLE, view, /*data*/ NULL);
 
 		/* Buttons */
-		struct title_button *b;
 		int x = theme->window_titlebar_padding_width;
 
 		/* Center vertically within titlebar */
@@ -90,20 +89,22 @@ ssd_titlebar_create(struct ssd *ssd)
 		wl_list_init(&subtree->buttons_left);
 		wl_list_init(&subtree->buttons_right);
 
-		wl_list_for_each(b, &rc.title_buttons_left, link) {
+		for (int b = 0; b < rc.nr_title_buttons_left; b++) {
+			enum lab_node_type type = rc.title_buttons_left[b];
 			struct lab_img **imgs =
-				theme->window[active].button_imgs[b->type];
-			attach_ssd_button(&subtree->buttons_left, b->type, parent,
+				theme->window[active].button_imgs[type];
+			attach_ssd_button(&subtree->buttons_left, type, parent,
 				imgs, x, y, view);
 			x += theme->window_button_width + theme->window_button_spacing;
 		}
 
 		x = width - theme->window_titlebar_padding_width + theme->window_button_spacing;
-		wl_list_for_each_reverse(b, &rc.title_buttons_right, link) {
+		for (int b = rc.nr_title_buttons_right - 1; b >= 0; b--) {
 			x -= theme->window_button_width + theme->window_button_spacing;
+			enum lab_node_type type = rc.title_buttons_right[b];
 			struct lab_img **imgs =
-				theme->window[active].button_imgs[b->type];
-			attach_ssd_button(&subtree->buttons_right, b->type, parent,
+				theme->window[active].button_imgs[type];
+			attach_ssd_button(&subtree->buttons_right, type, parent,
 				imgs, x, y, view);
 		}
 	}
@@ -223,8 +224,8 @@ update_visible_buttons(struct ssd *ssd)
 	int width = MAX(view->current.width - 2 * theme->window_titlebar_padding_width, 0);
 	int button_width = theme->window_button_width;
 	int button_spacing = theme->window_button_spacing;
-	int button_count_left = wl_list_length(&rc.title_buttons_left);
-	int button_count_right = wl_list_length(&rc.title_buttons_right);
+	int button_count_left = rc.nr_title_buttons_left;
+	int button_count_right = rc.nr_title_buttons_right;
 
 	/* Make sure infinite loop never occurs */
 	assert(button_width > 0);

--- a/src/theme.c
+++ b/src/theme.c
@@ -231,25 +231,16 @@ load_button(struct theme *theme, struct button *b, int active)
 	struct lab_img **rounded_img =
 		&button_imgs[b->type][b->state_set | LAB_BS_ROUNDED];
 
-	struct title_button *leftmost_button;
-	wl_list_for_each(leftmost_button,
-			&rc.title_buttons_left, link) {
-		if (leftmost_button->type == b->type) {
-			*rounded_img = lab_img_copy(*img);
-			lab_img_add_modifier(*rounded_img,
-				round_left_corner_button);
-		}
-		break;
+	if (rc.nr_title_buttons_left > 0
+			&& b->type == rc.title_buttons_left[0]) {
+		*rounded_img = lab_img_copy(*img);
+		lab_img_add_modifier(*rounded_img, round_left_corner_button);
 	}
-	struct title_button *rightmost_button;
-	wl_list_for_each_reverse(rightmost_button,
-			&rc.title_buttons_right, link) {
-		if (rightmost_button->type == b->type) {
-			*rounded_img = lab_img_copy(*img);
-			lab_img_add_modifier(*rounded_img,
-				round_right_corner_button);
-		}
-		break;
+	if (rc.nr_title_buttons_right > 0
+			&& b->type == rc.title_buttons_right
+				[rc.nr_title_buttons_right - 1]) {
+		*rounded_img = lab_img_copy(*img);
+		lab_img_add_modifier(*rounded_img, round_right_corner_button);
 	}
 }
 


### PR DESCRIPTION
Some more miscellaneous small cleanups. These are the last of what I've had collecting locally.

- A small refactoring to use fixed arrays for `rc.title_buttons_*`. These are just lists of `enum lab_node_type`, with a bounded size and no middle-insertions/removals, so linked lists are overkill. Also, the use of `wl_list_for_each[_reverse]` just to access the first or last entry in the list (corner button) was weird.

- Some little syntactic cleanups (add `const`, reorder initializers, add braces around a `case` block).

- Some minor tweaks to `.clang-format` to make it match our coding style a little better.