### PR TITLE
view: separate (un)minimize and (un)map logic

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -110,13 +110,7 @@ struct view_impl {
 	void (*set_activated)(struct view *view, bool activated);
 	void (*set_fullscreen)(struct view *view, bool fullscreen);
 	void (*notify_tiled)(struct view *view);
-	/*
-	 * client_request is true if the client unmapped its own
-	 * surface; false if we are just minimizing the view. The two
-	 * cases are similar but have subtle differences (e.g., when
-	 * minimizing we don't destroy the foreign toplevel handle).
-	 */
-	void (*unmap)(struct view *view, bool client_request);
+	void (*unmap)(struct view *view);
 	void (*maximize)(struct view *view, enum view_axis maximized);
 	void (*minimize)(struct view *view, bool minimize);
 	struct view *(*get_parent)(struct view *self);
@@ -591,6 +585,7 @@ void view_adjust_size(struct view *view, int *w, int *h);
 void view_evacuate_region(struct view *view);
 void view_on_output_destroy(struct view *view);
 void view_connect_map(struct view *view, struct wlr_surface *surface);
+void view_update_visibility(struct view *view);
 
 void view_init(struct view *view);
 void view_destroy(struct view *view);

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -145,7 +145,7 @@ desktop_topmost_focusable_view(struct server *server)
 			continue;
 		}
 		view = node_view_from_node(node);
-		if (view->mapped && view_is_focusable(view)) {
+		if (view_is_focusable(view) && !view->minimized) {
 			return view;
 		}
 	}

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -614,7 +614,7 @@ xdg_toplevel_view_append_children(struct view *self, struct wl_array *children)
 		if (view->type != LAB_XDG_SHELL_VIEW) {
 			continue;
 		}
-		if (!view->mapped && !view->minimized) {
+		if (!view->mapped) {
 			continue;
 		}
 		if (top_parent_of(view) != toplevel) {
@@ -757,15 +757,7 @@ xdg_toplevel_view_map(struct view *view)
 		view_set_output(view, output_nearest_to_cursor(view->server));
 	}
 
-	/*
-	 * For initially minimized views, we do not set view->mapped
-	 * nor enable the scene node. All other map logic (positioning,
-	 * creating foreign toplevel, etc.) happens as normal.
-	 */
-	if (!view->minimized) {
-		view->mapped = true;
-		wlr_scene_node_set_enabled(&view->scene_tree->node, true);
-	}
+	view->mapped = true;
 
 	if (!view->foreign_toplevel) {
 		view_impl_init_foreign_toplevel(view);
@@ -815,22 +807,11 @@ xdg_toplevel_view_map(struct view *view)
 }
 
 static void
-xdg_toplevel_view_unmap(struct view *view, bool client_request)
+xdg_toplevel_view_unmap(struct view *view)
 {
 	if (view->mapped) {
 		view->mapped = false;
-		wlr_scene_node_set_enabled(&view->scene_tree->node, false);
 		view_impl_unmap(view);
-	}
-
-	/*
-	 * If the view was explicitly unmapped by the client (rather
-	 * than just minimized), destroy the foreign toplevel handle so
-	 * the unmapped view doesn't show up in panels and the like.
-	 */
-	if (client_request && view->foreign_toplevel) {
-		foreign_toplevel_destroy(view->foreign_toplevel);
-		view->foreign_toplevel = NULL;
 	}
 }
 


### PR DESCRIPTION
Map/unmap logic is currently re-used for minimize/unminimize, but lots of it doesn't actually apply in that case. This is both confusing and creates some extra complexity, such as:

 - extra `client_request` parameter to `unmap()`, in which case it has to still do some cleanup even if `view->mapped` is already false
 - various `view->mapped || view->minimized` checks when we really just mean "is the view mapped"

To clean this all up, let's put the logic that really is common into new `view_on_show/on_hide()` functions, and stop using map/unmap for minimize/unminimize.

Note that this changes the meaning of `view->mapped`, which used to mean "mapped and not minimized" but now really just means "mapped". I left some `view->mapped` conditions as-is (rather than changing to `view->mapped && !view->minimized`) where it seemed to make sense.

Lightly tested, including some initially-minimized and client map/unmap cases. More testing appreciated.