### PR TITLE
view: fix unexpected view->tiled with SnapToEdge against centered view

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2161,7 +2161,8 @@ view_snap_to_edge(struct view *view, enum lab_edge edge,
 
 	view_set_shade(view, false);
 
-	if (lab_edge_is_cardinal(edge) && view->maximized == VIEW_AXIS_NONE) {
+	if (lab_edge_is_cardinal(edge) && view->maximized == VIEW_AXIS_NONE
+			&& view->tiled != LAB_EDGE_CENTER) {
 		enum lab_edge invert_edge = lab_edge_invert(edge);
 		/* Represents axis of snapping direction */
 		enum lab_edge parallel_mask = edge | invert_edge;


### PR DESCRIPTION
For merging before 0.9.2 release.

In #3081, I was missing that windows can be tiled to "center". As a result, after executing
`<action name="SnapToEdge" combined="yes" direction="left" />` against a center-tiled window, `view->tiled` is set to `CENTER|LEFT`, which is unexpected.

Functionally, this caused a bug that moving a tiled window to an adjacent output required one additional execution of `SnapToEdge`:
1. Snap a window to center with `<action name="SnapToEdge" combine="yes" direction="center" />` (`view->tiled=0` -> `view->tiled=CENTER`)
2. Snap the window to left with `<action name="SnapToEdge" combine="yes" direction="left" />` (`view->tiled=CENTER` -> `view->tiled=CENTER|LEFT`)
3. Try to move the window to the left-adjacent output with `<action name="SnapToEdge" combine="yes" direction="left" />`, but window position/geometry doesn't change (`view->tiled=CENTER|LEFT` -> `view->tiled=LEFT`)
4. Repeat (3.) and the window is finally moved to the left-adjacent output (`view->tiled=LEFT` -> `view->tiled=RIGHT`)