### PR TITLE
output: avoid use of wlr_scene_output.WLR_PRIVATE.index

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -257,6 +257,7 @@ struct server {
 	struct wl_list outputs;
 	struct wl_listener new_output;
 	struct wlr_output_layout *output_layout;
+	uint64_t next_output_id_bit;
 
 	struct wl_listener output_layout_change;
 	struct wlr_output_manager_v1 *output_manager;

--- a/include/output.h
+++ b/include/output.h
@@ -33,6 +33,18 @@ struct output {
 	struct wl_listener frame;
 	struct wl_listener request_state;
 
+	/*
+	 * Unique power-of-two ID used in bitsets such as view->outputs.
+	 * (This assumes there are never more than 64 outputs connected
+	 * at once; wlr_scene_output has a similar limitation.)
+	 *
+	 * There's currently no attempt to maintain the same ID if the
+	 * same physical output is disconnected and reconnected.
+	 * However, IDs do get reused eventually if enough outputs are
+	 * disconnected and connected again.
+	 */
+	uint64_t id_bit;
+
 	bool gamma_lut_changed;
 };
 

--- a/include/view.h
+++ b/include/view.h
@@ -158,7 +158,7 @@ struct view {
 	 * This is used to notify the foreign toplevel
 	 * implementation and to update the SSD invisible
 	 * resize area.
-	 * It is a bitset of output->scene_output->index.
+	 * It is a bitset of output->id_bit.
 	 */
 	uint64_t outputs;
 

--- a/src/view.c
+++ b/src/view.c
@@ -570,7 +570,7 @@ view_update_outputs(struct view *view)
 	wl_list_for_each(output, &view->server->outputs, link) {
 		if (output_is_usable(output) && wlr_output_layout_intersects(
 				layout, output->wlr_output, &view->current)) {
-			new_outputs |= (1ull << output->scene_output->WLR_PRIVATE.index);
+			new_outputs |= output->id_bit;
 		}
 	}
 
@@ -586,8 +586,7 @@ view_on_output(struct view *view, struct output *output)
 {
 	assert(view);
 	assert(output);
-	return output->scene_output
-			&& (view->outputs & (1ull << output->scene_output->WLR_PRIVATE.index));
+	return (view->outputs & output->id_bit) != 0;
 }
 
 void


### PR DESCRIPTION
We were only using it to allow quick bitset comparisons of sets of outputs (such as `view->outputs`). We can maintain our own bit IDs for this purpose and avoid using the private wlroots field.

Note: from my reading of `wlr_scene_output_create()`, it appears to always take the lowest unused index, resulting in aggressive re-use of index values when outputs are disconnected and reconnected. I've tried to make re-use as infrequent as possible. This could theoretically reduce the chance of a mix-up in `view_update_outputs()`, although I'm not aware of any practical scenario where it matters.

Lightly tested running nested with `WLR_WL_OUTPUTS=2`.