### PR TITLE
rcxml: ignore and warn on empty strings in configuration

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -33,8 +33,8 @@
 
   <!-- <font><theme> can be defined without an attribute to set all places -->
   <theme>
-    <name></name>
-    <icon></icon>
+    <!-- <name>Numix</name> -->
+    <!-- <icon>breeze</icon> -->
     <fallbackAppIcon>labwc</fallbackAppIcon>
     <titlebar>
       <layout>icon:iconify,max,close</layout>
@@ -218,9 +218,9 @@
     space automatically, so <margin> is only intended for other, specialist
     cases.
 
-    If output is left empty, the margin will be applied to all outputs.
+    If 'output' is not provided, the margin will be applied to all outputs.
 
-    <margin top="" bottom="" left="" right="" output="" />
+    <margin top="10" bottom="10" left="10" right="10" output="HDMI-A-1" />
   -->
 
   <!-- Percent based regions based on output usable area, % char is required -->
@@ -525,7 +525,11 @@
     If mouseEmulation is enabled, all touch up/down/motion events are
     translated to mouse button and motion events.
   -->
-  <touch deviceName="" mapToOutput="" mouseEmulation="no"/>
+  <touch>
+    <!-- <deviceName>ELAN2514:00 04F3:2AF1<deviceName> -->
+    <!-- <mapToOutput>HDMI-A-1</mapToOutput> -->
+    <mouseEmulation>no</mouseEmulation>
+  </touch>
 
   <!--
     The tablet cursor movement can be restricted to a single output.
@@ -552,7 +556,8 @@
     When using mouse emulation, the pen tip [tip] and the stylus buttons
     can be set to any available mouse button [Left|Right|Middle|..|Task].
   -->
-  <tablet mapToOutput="" rotate="0" mouseEmulation="no">
+  <tablet rotate="0" mouseEmulation="no">
+    <!-- <mapToOutput>HDMI-A-1</mapToOutput> -->
     <!-- Active area dimensions are in mm -->
     <area top="0.0" left="0.0" width="0.0" height="0.0" />
     <map button="Tip" to="Left" />
@@ -586,7 +591,7 @@
       - sendEventsMode [yes|no|disabledOnExternalMouse]
       - calibrationMatrix [six float values split by space]
       - scrollFactor [float]
-   
+
     The following <libinput>...</libinput> block may not be complete for
     your requirements. Default values are device specific. Only set an option
     if you require to override the default. Valid values must be inserted.
@@ -595,21 +600,21 @@
 
   <libinput>
     <device category="default">
-      <naturalScroll></naturalScroll>
-      <leftHanded></leftHanded>
-      <pointerSpeed></pointerSpeed>
-      <accelProfile></accelProfile>
+      <!-- <naturalScroll>no</naturalScroll> -->
+      <!-- <leftHanded>no</leftHanded> -->
+      <!-- <pointerSpeed>0.0</pointerSpeed> -->
+      <!-- <accelProfile>adaptive</accelProfile> -->
       <tap>yes</tap>
-      <tapButtonMap></tapButtonMap>
-      <tapAndDrag></tapAndDrag>
-      <dragLock></dragLock>
-      <threeFingerDrag></threeFingerDrag>
-      <middleEmulation></middleEmulation>
-      <disableWhileTyping></disableWhileTyping>
-      <clickMethod></clickMethod>
-      <scrollMethod></scrollMethod>
-      <sendEventsMode></sendEventsMode>
-      <calibrationMatrix></calibrationMatrix>
+      <!-- <tapButtonMap>lrm</tapButtonMap> -->
+      <!-- <tapAndDrag>yes</tapAndDrag> -->
+      <!-- <dragLock>yes</dragLock> -->
+      <!-- <threeFingerDrag>yes</threeFingerDrag> -->
+      <!-- <middleEmulation>no</middleEmulation> -->
+      <!-- <disableWhileTyping>yes</disableWhileTyping> -->
+      <!-- <clickMethod>buttonAreas</clickMethod> -->
+      <!-- <scrollMethod>twofinger</scrollMethod> -->
+      <!-- <sendEventsMode>yes</sendEventsMode> -->
+      <!-- <calibrationMatrix>1 0 0 0 1 0</calibrationMatrix> -->
       <scrollFactor>1.0</scrollFactor>
     </device>
   </libinput>
@@ -678,7 +683,7 @@
     <height>400</height>
     <initScale>2.0</initScale>
     <increment>0.2</increment>
-    <useFilter>true</useFilter>
+    <useFilter>yes</useFilter>
   </magnifier>
 
 </labwc_config>

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -714,6 +714,8 @@ fill_libinput_category(xmlNode *node)
 	char *key, *content;
 	LAB_XML_FOR_EACH(node, child, key, content) {
 		if (string_null_or_empty(content)) {
+			wlr_log(WLR_ERROR, "Empty string is not allowed for "
+				"<libinput><device><%s>. Ignoring.", key);
 			continue;
 		}
 		if (!strcmp(key, "category")) {
@@ -1076,7 +1078,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		return true;
 
 	} else if (str_space_only(content)) {
-		/* ignore empty leaf nodes other than above */
+		wlr_log(WLR_ERROR, "Empty string is not allowed for %s. "
+			"Ignoring.", nodename);
 
 	/* handle non-empty leaf nodes */
 	} else if (!strcmp(nodename, "decoration.core")) {


### PR DESCRIPTION
Closes #3160.

I rewrote the config parser in #2667, but it broke certain configurations by changing how empty strings are handled: they were just ignored before my parser rewrite, but after that, they are interpreted as just empty strings. So `<margin output="">` means `apply margin to an output named ""` rather than `apply margin to all the outputs`. In #3011, I wasn't aware this kind of breakages in functionalities.

On the other hand, using empty strings just to let the parser ignore them doesn't make sense and I think this is a bad practice (https://github.com/labwc/labwc/issues/3160#issuecomment-3499753127), though silently changing this behavior was certainly not ideal.

So, this PR restores the previous behavior of ignoring empty strings, and then prints an error message when ignoring them, encouraging users to avoid using empty strings just as a placeholder. Empty strings in `<libinput><device>` are exceptional; they represent device defaults (as described in https://github.com/labwc/labwc/pull/3011#issuecomment-3199450879), so they are still accepted without warnings. I commented out some entries in `rc.xml.all` so that reading it doesn't print any error messages. I think we can remove these checks in some releases later and interpret empty strings as they are.