### PR TITLE
xwayland: flush X11 connection after focus/activate

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -2260,7 +2260,9 @@ view_move_to_front(struct view *view)
 	 * to an incorrect X window depending on timing. To mitigate the
 	 * race, perform an explicit flush after restacking.
 	 */
-	xwayland_flush(view->server);
+	if (view->type == LAB_XWAYLAND_VIEW) {
+		xwayland_flush(view->server);
+	}
 #endif
 	cursor_update_focus(view->server);
 	desktop_update_top_layer_visibility(view->server);

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -946,6 +946,14 @@ xwayland_view_set_activated(struct view *view, bool activated)
 	}
 
 	wlr_xwayland_surface_activate(xwayland_surface, activated);
+	/*
+	 * Make sure that the X11-protocol messages (SetInputFocus etc.)
+	 * are sent immediately. This mitigates a race where the XWayland
+	 * server may generate an unwanted FocusOut event for the newly
+	 * activated window, if it receives mouse/pointer events over the
+	 * parallel wayland connection first.
+	 */
+	xwayland_flush(view->server);
 }
 
 static void


### PR DESCRIPTION
This mitigates a race where the XWayland server may generate an unwanted FocusOut event for the newly activated window, if it receives mouse/ pointer events over the parallel wayland connection first.

In particular, this fixes an issue with certain fullscreen applications (such as Minecraft) that self-minimize when receiving FocusOut.

Also limit a previous similar workaround to apply only to XWayland views.

Fixes:
- #3344

See also: https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/4044