### PR TITLE
Add `direction` option to `Resize` action

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -51,8 +51,12 @@ Actions are used in menus and keyboard/mouse bindings.
 	another window or screen edge. If set to "no", only move to
 	the next screen edge. Default is yes.
 
-*<action name="Resize" />*
+*<action name="Resize" direction="value" />*
 	Begin interactive resize of window under cursor.
+
+	*direction* [up|down|left|right|up-left|up-right|down-left|down-right]
+	Edge or corner from which to start resizing. If this is not provided,
+	the direction is inferred from the cursor position.
 
 *<action name="ResizeRelative" left="" right="" top="" bottom="" />*
 	Resize window relative to its current size. Values of left, right,


### PR DESCRIPTION
This introduces an optional `direction` argument to the `Resize` action, mirroring Fluxbox's `StartResizing [corner]` behavior.

Supported values (case-insensitive) are:
`up-left`, `up`, `up-right`, `left`, `right`, `down-left`, `down`, `down-right`.

If no direction is specified, the existing behavior is preserved and the resize edges are inferred from the current pointer position. The action documentation has been updated to describe the new argument. For example, using `down-right` lets you resize a window with right-click and drag always toward the same corner, no matter how close the pointer is to any other window edge or corner.

I don't know if Openbox has something similar as I'm coming from Fluxbox/X11 to labwc/Wayland. But in general this is a very simple and useful feature.