### PR TITLE
dnd: support DnD for touchscreens

### DIFF
--- a/src/dnd.c
+++ b/src/dnd.c
@@ -15,11 +15,17 @@ handle_drag_request(struct wl_listener *listener, void *data)
 {
 	struct seat *seat = wl_container_of(listener, seat, drag.events.request);
 	struct wlr_seat_request_start_drag_event *event = data;
+	struct wlr_touch_point *point = NULL;
 
 	if (wlr_seat_validate_pointer_grab_serial(
 			seat->seat, event->origin, event->serial)) {
 		wlr_seat_start_pointer_drag(seat->seat, event->drag,
 			event->serial);
+	} else if (wlr_seat_validate_touch_grab_serial(
+			seat->seat, event->origin, event->serial, &point)) {
+		wlr_seat_start_touch_drag(seat->seat, event->drag,
+			event->serial, point);
+		/* TODO: tablet grab */
 	} else {
 		wlr_data_source_destroy(event->drag->source);
 		wlr_log(WLR_ERROR, "wrong source for drag request");


### PR DESCRIPTION
Follows sway: https://github.com/swaywm/sway/blob/fa497964fd55632beacf5f425e964ae4893e25b9/sway/input/seat.c#L425-L431

DnD for tablet tools has not been addressed, so I think we should not close #3338 yet.

Note tested.

I think we can merge this PR in this cool-down period.