### PR TITLE
 workspaces: keep unfocusable omnipresent views visible

### DIFF
--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -469,11 +469,13 @@ workspaces_switch_to(struct workspace *target, bool update_focus)
 	lab_ext_workspace_set_active(
 		server->workspaces.current->ext_workspace, false);
 
-	/* Move Omnipresent views to new workspace */
+	/*
+	 * Move Omnipresent views to new workspace.
+	 * Not using for_each_view() since it skips views that
+	 * view_is_focusable() returns false (e.g. Conky).
+	 */
 	struct view *view;
-	enum lab_view_criteria criteria =
-		LAB_VIEW_CRITERIA_CURRENT_WORKSPACE;
-	for_each_view_reverse(view, &server->views, criteria) {
+	wl_list_for_each_reverse(view, &server->views, link) {
 		if (view->visible_on_all_workspaces) {
 			view_move_to_workspace(view, target);
 		}


### PR DESCRIPTION
Fixes #3376.

When switching between workspaces, we need to migrate omnipresent views to the new workspace so that they are kept visible. However, by using `for_each_view_reverse()` macro, we were not migrating omnipresent views that `view_is_focusable()` return false (e.g. Conky).

Use `wl_list_for_each_reverse()` macro instead to catch all the omnipresent views.