### PR TITLE
view: rework saving/restoring geometry across layout changes

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -215,11 +215,14 @@ struct view {
 	struct wlr_box natural_geometry;
 	/*
 	 * Whenever an output layout change triggers a view relocation, the
-	 * last pending position (or natural geometry) will be saved so the
-	 * view may be restored to its original location on a subsequent layout
-	 * change.
+	 * last pending position will be saved so the view may be restored
+	 * to its original location on a subsequent layout change.
 	 */
 	struct wlr_box last_layout_geometry;
+	/* Set temporarily when moving view due to layout change */
+	bool adjusting_for_layout_change;
+	/* True if original output was disconnected or disabled */
+	bool lost_output_due_to_layout_change;
 
 	/* used by xdg-shell views */
 	uint32_t pending_configure_serial;
@@ -533,7 +536,6 @@ bool view_titlebar_visible(struct view *view);
 void view_set_ssd_mode(struct view *view, enum lab_ssd_mode mode);
 void view_set_decorations(struct view *view, enum lab_ssd_mode mode, bool force_ssd);
 void view_toggle_fullscreen(struct view *view);
-void view_invalidate_last_layout_geometry(struct view *view);
 void view_adjust_for_layout_change(struct view *view);
 void view_move_to_edge(struct view *view, enum lab_edge direction, bool snap_to_windows);
 void view_grow_to_edge(struct view *view, enum lab_edge direction);

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -92,9 +92,6 @@ interactive_begin(struct view *view, enum input_mode mode, enum lab_edge edges)
 
 		/* Store natural geometry at start of move */
 		view_store_natural_geometry(view);
-		if (view_is_floating(view)) {
-			view_invalidate_last_layout_geometry(view);
-		}
 
 		/* Prevent region snapping when just moving via A-Left mousebind */
 		seat->region_prevent_snap = keyboard_get_all_modifiers(seat);
@@ -110,12 +107,6 @@ interactive_begin(struct view *view, enum input_mode mode, enum lab_edge edges)
 			 */
 			return;
 		}
-
-		/*
-		 * Resizing overrides any attempt to restore window
-		 * geometries altered by layout changes.
-		 */
-		view_invalidate_last_layout_geometry(view);
 
 		/*
 		 * If tiled or maximized in only one direction, reset


### PR DESCRIPTION
After several iterations, this is basically a complete re-work. The old implementation was difficult to follow and sometimes failed to restore fullscreen/maximized/tiled geometry correctly, since it was based entirely on natural (floating) geometry.

The new implementation:
 - always saves the actual (pending) geometry at first layout change
 - explicitly tracks whether a view has moved between outputs
 - consolidates invalidating the saved geometry into one place, rather than having lots of invalidate() calls sprinkled everywhere