### PR TITLE
osd-thumbnail: update default colors of selected window item

### DIFF
--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -358,10 +358,12 @@ all are supported.
 	Border width of selected window switcher items in pixels. Default is 2.
 
 *osd.window-switcher.style-thumbnail.item.active.border.color*
-	Color of border around selected window switcher items. Default is #589bda.
+	Color of border around selected window switcher items.
+	Default is *osd.label.text.color* with 50% opacity.
 
 *osd.window-switcher.style-thumbnail.item.active.bg.color*
-	Color of selected window switcher items. Default is #c7e2fc.
+	Color of selected window switcher items.
+	Default is *osd.label.text.color* with 15% opacity.
 
 *osd.window-switcher.style-thumbnail.item.icon.size*
 	Size of window icons in window switcher items in pixels. Default is 60.

--- a/docs/themerc
+++ b/docs/themerc
@@ -106,8 +106,8 @@ osd.window-switcher.style-thumbnail.item.width: 300
 osd.window-switcher.style-thumbnail.item.height: 250
 osd.window-switcher.style-thumbnail.item.padding: 10
 osd.window-switcher.style-thumbnail.item.active.border.width: 2
-osd.window-switcher.style-thumbnail.item.active.border.color: #589bda
-osd.window-switcher.style-thumbnail.item.active.bg.color: #c7e2fc
+osd.window-switcher.style-thumbnail.item.active.border.color: #706f6d
+osd.window-switcher.style-thumbnail.item.active.bg.color: #bfbcba
 osd.window-switcher.style-thumbnail.item.icon.size: 60
 
 osd.window-switcher.preview.border.width: 1


### PR DESCRIPTION
Extracted the first commit from #3118 for merging before 0.9.2 release.

## Commit message

Previously, the default values of `osd.window-switcher.style-thumbnail.item.active.{bg,border}.color` were blue. But they caused the selected window title in the window switcher to be unreadable due to duplicated colors of the text and background with Openbox themes like Numix.

Instead, this commit updates them to follow other themes configurations. The default border color of the selected window item is now `osd.label.text.color` with 50% opacity and the background is `osd.label.text.color` with 15% opacity.

For subpixel antialiasing to work, the background color is calculated by manually blending `osd.label.text.color` and `osd.bg.color`, rather than just updating the alpha with 50% or 15%.