### PR TITLE
windowSwitcher: add multi-monitor OSD support

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -339,7 +339,8 @@ this is for compatibility with Openbox.
 ## WINDOW SWITCHER
 
 ```
-<windowSwitcher show="yes" style="classic" preview="yes" outlines="yes" allWorkspaces="no" thumbnailLabelFormat="%T">
+<windowSwitcher preview="yes" outlines="yes" allWorkspaces="no">
+  <osd show="yes" style="classic" output="all" thumbnailLabelFormat="%T" />
   <fields>
     <field content="icon" width="5%" />
     <field content="desktop_entry_name" width="30%" />
@@ -348,14 +349,7 @@ this is for compatibility with Openbox.
 </windowSwitcher>
 ```
 
-*<windowSwitcher show="" style="" preview="" outlines="" allWorkspaces="" unshade="" thumbnailLabelFormat="">*
-	*show* [yes|no] Draw the OnScreenDisplay when switching between
-	windows. Default is yes.
-
-	*style* [classic|thumbnail] Configures the style of the OnScreenDisplay.
-	"classic" displays window information like icons and titles in a vertical list.
-	"thumbnail" shows window thumbnail, icon and title in grids.
-
+*<windowSwitcher preview="" outlines="" allWorkspaces="" unshade="">*
 	*preview* [yes|no] Preview the contents of the selected window when
 	switching between windows. Default is yes.
 
@@ -369,12 +363,26 @@ this is for compatibility with Openbox.
 	*unshade* [yes|no] Temporarily unshade windows when switching between
 	them and permanently unshade on the final selection. Default is yes.
 
+*<osd show="" style="" output="" thumbnailLabelFormat="" />*
+	*show* [yes|no] Draw the OnScreenDisplay when switching between
+	windows. Default is yes.
+
+	*style* [classic|thumbnail] Configures the style of the OSD.
+	"classic" displays window information like icons and titles in a vertical list.
+	"thumbnail" shows window thumbnail, icon and title in grids.
+
+	*output* [all|pointer|keyboard] Configures which monitor(s) show the OSD.
+	"all" displays the OSD on all monitors.
+	"pointer" displays the OSD on the monitor containing the mouse pointer.
+	"keyboard" displays the OSD on the monitor with keyboard focus.
+	Default is "all".
+
 	*thumbnailLabelFormat* Format to be used for the thumbnail label according to *custom*
-	field below, only applied when using *<windowSwitcher style="thumbnail" />*.
+	field below, only applied when using *<osd style="thumbnail" />*.
 	Default is "%T".
 
 *<windowSwitcher><fields><field content="" width="%">*
-	Define window switcher fields when using *<windowSwitcher style="classic" />*.
+	Define window switcher fields when using *<osd style="classic" />*.
 
 	*content* defines what the field shows and can be any of:
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -77,8 +77,8 @@
     </font>
   </theme>
 
-  <windowSwitcher show="yes" style="classic" preview="yes"
-      outlines="yes" allWorkspaces="no" unshade="yes">
+  <windowSwitcher preview="yes" outlines="yes" allWorkspaces="no" unshade="yes">
+    <osd show="yes" style="classic" output="all" thumbnailLabelFormat="%T" />
     <fields>
       <field content="icon" width="5%" />
       <field content="desktop_entry_name" width="30%" />
@@ -98,7 +98,8 @@
     Some contents are fixed-length and others are variable-length.
     See "man 5 labwc-config" for details.
 
-    <windowSwitcher show="yes" preview="no" outlines="no" allWorkspaces="yes">
+    <windowSwitcher preview="no" outlines="no" allWorkspaces="yes">
+      <osd show="yes" />
       <fields>
         <field content="workspace" width="5%" />
         <field content="state" width="3%" />
@@ -118,7 +119,8 @@
     then workspace name, then identifier/app-id, then the window title.
     It uses 100% of OSD window width.
 
-    <windowSwitcher show="yes" preview="no" outlines="no" allWorkspaces="yes">
+    <windowSwitcher preview="no" outlines="no" allWorkspaces="yes">
+      <osd show="yes" />
       <fields>
         <field content="custom" format="foobar %b %3s %-10o %-20W %-10i %t" width="100%" />
       </fields>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -183,6 +183,7 @@ struct rcxml {
 		enum lab_view_criteria criteria;
 		struct wl_list fields;  /* struct window_switcher_field.link */
 		enum window_switcher_style style;
+		enum osd_output_criteria output_criteria;
 		char *thumbnail_label_format;
 	} window_switcher;
 

--- a/include/config/types.h
+++ b/include/config/types.h
@@ -112,4 +112,10 @@ enum window_switcher_style {
 	WINDOW_SWITCHER_THUMBNAIL,
 };
 
+enum osd_output_criteria {
+	OSD_OUTPUT_ALL,
+	OSD_OUTPUT_POINTER,
+	OSD_OUTPUT_KEYBOARD,
+};
+
 #endif /* LABWC_CONFIG_TYPES_H */


### PR DESCRIPTION
# Add multi-monitor OSD support to window switcher

## Summary
Adds multi-monitor support to the window switcher OSD with configurable output criteria.

## Changes
- New `output` attribute with three modes:
  - `all`: Display OSD on all monitors (default)
  - `pointer`: Display on monitor containing the cursor
  - `keyboard`: Display on monitor with keyboard focus
- Refactored XML structure: OSD settings now nested under `<osd>` element

## Configuration Example
```xml
<windowSwitcher preview="yes" outlines="yes" allWorkspaces="no">
  <osd show="yes" style="classic" output="pointer" />
  <fields>
    ...
  </fields>
</windowSwitcher>
```

## Breaking Changes
The `<windowSwitcher>` element structure has changed. OSD-specific attributes (`show`, `style`, `thumbnailLabelFormat`) must now be placed within an `<osd>` child element. The new `output` attribute is also configured here.

### Migration Example
```diff
- <windowSwitcher show="yes" style="classic" preview="yes">
+ <windowSwitcher preview="yes">
+   <osd show="yes" style="classic" output="all" />
    <fields>...</fields>
  </windowSwitcher>
```