### PR TITLE
cycle: add `server->cycle_preview_tree`

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -237,6 +237,7 @@ struct server {
 	/* Tree for unmanaged xsurfaces without initialized view (usually popups) */
 	struct wlr_scene_tree *unmanaged_tree;
 #endif
+	struct wlr_scene_tree *cycle_preview_tree;
 	/* Tree for built in menu */
 	struct wlr_scene_tree *menu_tree;
 

--- a/src/cycle/cycle.c
+++ b/src/cycle/cycle.c
@@ -39,7 +39,8 @@ update_preview_outlines(struct view *view)
 			.border_width = theme->osd_window_switcher_preview_border_width,
 		};
 		rect = lab_scene_rect_create(&server->scene->tree, &opts);
-		wlr_scene_node_place_above(&rect->tree->node, &server->menu_tree->node);
+		wlr_scene_node_place_above(&rect->tree->node,
+			&server->cycle_preview_tree->node);
 		server->cycle.preview_outline = rect;
 	}
 
@@ -242,13 +243,8 @@ preview_selected_view(struct view *view)
 		cycle->preview_was_shaded = true;
 	}
 
-	/*
-	 * FIXME: This abuses an implementation detail of the always-on-top tree.
-	 *        Create a permanent server->osd_preview_tree instead that can
-	 *        also be used as parent for the preview outlines.
-	 */
 	wlr_scene_node_reparent(cycle->preview_node,
-		view->server->view_tree_always_on_top);
+		view->server->cycle_preview_tree);
 
 	/* Finally raise selected node to the top */
 	wlr_scene_node_raise_to_top(cycle->preview_node);

--- a/src/server.c
+++ b/src/server.c
@@ -563,21 +563,22 @@ server_init(struct server *server)
 	 * z-order for nodes which cover the whole work-area.  For per-output
 	 * scene-trees, see handle_new_output() in src/output.c
 	 *
-	 * | Type                | Scene Tree       | Per Output | Example
-	 * | ------------------- | ---------------- | ---------- | -------
-	 * | ext-session         | lock-screen      | Yes        | swaylock
-	 * | window switcher OSD | cycle_osd_tree   | Yes        |
-	 * | compositor-menu     | menu_tree        | No         | root-menu
-	 * | layer-shell         | layer-popups     | Yes        |
-	 * | layer-shell         | overlay-layer    | Yes        |
-	 * | layer-shell         | top-layer        | Yes        | waybar
-	 * | xwayland-OR         | unmanaged        | No         | dmenu
-	 * | xdg-popups          | xdg-popups       | No         |
-	 * | toplevels windows   | always-on-top    | No         |
-	 * | toplevels windows   | normal           | No         | firefox
-	 * | toplevels windows   | always-on-bottom | No         | pcmanfm-qt --desktop
-	 * | layer-shell         | bottom-layer     | Yes        | waybar
-	 * | layer-shell         | background-layer | Yes        | swaybg
+	 * | Scene Tree                         | Description
+	 * | ---------------------------------- | -------------------------------------
+	 * | output->session_lock_tree          | session lock surfaces (e.g. swaylock)
+	 * | output->cycle_osd_tree             | window switcher's on-screen display
+	 * | server->cycle_preview_tree         | window switcher's previewed window
+	 * | server->menu_tree                  | labwc's server-side menus
+	 * | output->layer_popup_tree           | xdg popups on layer surfaces
+	 * | output->layer_tree[3]              | overlay layer surfaces (e.g. rofi)
+	 * | output->layer_tree[2]              | top layer surfaces (e.g. waybar)
+	 * | server->unmanaged_tree             | unmanaged X11 surfaces (e.g. dmenu)
+	 * | server->xdg_popup_tree             | xdg popups on xdg windows
+	 * | server->view_tree_always_on_top    | always-on-top xdg/X11 windows
+	 * | server->view_tree                  | normal xdg/X11 windows (e.g. firefox)
+	 * | server->view_tree_always_on_bottom | always-on-bottom xdg/X11 windows
+	 * | output->layer_tree[1]              | bottom layer surfaces
+	 * | output->layer_tree[0]              | background layer surfaces (e.g. swaybg)
 	 */
 
 	server->view_tree_always_on_bottom = wlr_scene_tree_create(&server->scene->tree);
@@ -588,6 +589,7 @@ server_init(struct server *server)
 	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->tree);
 #endif
 	server->menu_tree = wlr_scene_tree_create(&server->scene->tree);
+	server->cycle_preview_tree = wlr_scene_tree_create(&server->scene->tree);
 
 	workspaces_init(server);
 


### PR DESCRIPTION
This PR just addresses the `FIXME` comment. The only change in this PR is that the previewed window is placed above top/overlay layer surfaces.

I also updated the comment in `server_init()` that describes our scene-tree order.