### PR TITLE
Fix double free for libxml2 < 2.13

### DIFF
--- a/src/common/xml.c
+++ b/src/common/xml.c
@@ -48,7 +48,7 @@ create_attribute_tree(const xmlAttr *attr)
 }
 
 /*
- * Consider <keybind name.action="ShowMenu" x.position.action="1" y.position="2" />.
+ * Consider <keybind name.action="ShowMenu" x.position.action="1" y.position.action="2" />.
  * These three attributes are represented by following trees.
  *    action(dst)---name
  *    action(src)---position---x


### PR DESCRIPTION
`xmlAddChild()` only unlinks the second argument since libxml2 2.13 ([ref](https://gnome.pages.gitlab.gnome.org/libxml2/html/tree_8h.html#a920e1354539cbcda18602501c96199c9)).
    
Regression from 503af105