### PR TITLE
 cycle: use dummy node to remember the scene position of previewed window 

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -307,8 +307,7 @@ struct server {
 		bool preview_was_shaded;
 		bool preview_was_enabled;
 		struct wlr_scene_node *preview_node;
-		struct wlr_scene_tree *preview_parent;
-		struct wlr_scene_node *preview_anchor;
+		struct wlr_scene_node *preview_dummy;
 		struct lab_scene_rect *preview_outline;
 	} cycle;
 


### PR DESCRIPTION
With this approach, we only need to store `cycle->dummy_node` instead of `cycle->preview_anchor` and `cycle->preview_parent` and we don't need to care about annoying cases like when the previewed window has no siblings or when a window tracked by `cycle->preview_anchor` is destroyed.