### PR TITLE
xwayland: Do not try to focus a window that was already in focus

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -55,7 +55,9 @@ set_or_offer_focus(struct view *view)
 		break;
 	case VIEW_WANTS_FOCUS_LIKELY:
 	case VIEW_WANTS_FOCUS_UNLIKELY:
-		view_offer_focus(view);
+		if (view->surface != seat->seat->keyboard_state.focused_surface) {
+			view_offer_focus(view);
+		}
 		break;
 	case VIEW_WANTS_FOCUS_NEVER:
 		break;


### PR DESCRIPTION
Old versions of Minecraft (<= 1.5.2) take input, but don’t set WM input hint, which leads to labwc trying to focus window on every click in the game. We had not this issue before 8fb2ece because `xwayland_view_wants_focus()` returns `VIEW_WANTS_FOCUS_ALWAYS` , and `set_or_offer_focus()` already checks if the focus was received before in this case.

Fixes: #3315