### PR TITLE
 cycle: update config to <osd output="all|cursor|focused">

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -371,10 +371,10 @@ this is for compatibility with Openbox.
 	"classic" displays window information like icons and titles in a vertical list.
 	"thumbnail" shows window thumbnail, icon and title in grids.
 
-	*output* [all|pointer|keyboard] Configures which monitor(s) show the OSD.
+	*output* [all|focused|cursor] Configures which monitor(s) show the OSD.
 	"all" displays the OSD on all monitors.
-	"pointer" displays the OSD on the monitor containing the mouse pointer.
-	"keyboard" displays the OSD on the monitor with keyboard focus.
+	"focused" displays the OSD on the monitor with keyboard focus.
+	"cursor" displays the OSD on the monitor containing the mouse pointer.
 	Default is "all".
 
 	*thumbnailLabelFormat* Format to be used for the thumbnail label according to *custom*

--- a/include/config/types.h
+++ b/include/config/types.h
@@ -114,8 +114,8 @@ enum cycle_osd_style {
 
 enum cycle_osd_output_criteria {
 	CYCLE_OSD_OUTPUT_ALL,
-	CYCLE_OSD_OUTPUT_POINTER,
-	CYCLE_OSD_OUTPUT_KEYBOARD,
+	CYCLE_OSD_OUTPUT_CURSOR,
+	CYCLE_OSD_OUTPUT_FOCUSED,
 };
 
 #endif /* LABWC_CONFIG_TYPES_H */

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1222,13 +1222,13 @@ entry(xmlNode *node, char *nodename, char *content)
 	} else if (!strcasecmp(nodename, "output.osd.windowSwitcher")) {
 		if (!strcasecmp(content, "all")) {
 			rc.window_switcher.output_criteria = CYCLE_OSD_OUTPUT_ALL;
-		} else if (!strcasecmp(content, "pointer")) {
-			rc.window_switcher.output_criteria = CYCLE_OSD_OUTPUT_POINTER;
-		} else if (!strcasecmp(content, "keyboard")) {
-			rc.window_switcher.output_criteria = CYCLE_OSD_OUTPUT_KEYBOARD;
+		} else if (!strcasecmp(content, "cursor")) {
+			rc.window_switcher.output_criteria = CYCLE_OSD_OUTPUT_CURSOR;
+		} else if (!strcasecmp(content, "focused")) {
+			rc.window_switcher.output_criteria = CYCLE_OSD_OUTPUT_FOCUSED;
 		} else {
 			wlr_log(WLR_ERROR, "Invalid windowSwitcher output %s: "
-				"should be one of all|pointer|keyboard", content);
+				"should be one of all|focused|cursor", content);
 		}
 
 	/* The following two are for backward compatibility only. */

--- a/src/cycle/cycle.c
+++ b/src/cycle/cycle.c
@@ -299,10 +299,10 @@ init_cycle(struct server *server)
 			}
 			break;
 		}
-		case CYCLE_OSD_OUTPUT_POINTER:
+		case CYCLE_OSD_OUTPUT_CURSOR:
 			create_osd_on_output(output_nearest_to_cursor(server));
 			break;
-		case CYCLE_OSD_OUTPUT_KEYBOARD: {
+		case CYCLE_OSD_OUTPUT_FOCUSED: {
 			struct output *output;
 			if (server->active_view) {
 				output = server->active_view->output;


### PR DESCRIPTION
CC @SametAylak

Looking back #3201,  I think `<windowSwitcher><osd output="keyboard">` is a bit unclear and hard to interpret as "show OSD in the output with keyboard focus". Also, we use "cursor" instead of "pointer" in other configurations like `<placement policy="cursor">` and `<action name="ShowMenu" atCursor="">`.

So let's replace `output="all|pointer|keyboard"` with `output="all|cursor|focused"`. In documentation, I reordered them to `output="all|focused|cursor"` as `focused` feels like a bit more sophisticated and general policy.

Sorry for my indecisive steering!