### PR TITLE
scripts/check: run max $(nproc) checkpatch.pl processes

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -20,7 +20,7 @@ run_checks () {
 	fi
 
 	find src/ include/ clients/ t/ \( -name "*.c" -o -name "*.h" \) -type f -print0 |
-	nice xargs -0 --max-args 1 --max-procs $(nproc) \
+	nice xargs -0 --max-args 16 --max-procs $(nproc) \
 		scripts/checkpatch.pl --terse --no-tree --strict --file
 	return $?
 }


### PR DESCRIPTION
Each of those checking "number-of-files" / $(nproc) files.

This is significantly faster and uses less resources than running checkpatch.pl separately for every file.

To count the number of files, the file name list was first written to a temporary file.

There is chance, albeit improbable, that shell fails to execute an exit trap when its execution is interrupted. Therefore before the last use of this temporary file shell opens it for fd 8 and then removes its directory entry (along with the exit trap) and finally redirects the file content to xargs with <&8.

--

On one system 4-core system I tested to check all 208 files, best time now 22 secs - before 34 secs.

Cold machine, warm cache, fast SSD 

tried also `echo 3 > /proc/sys/vm/drop_caches` and/or 8 parallel processes but did not see much difference :o

anyway, before 208 forks, execves and perl inintialisations and arg parsing, each checking one file,
now 4 forks, execves... and each checking 52 files
