### PR TITLE
desktop: use for_each_view() in desktop_topmost_focusable_view()

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -188,6 +188,7 @@ struct server {
 	struct wlr_xdg_toplevel_icon_manager_v1 *xdg_toplevel_icon_manager;
 	struct wl_listener xdg_toplevel_icon_set_icon;
 
+	/* front to back order */
 	struct wl_list views;
 	uint64_t next_view_creation_id;
 	struct wl_list unmanaged_surfaces;

--- a/include/view.h
+++ b/include/view.h
@@ -345,7 +345,7 @@ void view_query_free(struct view_query *view);
 bool view_matches_query(struct view *view, struct view_query *query);
 
 /**
- * for_each_view() - iterate over all views which match criteria
+ * for_each_view() - iterate over all views which match criteria (front to back)
  * @view: Iterator.
  * @head: Head of list to iterate over.
  * @criteria: Criteria to match against.
@@ -361,7 +361,7 @@ bool view_matches_query(struct view *view, struct view_query *query);
 	     view = view_next(head, view, criteria))
 
 /**
- * for_each_view_reverse() - iterate over all views which match criteria
+ * for_each_view_reverse() - iterate over all views which match criteria (back to front)
  * @view: Iterator.
  * @head: Head of list to iterate over.
  * @criteria: Criteria to match against.

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -138,7 +138,7 @@ static struct view *
 desktop_topmost_focusable_view(struct server *server)
 {
 	struct view *view;
-	for_each_view_reverse(view, &server->views,
+	for_each_view(view, &server->views,
 			LAB_VIEW_CRITERIA_CURRENT_WORKSPACE) {
 		if (!view->minimized) {
 			return view;


### PR DESCRIPTION
Fixes a regression in #3348 that the bottom-most view is focused when when an exclusive layer surface (e.g. fuzzel) is unfocused.

Also, added some comments to clarify the order.