### PR TITLE
config/rcxml.c: prevent wrong parse_bool() err message

### DIFF
--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -684,15 +684,15 @@ get_send_events_mode(const char *s)
 		goto err;
 	}
 
+	if (!strcasecmp(s, "disabledOnExternalMouse")) {
+		return LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE;
+	}
+
 	int ret = parse_bool(s, -1);
 	if (ret >= 0) {
 		return ret
 			? LIBINPUT_CONFIG_SEND_EVENTS_ENABLED
 			: LIBINPUT_CONFIG_SEND_EVENTS_DISABLED;
-	}
-
-	if (!strcasecmp(s, "disabledOnExternalMouse")) {
-		return LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE;
 	}
 
 err:


### PR DESCRIPTION
by only parsing the boolean when it is not `disabledOnExternalMouse`.

Fixes:
- #3293