### PR TITLE
view: store title/app_id in view

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -106,7 +106,6 @@ struct view_size_hints {
 struct view_impl {
 	void (*configure)(struct view *view, struct wlr_box geo);
 	void (*close)(struct view *view);
-	const char *(*get_string_prop)(struct view *view, const char *prop);
 	void (*map)(struct view *view);
 	void (*set_activated)(struct view *view, bool activated);
 	void (*set_fullscreen)(struct view *view, bool fullscreen);
@@ -172,6 +171,10 @@ struct view {
 	struct wlr_surface *surface;
 	struct wlr_scene_tree *scene_tree;
 	struct wlr_scene_tree *content_tree;
+
+	/* These are never NULL and an empty string is set instead. */
+	char *title;
+	char *app_id; /* WM_CLASS for xwayland windows */
 
 	bool mapped;
 	bool been_mapped;
@@ -571,9 +574,8 @@ bool view_on_output(struct view *view, struct output *output);
  */
 bool view_has_strut_partial(struct view *view);
 
-const char *view_get_string_prop(struct view *view, const char *prop);
-void view_update_title(struct view *view);
-void view_update_app_id(struct view *view);
+void view_set_title(struct view *view, const char *title);
+void view_set_app_id(struct view *view, const char *app_id);
 void view_reload_ssd(struct view *view);
 
 void view_set_shade(struct view *view, bool shaded);

--- a/src/debug.c
+++ b/src/debug.c
@@ -71,11 +71,10 @@ get_view_part(struct view *view, struct wlr_scene_node *node)
 		return NULL;
 	}
 	if (node == &view->scene_tree->node) {
-		const char *app_id = view_get_string_prop(view, "app_id");
-		if (string_null_or_empty(app_id)) {
+		if (string_null_or_empty(view->app_id)) {
 			return "view";
 		}
-		snprintf(view_name, sizeof(view_name), "view (%s)", app_id);
+		snprintf(view_name, sizeof(view_name), "view (%s)", view->app_id);
 		return view_name;
 	}
 	if (node == &view->content_tree->node) {

--- a/src/foreign-toplevel/ext-foreign.c
+++ b/src/foreign-toplevel/ext-foreign.c
@@ -32,8 +32,8 @@ handle_new_app_id(struct wl_listener *listener, void *data)
 	assert(ext_toplevel->handle);
 
 	struct wlr_ext_foreign_toplevel_handle_v1_state state = {
-		.title = view_get_string_prop(ext_toplevel->view, "title"),
-		.app_id = view_get_string_prop(ext_toplevel->view, "app_id")
+		.title = ext_toplevel->view->title,
+		.app_id = ext_toplevel->view->app_id,
 	};
 	wlr_ext_foreign_toplevel_handle_v1_update_state(ext_toplevel->handle,
 		&state);
@@ -47,8 +47,8 @@ handle_new_title(struct wl_listener *listener, void *data)
 	assert(ext_toplevel->handle);
 
 	struct wlr_ext_foreign_toplevel_handle_v1_state state = {
-		.title = view_get_string_prop(ext_toplevel->view, "title"),
-		.app_id = view_get_string_prop(ext_toplevel->view, "app_id")
+		.title = ext_toplevel->view->title,
+		.app_id = ext_toplevel->view->app_id,
 	};
 	wlr_ext_foreign_toplevel_handle_v1_update_state(ext_toplevel->handle,
 		&state);
@@ -63,15 +63,15 @@ ext_foreign_toplevel_init(struct ext_foreign_toplevel *ext_toplevel,
 	ext_toplevel->view = view;
 
 	struct wlr_ext_foreign_toplevel_handle_v1_state state = {
-		.title = view_get_string_prop(view, "title"),
-		.app_id = view_get_string_prop(view, "app_id")
+		.title = view->title,
+		.app_id = view->app_id,
 	};
 	ext_toplevel->handle = wlr_ext_foreign_toplevel_handle_v1_create(
 		view->server->foreign_toplevel_list, &state);
 
 	if (!ext_toplevel->handle) {
 		wlr_log(WLR_ERROR, "cannot create ext toplevel handle for (%s)",
-			view_get_string_prop(view, "title"));
+			view->title);
 		return;
 	}
 

--- a/src/foreign-toplevel/wlr-foreign.c
+++ b/src/foreign-toplevel/wlr-foreign.c
@@ -94,13 +94,8 @@ handle_new_app_id(struct wl_listener *listener, void *data)
 		wl_container_of(listener, wlr_toplevel, on_view.new_app_id);
 	assert(wlr_toplevel->handle);
 
-	const char *app_id = view_get_string_prop(wlr_toplevel->view, "app_id");
-	const char *wlr_app_id = wlr_toplevel->handle->app_id;
-	if (app_id && wlr_app_id && !strcmp(app_id, wlr_app_id)) {
-		/* Don't send app_id if they are the same */
-		return;
-	}
-	wlr_foreign_toplevel_handle_v1_set_app_id(wlr_toplevel->handle, app_id);
+	wlr_foreign_toplevel_handle_v1_set_app_id(wlr_toplevel->handle,
+		wlr_toplevel->view->app_id);
 }
 
 static void
@@ -110,13 +105,8 @@ handle_new_title(struct wl_listener *listener, void *data)
 		wl_container_of(listener, wlr_toplevel, on_view.new_title);
 	assert(wlr_toplevel->handle);
 
-	const char *title = view_get_string_prop(wlr_toplevel->view, "title");
-	const char *wlr_title = wlr_toplevel->handle->title;
-	if (title && wlr_title && !strcmp(title, wlr_title)) {
-		/* Don't send title if they are the same */
-		return;
-	}
-	wlr_foreign_toplevel_handle_v1_set_title(wlr_toplevel->handle, title);
+	wlr_foreign_toplevel_handle_v1_set_title(wlr_toplevel->handle,
+		wlr_toplevel->view->title);
 }
 
 static void
@@ -202,7 +192,7 @@ wlr_foreign_toplevel_init(struct wlr_foreign_toplevel *wlr_toplevel,
 		view->server->foreign_toplevel_manager);
 	if (!wlr_toplevel->handle) {
 		wlr_log(WLR_ERROR, "cannot create wlr foreign toplevel handle for (%s)",
-			view_get_string_prop(view, "title"));
+			view->title);
 		return;
 	}
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -900,8 +900,8 @@ update_client_list_combined_menu(struct server *server)
 
 		wl_list_for_each(view, &server->views, link) {
 			if (view->workspace == workspace) {
-				const char *title = view_get_string_prop(view, "title");
-				if (!view->foreign_toplevel || string_null_or_empty(title)) {
+				if (!view->foreign_toplevel
+						|| string_null_or_empty(view->title)) {
 					continue;
 				}
 
@@ -909,9 +909,9 @@ update_client_list_combined_menu(struct server *server)
 					buf_add(&buffer, "*");
 				}
 				if (view->minimized) {
-					buf_add_fmt(&buffer, "(%s)", title);
+					buf_add_fmt(&buffer, "(%s)", view->title);
 				} else {
-					buf_add(&buffer, title);
+					buf_add(&buffer, view->title);
 				}
 				item = item_create(menu, buffer.data, NULL,
 					/*show arrow*/ false);

--- a/src/osd/osd-thumbnail.c
+++ b/src/osd/osd-thumbnail.c
@@ -155,12 +155,11 @@ create_item_scene(struct wlr_scene_tree *parent, struct view *view,
 	}
 
 	/* title */
-	const char *title = view_get_string_prop(view, "title");
 	item->normal_title = create_title(item->tree, switcher_theme,
-		title, theme->osd_label_text_color,
+		view->title, theme->osd_label_text_color,
 		theme->osd_bg_color, title_y);
 	item->active_title = create_title(item->tree, switcher_theme,
-		title, theme->osd_label_text_color,
+		view->title, theme->osd_label_text_color,
 		switcher_theme->item_active_bg_color, title_y);
 
 	/* icon */

--- a/src/scaled-buffer/scaled-icon-buffer.c
+++ b/src/scaled-buffer/scaled-icon-buffer.c
@@ -281,7 +281,7 @@ handle_view_new_app_id(struct wl_listener *listener, void *data)
 	struct scaled_icon_buffer *self =
 		wl_container_of(listener, self, on_view.new_app_id);
 
-	const char *app_id = view_get_string_prop(self->view, "app_id");
+	const char *app_id = self->view->app_id;
 	if (str_equal(app_id, self->view_app_id)) {
 		return;
 	}

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -440,14 +440,13 @@ ssd_update_title(struct ssd *ssd)
 	}
 
 	struct view *view = ssd->view;
-	const char *title = view_get_string_prop(view, "title");
-	if (string_null_or_empty(title)) {
+	if (string_null_or_empty(view->title)) {
 		return;
 	}
 
 	struct theme *theme = view->server->theme;
 	struct ssd_state_title *state = &ssd->state.title;
-	bool title_unchanged = state->text && !strcmp(title, state->text);
+	bool title_unchanged = state->text && !strcmp(view->title, state->text);
 
 	int offset_left, offset_right;
 	get_title_offsets(ssd, &offset_left, &offset_right);
@@ -473,7 +472,7 @@ ssd_update_title(struct ssd *ssd)
 		}
 
 		const float bg_color[4] = {0, 0, 0, 0}; /* ignored */
-		scaled_font_buffer_update(subtree->title, title,
+		scaled_font_buffer_update(subtree->title, view->title,
 			title_bg_width, font,
 			text_color, bg_color);
 
@@ -483,10 +482,7 @@ ssd_update_title(struct ssd *ssd)
 	}
 
 	if (!title_unchanged) {
-		if (state->text) {
-			free(state->text);
-		}
-		state->text = xstrdup(title);
+		xstrdup_replace(state->text, view->title);
 	}
 	ssd_update_title_positions(ssd, offset_left, offset_right);
 }

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -10,8 +10,6 @@ void
 view_impl_map(struct view *view)
 {
 	desktop_focus_view(view, /*raise*/ true);
-	view_update_title(view);
-	view_update_app_id(view);
 	if (!view->been_mapped) {
 		window_rules_apply(view, LAB_WINDOW_RULE_EVENT_ON_FIRST_MAP);
 	}
@@ -36,8 +34,7 @@ view_impl_map(struct view *view)
 	desktop_update_top_layer_visibility(view->server);
 
 	wlr_log(WLR_DEBUG, "[map] identifier=%s, title=%s",
-		view_get_string_prop(view, "app_id"),
-		view_get_string_prop(view, "title"));
+		view->app_id, view->title);
 }
 
 void


### PR DESCRIPTION
This simplifies our codes and eliminates duplicated `view.events.new_{title,app_id}` events. This should not change any behaviors.

I think we can also remove `ssd_state_title.text` in a follow-up PR.