### PR TITLE
osd: use wlr_output_effective_resolution() to get output geometry

### DIFF
--- a/src/osd/osd-classic.c
+++ b/src/osd/osd-classic.c
@@ -84,10 +84,13 @@ osd_classic_create(struct output *output, struct wl_array *views)
 	bool show_workspace = wl_list_length(&rc.workspace_config.workspaces) > 1;
 	const char *workspace_name = server->workspaces.current->name;
 
+	int output_width, output_height;
+	wlr_output_effective_resolution(output->wlr_output,
+		&output_width, &output_height);
+
 	int w = switcher_theme->width;
 	if (switcher_theme->width_is_percent) {
-		w = output->wlr_output->width / output->wlr_output->scale
-			* switcher_theme->width / 100;
+		w = output_width * switcher_theme->width / 100;
 	}
 	int h = wl_array_len(views) * switcher_theme->item_height
 		+ 2 * rc.theme->osd_border_width + 2 * switcher_theme->padding;

--- a/src/osd/osd-thumbnail.c
+++ b/src/osd/osd-thumbnail.c
@@ -180,7 +180,9 @@ get_items_geometry(struct output *output, struct theme *theme,
 {
 	struct window_switcher_thumbnail_theme *switcher_theme =
 		&theme->osd_window_switcher_thumbnail;
-	int output_width = output->wlr_output->width / output->wlr_output->scale;
+	int output_width, output_height;
+	wlr_output_effective_resolution(output->wlr_output,
+		&output_width, &output_height);
 	int padding = theme->osd_border_width + switcher_theme->padding;
 
 	int max_bg_width = switcher_theme->max_width;


### PR DESCRIPTION
Before this commit, output transformations were not taken into account:

|Before|After|
|-|-|
| <img width="1920" height="1080" alt="20251102_01h25m10s_grim" src="https://github.com/user-attachments/assets/c4d4507b-fa19-4834-89cc-e0a690080dd4" /> | <img width="1920" height="1080" alt="20251102_01h24m59s_grim" src="https://github.com/user-attachments/assets/d77c3034-b246-4528-a336-407190baec48" /> |


`themerc-override`:

```
osd.window-switcher.style-thumbnail.width: 80%
osd.window-switcher.style-thumbnail.width.max: 80%
```
