### PR TITLE
output: suppress error when output position is unavailable

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -880,14 +880,9 @@ wlr_output_configuration_v1 *create_output_config(struct server *server)
 			wlr_output_configuration_v1_destroy(config);
 			return NULL;
 		}
-		struct wlr_box box;
-		wlr_output_layout_get_box(server->output_layout,
-			output->wlr_output, &box);
-		if (!wlr_box_empty(&box)) {
-			head->state.x = box.x;
-			head->state.y = box.y;
-		} else {
-			wlr_log(WLR_ERROR, "failed to get output layout box");
+		if (output_is_usable(output)) {
+			head->state.x = output->scene_output->x;
+			head->state.y = output->scene_output->y;
 		}
 	}
 	return config;


### PR DESCRIPTION
Fixes #3313.

This PR removes the "failed to get output layout box" error printed when disabling an output with `wlr-randr`.

Also, use `output->scene_output->{x,y}` instead of calling `wlr_output_layout_get_box()` for simplicity. The positions of scene-outputs are synced with the output-layout-outputs.