### PR TITLE
labnag: use overlay layer by default

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -286,6 +286,7 @@ this is for compatibility with Openbox.
 		--border-bottom-size 1 \\
 		--button-border-size 3 \\
 		--keyboard-focus on-demand \\
+		--layer overlay \\
 		--timeout 0
 	```
 

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1646,6 +1646,7 @@ post_processing(void)
 				"--border-bottom-size 1 "
 				"--button-border-size 3 "
 				"--keyboard-focus on-demand "
+				"--layer overlay "
 				"--timeout 0");
 	}
 	if (!rc.fallback_app_icon_name) {


### PR DESCRIPTION
...so that the dialog is still visible when some client is using fullscreen mode.