### PR TITLE
osd-classic: fix miscalculation for osd width in percentage

### DIFF
--- a/src/osd/osd-classic.c
+++ b/src/osd/osd-classic.c
@@ -86,7 +86,8 @@ osd_classic_create(struct output *output, struct wl_array *views)
 
 	int w = switcher_theme->width;
 	if (switcher_theme->width_is_percent) {
-		w = output->wlr_output->width * switcher_theme->width / 100;
+		w = output->wlr_output->width / output->wlr_output->scale
+			* switcher_theme->width / 100;
 	}
 	int h = wl_array_len(views) * switcher_theme->item_height
 		+ 2 * rc.theme->osd_border_width + 2 * switcher_theme->padding;


### PR DESCRIPTION
Fixes a regression in 75eb370.

I guess I thought that we could be completely unaware of output scale when moving from cairo textures to scene nodes, but it was wrong.