### PR TITLE
view: don't update top layer visibility in `view_discover_output()`

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -461,10 +461,6 @@ view_discover_output(struct view *view, struct wlr_box *geometry)
 
 	if (output && output != view->output) {
 		view->output = output;
-		/* Show fullscreen views above top-layer */
-		if (view->fullscreen) {
-			desktop_update_top_layer_visibility(view->server);
-		}
 		return true;
 	}
 


### PR DESCRIPTION
This PR does not change any behaviors.

We don't need to call `desktop_update_top_layer_visibility()` in `view_discover_output()` since it's called in `view_update_outputs()`.