### PR TITLE
xwayland: flush XCB connection to mitigate race between Raise and input

### DIFF
--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -77,5 +77,7 @@ void xwayland_update_workarea(struct server *server);
 
 void xwayland_reset_cursor(struct server *server);
 
+void xwayland_flush(struct server *server);
+
 #endif /* HAVE_XWAYLAND */
 #endif /* LABWC_XWAYLAND_H */

--- a/src/view.c
+++ b/src/view.c
@@ -35,6 +35,7 @@
 
 #if HAVE_XWAYLAND
 #include <wlr/xwayland.h>
+#include "xwayland.h"
 #endif
 
 struct view *
@@ -2247,6 +2248,17 @@ view_move_to_front(struct view *view)
 		move_to_front(view);
 	}
 
+#if HAVE_XWAYLAND
+	/*
+	 * view_move_to_front() is typically called on each mouse press
+	 * via Raise action. This means we are restacking windows just
+	 * about at the same time we send the mouse press input to the
+	 * X server, and creates a race where the mouse press could go
+	 * to an incorrect X window depending on timing. To mitigate the
+	 * race, perform an explicit flush after restacking.
+	 */
+	xwayland_flush(view->server);
+#endif
 	cursor_update_focus(view->server);
 	desktop_update_top_layer_visibility(view->server);
 }

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -1438,3 +1438,13 @@ xwayland_update_workarea(struct server *server)
 	};
 	wlr_xwayland_set_workareas(server->xwayland, &workarea, 1);
 }
+
+void
+xwayland_flush(struct server *server)
+{
+	if (!server->xwayland || !server->xwayland->xwm) {
+		return;
+	}
+
+	xcb_flush(wlr_xwayland_get_xwm_connection(server->xwayland));
+}


### PR DESCRIPTION
Fixes the mouse input issue with Xaw test client from:
- #3152 