### PR TITLE
Add support for toplevel capture

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -284,6 +284,9 @@ struct server {
 	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
 	struct wlr_ext_foreign_toplevel_list_v1 *foreign_toplevel_list;
 
+	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *ext_foreign_toplevel_image_capture_source_manager_v1;
+	struct wl_listener new_foreign_toplevel_capture_request;
+
 	struct wlr_drm_lease_v1_manager *drm_lease_manager;
 	struct wl_listener drm_lease_request;
 

--- a/include/view.h
+++ b/include/view.h
@@ -168,6 +168,9 @@ struct view {
 	struct wlr_scene_tree *scene_tree;
 	struct wlr_scene_tree *content_tree; /* may be NULL for unmapped view */
 
+	struct wlr_scene *image_capture_scene;
+	struct wlr_ext_image_capture_source_v1 *image_capture_source;
+
 	/* These are never NULL and an empty string is set instead. */
 	char *title;
 	char *app_id; /* WM_CLASS for xwayland windows */
@@ -299,6 +302,8 @@ struct xdg_toplevel_view {
 
 	/* Optional black background fill behind fullscreen view */
 	struct wlr_scene_rect *fullscreen_bg;
+
+	struct wlr_scene_tree *image_capture_tree;
 
 	/* Events unique to xdg-toplevel views */
 	struct wl_listener set_app_id;

--- a/src/foreign-toplevel/ext-foreign.c
+++ b/src/foreign-toplevel/ext-foreign.c
@@ -75,6 +75,8 @@ ext_foreign_toplevel_init(struct ext_foreign_toplevel *ext_toplevel,
 		return;
 	}
 
+	ext_toplevel->handle->data = view;
+
 	/* Client side requests */
 	ext_toplevel->on.handle_destroy.notify = handle_handle_destroy;
 	wl_signal_add(&ext_toplevel->handle->events.destroy, &ext_toplevel->on.handle_destroy);

--- a/src/view.c
+++ b/src/view.c
@@ -2525,6 +2525,12 @@ view_init(struct view *view)
 	wl_signal_init(&view->events.set_icon);
 	wl_signal_init(&view->events.destroy);
 
+	view->image_capture_scene = wlr_scene_create();
+	if (view->image_capture_scene == NULL) {
+	    wlr_log(WLR_ERROR, "not image_capture_scene");
+	}
+	view->image_capture_scene->restack_xwayland_surfaces = false;
+
 	view->title = xstrdup("");
 	view->app_id = xstrdup("");
 }
@@ -2591,6 +2597,11 @@ view_destroy(struct view *view)
 	if (view->scene_tree) {
 		wlr_scene_node_destroy(&view->scene_tree->node);
 		view->scene_tree = NULL;
+	}
+
+	if (view->image_capture_scene) {
+		wlr_scene_node_destroy(&view->image_capture_scene->tree.node);
+		view->image_capture_scene = NULL;
 	}
 
 	assert(wl_list_empty(&view->events.new_app_id.listener_list));

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -1030,6 +1030,11 @@ handle_new_xdg_toplevel(struct wl_listener *listener, void *data)
 		free(xdg_toplevel_view);
 		return;
 	}
+
+	xdg_toplevel_view->image_capture_tree =
+		wlr_scene_xdg_surface_create(&view->image_capture_scene->tree,
+									 xdg_surface);
+
 	view->content_tree = tree;
 	node_descriptor_create(&view->scene_tree->node,
 		LAB_NODE_VIEW, view, /*data*/ NULL);


### PR DESCRIPTION
This PR implements `ext_foreign_toplevel_image_capture_source_manager_v1`. For reference, Sway has already added support for toplevel capture in this commit: https://github.com/swaywm/sway/commit/170c9c9525f54e8c1ba03847d5f9b01fc24b8c89 