### PR TITLE
 view: decouple always-on-top windows from the omnipresent state

### DIFF
--- a/include/config/types.h
+++ b/include/config/types.h
@@ -62,10 +62,7 @@ enum lab_view_criteria {
 	/* No filter -> all focusable views */
 	LAB_VIEW_CRITERIA_NONE = 0,
 
-	/*
-	 * Includes always-on-top views, e.g.
-	 * what is visible on the current workspace
-	 */
+	/* Includes omnipresent (visible on all desktops) views */
 	LAB_VIEW_CRITERIA_CURRENT_WORKSPACE       = 1 << 0,
 
 	/* Positive criteria */

--- a/include/workspaces.h
+++ b/include/workspaces.h
@@ -8,14 +8,12 @@
 
 struct seat;
 struct server;
-struct wlr_scene_tree;
 
 struct workspace {
 	struct wl_list link; /* struct server.workspaces */
 	struct server *server;
 
 	char *name;
-	struct wlr_scene_tree *tree;
 
 	struct lab_cosmic_workspace *cosmic_workspace;
 	struct {

--- a/src/debug.c
+++ b/src/debug.c
@@ -106,15 +106,6 @@ get_special(struct server *server, struct wlr_scene_node *node)
 	if (node == &server->view_tree_always_on_top->node) {
 		return "server->always_on_top";
 	}
-	if (node->parent == server->view_tree) {
-		struct workspace *workspace;
-		wl_list_for_each(workspace, &server->workspaces.all, link) {
-			if (&workspace->tree->node == node) {
-				return workspace->name;
-			}
-		}
-		return "unknown workspace";
-	}
 	if (node->parent == &server->scene->tree) {
 		struct output *output;
 		wl_list_for_each(output, &server->outputs, link) {

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -96,9 +96,9 @@ desktop_focus_view(struct view *view, bool raise)
 
 	/*
 	 * Switch workspace if necessary to make the view visible
-	 * (unnecessary for "always on {top,bottom}" views).
+	 * (unnecessary for omnipresent views).
 	 */
-	if (!view_is_always_on_top(view) && !view_is_always_on_bottom(view)) {
+	if (!view->visible_on_all_workspaces) {
 		workspaces_switch_to(view->workspace, /*update_focus*/ false);
 	}
 

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -1019,7 +1019,7 @@ handle_new_xdg_toplevel(struct wl_listener *listener, void *data)
 	}
 
 	view->workspace = server->workspaces.current;
-	view->scene_tree = wlr_scene_tree_create(view->workspace->tree);
+	view->scene_tree = wlr_scene_tree_create(server->view_tree);
 	wlr_scene_node_set_enabled(&view->scene_tree->node, false);
 
 	struct wlr_scene_tree *tree = wlr_scene_xdg_surface_create(

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -1010,7 +1010,7 @@ xwayland_view_create(struct server *server,
 	xsurface->data = view;
 
 	view->workspace = server->workspaces.current;
-	view->scene_tree = wlr_scene_tree_create(view->workspace->tree);
+	view->scene_tree = wlr_scene_tree_create(server->view_tree);
 	node_descriptor_create(&view->scene_tree->node,
 		LAB_NODE_VIEW, view, /*data*/ NULL);
 


### PR DESCRIPTION
Fixes #1151.

Before this PR, always-on-{top,bottom} windows were always visible on all workspaces (omnipresent) because the they were not in per-workspace trees like normal windows. This PR fixes this by removing per-workspace trees and instead showing/hiding views individually based on `view->workspace`.

This PR also updates `desktop_focus_output()` and `desktop_topmost_focusable_view()` to use `for_each_view()` instead of scene graph traversal. The functional changes will be that always-on-{top,bottom} windows can be now focused when layer-shell or session-lock surface loses focus, when switching workspaces, when `FocusOutput` action is executed, etc.