### PR TITLE
view: cancel interactive move/resize when minimized/unmapped

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2439,6 +2439,11 @@ view_update_visibility(struct view *view)
 	if (view_has_strut_partial(view)) {
 		output_update_all_usable_areas(view->server, false);
 	}
+
+	/* View might have been unmapped/minimized during move/resize */
+	if (!visible) {
+		interactive_cancel(view);
+	}
 }
 
 void
@@ -2544,8 +2549,11 @@ view_destroy(struct view *view)
 		view->foreign_toplevel = NULL;
 	}
 
+	/*
+	 * This check is (in theory) redundant since interactive_cancel()
+	 * is called at unmap. Leaving it here just to be sure.
+	 */
 	if (server->grabbed_view == view) {
-		/* Application got killed while moving around */
 		interactive_cancel(view);
 	}
 


### PR DESCRIPTION
Currently, with enough dexterity, you can minimize a window via hotkey with one hand while continuing to move it (now invisible) with the mouse in your other hand. The same can probably happen with XWayland windows that self-unmap at an inconvenient time.

Probably not a common occurrence, but it's trivial to handle.