### PR TITLE
[just for debugging] show key states in the monitor

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -436,6 +436,10 @@ Actions are used in menus and keyboard/mouse bindings.
 	If used as the only action for a binding: clear an earlier defined
 	binding.
 
+*<action name="DebugToggleKeyStateIndicator" />*
+	Toggle visibility of key-state on-screen display (OSD). Note: This is for
+	debugging purposes only.
+
 # CONDITIONAL ACTIONS
 
 Actions that execute other actions. Used in keyboard/mouse bindings.

--- a/include/input/key-state.h
+++ b/include/input/key-state.h
@@ -5,11 +5,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+struct seat;
+
 /*
  * All keycodes in these functions are (Linux) libinput evdev scancodes which is
  * what 'wlr_keyboard' uses (e.g. 'seat->keyboard_group->keyboard->keycodes').
  * Note: These keycodes are different to XKB scancodes by a value of 8.
  */
+
+void key_state_indicator_update(struct seat *seat);
+void key_state_indicator_toggle(void);
 
 /**
  * key_state_pressed_sent_keycodes - generate array of pressed+sent keys

--- a/src/action.c
+++ b/src/action.c
@@ -21,6 +21,7 @@
 #include "cycle.h"
 #include "debug.h"
 #include "input/keyboard.h"
+#include "input/key-state.h"
 #include "labwc.h"
 #include "magnifier.h"
 #include "menu/menu.h"
@@ -133,7 +134,8 @@ struct action_arg_list {
 	X(ZOOM_IN, "ZoomIn") \
 	X(ZOOM_OUT, "ZoomOut") \
 	X(WARP_CURSOR, "WarpCursor") \
-	X(HIDE_CURSOR, "HideCursor")
+	X(HIDE_CURSOR, "HideCursor") \
+	X(DEBUG_TOGGLE_KEY_STATE_INDICATOR, "DebugToggleKeyStateIndicator")
 
 /*
  * Will expand to:
@@ -1569,6 +1571,9 @@ run_action(struct view *view, struct action *action,
 	}
 	case ACTION_TYPE_HIDE_CURSOR:
 		cursor_set_visible(&server.seat, false);
+		break;
+	case ACTION_TYPE_DEBUG_TOGGLE_KEY_STATE_INDICATOR:
+		key_state_indicator_toggle();
 		break;
 	case ACTION_TYPE_INVALID:
 		wlr_log(WLR_ERROR, "Not executing unknown action");

--- a/src/input/key-state.c
+++ b/src/input/key-state.c
@@ -4,9 +4,170 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <wlr/types/wlr_keyboard.h>
+#include <wlr/types/wlr_scene.h>
+#include <xkbcommon/xkbcommon.h>
+#include "config/rcxml.h"
+#include "common/buf.h"
 #include "common/set.h"
+#include "input/keyboard.h"
+#include "labwc.h"
+#include "scaled-buffer/scaled-font-buffer.h"
 
 static struct lab_set pressed, bound, pressed_sent;
+
+static bool show_debug_indicator;
+static struct indicator_state {
+	struct wlr_scene_tree *tree;
+	struct scaled_font_buffer *sfb_pressed;
+	struct scaled_font_buffer *sfb_bound;
+	struct scaled_font_buffer *sfb_pressed_sent;
+	struct scaled_font_buffer *sfb_modifiers;
+	struct xkb_keymap *keymap;
+} indicator_state;
+
+static const char *
+keycode_to_keyname(struct xkb_keymap *keymap, uint32_t keycode)
+{
+	const xkb_keysym_t *syms;
+	int syms_len = xkb_keymap_key_get_syms_by_level(keymap, keycode + 8, 0, 0, &syms);
+	if (!syms_len) {
+		return NULL;
+	}
+
+	static char buf[256];
+	if (!xkb_keysym_get_name(syms[0], buf, sizeof(buf))) {
+		return NULL;
+	}
+
+	return buf;
+}
+
+static const char *
+modifier_to_name(uint32_t modifier)
+{
+	switch (modifier) {
+	case WLR_MODIFIER_SHIFT:
+		return "S";
+	case WLR_MODIFIER_CAPS:
+		return "caps";
+	case WLR_MODIFIER_CTRL:
+		return "C";
+	case WLR_MODIFIER_ALT:
+		return "A";
+	case WLR_MODIFIER_MOD2:
+		return "numlock";
+	case WLR_MODIFIER_MOD3:
+		return "H";
+	case WLR_MODIFIER_LOGO:
+		return "W";
+	case WLR_MODIFIER_MOD5:
+		return "M";
+	default:
+		return "?";
+	}
+}
+
+static void
+init_indicator(struct indicator_state *state)
+{
+	state->tree = wlr_scene_tree_create(&server.scene->tree);
+	wlr_scene_node_set_enabled(&state->tree->node, false);
+
+	state->sfb_pressed = scaled_font_buffer_create(state->tree);
+	wlr_scene_node_set_position(&state->sfb_pressed->scene_buffer->node, 0, 0);
+	state->sfb_bound = scaled_font_buffer_create(state->tree);
+	wlr_scene_node_set_position(&state->sfb_bound->scene_buffer->node, 0, 20);
+	state->sfb_pressed_sent = scaled_font_buffer_create(state->tree);
+	wlr_scene_node_set_position(&state->sfb_pressed_sent->scene_buffer->node, 0, 40);
+	state->sfb_modifiers = scaled_font_buffer_create(state->tree);
+	wlr_scene_node_set_position(&state->sfb_modifiers->scene_buffer->node, 0, 60);
+
+	struct xkb_rule_names rules = { 0 };
+	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	state->keymap = xkb_map_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+}
+
+static void
+update_key_indicator_callback(void *data)
+{
+	struct seat *seat = data;
+	uint32_t all_modifiers = keyboard_get_all_modifiers(seat);
+	float black[4] = {0, 0, 0, 1};
+	float white[4] = {1, 1, 1, 1};
+
+	if (!indicator_state.tree) {
+		init_indicator(&indicator_state);
+	}
+
+	if (show_debug_indicator) {
+		wlr_scene_node_set_enabled(&indicator_state.tree->node, true);
+	} else {
+		wlr_scene_node_set_enabled(&indicator_state.tree->node, false);
+		return;
+	}
+
+	struct buf buf = BUF_INIT;
+
+	buf_add(&buf, "pressed=");
+	for (int i = 0; i < pressed.size; i++) {
+		const char *keyname = keycode_to_keyname(indicator_state.keymap,
+					pressed.values[i]);
+		buf_add_fmt(&buf, "%s (%d), ", keyname, pressed.values[i]);
+	}
+	scaled_font_buffer_update(indicator_state.sfb_pressed, buf.data,
+		-1, &rc.font_osd, black, white);
+
+	buf_clear(&buf);
+	buf_add(&buf, "bound=");
+	for (int i = 0; i < bound.size; i++) {
+		const char *keyname = keycode_to_keyname(indicator_state.keymap,
+					bound.values[i]);
+		buf_add_fmt(&buf, "%s (%d), ", keyname, bound.values[i]);
+	}
+	scaled_font_buffer_update(indicator_state.sfb_bound, buf.data,
+		-1, &rc.font_osd, black, white);
+
+	buf_clear(&buf);
+	buf_add(&buf, "pressed_sent=");
+	for (int i = 0; i < pressed_sent.size; i++) {
+		const char *keyname = keycode_to_keyname(indicator_state.keymap,
+					pressed_sent.values[i]);
+		buf_add_fmt(&buf, "%s (%d), ", keyname, pressed_sent.values[i]);
+	}
+	scaled_font_buffer_update(indicator_state.sfb_pressed_sent, buf.data, -1,
+		&rc.font_osd, black, white);
+
+	buf_clear(&buf);
+	buf_add(&buf, "modifiers=");
+	for (int i = 0; i <= 7; i++) {
+		uint32_t mod = 1 << i;
+		if (all_modifiers & mod) {
+			buf_add_fmt(&buf, "%s, ", modifier_to_name(mod));
+		}
+	}
+	buf_add_fmt(&buf, "(%d)", all_modifiers);
+	scaled_font_buffer_update(indicator_state.sfb_modifiers, buf.data, -1,
+		&rc.font_osd, black, white);
+
+	buf_reset(&buf);
+}
+
+void
+key_state_indicator_update(struct seat *seat)
+{
+	if (!show_debug_indicator) {
+		return;
+	}
+	wl_event_loop_add_idle(server.wl_event_loop,
+		update_key_indicator_callback, seat);
+}
+
+void
+key_state_indicator_toggle(void)
+{
+	show_debug_indicator = !show_debug_indicator;
+}
 
 static void
 report(struct lab_set *key_set, const char *msg)

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -133,6 +133,8 @@ handle_modifiers(struct wl_listener *listener, void *data)
 	struct seat *seat = keyboard->base.seat;
 	struct wlr_keyboard *wlr_keyboard = keyboard->wlr_keyboard;
 
+	key_state_indicator_update(seat);
+
 	if (server.input_mode == LAB_INPUT_STATE_MOVE) {
 		/* Any change to the modifier state re-enable region snap */
 		seat->region_prevent_snap = false;
@@ -616,6 +618,9 @@ handle_key(struct wl_listener *listener, void *data)
 	struct seat *seat = keyboard->base.seat;
 	struct wlr_keyboard_key_event *event = data;
 	struct wlr_seat *wlr_seat = seat->wlr_seat;
+
+	key_state_indicator_update(seat);
+
 	idle_manager_notify_activity(seat->wlr_seat);
 
 	/* any new press/release cancels current keybind repeat */


### PR DESCRIPTION
I originally made this to help debugging #2771. I'm opening this PR just to make this more accessible as this seems to be useful for debugging keyboard issues in general like #3238.

Perhaps we can integrate this to `labnag` instead by allowing clearing its message, but I'm not sure.

Shift+Ctrl+Alt+Z: show the key indicator
Shift+Ctrl+Alt+X: hide the key indicator

<img width="1920" height="1080" alt="20251207_17h25m37s_grim" src="https://github.com/user-attachments/assets/04c2870d-f156-4bba-8e94-7952fa801fe1" />
