### PR TITLE
ext-workspace: add `workspace_enter/leave` notifications and wire up `enter` on workspace switch

### DIFF
--- a/include/protocols/ext-workspace.h
+++ b/include/protocols/ext-workspace.h
@@ -106,4 +106,13 @@ void lab_ext_workspace_set_coordinates(struct lab_ext_workspace *workspace,
 
 void lab_ext_workspace_destroy(struct lab_ext_workspace *workspace);
 
+/* Notify clients that a workspace has entered/left the currently bound output group.
+ * This emits workspace_enter/leave for all clients that have both the group and the
+ * workspace bound, mirroring the initial-state emission.
+ */
+void lab_ext_workspace_group_workspace_enter(struct lab_ext_workspace_group *group,
+	struct lab_ext_workspace *workspace);
+void lab_ext_workspace_group_workspace_leave(struct lab_ext_workspace_group *group,
+	struct lab_ext_workspace *workspace);
+
 #endif /* LABWC_PROTOCOLS_EXT_WORKSPACES_H */

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -237,6 +237,12 @@ add_workspace(struct server *server, const char *name)
 	lab_ext_workspace_set_name(workspace->ext_workspace, name);
 	lab_ext_workspace_set_active(workspace->ext_workspace, active);
 
+	/* Notify ext-workspace listeners for active workspace only */
+	if (active) {
+		lab_ext_workspace_group_workspace_enter(
+			server->workspaces.ext_group, workspace->ext_workspace);
+	}
+
 	workspace->on_ext.activate.notify = handle_ext_workspace_activate;
 	wl_signal_add(&workspace->ext_workspace->events.activate,
 		&workspace->on_ext.activate);
@@ -427,6 +433,10 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	lab_ext_workspace_set_active(
 		server->workspaces.current->ext_workspace, false);
 
+	/* Notify ext-workspace listeners */
+	lab_ext_workspace_group_workspace_leave(
+		server->workspaces.ext_group, server->workspaces.current->ext_workspace);
+
 	/* Move Omnipresent views to new workspace */
 	struct view *view;
 	enum lab_view_criteria criteria =
@@ -482,6 +492,11 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	desktop_update_top_layer_visibility(server);
 
 	lab_cosmic_workspace_set_active(target->cosmic_workspace, true);
+
+	/* Notify ext-workspace listeners */
+	lab_ext_workspace_group_workspace_enter(
+		server->workspaces.ext_group, target->ext_workspace);
+
 	lab_ext_workspace_set_active(target->ext_workspace, true);
 }
 


### PR DESCRIPTION
## Summary
This PR introduces runtime `workspace_enter` / `workspace_leave` event notifications in the `ext-workspace` protocol and wires `workspace_enter` into the compositor's workspace switch path so clients (panels, pagers, taskbars) can react immediately when a workspace becomes visible on the currently bound output group. No protocol XML changes are required; this mirrors the initial-state emission semantics at bind time. Debug messages are emitted on enter/leave to make verification easy with `WLR_DEBUG`.

## Why
Many status bars/pagers rely on knowing when a workspace actually becomes visible on the user's active output group. Previously, clients only received the initial state on bind; dynamic transitions (e.g., switching to workspace 2) weren't explicitly signaled. Emitting `workspace_enter/leave` keeps client state accurate without polling.

## Implementation
The `*_enter/leave` helpers iterate group resources and workspace resources, match by client, and send the appropriate `workspace_enter/leave` to that client only. Include defensive `NULL` checks and debug logging (workspace name). On `workspaces_switch_to`, we emit `workspace_enter` for the target workspace just before setting it active. A `*_leave` hook is provided and can be used where the previous workspace actually leaves the bound group - e.g., when you finalize the old → new transition or in output/group reconfiguration paths.

### New Helpers (internal API)
```
lab_ext_workspace_group_workspace_enter(struct lab_ext_workspace_group *group, struct lab_ext_workspace *workspace)
lab_ext_workspace_group_workspace_leave(struct lab_ext_workspace_group *group, struct lab_ext_workspace *workspace)
```

These notify all clients that have both the group and the workspace bound, mirroring the initial-state emission behavior.

### Compositor Flow Changes
`workspaces_switch_to(...)` now calls `lab_ext_workspace_group_workspace_enter(server->workspaces.ext_group, target->ext_workspace);` right before marking the target ext-workspace active. This ensures clients learn that the workspace has entered the currently bound group as soon as the switch occurs.

### Protocol Impact
* No wire changes: Uses existing ext_workspace_group_handle_v1_send_workspace_enter/leave events.
* Client compatibility: Old clients are unaffected. New clients can subscribe to the events for better UX.

## Testing

1. Build & run
    * Build labwc and run with `labwc -d`.
2. Switch workspaces
    * Use your normal bindings to switch to another workspace in the same output group.
    * Expect logs like:
      * `ext-workspace: enter name='2'`
      * (If/when wired) `ext-workspace: leave name='1'`
3. Regression
    * Open/close views, move omnipresent views, and verify no change in existing behavior except the new notifications.