### PR TITLE
Refactor window switcher

### DIFF
--- a/include/cycle.h
+++ b/include/cycle.h
@@ -87,7 +87,7 @@ struct cycle_osd_impl {
 	 * Create a scene-tree of OSD for an output.
 	 * This sets output->cycle_osd.{items,tree}.
 	 */
-	void (*create)(struct output *output, struct wl_array *views);
+	void (*create)(struct output *output);
 	/*
 	 * Update output->cycle_osd.tree to highlight
 	 * server->cycle_state.selected_view.

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -303,6 +303,7 @@ struct server {
 	/* Set when in cycle (alt-tab) mode */
 	struct cycle_state {
 		struct view *selected_view;
+		struct wl_list views;
 		bool preview_was_shaded;
 		bool preview_was_enabled;
 		struct wlr_scene_node *preview_node;

--- a/include/view.h
+++ b/include/view.h
@@ -134,6 +134,9 @@ struct view {
 	const struct view_impl *impl;
 	struct wl_list link;
 
+	/* This is cleared when the view is not in the cycle list */
+	struct wl_list cycle_link;
+
 	/*
 	 * The primary output that the view is displayed on. Specifically:
 	 *
@@ -382,15 +385,6 @@ struct view *view_next(struct wl_list *head, struct view *view,
  * Returns NULL if there are no views matching the criteria.
  */
 struct view *view_prev(struct wl_list *head, struct view *view,
-	enum lab_view_criteria criteria);
-
-/*
- * Same as `view_next()` except that they iterate one whole cycle rather than
- * stopping at the list-head
- */
-struct view *view_next_no_head_stop(struct wl_list *head, struct view *from,
-	enum lab_view_criteria criteria);
-struct view *view_prev_no_head_stop(struct wl_list *head, struct view *from,
 	enum lab_view_criteria criteria);
 
 /**

--- a/src/cycle/osd-thumbnail.c
+++ b/src/cycle/osd-thumbnail.c
@@ -5,11 +5,11 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_scene.h>
 #include "config/rcxml.h"
-#include "common/array.h"
 #include "common/box.h"
 #include "common/buf.h"
 #include "common/lab-scene-rect.h"
 #include "common/list.h"
+#include "common/mem.h"
 #include "cycle.h"
 #include "labwc.h"
 #include "node.h"
@@ -226,7 +226,7 @@ get_items_geometry(struct output *output, struct theme *theme,
 }
 
 static void
-cycle_osd_thumbnail_create(struct output *output, struct wl_array *views)
+cycle_osd_thumbnail_create(struct output *output)
 {
 	assert(!output->cycle_osd.tree && wl_list_empty(&output->cycle_osd.items));
 
@@ -238,17 +238,17 @@ cycle_osd_thumbnail_create(struct output *output, struct wl_array *views)
 
 	output->cycle_osd.tree = wlr_scene_tree_create(output->cycle_osd_tree);
 
-	int nr_views = wl_array_len(views);
+	int nr_views = wl_list_length(&server->cycle.views);
 	assert(nr_views > 0);
 	int nr_rows, nr_cols;
 	get_items_geometry(output, theme, nr_views, &nr_rows, &nr_cols);
 
 	/* items */
-	struct view **view;
+	struct view *view;
 	int index = 0;
-	wl_array_for_each(view, views) {
+	wl_list_for_each(view, &server->cycle.views, cycle_link) {
 		struct cycle_osd_thumbnail_item *item = create_item_scene(
-			output->cycle_osd.tree, *view, output);
+			output->cycle_osd.tree, view, output);
 		if (!item) {
 			break;
 		}

--- a/src/server.c
+++ b/src/server.c
@@ -549,6 +549,7 @@ server_init(struct server *server)
 
 	wl_list_init(&server->views);
 	wl_list_init(&server->unmanaged_surfaces);
+	wl_list_init(&server->cycle.views);
 
 	server->scene = wlr_scene_create();
 	if (!server->scene) {

--- a/src/view.c
+++ b/src/view.c
@@ -345,48 +345,6 @@ view_prev(struct wl_list *head, struct view *view, enum lab_view_criteria criter
 	return NULL;
 }
 
-struct view *
-view_next_no_head_stop(struct wl_list *head, struct view *from,
-		enum lab_view_criteria criteria)
-{
-	assert(head);
-
-	struct wl_list *elm = from ? &from->link : head;
-
-	struct wl_list *end = elm;
-	for (elm = elm->next; elm != end; elm = elm->next) {
-		if (elm == head) {
-			continue;
-		}
-		struct view *view = wl_container_of(elm, view, link);
-		if (matches_criteria(view, criteria)) {
-			return view;
-		}
-	}
-	return from;
-}
-
-struct view *
-view_prev_no_head_stop(struct wl_list *head, struct view *from,
-		enum lab_view_criteria criteria)
-{
-	assert(head);
-
-	struct wl_list *elm = from ? &from->link : head;
-
-	struct wl_list *end = elm;
-	for (elm = elm->prev; elm != end; elm = elm->prev) {
-		if (elm == head) {
-			continue;
-		}
-		struct view *view = wl_container_of(elm, view, link);
-		if (matches_criteria(view, criteria)) {
-			return view;
-		}
-	}
-	return from;
-}
-
 void
 view_array_append(struct server *server, struct wl_array *views,
 		enum lab_view_criteria criteria)


### PR DESCRIPTION
This is motivated by #3229, but this PR contains some cleaups that are not directly related to it.

~The first one is avoiding the word "osd" for describing window switcher in general. The second one is extracting osd initialization code from `update_switcher()` (prior `update_osd()`). The third one is saving a fixed array of windows at the start of window switching, which helps #3229.~

~Let's review & merge one by one.~

## 1. Clarify the lifecycle of window switcher states

The role of `update_cycle()` was a bit complex; it both initializes and updates the window switcher, and calls `cycle_finish()` if it failed to initialize it. Also, it was a bit hard to follow what happens in `cycle_on_view_destroy()` when the window being cycled is destroyed. So this PR splits `update_cycle()` into `init_cycle()` and `update_cycle()`, and clarifies:
- `init_cycle()`: initializes the window switcher (e.g. OSD).
- `update_cycle()`: updates the window switcher states including OSD, preview and outlines.
- `destroy_cycle()`: clears all the window switcher states.

Whenever a window destroyed, `cycle_reinitialize()` (renamed from `cycle_on_view_destroy()` with calling it from map/unmap handler in mind) calls `init_cycle()`, sets the new selected window, and calls `update_cycle()`.

## 2. Remember cycled window list in `server->cycle.views`

We had duplicated logic to determine which windows to be cycled: `updated_cycle()` determined which windows to be shown in the OSD, but `get_next_selected_view()` also determined which window to cycle next via `view_next_no_head_stop()`/`view_prev_no_head_stop()`. Instead, this PR creates a list of windows to be cycled at the start of window switching and then iterate over it when cycling windows. This allows smoothly supports different window orders (#3229). For example, we can sort the cycle windows by its title like this:

```diff
diff --git a/src/cycle/cycle.c b/src/cycle/cycle.c
index 292e6436..87508e4f 100644
--- a/src/cycle/cycle.c
+++ b/src/cycle/cycle.c
@@ -276,13 +276,28 @@ create_osd_on_output(struct output *output)
 	assert(output->cycle_osd.tree);
 }
 
+static void
+insert_view_ordered_by_title(struct wl_list *views, struct view *new_view)
+{
+	struct wl_list *link = views;
+	struct view *view;
+	wl_list_for_each(view, views, cycle_link) {
+		if (strcmp(new_view->title, view->title) < 0) {
+			break;
+		}
+		link = &view->cycle_link;
+	}
+	wl_list_insert(link, &new_view->cycle_link);
+}
+
 /* Return false on failure */
 static bool
 init_cycle(struct server *server)
 {
 	struct view *view;
 	for_each_view(view, &server->views, rc.window_switcher.criteria) {
-		wl_list_append(&server->cycle.views, &view->cycle_link);
+		// wl_list_append(&server->cycle.views, &view->cycle_link);
+		insert_view_ordered_by_title(&server->cycle.views, view);
 	}
 	if (wl_list_empty(&server->cycle.views)) {
 		wlr_log(WLR_DEBUG, "no views to switch between");

```

Note that this change might degrade user experience by not being able to cycle through windows newly spawned during window switching. Before this PR, they were not shown in the OSD but they can be cycled. I think we can fix this by calling `cycle_reinitialize()` from map/unmap handlers instead of view destroy handler later.

Another change in this PR is that the previous/next window of `server->active_view` (instead of the topmost window) is always selected at the start of window switching. This makes sure that Alt-Tab + Alt-Shift-Tab selects the originally focused window even when it's not the topmost window.