### PR TITLE
Map/unmap/minimize logic cleanups

### DIFF
--- a/src/foreign-toplevel/foreign.c
+++ b/src/foreign-toplevel/foreign.c
@@ -18,7 +18,6 @@ struct foreign_toplevel *
 foreign_toplevel_create(struct view *view)
 {
 	assert(view);
-	assert(view->mapped);
 
 	struct foreign_toplevel *toplevel = znew(*toplevel);
 	wlr_foreign_toplevel_init(&toplevel->wlr_toplevel, view);

--- a/src/view-impl-common.c
+++ b/src/view-impl-common.c
@@ -9,7 +9,10 @@
 void
 view_impl_map(struct view *view)
 {
-	desktop_focus_view(view, /*raise*/ true);
+	/* Leave minimized, if minimized before map */
+	if (!view->minimized) {
+		desktop_focus_view(view, /*raise*/ true);
+	}
 	if (!view->been_mapped) {
 		window_rules_apply(view, LAB_WINDOW_RULE_EVENT_ON_FIRST_MAP);
 	}

--- a/src/view.c
+++ b/src/view.c
@@ -2473,18 +2473,7 @@ static void
 handle_map(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, mappable.map);
-	if (view->minimized) {
-		/*
-		 * The view->impl functions do not directly support
-		 * mapping a view while minimized. Instead, mark it as
-		 * not minimized, map it, and then minimize it again.
-		 */
-		view->minimized = false;
-		view->impl->map(view);
-		view_minimize(view, true);
-	} else {
-		view->impl->map(view);
-	}
+	view->impl->map(view);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -832,8 +832,15 @@ xwayland_view_map(struct view *view)
 	 */
 	handle_map_request(&xwayland_view->map_request, NULL);
 
-	view->mapped = true;
-	wlr_scene_node_set_enabled(&view->scene_tree->node, true);
+	/*
+	 * For initially minimized views, we do not set view->mapped
+	 * nor enable the scene node. All other map logic (positioning,
+	 * creating foreign toplevel, etc.) happens as normal.
+	 */
+	if (!view->minimized) {
+		view->mapped = true;
+		wlr_scene_node_set_enabled(&view->scene_tree->node, true);
+	}
 
 	if (view->surface != xwayland_surface->surface) {
 		set_surface(view, xwayland_surface->surface);


### PR DESCRIPTION
A couple of fixes to make the map/unmap/minimize logic a bit easier to follow. There shouldn't be any behavioral change, except *possibly* eliminating some spurious minimize/un-minimize transitions for initially minimized views.

Descriptions below copied-and-pasted from the commit messages.

- xwayland: connect commit and surface_destroy handlers together
    
    Factor out set_surface() which consolidates connecting/disconnecting
    the wlr_surface event listeners in one place.
    
    In theory, this means we can receive commit events for minimized views.
    However, with a test app that resizes itself, I didn't see any change,
    i.e. the commits still don't come through until un-minimize. It's
    possible they are being filtered at wlroots or protocol level.
    
    Also remove an old, semi-related TODO from view.c.

- view: less hacky support for minimize-before-map
    
    The previous "minimal fix" (5148c2aa3140) worked but was a bit of a
    hack, as it basically un-minimized and then immediately minimized the
    view again at map. It's not actually too difficult to make the map
    handlers aware of minimized views, eliminating the need for the hack.
    
    Note: this depends on the previous commit ("xwayland: connect commit
    and surface_destroy handlers together") otherwise the xwayland map
    handler registers the commit handler twice, leading to a crash.