### PR TITLE
Add osd.window-switcher.style-classic.item.active.{border,bg}.color

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -327,6 +327,14 @@ all are supported.
 	Border width of the selection box in the window switcher in pixels.
 	Default is 2.
 
+*osd.window-switcher.style-classic.item.active.border.color*
+	Border color around the selected window switcher item.
+	Default is *osd.label.text.color* with 50% opacity.
+
+*osd.window-switcher.style-classic.item.active.bg.color*
+	Background color of the selected window switcher item.
+	Default is *osd.label.text.color* with 15% opacity.
+
 *osd.window-switcher.style-classic.item.icon.size*
 	Size of the icon in window switcher, in pixels.
 	If not set, the font size derived from <theme><font place="OnScreenDisplay">

--- a/docs/themerc
+++ b/docs/themerc
@@ -97,6 +97,8 @@ osd.window-switcher.style-classic.padding: 4
 osd.window-switcher.style-classic.item.padding.x: 10
 osd.window-switcher.style-classic.item.padding.y: 1
 osd.window-switcher.style-classic.item.active.border.width: 2
+osd.window-switcher.style-classic.item.active.border.color: #706f6d
+osd.window-switcher.style-classic.item.active.bg.color: #bfbcba
 # The icon size the same as the font size by default
 # osd.window-switcher.style-classic.item.icon.size: 50
 

--- a/include/theme.h
+++ b/include/theme.h
@@ -170,6 +170,8 @@ struct theme {
 		int item_padding_x;
 		int item_padding_y;
 		int item_active_border_width;
+		float item_active_border_color[4];
+		float item_active_bg_color[4];
 		int item_icon_size;
 		bool width_is_percent;
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -604,6 +604,8 @@ theme_builtin(struct theme *theme, struct server *server)
 	theme->osd_window_switcher_classic.item_padding_x = 10;
 	theme->osd_window_switcher_classic.item_padding_y = 1;
 	theme->osd_window_switcher_classic.item_active_border_width = 2;
+	theme->osd_window_switcher_classic.item_active_border_color[0] = FLT_MIN;
+	theme->osd_window_switcher_classic.item_active_bg_color[0] = FLT_MIN;
 	theme->osd_window_switcher_classic.item_icon_size = -1;
 
 	theme->osd_window_switcher_thumbnail.max_width = 80;
@@ -988,6 +990,12 @@ entry(struct theme *theme, const char *key, const char *value)
 		switcher_classic_theme->item_active_border_width =
 			get_int_if_positive(value,
 				"osd.window-switcher.style-classic.item.active.border.width");
+	}
+	if (match_glob(key, "osd.window-switcher.style-classic.item.active.border.color")) {
+		parse_color(value, switcher_classic_theme->item_active_border_color);
+	}
+	if (match_glob(key, "osd.window-switcher.style-classic.item.active.bg.color")) {
+		parse_color(value, switcher_classic_theme->item_active_bg_color);
 	}
 	if (match_glob(key, "osd.window-switcher.style-classic.item.icon.size")
 			|| match_glob(key, "osd.window-switcher.item.icon.size")) {
@@ -1745,6 +1753,14 @@ post_processing(struct theme *theme)
 		 */
 		memcpy(theme->osd_border_color, theme->osd_label_text_color,
 			sizeof(theme->osd_border_color));
+	}
+	if (switcher_classic_theme->item_active_border_color[0] == FLT_MIN) {
+		blend_color_with_bg(switcher_classic_theme->item_active_border_color,
+			theme->osd_label_text_color, 0.50, theme->osd_bg_color);
+	}
+	if (switcher_classic_theme->item_active_bg_color[0] == FLT_MIN) {
+		blend_color_with_bg(switcher_classic_theme->item_active_bg_color,
+			theme->osd_label_text_color, 0.15, theme->osd_bg_color);
 	}
 	if (switcher_thumb_theme->item_active_border_color[0] == FLT_MIN) {
 		blend_color_with_bg(switcher_thumb_theme->item_active_border_color,


### PR DESCRIPTION
For post-0.9.2.

These theme options configures the border/background of selected window item in the `classic` style window siwtcher. Previously, the OSD text color (default: black) was used as the border and background was transparent.

Now the default theme is updated to use #589bda as the border color and #c7e2fc as the background color, which are the same as the `thumbnail` style window switcher.

Screenshot of the new default look:

<img width="1278" height="718" alt="20251001_14h35m54s_grim" src="https://github.com/user-attachments/assets/0d4164d1-e994-445f-b864-7a54d48236f6" />

I'll appreciate feedbacks. If the default colors are not preferable, I think we can update the default colors of `thumbnail` style window switcher for consistency before 0.9.2 release.