### PR TITLE
Avoid double use of `struct workspace`

### DIFF
--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -57,6 +57,11 @@ struct usable_area_override {
 	struct wl_list link; /* struct rcxml.usable_area_overrides */
 };
 
+struct workspace_config {
+	struct wl_list link; /* struct rcxml.workspace_config.workspaces */
+	char *name;
+};
+
 struct rcxml {
 	/* from command line */
 	char *config_dir;
@@ -170,7 +175,7 @@ struct rcxml {
 		int min_nr_workspaces;
 		char *initial_workspace_name;
 		char *prefix;
-		struct wl_list workspaces;  /* struct workspace.link */
+		struct wl_list workspaces;  /* struct workspace_config.link */
 	} workspace_config;
 
 	/* Regions */

--- a/include/workspaces.h
+++ b/include/workspaces.h
@@ -10,12 +10,8 @@ struct seat;
 struct server;
 struct wlr_scene_tree;
 
-/* Double use: as config in config/rcxml.c and as instance in workspaces.c */
 struct workspace {
-	struct wl_list link; /*
-			      * struct server.workspaces
-			      * struct rcxml.workspace_config.workspaces
-			      */
+	struct wl_list link; /* struct server.workspaces */
 	struct server *server;
 
 	char *name;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1309,9 +1309,9 @@ entry(xmlNode *node, char *nodename, char *content)
 			" Use <windowSwitcher outlines=\"\" />");
 
 	} else if (!strcasecmp(nodename, "name.names.desktops")) {
-		struct workspace *workspace = znew(*workspace);
-		workspace->name = xstrdup(content);
-		wl_list_append(&rc.workspace_config.workspaces, &workspace->link);
+		struct workspace_config *conf = znew(*conf);
+		conf->name = xstrdup(content);
+		wl_list_append(&rc.workspace_config.workspaces, &conf->link);
 	} else if (!strcasecmp(nodename, "popupTime.desktops")) {
 		rc.workspace_config.popuptime = atoi(content);
 	} else if (!strcasecmp(nodename, "initial.desktops")) {
@@ -1784,15 +1784,14 @@ post_processing(void)
 		}
 
 		struct buf b = BUF_INIT;
-		struct workspace *workspace;
 		for (int i = nr_workspaces; i < rc.workspace_config.min_nr_workspaces; i++) {
-			workspace = znew(*workspace);
+			struct workspace_config *conf = znew(*conf);
 			if (!string_null_or_empty(rc.workspace_config.prefix)) {
 				buf_add_fmt(&b, "%s ", rc.workspace_config.prefix);
 			}
 			buf_add_fmt(&b, "%d", i + 1);
-			workspace->name = xstrdup(b.data);
-			wl_list_append(&rc.workspace_config.workspaces, &workspace->link);
+			conf->name = xstrdup(b.data);
+			wl_list_append(&rc.workspace_config.workspaces, &conf->link);
 			buf_clear(&b);
 		}
 		buf_reset(&b);
@@ -2011,7 +2010,7 @@ rcxml_finish(void)
 		zfree(l);
 	}
 
-	struct workspace *w, *w_tmp;
+	struct workspace_config *w, *w_tmp;
 	wl_list_for_each_safe(w, w_tmp, &rc.workspace_config.workspaces, link) {
 		wl_list_remove(&w->link);
 		zfree(w->name);


### PR DESCRIPTION
`struct workspace` was used both for representing an actual workspace and for an entry of workspace configuration. Avoid it for clarity.