### PR TITLE
cursor: allow movement until entering the constraint surface

### DIFF
--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -840,10 +840,12 @@ apply_constraint(struct seat *seat, struct wlr_pointer *pointer, double *x, doub
 	if (!seat->server->active_view) {
 		return;
 	}
-	if (!seat->current_constraint || pointer->base.type != WLR_INPUT_DEVICE_POINTER) {
+	if (!seat->current_constraint
+			|| pointer->base.type != WLR_INPUT_DEVICE_POINTER
+			|| seat->current_constraint->type
+				!= WLR_POINTER_CONSTRAINT_V1_CONFINED) {
 		return;
 	}
-	assert(seat->current_constraint->type == WLR_POINTER_CONSTRAINT_V1_CONFINED);
 
 	double sx = seat->cursor->x;
 	double sy = seat->cursor->y;
@@ -866,7 +868,9 @@ cursor_locked(struct seat *seat, struct wlr_pointer *pointer)
 {
 	return seat->current_constraint
 		&& pointer->base.type == WLR_INPUT_DEVICE_POINTER
-		&& seat->current_constraint->type == WLR_POINTER_CONSTRAINT_V1_LOCKED;
+		&& seat->current_constraint->type == WLR_POINTER_CONSTRAINT_V1_LOCKED
+		&& seat->current_constraint->surface
+			== seat->seat->pointer_state.focused_surface;
 }
 
 static void


### PR DESCRIPTION
Fixes the issue pointed out in https://github.com/labwc/labwc/issues/2779#issuecomment-3588121048 where the cursor would get stuck (immovable) outside the window of a Wine/Wayland game, if it was already outside when the game started (common with a 4:3 game on a 16:9 screen). Now one can manually move the cursor into the game window, at which point it becomes locked.

This is a minimal/interim fix. Ideally we should warp the cursor into the constraint area automatically, but that would be a bit more work.

The change to apply_constraint() just turns an assert-failure into a safe no-op return, since the function is now entered for "locked" as well as "confined" constraint types.