### PR TITLE
 layer: update pointer focus on unmap

### DIFF
--- a/src/layers.c
+++ b/src/layers.c
@@ -378,6 +378,7 @@ handle_unmap(struct wl_listener *listener, void *data)
 	if (seat->focused_layer == layer_surface) {
 		try_to_focus_next_layer_or_toplevel(layer->server);
 	}
+	cursor_update_focus(layer->server);
 
 	layer->being_unmapped = false;
 }
@@ -454,6 +455,7 @@ handle_popup_destroy(struct wl_listener *listener, void *data)
 		wl_list_remove(&popup->commit.link);
 	}
 
+	/* TODO: do this on unmap instead? */
 	if (surface_is_focused(seat, popup->wlr_popup->base->surface)) {
 		/* Give focus back to whoever had it before the popup */
 		if (popup->parent_was_focused && popup->wlr_popup->parent) {
@@ -462,6 +464,7 @@ handle_popup_destroy(struct wl_listener *listener, void *data)
 			desktop_focus_topmost_view(popup->server);
 		}
 	}
+	cursor_update_focus(popup->server);
 
 	free(popup);
 }


### PR DESCRIPTION
Ensure that pointer focus is restored to the surface below when a layer surface or popup is unmapped. Can be tested like below:

1. Open a terminal and move the cursor over it so it becomes an I-beam
2. Open a launcher (e.g. fuzzel) so the cursor becomes an arrow
3. Close the launcher
4. The cursor should become an I-beam again

https://github.com/user-attachments/assets/f287cfb2-733b-4364-a5dc-1b30f41c6294

Note: this commit restores `cursor_update_focus()` in `handle_popup_destroy()` which was removed in #3165. I don't remember why it was removed.