### PR TITLE
osd: allow window switcher to temporary unshade windows

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -352,7 +352,7 @@ this is for compatibility with Openbox.
 </windowSwitcher>
 ```
 
-*<windowSwitcher show="" style="" preview="" outlines="" allWorkspaces="">*
+*<windowSwitcher show="" style="" preview="" outlines="" allWorkspaces="" unshade="">*
 	*show* [yes|no] Draw the OnScreenDisplay when switching between
 	windows. Default is yes.
 
@@ -369,6 +369,9 @@ this is for compatibility with Openbox.
 	*allWorkspaces* [yes|no] Show windows regardless of what workspace
 	they are on. Default no (that is only windows on the current workspace
 	are shown).
+
+	*unshade* [yes|no] Temporarily unshade windows while using A-Tab and
+	permanentele unshade on the final selection. Default is yes.
 
 *<windowSwitcher><fields><field content="" width="%">*
 	Define window switcher fields when using *<windowSwitcher style="classic" />*.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -79,7 +79,8 @@
     </font>
   </theme>
 
-  <windowSwitcher show="yes" style="classic" preview="yes" outlines="yes" allWorkspaces="no">
+  <windowSwitcher show="yes" style="classic" preview="yes"
+      outlines="yes" allWorkspaces="no" unshade="yes">
     <fields>
       <field content="icon" width="5%" />
       <field content="desktop_entry_name" width="30%" />

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -179,6 +179,7 @@ struct rcxml {
 		bool show;
 		bool preview;
 		bool outlines;
+		bool unshade;
 		enum lab_view_criteria criteria;
 		struct wl_list fields;  /* struct window_switcher_field.link */
 		enum window_switcher_style style;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -303,11 +303,13 @@ struct server {
 	/* Set when in cycle (alt-tab) mode */
 	struct osd_state {
 		struct view *cycle_view;
+		bool preview_was_shaded;
 		bool preview_was_enabled;
 		struct wlr_scene_node *preview_node;
 		struct wlr_scene_tree *preview_parent;
 		struct wlr_scene_node *preview_anchor;
 		struct lab_scene_rect *preview_outline;
+		struct view *preview_view;
 	} osd_state;
 
 	struct theme *theme;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1217,6 +1217,8 @@ entry(xmlNode *node, char *nodename, char *content)
 			rc.window_switcher.criteria &=
 				~LAB_VIEW_CRITERIA_CURRENT_WORKSPACE;
 		}
+	} else if (!strcasecmp(nodename, "unshade.windowSwitcher")) {
+		set_bool(content, &rc.window_switcher.unshade);
 
 	/* Remove this long term - just a friendly warning for now */
 	} else if (strstr(nodename, "windowswitcher.core")) {
@@ -1429,6 +1431,7 @@ rcxml_init(void)
 	rc.window_switcher.style = WINDOW_SWITCHER_CLASSIC;
 	rc.window_switcher.preview = true;
 	rc.window_switcher.outlines = true;
+	rc.window_switcher.unshade = true;
 	rc.window_switcher.criteria = LAB_VIEW_CRITERIA_CURRENT_WORKSPACE
 		| LAB_VIEW_CRITERIA_ROOT_TOPLEVEL
 		| LAB_VIEW_CRITERIA_NO_SKIP_WINDOW_SWITCHER;

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -96,6 +96,9 @@ end_cycling(struct server *server)
 	/* FIXME: osd_finish() transiently sets focus to the old surface */
 	osd_finish(server);
 	/* Note that server->osd_state.cycle_view is cleared at this point */
+	if (rc.window_switcher.unshade) {
+		view_set_shade(cycle_view, false);
+	}
 	desktop_focus_view(cycle_view, /*raise*/ true);
 }
 

--- a/src/osd/osd.c
+++ b/src/osd/osd.c
@@ -160,9 +160,14 @@ restore_preview_node(struct server *server)
 		if (!osd_state->preview_was_enabled) {
 			wlr_scene_node_set_enabled(osd_state->preview_node, false);
 		}
+		if (osd_state->preview_was_shaded) {
+			view_set_shade(osd_state->preview_view, true);
+		}
 		osd_state->preview_node = NULL;
 		osd_state->preview_parent = NULL;
 		osd_state->preview_anchor = NULL;
+		osd_state->preview_view = NULL;
+		osd_state->preview_was_shaded = false;
 	}
 }
 
@@ -229,6 +234,7 @@ preview_cycled_view(struct view *view)
 	/* Store some pointers so we can reset the preview later on */
 	osd_state->preview_node = &view->scene_tree->node;
 	osd_state->preview_parent = view->scene_tree->node.parent;
+	osd_state->preview_view = view;
 
 	/* Remember the sibling right before the selected node */
 	osd_state->preview_anchor = lab_wlr_scene_get_prev_node(
@@ -243,6 +249,10 @@ preview_cycled_view(struct view *view)
 	osd_state->preview_was_enabled = osd_state->preview_node->enabled;
 	if (!osd_state->preview_was_enabled) {
 		wlr_scene_node_set_enabled(osd_state->preview_node, true);
+	}
+	if (rc.window_switcher.unshade && osd_state->preview_view->shaded) {
+		view_set_shade(osd_state->preview_view, false);
+		osd_state->preview_was_shaded = true;
 	}
 
 	/*


### PR DESCRIPTION
This can be configured with a new unshade="yes|no" argument for windowSwitcher in rc.xml

Fixes:
- #3111

----

For post-release.
The view preview outlines for temporarily unshaded windows are only visible on the titlebar and don't cover the whole window like for normal windows. It could be changed by changing the order of outlines and preview if preferred but I kept this behavior in for now because it provides additional state to the user.

I decided against bypassing `view_set_shade()` (e.g. enabling / disabling the content scene node manually) because shaded windows have their border disabled and it would require the OSD to manipulate internal SSD state.

Testing appreciated, especially to figure out a sensible default for `<windowSwitcher unshade="yes|no" />`. Personally I don't really use shading so its hard for me to tell what feels better / more consistent.