### PR TITLE
docs/: remove XML declarations in .xml files

### DIFF
--- a/docs/menu.xml
+++ b/docs/menu.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
 <openbox_menu>
 <!-- Note: for localization support of menu items "client-menu" has to be removed here -->
 <menu id="client-menu">

--- a/docs/rc.xml
+++ b/docs/rc.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0"?>
-
 <!--
   This is a very simple config file with many options missing. For a complete
   set of options with comments, see docs/rc.xml.all

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -1,5 +1,3 @@
-<?xml version="1.0"?>
-
 <!--
   This file contains all supported config elements & attributes with
   default values.


### PR DESCRIPTION
...because we don't like them anymore and libxml2 does not consider them mandatory.