### PR TITLE
chase wlroots: ime: don't use `data` in kb grab destroy handler (MR 5170)

### DIFF
--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -309,7 +309,8 @@ handle_keyboard_grab_destroy(struct wl_listener *listener, void *data)
 {
 	struct input_method_relay *relay =
 		wl_container_of(listener, relay, keyboard_grab_destroy);
-	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab = data;
+	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab =
+		relay->input_method->keyboard_grab;
 	assert(keyboard_grab);
 
 	wl_list_remove(&relay->keyboard_grab_destroy.link);


### PR DESCRIPTION
Chase https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5170

## Background

My MR in wlroots ([!5107](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5107)) stopped emitting `wlr_input_method_v2` on its `commit`/`destroy` events, but didn't stop emitting `wlr_input_method_keyboard_grab_v2` on its `destroy` event. That was because `handle_keyboard_grab_destroy()` was called *after* `handle_input_method_destroy()` for some reason, which caused segfault when dereferencing `relay->input_method.keyboard_grab` in `handle_keyboard_grab_destroy()`.

MR 5170 reversed this weired order of destroy handler calls, and finally stopped emitting `wlr_input_method_keyboard_grab_v2` on its `destroy` event.