### PR TITLE
osd: make empty string "" in thumbnailLabelFormat not show any text

### DIFF
--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1068,6 +1068,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		load_default_mouse_bindings();
 	} else if (!strcasecmp(nodename, "prefix.desktops")) {
 		xstrdup_replace(rc.workspace_config.prefix, content);
+	} else if (!strcasecmp(nodename, "thumbnailLabelFormat.windowSwitcher")) {
+		xstrdup_replace(rc.window_switcher.thumbnail_label_format, content);
 
 	} else if (!lab_xml_node_is_leaf(node)) {
 		/* parse children of nested nodes other than above */
@@ -1208,8 +1210,6 @@ entry(xmlNode *node, char *nodename, char *content)
 		} else if (!strcasecmp(content, "thumbnail")) {
 			rc.window_switcher.style = WINDOW_SWITCHER_THUMBNAIL;
 		}
-	} else if (!strcasecmp(nodename, "thumbnailLabelFormat.windowSwitcher")) {
-		xstrdup_replace(rc.window_switcher.thumbnail_label_format, content);
 	} else if (!strcasecmp(nodename, "preview.windowSwitcher")) {
 		set_bool(content, &rc.window_switcher.preview);
 	} else if (!strcasecmp(nodename, "outlines.windowSwitcher")) {


### PR DESCRIPTION
saw this

https://github.com/labwc/labwc/issues/3160#issuecomment-3499753127
> for example the OSD format strings where the user may actually want an empty string and it should not fall back to its default value in that case.

and noticed empty string was ignored in `thumbnailLabelFormat`, instead it used the default format "%T", while `<fields><field content="custom">` does accept the empty string and shows empty space.

with this commit this is possible:

<img width="648" height="307" alt="qse_1762484165" src="https://github.com/user-attachments/assets/c671c150-8d83-4d91-9acd-d3feff029b65" />
