### PR TITLE
cycle: refactor to aggregate type definitions into cycle.h

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -303,16 +303,7 @@ struct server {
 	struct wlr_security_context_manager_v1 *security_context_manager_v1;
 
 	/* Set when in cycle (alt-tab) mode */
-	struct cycle_state {
-		struct view *selected_view;
-		struct wl_list views;
-		bool preview_was_shaded;
-		bool preview_was_enabled;
-		struct wlr_scene_node *preview_node;
-		struct wlr_scene_node *preview_dummy;
-		struct lab_scene_rect *preview_outline;
-		struct cycle_filter filter;
-	} cycle;
+	struct cycle_state cycle;
 
 	struct theme *theme;
 

--- a/include/output.h
+++ b/include/output.h
@@ -19,11 +19,6 @@ struct output {
 	struct wlr_scene_tree *session_lock_tree;
 	struct wlr_scene_buffer *workspace_osd;
 
-	struct cycle_osd_scene {
-		struct wl_list items; /* struct cycle_osd_item */
-		struct wlr_scene_tree *tree;
-	} cycle_osd;
-
 	/* In output-relative scene coordinates */
 	struct wlr_box usable_area;
 

--- a/src/output.c
+++ b/src/output.c
@@ -542,7 +542,6 @@ handle_new_output(struct wl_listener *listener, void *data)
 	wl_signal_add(&wlr_output->events.request_state, &output->request_state);
 
 	wl_list_init(&output->regions);
-	wl_list_init(&output->cycle_osd.items);
 
 	/*
 	 * Create layer-trees (background, bottom, top and overlay) and

--- a/src/server.c
+++ b/src/server.c
@@ -550,6 +550,7 @@ server_init(struct server *server)
 	wl_list_init(&server->views);
 	wl_list_init(&server->unmanaged_surfaces);
 	wl_list_init(&server->cycle.views);
+	wl_list_init(&server->cycle.osd_outputs);
 
 	server->scene = wlr_scene_create();
 	if (!server->scene) {


### PR DESCRIPTION
Preparation for #3291.

We declared `cycle_state` struct in `labwc.h` and `cycle_osd_scene` struct in `output.h`, which was unclean in terms of separation of concerns.

So this PR firstly moves `cycle_state` to `cycle.h`, then replaces `cycle_osd_scene` in `output.h` with `cycle_osd_output` in `cycle.h` which is dynamically allocated in a similar manner to `session_lock_output`. This ensures that all states about alt-tabbing are stored in server->cycle.

Also, this PR fixes a rare memory leak in `output->cycle_osd.items` when an output is destroyed while alt-tabbing, by freeing it when the osd tree is destroyed.