### PR TITLE
view: avoid restacking when view (or a sub-view) is already in front

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2232,6 +2232,18 @@ void
 view_move_to_front(struct view *view)
 {
 	assert(view);
+	struct server *server = view->server;
+	assert(!wl_list_empty(&server->views));
+
+	/*
+	 * Check whether the view is already in front, or is the root
+	 * parent of the view in front (in which case we don't want to
+	 * raise it in front of its sub-view).
+	 */
+	struct view *front = wl_container_of(server->views.next, front, link);
+	if (view == front || view == view_get_root(front)) {
+		return;
+	}
 
 	struct view *root = view_get_root(view);
 	assert(root);


### PR DESCRIPTION
Currently, every click within a sub-view results in first restacking the parent view in front, and then the sub-view. This is unnecessary and has caused issues in the past, such as with Xaw popups (which we've worked around in d748dc78bc0e by adding an `xcb_flush()`).

It would be better not to do the unnecessary restacking at all.

Note: this fixes the Xaw popup issue from #3152 on its own, and means we could probably revert d748dc78bc0e if we wanted. Not sure if we want to do that yet, or later, or at all.