### PR TITLE
tree-wide: do not try to use outputs with no scene_output

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -1409,7 +1409,7 @@ run_action(struct view *view, struct server *server, struct action *action,
 			break;
 		}
 		struct output *output = view->output;
-		if (!output) {
+		if (!output_is_usable(output)) {
 			break;
 		}
 		const char *region_name = action_get_str(action, "region", NULL);

--- a/src/layers.c
+++ b/src/layers.c
@@ -145,7 +145,7 @@ try_to_focus_next_layer_or_toplevel(struct server *server)
 {
 	struct seat *seat = &server->seat;
 	struct output *output = output_nearest_to_cursor(server);
-	if (!output) {
+	if (!output_is_usable(output)) {
 		goto no_output;
 	}
 
@@ -589,16 +589,14 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 	struct wlr_layer_surface_v1 *layer_surface = data;
 
 	if (!layer_surface->output) {
-		struct wlr_output *output = wlr_output_layout_output_at(
-			server->output_layout, server->seat.cursor->x,
-			server->seat.cursor->y);
-		if (!output) {
+		struct output *output = output_nearest_to_cursor(server);
+		if (!output_is_usable(output)) {
 			wlr_log(WLR_INFO,
 				"No output available to assign layer surface");
 			wlr_layer_surface_v1_destroy(layer_surface);
 			return;
 		}
-		layer_surface->output = output;
+		layer_surface->output = output->wlr_output;
 	}
 
 	struct lab_layer_surface *surface = znew(*surface);

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -731,7 +731,7 @@ menu_reposition(struct menu *menu, struct wlr_box anchor_rect)
 	/* Get output usable area to place the menu within */
 	struct output *output = output_nearest_to(menu->server,
 		anchor_rect.x, anchor_rect.y);
-	if (!output) {
+	if (!output_is_usable(output)) {
 		wlr_log(WLR_ERROR, "no output found around (%d,%d)",
 			anchor_rect.x, anchor_rect.y);
 		return;

--- a/src/regions.c
+++ b/src/regions.c
@@ -53,7 +53,7 @@ regions_from_cursor(struct server *server)
 	struct wlr_output *wlr_output = wlr_output_layout_output_at(
 		server->output_layout, lx, ly);
 	struct output *output = output_from_wlr_output(server, wlr_output);
-	if (!output) {
+	if (!output_is_usable(output)) {
 		return NULL;
 	}
 

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -95,7 +95,7 @@ ssd_extents_update(struct ssd *ssd)
 		wlr_scene_node_set_enabled(&ssd->extents.tree->node, true);
 	}
 
-	if (!view->output) {
+	if (!output_is_usable(view->output)) {
 		return;
 	}
 

--- a/src/view.c
+++ b/src/view.c
@@ -1104,7 +1104,7 @@ view_place_by_policy(struct view *view, bool allow_cursor,
 void
 view_constrain_size_to_that_of_usable_area(struct view *view)
 {
-	if (!view || !view->output || view->fullscreen) {
+	if (!view || !output_is_usable(view->output) || view->fullscreen) {
 		return;
 	}
 
@@ -1918,7 +1918,7 @@ view_move_to_edge(struct view *view, enum lab_edge direction, bool snap_to_windo
 	/* Otherwise, move to edge of next adjacent display, if possible */
 	struct output *output =
 		output_get_adjacent(view->output, direction, /* wrap */ false);
-	if (!output) {
+	if (!output_is_usable(output)) {
 		return;
 	}
 
@@ -2098,7 +2098,7 @@ view_snap_to_edge(struct view *view, enum lab_edge edge,
 			 */
 			output = output_get_adjacent(view->output, edge,
 				/* wrap */ false);
-			if (!output) {
+			if (!output_is_usable(output)) {
 				return;
 			}
 			edge = invert_edge;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -500,7 +500,7 @@ handle_request_maximize(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	if (!view->mapped && !view->output) {
+	if (!view->mapped && !output_is_usable(view->output)) {
 		view_set_output(view, output_nearest_to_cursor(view->server));
 	}
 	bool maximized = toplevel->requested.maximized;
@@ -521,7 +521,7 @@ handle_request_fullscreen(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	if (!view->mapped && !view->output) {
+	if (!view->mapped && !output_is_usable(view->output)) {
 		view_set_output(view, output_nearest_to_cursor(view->server));
 	}
 	set_fullscreen_from_request(view,
@@ -819,7 +819,7 @@ handle_map(struct wl_listener *listener, void *data)
 	 * An output should have been chosen when the surface was first
 	 * created, but take one more opportunity to assign an output if not.
 	 */
-	if (!view->output) {
+	if (!output_is_usable(view->output)) {
 		view_set_output(view, output_nearest_to_cursor(view->server));
 	}
 

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -228,7 +228,7 @@ ensure_initial_geometry_and_output(struct view *view)
 			view->pending = view->current;
 		}
 	}
-	if (!view->output) {
+	if (!output_is_usable(view->output)) {
 		/*
 		 * Just use the cursor output since we don't know yet
 		 * whether the surface position is meaningful.


### PR DESCRIPTION
- check for valid `scene_output` in `output_is_usable()`
- change many `output != NULL` checks to use `output_is_usable()`
- remove one now-redundant separate check for valid `scene_output`

Fixes a crash at startup (with `autoEnableOutputs=no`) due to dereferencing null `scene_output` in `create_output_config()` since 7d7ece21d98d9e02b8834feb1138bae30a8ed271 ("output: suppress error when output position is unavailable").

Fixes:
- #3357