### PR TITLE
Halt window switcher on Reconfigure

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -97,6 +97,7 @@ reload_config_and_theme(struct server *server)
 		view_reload_ssd(view);
 	}
 
+	cycle_finish(server, /*switch_focus*/ false);
 	menu_reconfigure(server);
 	seat_reconfigure(server);
 	regions_reconfigure(server);


### PR DESCRIPTION
Fixes https://github.com/labwc/labwc/pull/3291#issuecomment-3699530353.

There was an invalid memory access (since #2981) with following steps:

1. Press Alt-Tab
2. Update `<windowSwitcher><osd><style>` from `classic` to `thumbnail`
3. Run `Reconfigure`
4. Press Alt-Tab again

...because `cycle_osd_thumbnail_update()` is called even though `cycle_osd_output->items` holds `cycle_osd_classic_item`.

This PR halts window switcher on `Reconfigure` to clear `cycle_osd_output->items` and avoid that invalid memory access.