### PR TITLE
osd: move end_cycling() into osd_finish()

### DIFF
--- a/include/osd.h
+++ b/include/osd.h
@@ -53,7 +53,7 @@ void osd_begin(struct server *server, enum lab_cycle_dir direction);
 void osd_cycle(struct server *server, enum lab_cycle_dir direction);
 
 /* Closes the OSD */
-void osd_finish(struct server *server);
+void osd_finish(struct server *server, bool switch_focus);
 
 /* Notify OSD about a destroying view */
 void osd_on_view_destroy(struct view *view);


### PR DESCRIPTION
...so that we can use `osd_finish()` to support clicking an osd item to focus its associated window: https://github.com/labwc/labwc/commit/eac5f0f892d7350053b0b070c50ddd3f2b93ccbb