### PR TITLE
[osd] add custom field to thumbnail style

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -339,7 +339,7 @@ this is for compatibility with Openbox.
 ## WINDOW SWITCHER
 
 ```
-<windowSwitcher show="yes" style="classic" preview="yes" outlines="yes" allWorkspaces="no">
+<windowSwitcher show="yes" style="classic" preview="yes" outlines="yes" allWorkspaces="no" thumbnailLabelFormat="%T">
   <fields>
     <field content="icon" width="5%" />
     <field content="desktop_entry_name" width="30%" />
@@ -348,7 +348,7 @@ this is for compatibility with Openbox.
 </windowSwitcher>
 ```
 
-*<windowSwitcher show="" style="" preview="" outlines="" allWorkspaces="" unshade="">*
+*<windowSwitcher show="" style="" preview="" outlines="" allWorkspaces="" unshade="" thumbnailLabelFormat="">*
 	*show* [yes|no] Draw the OnScreenDisplay when switching between
 	windows. Default is yes.
 
@@ -368,6 +368,10 @@ this is for compatibility with Openbox.
 
 	*unshade* [yes|no] Temporarily unshade windows when switching between
 	them and permanently unshade on the final selection. Default is yes.
+
+	*thumbnailLabelFormat* Format to be used for the thumbnail label according to *custom*
+	field below, only applied when using *<windowSwitcher style="thumbnail" />*.
+	Default is "%T".
 
 *<windowSwitcher><fields><field content="" width="%">*
 	Define window switcher fields when using *<windowSwitcher style="classic" />*.

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -183,6 +183,7 @@ struct rcxml {
 		enum lab_view_criteria criteria;
 		struct wl_list fields;  /* struct window_switcher_field.link */
 		enum window_switcher_style style;
+		char *thumbnail_label_format;
 	} window_switcher;
 
 	struct wl_list window_rules; /* struct window_rule.link */

--- a/include/osd.h
+++ b/include/osd.h
@@ -65,6 +65,9 @@ void osd_on_cursor_release(struct server *server, struct wlr_scene_node *node);
 /* Used by osd.c internally to render window switcher fields */
 void osd_field_get_content(struct window_switcher_field *field,
 	struct buf *buf, struct view *view);
+/* Sets view info to buf according to format */
+void osd_field_set_custom(struct buf *buf, struct view *view,
+	const char *format);
 
 /* Used by rcxml.c when parsing the config */
 void osd_field_arg_from_xml_node(struct window_switcher_field *field,

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1208,6 +1208,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else if (!strcasecmp(content, "thumbnail")) {
 			rc.window_switcher.style = WINDOW_SWITCHER_THUMBNAIL;
 		}
+	} else if (!strcasecmp(nodename, "thumbnailLabelFormat.windowSwitcher")) {
+		xstrdup_replace(rc.window_switcher.thumbnail_label_format, content);
 	} else if (!strcasecmp(nodename, "preview.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.preview);
 	} else if (!strcasecmp(nodename, "outlines.windowSwitcher")) {
@@ -1429,6 +1431,7 @@ rcxml_init(void)
 
 	rc.window_switcher.show = true;
 	rc.window_switcher.style = WINDOW_SWITCHER_CLASSIC;
+	rc.window_switcher.thumbnail_label_format = xstrdup("%T");
 	rc.window_switcher.preview = true;
 	rc.window_switcher.outlines = true;
 	rc.window_switcher.unshade = true;
@@ -1905,6 +1908,7 @@ rcxml_finish(void)
 	zfree(rc.fallback_app_icon_name);
 	zfree(rc.workspace_config.prefix);
 	zfree(rc.tablet.output_name);
+	zfree(rc.window_switcher.thumbnail_label_format);
 
 	clear_title_layout();
 

--- a/src/osd/osd-field.c
+++ b/src/osd/osd-field.c
@@ -189,9 +189,6 @@ field_set_title_short(struct buf *buf, struct view *view, const char *format)
 	buf_add(buf, get_title_if_different(view));
 }
 
-static void field_set_custom(struct buf *buf, struct view *view,
-	const char *format);
-
 static const struct field_converter field_converter[LAB_FIELD_COUNT] = {
 	[LAB_FIELD_TYPE]               = { 'B', field_set_type },
 	[LAB_FIELD_TYPE_SHORT]         = { 'b', field_set_type_short },
@@ -207,11 +204,11 @@ static const struct field_converter field_converter[LAB_FIELD_COUNT] = {
 	[LAB_FIELD_TITLE]              = { 'T', field_set_title },
 	[LAB_FIELD_TITLE_SHORT]        = { 't', field_set_title_short },
 	/* fmt_char can never be matched so prevents LAB_FIELD_CUSTOM recursion */
-	[LAB_FIELD_CUSTOM]             = { '\0', field_set_custom },
+	[LAB_FIELD_CUSTOM]             = { '\0', osd_field_set_custom },
 };
 
-static void
-field_set_custom(struct buf *buf, struct view *view, const char *format)
+void
+osd_field_set_custom(struct buf *buf, struct view *view, const char *format)
 {
 	if (!format) {
 		wlr_log(WLR_ERROR, "Missing format for custom window switcher field");


### PR DESCRIPTION
I was trying to add some customization to OSD, and adding only the custom field seemed simple enough, if this is not desired or the code isn't good, feel free to close it or suggest changes.

<img width="1237" height="612" alt="qse_1762237714" src="https://github.com/user-attachments/assets/a69da8e7-352b-4066-83fb-ef28534c7ef5" />
