### PR TITLE
Correct semantically-significant typo in labwc-config docs

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -26,7 +26,7 @@ should (a) allow the first-identified configuration file to supersede any
 others, or (b) define rules for merging the information from more than one file.
 
 By default, labwc uses option (a), reading only the first file identified.  With
-the --merge-config option, the search order is reserved, but every configuration
+the --merge-config option, the search order is reversed, but every configuration
 file encountered is processed in turn. Thus, user-specific files will augment
 system-wide configurations, with conflicts favoring the user-specific
 alternative.


### PR DESCRIPTION
"reserved" here implies that configuration files are parsed in the same order as before; "reversed" correctly implies they are parsed from least important to most important.  This wording is supported by code such as https://github.com/labwc/labwc/blob/7f0abed9c8c9859c4962c8feecfbe0b0a2ebb008/src/config/rcxml.c#L1924-L1931