### PR TITLE
rcxml: move <maximizedDecoration> from <core> to <theme>

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -171,7 +171,6 @@ this is for compatibility with Openbox.
 ```
 <core>
   <decoration>server</decoration>
-  <maximizedDecoration>titlebar</maximizedDecoration>
   <gap>0</gap>
   <adaptiveSync>no</adaptiveSync>
   <allowTearing>no</allowTearing>
@@ -187,11 +186,6 @@ this is for compatibility with Openbox.
 	Specify server or client side decorations for xdg-shell windows. Note
 	that it is not always possible to turn off client side decorations.
 	Default is server.
-
-*<core><maximizedDecoration>* [titlebar|none]
-	Specify how server side decorations are shown for maximized windows.
-	*titlebar* shows titlebar above a maximized window. *none* shows no server
-	side decorations around a maximized window. Default is titlebar.
 
 *<core><gap>*
 	The distance in pixels between windows and output edges when using
@@ -602,6 +596,11 @@ extending outward from the snapped edge.
 *<theme><keepBorder>* [yes|no]
 	Even when disabling server side decorations via ToggleDecorations,
 	keep a small border (and resize area) around the window. Default is yes.
+
+*<theme><maximizedDecoration>* [titlebar|none]
+	Specify how server side decorations are shown for maximized windows.
+	*titlebar* shows titlebar above a maximized window. *none* shows no server
+	side decorations around a maximized window. Default is titlebar.
 
 *<theme><dropShadows>* [yes|no]
 	Should drop-shadows be rendered behind windows. Default is no.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -11,7 +11,6 @@
 
   <core>
     <decoration>server</decoration>
-    <maximizedDecoration>titlebar</maximizedDecoration>
     <gap>0</gap>
     <adaptiveSync>no</adaptiveSync>
     <allowTearing>no</allowTearing>
@@ -45,6 +44,7 @@
     </titlebar>
     <cornerRadius>8</cornerRadius>
     <keepBorder>yes</keepBorder>
+    <maximizedDecoration>titlebar</maximizedDecoration>
     <dropShadows>no</dropShadows>
     <dropShadowsOnTiled>no</dropShadowsOnTiled>
     <font place="ActiveWindow">

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1083,12 +1083,6 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else {
 			rc.xdg_shell_server_side_deco = true;
 		}
-	} else if (!strcasecmp(nodename, "maximizedDecoration.core")) {
-		if (!strcasecmp(content, "titlebar")) {
-			rc.hide_maximized_window_titlebar = false;
-		} else if (!strcasecmp(content, "none")) {
-			rc.hide_maximized_window_titlebar = true;
-		}
 	} else if (!strcmp(nodename, "gap.core")) {
 		rc.gap = atoi(content);
 	} else if (!strcasecmp(nodename, "adaptiveSync.core")) {
@@ -1130,6 +1124,12 @@ entry(xmlNode *node, char *nodename, char *content)
 		rc.corner_radius = atoi(content);
 	} else if (!strcasecmp(nodename, "keepBorder.theme")) {
 		set_bool(content, &rc.ssd_keep_border);
+	} else if (!strcasecmp(nodename, "maximizedDecoration.theme")) {
+		if (!strcasecmp(content, "titlebar")) {
+			rc.hide_maximized_window_titlebar = false;
+		} else if (!strcasecmp(content, "none")) {
+			rc.hide_maximized_window_titlebar = true;
+		}
 	} else if (!strcasecmp(nodename, "dropShadows.theme")) {
 		set_bool(content, &rc.shadows_enabled);
 	} else if (!strcasecmp(nodename, "dropShadowsOnTiled.theme")) {


### PR DESCRIPTION
For merging before 0.9.2 release.

I put it in `<core>` just because there's `<core><decoration>`, but now I think it should be in `<theme>` instead because `<theme>` contains many other configurations for SSD styles, like `<titlebar>`, `<keepBorder>` and `<dropShadows>`. `<core><decoration>` is a bit different from them as it configures which of SSD and CSD we should advise apps to use, rather than how SSD should look.