### PR TITLE
interactive: set grab parameters at cursor press

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -414,6 +414,7 @@ void seat_focus_override_end(struct seat *seat, bool restore_focus);
  */
 void interactive_anchor_to_cursor(struct server *server, struct wlr_box *geo);
 
+void interactive_set_grab_context(struct cursor_context *ctx);
 void interactive_begin(struct view *view, enum input_mode mode,
 	enum lab_edge edges);
 void interactive_finish(struct view *view);

--- a/src/action.c
+++ b/src/action.c
@@ -1262,6 +1262,14 @@ run_action(struct view *view, struct server *server, struct action *action,
 		break;
 	case ACTION_TYPE_MOVE:
 		if (view) {
+			/*
+			 * If triggered by mousebind, grab context was already
+			 * set by button press handling. For keybind-triggered
+			 * Move, set it now from current cursor position.
+			 */
+			if (view != server->seat.pressed.ctx.view) {
+				interactive_set_grab_context(ctx);
+			}
 			interactive_begin(view, LAB_INPUT_STATE_MOVE,
 				LAB_EDGE_NONE);
 		}
@@ -1285,9 +1293,13 @@ run_action(struct view *view, struct server *server, struct action *action,
 			 */
 			enum lab_edge resize_edges =
 				action_get_int(action, "direction", LAB_EDGE_NONE);
-			if (resize_edges == LAB_EDGE_NONE) {
-				resize_edges = cursor_get_resize_edges(
-					server->seat.cursor, ctx);
+			/*
+			 * If triggered by mousebind, grab context was already
+			 * set by button press handling. For keybind-triggered
+			 * Resize, set it now from current cursor position.
+			 */
+			if (view != server->seat.pressed.ctx.view) {
+				interactive_set_grab_context(ctx);
 			}
 			interactive_begin(view, LAB_INPUT_STATE_RESIZE,
 				resize_edges);

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -1147,6 +1147,7 @@ cursor_process_button_press(struct seat *seat, uint32_t button, uint32_t time_ms
 	if (ctx.view || ctx.surface) {
 		/* Store cursor context for later action processing */
 		cursor_context_save(&seat->pressed, &ctx);
+		interactive_set_grab_context(&ctx);
 	}
 
 	if (server->input_mode == LAB_INPUT_STATE_MENU) {
@@ -1277,6 +1278,9 @@ cursor_finish_button_release(struct seat *seat, uint32_t button)
 		/* Exit interactive move/resize mode */
 		interactive_finish(server->grabbed_view);
 		return true;
+	} else if (server->grabbed_view) {
+		/* Button was released without starting move/resize */
+		interactive_cancel(server->grabbed_view);
 	}
 
 	return false;

--- a/src/view.c
+++ b/src/view.c
@@ -1432,14 +1432,11 @@ view_maximize(struct view *view, enum view_axis axis)
 	bool store_natural_geometry = !in_interactive_move(view);
 	view_set_shade(view, false);
 
-	if (axis != VIEW_AXIS_NONE) {
-		/*
-		 * Maximize via keybind or client request cancels
-		 * interactive move/resize since we can't move/resize
-		 * a maximized view.
-		 */
-		interactive_cancel(view);
-	}
+	/*
+	 * Maximize/unmaximize via keybind or client request cancels
+	 * interactive move/resize.
+	 */
+	interactive_cancel(view);
 
 	/*
 	 * Update natural geometry for any axis that wasn't already

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -454,11 +454,11 @@ handle_request_move(struct wl_listener *listener, void *data)
 	 * the provided serial against a list of button press serials sent to
 	 * this client, to prevent the client from requesting this whenever they
 	 * want.
+	 *
+	 * Note: interactive_begin() checks that view == server->grabbed_view.
 	 */
 	struct view *view = wl_container_of(listener, view, request_move);
-	if (view == view->server->seat.pressed.ctx.view) {
-		interactive_begin(view, LAB_INPUT_STATE_MOVE, LAB_EDGE_NONE);
-	}
+	interactive_begin(view, LAB_INPUT_STATE_MOVE, LAB_EDGE_NONE);
 }
 
 static void
@@ -471,12 +471,12 @@ handle_request_resize(struct wl_listener *listener, void *data)
 	 * the provided serial against a list of button press serials sent to
 	 * this client, to prevent the client from requesting this whenever they
 	 * want.
+	 *
+	 * Note: interactive_begin() checks that view == server->grabbed_view.
 	 */
 	struct wlr_xdg_toplevel_resize_event *event = data;
 	struct view *view = wl_container_of(listener, view, request_resize);
-	if (view == view->server->seat.pressed.ctx.view) {
-		interactive_begin(view, LAB_INPUT_STATE_RESIZE, event->edges);
-	}
+	interactive_begin(view, LAB_INPUT_STATE_RESIZE, event->edges);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -288,11 +288,11 @@ handle_request_move(struct wl_listener *listener, void *data)
 	 * the provided serial against a list of button press serials sent to
 	 * this client, to prevent the client from requesting this whenever they
 	 * want.
+	 *
+	 * Note: interactive_begin() checks that view == server->grabbed_view.
 	 */
 	struct view *view = wl_container_of(listener, view, request_move);
-	if (view == view->server->seat.pressed.ctx.view) {
-		interactive_begin(view, LAB_INPUT_STATE_MOVE, LAB_EDGE_NONE);
-	}
+	interactive_begin(view, LAB_INPUT_STATE_MOVE, LAB_EDGE_NONE);
 }
 
 static void
@@ -305,12 +305,12 @@ handle_request_resize(struct wl_listener *listener, void *data)
 	 * the provided serial against a list of button press serials sent to
 	 * this client, to prevent the client from requesting this whenever they
 	 * want.
+	 *
+	 * Note: interactive_begin() checks that view == server->grabbed_view.
 	 */
 	struct wlr_xwayland_resize_event *event = data;
 	struct view *view = wl_container_of(listener, view, request_resize);
-	if (view == view->server->seat.pressed.ctx.view) {
-		interactive_begin(view, LAB_INPUT_STATE_RESIZE, event->edges);
-	}
+	interactive_begin(view, LAB_INPUT_STATE_RESIZE, event->edges);
 }
 
 static void


### PR DESCRIPTION
Add `interactive_set_grab_context()` which is called when the mouse button is first pressed, before `interactive_begin()`. This fixes two small issues:

- The cursor origin position for interactive move/resize was slightly off (depending on mouse resolution), because it was set after the mouse had already moved slightly. Now it's exact.

- If app- or keybind-initiated maximize (etc.) happened after the button press but before the mouse was moved, then `interactive_begin()` would still start move/resize even though the view might now be far away from the cursor. Now `interactive_cancel()` works as expected, even if called before interactive_begin().

Also, make sure to call `interactive_cancel()` for un-maximize as well.

Fixes:
- #3371

Creating as draft for now since the code is a bit tricky, there might be some case I missed. Interactive move/resize via touchscreen or tablet seems like it would not work, but likely didn't before either (don't have HW to test it on currently).