### PR TITLE
view: update top layer visiblity at unmap instead of destroy

### DIFF
--- a/include/output.h
+++ b/include/output.h
@@ -69,4 +69,13 @@ void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
 void output_enable_adaptive_sync(struct output *output, bool enabled);
 
+/**
+ * Notifies whether a fullscreen view is displayed on the given output.
+ * Depending on user config, this may enable/disable adaptive sync.
+ *
+ * Does nothing if output is NULL or disabled.
+ */
+void output_set_has_fullscreen_view(struct output *output,
+	bool has_fullscreen_view);
+
 #endif // LABWC_OUTPUT_H

--- a/src/output.c
+++ b/src/output.c
@@ -1144,3 +1144,15 @@ output_enable_adaptive_sync(struct output *output, bool enabled)
 			enabled ? "en" : "dis", output->wlr_output->name);
 	}
 }
+
+void
+output_set_has_fullscreen_view(struct output *output, bool has_fullscreen_view)
+{
+	if (rc.adaptive_sync != LAB_ADAPTIVE_SYNC_FULLSCREEN
+			|| !output_is_usable(output)) {
+		return;
+	}
+	/* Enable adaptive sync if view is fullscreen */
+	output_enable_adaptive_sync(output, has_fullscreen_view);
+	output_state_commit(output);
+}

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /* view-impl-common.c: common code for shell view->impl functions */
 #include "view-impl-common.h"
-#include "config/rcxml.h"
 #include "foreign-toplevel/foreign.h"
 #include "labwc.h"
 #include "output.h"
-#include "output-state.h"
 #include "view.h"
 #include "window-rules.h"
 
@@ -65,10 +63,8 @@ view_impl_unmap(struct view *view)
 	 * views. It should probably be combined with the existing
 	 * logic in desktop_update_top_layer_visibility().
 	 */
-	if (view->fullscreen && rc.adaptive_sync == LAB_ADAPTIVE_SYNC_FULLSCREEN
-			&& output_is_usable(view->output)) {
-		output_enable_adaptive_sync(view->output, false);
-		output_state_commit(view->output);
+	if (view->fullscreen) {
+		output_set_has_fullscreen_view(view->output, false);
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -21,7 +21,6 @@
 #include "menu/menu.h"
 #include "osd.h"
 #include "output.h"
-#include "output-state.h"
 #include "placement.h"
 #include "regions.h"
 #include "resize-indicator.h"
@@ -513,20 +512,6 @@ view_discover_output(struct view *view, struct wlr_box *geometry)
 	return false;
 }
 
-static void
-set_adaptive_sync_fullscreen(struct view *view)
-{
-	if (!output_is_usable(view->output)) {
-		return;
-	}
-	if (rc.adaptive_sync != LAB_ADAPTIVE_SYNC_FULLSCREEN) {
-		return;
-	}
-	/* Enable adaptive sync if view is fullscreen */
-	output_enable_adaptive_sync(view->output, view->fullscreen);
-	output_state_commit(view->output);
-}
-
 void
 view_set_activated(struct view *view, bool activated)
 {
@@ -548,7 +533,7 @@ view_set_activated(struct view *view, bool activated)
 			keyboard_update_layout(&view->server->seat, view->keyboard_layout);
 		}
 	}
-	set_adaptive_sync_fullscreen(view);
+	output_set_has_fullscreen_view(view->output, view->fullscreen);
 }
 
 void
@@ -1786,7 +1771,7 @@ view_set_fullscreen(struct view *view, bool fullscreen)
 	} else {
 		view_apply_special_geometry(view);
 	}
-	set_adaptive_sync_fullscreen(view);
+	output_set_has_fullscreen_view(view->output, view->fullscreen);
 }
 
 static bool


### PR DESCRIPTION
It's possible for a fullscreen xwayland view to be unmapped without being destroyed. In this case, we need to update top layer visibility, otherwise panels and the like will remain hidden.

Since unmap is always called before destroy, it's sufficient to do the update only in view_impl_unmap() and not in view_destroy().

Adaptive sync logic needs work still, but I tried to minimize changes to it since I don't have hardware to test it.

Test case (run with no other views open):
```
#include <QApplication>
#include <QWidget>
#include <QTimer>
#include <stdlib.h>

int main(int argc, char *argv[]) {
    setenv("QT_QPA_PLATFORM", "xcb", 1);
    QApplication app(argc, argv);
    QWidget window;
    window.showFullScreen();
    QTimer::singleShot(1000, &window, &QWidget::hide);
    return app.exec();
}
```