### PR TITLE
view: eliminate store_natural_geometry arguments

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -512,8 +512,7 @@ void view_constrain_size_to_that_of_usable_area(struct view *view);
 
 void view_set_maximized(struct view *view, enum view_axis maximized);
 void view_set_untiled(struct view *view);
-void view_maximize(struct view *view, enum view_axis axis,
-	bool store_natural_geometry);
+void view_maximize(struct view *view, enum view_axis axis);
 void view_set_fullscreen(struct view *view, bool fullscreen);
 void view_toggle_maximize(struct view *view, enum view_axis axis);
 bool view_wants_decorations(struct view *view);
@@ -540,8 +539,8 @@ void view_move_to_edge(struct view *view, enum lab_edge direction, bool snap_to_
 void view_grow_to_edge(struct view *view, enum lab_edge direction);
 void view_shrink_to_edge(struct view *view, enum lab_edge direction);
 void view_snap_to_edge(struct view *view, enum lab_edge direction,
-	bool across_outputs, bool combine, bool store_natural_geometry);
-void view_snap_to_region(struct view *view, struct region *region, bool store_natural_geometry);
+	bool across_outputs, bool combine);
+void view_snap_to_region(struct view *view, struct region *region);
 void view_move_to_output(struct view *view, struct output *output);
 
 void view_move_to_front(struct view *view);

--- a/src/action.c
+++ b/src/action.c
@@ -1146,7 +1146,7 @@ run_action(struct view *view, struct server *server, struct action *action,
 			}
 			bool combine = action_get_bool(action, "combine", false);
 			view_snap_to_edge(view, edge, /*across_outputs*/ true,
-				combine, /*store_natural_geometry*/ true);
+				combine);
 		}
 		break;
 	case ACTION_TYPE_GROW_TO_EDGE:
@@ -1203,16 +1203,14 @@ run_action(struct view *view, struct server *server, struct action *action,
 		if (view) {
 			enum view_axis axis = action_get_int(action,
 				"direction", VIEW_AXIS_BOTH);
-			view_maximize(view, axis,
-				/*store_natural_geometry*/ true);
+			view_maximize(view, axis);
 		}
 		break;
 	case ACTION_TYPE_UNMAXIMIZE:
 		if (view) {
 			enum view_axis axis = action_get_int(action,
 				"direction", VIEW_AXIS_BOTH);
-			view_maximize(view, view->maximized & ~axis,
-				/*store_natural_geometry*/ true);
+			view_maximize(view, view->maximized & ~axis);
 		}
 		break;
 	case ACTION_TYPE_TOGGLE_FULLSCREEN:
@@ -1426,8 +1424,7 @@ run_action(struct view *view, struct server *server, struct action *action,
 				view_apply_natural_geometry(view);
 				break;
 			}
-			view_snap_to_region(view, region,
-				/*store_natural_geometry*/ true);
+			view_snap_to_region(view, region);
 		} else {
 			wlr_log(WLR_ERROR, "Invalid SnapToRegion id: '%s'", region_name);
 		}
@@ -1435,8 +1432,7 @@ run_action(struct view *view, struct server *server, struct action *action,
 	}
 	case ACTION_TYPE_UNSNAP:
 		if (view && !view->fullscreen && !view_is_floating(view)) {
-			view_maximize(view, VIEW_AXIS_NONE,
-				/* store_natural_geometry */ false);
+			view_maximize(view, VIEW_AXIS_NONE);
 			view_set_untiled(view);
 			view_apply_natural_geometry(view);
 		}

--- a/src/foreign-toplevel/wlr-foreign.c
+++ b/src/foreign-toplevel/wlr-foreign.c
@@ -26,8 +26,7 @@ handle_request_maximize(struct wl_listener *listener, void *data)
 	struct wlr_foreign_toplevel_handle_v1_maximized_event *event = data;
 
 	view_maximize(wlr_toplevel->view,
-		event->maximized ? VIEW_AXIS_BOTH : VIEW_AXIS_NONE,
-		/*store_natural_geometry*/ true);
+		event->maximized ? VIEW_AXIS_BOTH : VIEW_AXIS_NONE);
 }
 
 static void

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -273,17 +273,12 @@ snap_to_edge(struct view *view)
 	enum lab_edge edge = edge1 | edge2;
 
 	view_set_output(view, output);
-	/*
-	 * Don't store natural geometry here (it was
-	 * stored already in interactive_begin())
-	 */
 	if (edge == LAB_EDGE_TOP && rc.snap_top_maximize) {
 		/* <topMaximize> */
-		view_maximize(view, VIEW_AXIS_BOTH,
-			/*store_natural_geometry*/ false);
+		view_maximize(view, VIEW_AXIS_BOTH);
 	} else {
 		view_snap_to_edge(view, edge, /*across_outputs*/ false,
-			/*combine*/ false, /*store_natural_geometry*/ false);
+			/*combine*/ false);
 	}
 
 	return true;
@@ -298,8 +293,7 @@ snap_to_region(struct view *view)
 
 	struct region *region = regions_from_cursor(view->server);
 	if (region) {
-		view_snap_to_region(view, region,
-			/*store_natural_geometry*/ false);
+		view_snap_to_region(view, region);
 		return true;
 	}
 	return false;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -225,8 +225,7 @@ handle_commit(struct wl_listener *listener, void *data)
 			set_fullscreen_from_request(view, &toplevel->requested);
 		}
 		if (toplevel->requested.maximized) {
-			view_maximize(view, VIEW_AXIS_BOTH,
-				/*store_natural_geometry*/ true);
+			view_maximize(view, VIEW_AXIS_BOTH);
 		}
 		return;
 	}
@@ -505,8 +504,7 @@ handle_request_maximize(struct wl_listener *listener, void *data)
 		view_set_output(view, output_nearest_to_cursor(view->server));
 	}
 	bool maximized = toplevel->requested.maximized;
-	view_maximize(view, maximized ? VIEW_AXIS_BOTH : VIEW_AXIS_NONE,
-		/*store_natural_geometry*/ true);
+	view_maximize(view, maximized ? VIEW_AXIS_BOTH : VIEW_AXIS_NONE);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -470,7 +470,7 @@ handle_request_maximize(struct wl_listener *listener, void *data)
 	if (surf->maximized_horz) {
 		maximize |= VIEW_AXIS_HORIZONTAL;
 	}
-	view_maximize(view, maximize, /*store_natural_geometry*/ true);
+	view_maximize(view, maximize);
 }
 
 static void
@@ -704,7 +704,7 @@ handle_map_request(struct wl_listener *listener, void *data)
 	if (xsurface->maximized_vert) {
 		axis |= VIEW_AXIS_VERTICAL;
 	}
-	view_maximize(view, axis, /*store_natural_geometry*/ true);
+	view_maximize(view, axis);
 	/*
 	 * We could also call set_initial_position() here, but it's not
 	 * really necessary until the view is actually mapped (and at


### PR DESCRIPTION
These were added to fix handling of natural geometry for snap-to-edge behavior back in 9021020f6e37 and seemed like a good idea at the time. Since then, the number of call sites has exploded, so it seems more maintainable to put explicit checks for interactive move within the three functions affected.