### PR TITLE
[RFC] tree-wide: rename seat->seat to seat->wlr_seat for clarity

### DIFF
--- a/include/idle.h
+++ b/include/idle.h
@@ -6,6 +6,6 @@ struct wl_display;
 struct wlr_seat;
 
 void idle_manager_create(struct wl_display *display);
-void idle_manager_notify_activity(struct wlr_seat *seat);
+void idle_manager_notify_activity(struct wlr_seat *wlr_seat);
 
 #endif /* LABWC_IDLE_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -23,7 +23,7 @@ enum input_mode {
 };
 
 struct seat {
-	struct wlr_seat *seat;
+	struct wlr_seat *wlr_seat;
 	struct wlr_keyboard_group *keyboard_group;
 
 	struct wl_list touch_points; /* struct touch_point.link */

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -49,13 +49,13 @@ set_or_offer_focus(struct view *view)
 	struct seat *seat = &server.seat;
 	switch (view_wants_focus(view)) {
 	case VIEW_WANTS_FOCUS_ALWAYS:
-		if (view->surface != seat->seat->keyboard_state.focused_surface) {
+		if (view->surface != seat->wlr_seat->keyboard_state.focused_surface) {
 			seat_focus_surface(seat, view->surface);
 		}
 		break;
 	case VIEW_WANTS_FOCUS_LIKELY:
 	case VIEW_WANTS_FOCUS_UNLIKELY:
-		if (view->surface != seat->seat->keyboard_state.focused_surface) {
+		if (view->surface != seat->wlr_seat->keyboard_state.focused_surface) {
 			view_offer_focus(view);
 		}
 		break;

--- a/src/dnd.c
+++ b/src/dnd.c
@@ -18,8 +18,8 @@ handle_drag_request(struct wl_listener *listener, void *data)
 	struct wlr_seat_request_start_drag_event *event = data;
 
 	if (wlr_seat_validate_pointer_grab_serial(
-			seat->seat, event->origin, event->serial)) {
-		wlr_seat_start_pointer_drag(seat->seat, event->drag,
+			seat->wlr_seat, event->origin, event->serial)) {
+		wlr_seat_start_pointer_drag(seat->wlr_seat, event->drag,
 			event->serial);
 	} else {
 		wlr_data_source_destroy(event->drag->source);
@@ -91,9 +91,9 @@ dnd_init(struct seat *seat)
 	seat->drag.events.start.notify = handle_drag_start;
 	seat->drag.events.destroy.notify = handle_drag_destroy;
 
-	wl_signal_add(&seat->seat->events.request_start_drag,
+	wl_signal_add(&seat->wlr_seat->events.request_start_drag,
 		&seat->drag.events.request);
-	wl_signal_add(&seat->seat->events.start_drag, &seat->drag.events.start);
+	wl_signal_add(&seat->wlr_seat->events.start_drag, &seat->drag.events.start);
 	/*
 	 * destroy.notify is listened to in handle_drag_start() and reset in
 	 * handle_drag_destroy()

--- a/src/idle.c
+++ b/src/idle.c
@@ -84,7 +84,7 @@ idle_manager_create(struct wl_display *display)
 }
 
 void
-idle_manager_notify_activity(struct wlr_seat *seat)
+idle_manager_notify_activity(struct wlr_seat *wlr_seat)
 {
 	/*
 	 * The display destroy event might have been triggered
@@ -96,5 +96,5 @@ idle_manager_notify_activity(struct wlr_seat *seat)
 		return;
 	}
 
-	wlr_idle_notifier_v1_notify_activity(manager->ext, seat);
+	wlr_idle_notifier_v1_notify_activity(manager->ext, wlr_seat);
 }

--- a/src/input/cursor.c
+++ b/src/input/cursor.c
@@ -180,7 +180,7 @@ handle_request_set_cursor(struct wl_listener *listener, void *data)
 	 */
 	struct wlr_seat_pointer_request_set_cursor_event *event = data;
 	struct wlr_seat_client *focused_client =
-		seat->seat->pointer_state.focused_client;
+		seat->wlr_seat->pointer_state.focused_client;
 
 	/*
 	 * This can be sent by any client, so we check to make sure this one
@@ -205,7 +205,7 @@ handle_request_set_shape(struct wl_listener *listener, void *data)
 	struct wlr_cursor_shape_manager_v1_request_set_shape_event *event = data;
 	const char *shape_name = wlr_cursor_shape_v1_name(event->shape);
 	struct seat *seat = wl_container_of(listener, seat, request_set_shape);
-	struct wlr_seat_client *focused_client = seat->seat->pointer_state.focused_client;
+	struct wlr_seat_client *focused_client = seat->wlr_seat->pointer_state.focused_client;
 
 	/* Prevent setting a cursor image when moving or resizing */
 	if (server.input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
@@ -250,7 +250,7 @@ handle_request_set_selection(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(
 		listener, seat, request_set_selection);
 	struct wlr_seat_request_set_selection_event *event = data;
-	wlr_seat_set_selection(seat->seat, event->source,
+	wlr_seat_set_selection(seat->wlr_seat, event->source,
 		event->serial);
 }
 
@@ -260,7 +260,7 @@ handle_request_set_primary_selection(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(
 		listener, seat, request_set_primary_selection);
 	struct wlr_seat_request_set_primary_selection_event *event = data;
-	wlr_seat_set_primary_selection(seat->seat, event->source,
+	wlr_seat_set_primary_selection(seat->wlr_seat, event->source,
 		event->serial);
 }
 
@@ -418,10 +418,10 @@ cursor_update_image(struct seat *seat)
 		 * a new output instance), we have to force a re-enter of
 		 * the surface so the client sets its own cursor again.
 		 */
-		if (seat->seat->pointer_state.focused_surface) {
+		if (seat->wlr_seat->pointer_state.focused_surface) {
 			seat->server_cursor = LAB_CURSOR_DEFAULT;
 			wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager, "");
-			wlr_seat_pointer_clear_focus(seat->seat);
+			wlr_seat_pointer_clear_focus(seat->wlr_seat);
 			cursor_update_focus();
 		}
 		return;
@@ -515,7 +515,7 @@ update_pressed_surface(struct seat *seat, const struct cursor_context *ctx)
 	 * context menus (in contrast) do not use an XDG popup grab and
 	 * do not work properly if we send leave/enter events.
 	 */
-	if (!wlr_seat_pointer_has_grab(seat->seat)) {
+	if (!wlr_seat_pointer_has_grab(seat->wlr_seat)) {
 		return false;
 	}
 	if (seat->pressed.ctx.surface && ctx->surface != seat->pressed.ctx.surface) {
@@ -537,7 +537,7 @@ cursor_update_common(const struct cursor_context *ctx,
 		struct cursor_context *notified_ctx)
 {
 	struct seat *seat = &server.seat;
-	struct wlr_seat *wlr_seat = seat->seat;
+	struct wlr_seat *wlr_seat = seat->wlr_seat;
 
 	ssd_update_hovered_button(ctx->node);
 
@@ -748,7 +748,7 @@ warp_cursor_to_constraint_hint(struct seat *seat,
 			server.active_view->current.y + sy);
 
 		/* Make sure we are not sending unnecessary surface movements */
-		wlr_seat_pointer_warp(seat->seat, sx, sy);
+		wlr_seat_pointer_warp(seat->wlr_seat, sx, sy);
 	}
 }
 
@@ -868,7 +868,7 @@ cursor_locked(struct seat *seat, struct wlr_pointer *pointer)
 		&& pointer->base.type == WLR_INPUT_DEVICE_POINTER
 		&& seat->current_constraint->type == WLR_POINTER_CONSTRAINT_V1_LOCKED
 		&& seat->current_constraint->surface
-			== seat->seat->pointer_state.focused_surface;
+			== seat->wlr_seat->pointer_state.focused_surface;
 }
 
 static void
@@ -892,7 +892,7 @@ preprocess_cursor_motion(struct seat *seat, struct wlr_pointer *pointer,
 	double sx, sy;
 	bool notify = cursor_process_motion(time_msec, &sx, &sy);
 	if (notify) {
-		wlr_seat_pointer_notify_motion(seat->seat, time_msec, sx, sy);
+		wlr_seat_pointer_notify_motion(seat->wlr_seat, time_msec, sx, sy);
 	}
 }
 
@@ -918,7 +918,7 @@ handle_motion(struct wl_listener *listener, void *data)
 	 */
 	struct seat *seat = wl_container_of(listener, seat, on_cursor.motion);
 	struct wlr_pointer_motion_event *event = data;
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	if (seat->cursor_scroll_wheel_emulation) {
@@ -950,7 +950,7 @@ handle_motion(struct wl_listener *listener, void *data)
 	} else {
 		wlr_relative_pointer_manager_v1_send_relative_motion(
 			server.relative_pointer_manager,
-			seat->seat, (uint64_t)event->time_msec * 1000,
+			seat->wlr_seat, (uint64_t)event->time_msec * 1000,
 			event->delta_x, event->delta_y, event->unaccel_dx,
 			event->unaccel_dy);
 
@@ -972,7 +972,7 @@ handle_motion_absolute(struct wl_listener *listener, void *data)
 	 */
 	struct seat *seat = wl_container_of(listener, seat, on_cursor.motion_absolute);
 	struct wlr_pointer_motion_absolute_event *event = data;
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	double lx, ly;
@@ -1174,7 +1174,7 @@ cursor_process_button_press(struct seat *seat, uint32_t button, uint32_t time_ms
 	}
 
 	if (ctx.type != LAB_NODE_CLIENT && ctx.type != LAB_NODE_LAYER_SURFACE
-			&& wlr_seat_pointer_has_grab(seat->seat)) {
+			&& wlr_seat_pointer_has_grab(seat->wlr_seat)) {
 		/*
 		 * If we have an active popup grab (an open popup) we want to
 		 * cancel that grab whenever the user presses on anything that
@@ -1183,7 +1183,7 @@ cursor_process_button_press(struct seat *seat, uint32_t button, uint32_t time_ms
 		 *
 		 * Note: This does not work for XWayland clients
 		 */
-		wlr_seat_pointer_end_grab(seat->seat);
+		wlr_seat_pointer_end_grab(seat->wlr_seat);
 		lab_set_add(&seat->bound_buttons, button);
 		return false;
 	}
@@ -1287,7 +1287,7 @@ handle_button(struct wl_listener *listener, void *data)
 	 */
 	struct seat *seat = wl_container_of(listener, seat, on_cursor.button);
 	struct wlr_pointer_button_event *event = data;
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	bool notify;
@@ -1296,7 +1296,7 @@ handle_button(struct wl_listener *listener, void *data)
 		notify = cursor_process_button_press(seat, event->button,
 			event->time_msec);
 		if (notify) {
-			wlr_seat_pointer_notify_button(seat->seat, event->time_msec,
+			wlr_seat_pointer_notify_button(seat->wlr_seat, event->time_msec,
 				event->button, event->state);
 		}
 		break;
@@ -1304,7 +1304,7 @@ handle_button(struct wl_listener *listener, void *data)
 		notify = cursor_process_button_release(seat, event->button,
 			event->time_msec);
 		if (notify) {
-			wlr_seat_pointer_notify_button(seat->seat, event->time_msec,
+			wlr_seat_pointer_notify_button(seat->wlr_seat, event->time_msec,
 				event->button, event->state);
 		}
 		cursor_finish_button_release(seat, event->button);
@@ -1433,7 +1433,7 @@ handle_axis(struct wl_listener *listener, void *data)
 	 */
 	struct seat *seat = wl_container_of(listener, seat, on_cursor.axis);
 	struct wlr_pointer_axis_event *event = data;
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	/* input->scroll_factor is set for pointer/touch devices */
@@ -1447,7 +1447,7 @@ handle_axis(struct wl_listener *listener, void *data)
 
 	if (notify) {
 		/* Notify the client with pointer focus of the axis event. */
-		wlr_seat_pointer_notify_axis(seat->seat, event->time_msec,
+		wlr_seat_pointer_notify_axis(seat->wlr_seat, event->time_msec,
 			event->orientation, scroll_factor * event->delta,
 			round(scroll_factor * event->delta_discrete),
 			event->source, event->relative_direction);
@@ -1466,7 +1466,7 @@ handle_frame(struct wl_listener *listener, void *data)
 	 */
 	struct seat *seat = wl_container_of(listener, seat, on_cursor.frame);
 	/* Notify the client with pointer focus of the frame event. */
-	wlr_seat_pointer_notify_frame(seat->seat);
+	wlr_seat_pointer_notify_frame(seat->wlr_seat);
 }
 
 void
@@ -1486,12 +1486,12 @@ cursor_emulate_axis(struct seat *seat, struct wlr_input_device *device,
 	bool notify = process_cursor_axis(orientation, delta, delta_discrete);
 	if (notify) {
 		/* Notify the client with pointer focus of the axis event. */
-		wlr_seat_pointer_notify_axis(seat->seat, time_msec,
+		wlr_seat_pointer_notify_axis(seat->wlr_seat, time_msec,
 			orientation, scroll_factor * delta,
 			round(scroll_factor * delta_discrete),
 			source, WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
 	}
-	wlr_seat_pointer_notify_frame(seat->seat);
+	wlr_seat_pointer_notify_frame(seat->wlr_seat);
 }
 
 void
@@ -1505,16 +1505,16 @@ cursor_emulate_move(struct seat *seat, struct wlr_input_device *device,
 
 	wlr_relative_pointer_manager_v1_send_relative_motion(
 		server.relative_pointer_manager,
-		seat->seat, (uint64_t)time_msec * 1000,
+		seat->wlr_seat, (uint64_t)time_msec * 1000,
 		dx, dy, dx, dy);
 
 	wlr_cursor_move(seat->cursor, device, dx, dy);
 	double sx, sy;
 	bool notify = cursor_process_motion(time_msec, &sx, &sy);
 	if (notify) {
-		wlr_seat_pointer_notify_motion(seat->seat, time_msec, sx, sy);
+		wlr_seat_pointer_notify_motion(seat->wlr_seat, time_msec, sx, sy);
 	}
-	wlr_seat_pointer_notify_frame(seat->seat);
+	wlr_seat_pointer_notify_frame(seat->wlr_seat);
 }
 
 void
@@ -1540,18 +1540,18 @@ cursor_emulate_button(struct seat *seat, uint32_t button,
 	case WL_POINTER_BUTTON_STATE_PRESSED:
 		notify = cursor_process_button_press(seat, button, time_msec);
 		if (notify) {
-			wlr_seat_pointer_notify_button(seat->seat, time_msec, button, state);
+			wlr_seat_pointer_notify_button(seat->wlr_seat, time_msec, button, state);
 		}
 		break;
 	case WL_POINTER_BUTTON_STATE_RELEASED:
 		notify = cursor_process_button_release(seat, button, time_msec);
 		if (notify) {
-			wlr_seat_pointer_notify_button(seat->seat, time_msec, button, state);
+			wlr_seat_pointer_notify_button(seat->wlr_seat, time_msec, button, state);
 		}
 		cursor_finish_button_release(seat, button);
 		break;
 	}
-	wlr_seat_pointer_notify_frame(seat->seat);
+	wlr_seat_pointer_notify_frame(seat->wlr_seat);
 }
 
 static void
@@ -1630,7 +1630,7 @@ cursor_init(struct seat *seat)
 	touch_init(seat);
 	tablet_init(seat);
 
-	CONNECT_SIGNAL(seat->seat, seat, request_set_cursor);
+	CONNECT_SIGNAL(seat->wlr_seat, seat, request_set_cursor);
 
 	struct wlr_cursor_shape_manager_v1 *cursor_shape_manager =
 		wlr_cursor_shape_manager_v1_create(server.wl_display,
@@ -1641,8 +1641,8 @@ cursor_init(struct seat *seat)
 	}
 
 	CONNECT_SIGNAL(cursor_shape_manager, seat, request_set_shape);
-	CONNECT_SIGNAL(seat->seat, seat, request_set_selection);
-	CONNECT_SIGNAL(seat->seat, seat, request_set_primary_selection);
+	CONNECT_SIGNAL(seat->wlr_seat, seat, request_set_selection);
+	CONNECT_SIGNAL(seat->wlr_seat, seat, request_set_primary_selection);
 }
 
 void cursor_finish(struct seat *seat)

--- a/src/input/gestures.c
+++ b/src/input/gestures.c
@@ -12,11 +12,11 @@ handle_pinch_begin(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(listener, seat, pinch_begin);
 	struct wlr_pointer_pinch_begin_event *event = data;
 
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_pinch_begin(seat->pointer_gestures,
-		seat->seat, event->time_msec, event->fingers);
+		seat->wlr_seat, event->time_msec, event->fingers);
 }
 
 static void
@@ -25,11 +25,11 @@ handle_pinch_update(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(listener, seat, pinch_update);
 	struct wlr_pointer_pinch_update_event *event = data;
 
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_pinch_update(seat->pointer_gestures,
-		seat->seat, event->time_msec, event->dx, event->dy,
+		seat->wlr_seat, event->time_msec, event->dx, event->dy,
 		event->scale, event->rotation);
 }
 
@@ -39,11 +39,11 @@ handle_pinch_end(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(listener, seat, pinch_end);
 	struct wlr_pointer_pinch_end_event *event = data;
 
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_pinch_end(seat->pointer_gestures,
-		seat->seat, event->time_msec, event->cancelled);
+		seat->wlr_seat, event->time_msec, event->cancelled);
 }
 
 static void
@@ -52,11 +52,11 @@ handle_swipe_begin(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(listener, seat, swipe_begin);
 	struct wlr_pointer_swipe_begin_event *event = data;
 
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_swipe_begin(seat->pointer_gestures,
-		seat->seat, event->time_msec, event->fingers);
+		seat->wlr_seat, event->time_msec, event->fingers);
 }
 
 static void
@@ -65,11 +65,11 @@ handle_swipe_update(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(listener, seat, swipe_update);
 	struct wlr_pointer_swipe_update_event *event = data;
 
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_swipe_update(seat->pointer_gestures,
-		seat->seat, event->time_msec, event->dx, event->dy);
+		seat->wlr_seat, event->time_msec, event->dx, event->dy);
 }
 
 static void
@@ -78,11 +78,11 @@ handle_swipe_end(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(listener, seat, swipe_end);
 	struct wlr_pointer_swipe_end_event *event = data;
 
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_swipe_end(seat->pointer_gestures,
-		seat->seat, event->time_msec, event->cancelled);
+		seat->wlr_seat, event->time_msec, event->cancelled);
 }
 
 static void
@@ -91,11 +91,11 @@ handle_hold_begin(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(listener, seat, hold_begin);
 	struct wlr_pointer_hold_begin_event *event = data;
 
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_hold_begin(seat->pointer_gestures,
-		seat->seat, event->time_msec, event->fingers);
+		seat->wlr_seat, event->time_msec, event->fingers);
 }
 
 static void
@@ -104,11 +104,11 @@ handle_hold_end(struct wl_listener *listener, void *data)
 	struct seat *seat = wl_container_of(listener, seat, hold_end);
 	struct wlr_pointer_hold_end_event *event = data;
 
-	idle_manager_notify_activity(seat->seat);
+	idle_manager_notify_activity(seat->wlr_seat);
 	cursor_set_visible(seat, /* visible */ true);
 
 	wlr_pointer_gestures_v1_send_hold_end(seat->pointer_gestures,
-		seat->seat, event->time_msec, event->cancelled);
+		seat->wlr_seat, event->time_msec, event->cancelled);
 }
 
 void

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -330,7 +330,7 @@ handle_input_method_grab_keyboard(struct wl_listener *listener, void *data)
 	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab = data;
 
 	struct wlr_keyboard *active_keyboard =
-		wlr_seat_get_keyboard(relay->seat->seat);
+		wlr_seat_get_keyboard(relay->seat->wlr_seat);
 
 	if (!is_keyboard_emulated_by_input_method(
 			active_keyboard, relay->input_method)) {
@@ -414,7 +414,7 @@ handle_new_input_method(struct wl_listener *listener, void *data)
 	struct input_method_relay *relay =
 		wl_container_of(listener, relay, new_input_method);
 	struct wlr_input_method_v2 *input_method = data;
-	if (relay->seat->seat != input_method->seat) {
+	if (relay->seat->wlr_seat != input_method->seat) {
 		return;
 	}
 
@@ -536,7 +536,7 @@ handle_new_text_input(struct wl_listener *listener, void *data)
 	struct input_method_relay *relay =
 		wl_container_of(listener, relay, new_text_input);
 	struct wlr_text_input_v3 *wlr_text_input = data;
-	if (relay->seat->seat != wlr_text_input->seat) {
+	if (relay->seat->wlr_seat != wlr_text_input->seat) {
 		return;
 	}
 

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -90,7 +90,7 @@ seat_client_from_keyboard_resource(struct wl_resource *resource)
 }
 
 static void
-broadcast_modifiers_to_unfocused_clients(struct wlr_seat *seat,
+broadcast_modifiers_to_unfocused_clients(struct wlr_seat *wlr_seat,
 		const struct keyboard *keyboard,
 		const struct wlr_keyboard_modifiers *modifiers)
 {
@@ -100,8 +100,8 @@ broadcast_modifiers_to_unfocused_clients(struct wlr_seat *seat,
 	}
 
 	struct wlr_seat_client *client;
-	wl_list_for_each(client, &seat->clients, link) {
-		if (client == seat->keyboard_state.focused_client) {
+	wl_list_for_each(client, &wlr_seat->clients, link) {
+		if (client == wlr_seat->keyboard_state.focused_client) {
 			/*
 			 * We've already notified the focused client by calling
 			 * wlr_seat_keyboard_notify_modifiers()
@@ -159,7 +159,7 @@ handle_modifiers(struct wl_listener *listener, void *data)
 
 	if (!input_method_keyboard_grab_forward_modifiers(keyboard)) {
 		/* Send modifiers to focused client */
-		wlr_seat_keyboard_notify_modifiers(seat->seat,
+		wlr_seat_keyboard_notify_modifiers(seat->wlr_seat,
 			&wlr_keyboard->modifiers);
 
 		/*
@@ -181,7 +181,7 @@ handle_modifiers(struct wl_listener *listener, void *data)
 		 * consequences. If so, modifiers ought to still be passed to
 		 * clients with pointer-focus (see issue #2271)
 		 */
-		broadcast_modifiers_to_unfocused_clients(seat->seat,
+		broadcast_modifiers_to_unfocused_clients(seat->wlr_seat,
 			keyboard, &wlr_keyboard->modifiers);
 	}
 }
@@ -615,8 +615,8 @@ handle_key(struct wl_listener *listener, void *data)
 	struct keyboard *keyboard = wl_container_of(listener, keyboard, key);
 	struct seat *seat = keyboard->base.seat;
 	struct wlr_keyboard_key_event *event = data;
-	struct wlr_seat *wlr_seat = seat->seat;
-	idle_manager_notify_activity(seat->seat);
+	struct wlr_seat *wlr_seat = seat->wlr_seat;
+	idle_manager_notify_activity(seat->wlr_seat);
 
 	/* any new press/release cancels current keybind repeat */
 	keyboard_cancel_keybind_repeat(keyboard);

--- a/src/input/tablet-pad.c
+++ b/src/input/tablet-pad.c
@@ -185,7 +185,7 @@ tablet_pad_create(struct seat *seat, struct wlr_input_device *wlr_device)
 	pad->pad = wlr_tablet_pad_from_input_device(wlr_device);
 	if (server.tablet_manager) {
 		pad->pad_v2 = wlr_tablet_pad_create(
-			server.tablet_manager, seat->seat, wlr_device);
+			server.tablet_manager, seat->wlr_seat, wlr_device);
 	}
 	pad->pad->data = pad;
 	wlr_log(WLR_INFO, "tablet pad capabilities: %zu button(s) %zu strip(s) %zu ring(s)",

--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -42,7 +42,7 @@ handle_set_cursor(struct wl_listener *listener, void *data)
 
 	struct seat *seat = tool->seat;
 	struct wlr_seat_client *focused_client =
-		seat->seat->pointer_state.focused_client;
+		seat->wlr_seat->pointer_state.focused_client;
 
 	if (server.input_mode != LAB_INPUT_STATE_PASSTHROUGH) {
 		return;
@@ -77,7 +77,7 @@ tablet_tool_create(struct seat *seat,
 	tool->seat = seat;
 	tool->tool_v2 =
 		wlr_tablet_tool_create(server.tablet_manager,
-			seat->seat, wlr_tablet_tool);
+			seat->wlr_seat, wlr_tablet_tool);
 	wlr_tablet_tool->data = tool;
 	wlr_log(WLR_INFO, "tablet tool capabilities:%s%s%s%s%s%s",
 		wlr_tablet_tool->tilt ? " tilt" : "",
@@ -309,7 +309,7 @@ notify_motion(struct drawing_tablet *tablet, struct drawing_tablet_tool *tool,
 			 * sure what will break since I have the feeling that a
 			 * lot of internals rely on correct pointer focus.
 			 */
-			wlr_seat_pointer_notify_motion(tool->seat->seat, time, -1, -1);
+			wlr_seat_pointer_notify_motion(tool->seat->wlr_seat, time, -1, -1);
 		}
 	}
 }
@@ -325,7 +325,7 @@ handle_tablet_tool_proximity(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	idle_manager_notify_activity(tablet->seat->seat);
+	idle_manager_notify_activity(tablet->seat->wlr_seat);
 	cursor_set_visible(tablet->seat, /* visible */ true);
 
 	if (!tool) {
@@ -393,7 +393,7 @@ handle_tablet_tool_axis(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	idle_manager_notify_activity(tablet->seat->seat);
+	idle_manager_notify_activity(tablet->seat->wlr_seat);
 	cursor_set_visible(tablet->seat, /* visible */ true);
 
 	/*
@@ -565,7 +565,7 @@ handle_tablet_tool_tip(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	idle_manager_notify_activity(tablet->seat->seat);
+	idle_manager_notify_activity(tablet->seat->wlr_seat);
 	cursor_set_visible(tablet->seat, /* visible */ true);
 
 	double x, y, dx, dy;
@@ -644,7 +644,7 @@ handle_tablet_tool_button(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	idle_manager_notify_activity(tablet->seat->seat);
+	idle_manager_notify_activity(tablet->seat->wlr_seat);
 	cursor_set_visible(tablet->seat, /* visible */ true);
 
 	double x, y, dx, dy;
@@ -721,7 +721,7 @@ tablet_create(struct seat *seat, struct wlr_input_device *wlr_device)
 	tablet->tablet->data = tablet;
 	if (server.tablet_manager) {
 		tablet->tablet_v2 = wlr_tablet_create(
-			server.tablet_manager, seat->seat, wlr_device);
+			server.tablet_manager, seat->wlr_seat, wlr_device);
 	}
 	wlr_log(WLR_INFO, "tablet dimensions: %.2fmm x %.2fmm",
 		tablet->tablet->width_mm, tablet->tablet->height_mm);

--- a/src/layers.c
+++ b/src/layers.c
@@ -429,7 +429,7 @@ handle_map(struct wl_listener *listener, void *data)
 static bool
 surface_is_focused(struct seat *seat, struct wlr_surface *surface)
 {
-	return seat->seat->keyboard_state.focused_surface == surface;
+	return seat->wlr_seat->keyboard_state.focused_surface == surface;
 }
 
 static void

--- a/src/seat.c
+++ b/src/seat.c
@@ -434,7 +434,7 @@ new_keyboard(struct seat *seat, struct wlr_input_device *device, bool is_virtual
 
 	keyboard_setup_handlers(keyboard);
 
-	wlr_seat_set_keyboard(seat->seat, kb);
+	wlr_seat_set_keyboard(seat->wlr_seat, kb);
 
 	return (struct input *)keyboard;
 }
@@ -515,7 +515,7 @@ seat_update_capabilities(struct seat *seat)
 			break;
 		}
 	}
-	wlr_seat_set_capabilities(seat->seat, caps);
+	wlr_seat_set_capabilities(seat->wlr_seat, caps);
 }
 
 static void
@@ -630,8 +630,8 @@ seat_init(void)
 {
 	struct seat *seat = &server.seat;
 
-	seat->seat = wlr_seat_create(server.wl_display, "seat0");
-	if (!seat->seat) {
+	seat->wlr_seat = wlr_seat_create(server.wl_display, "seat0");
+	if (!seat->wlr_seat) {
 		wlr_log(WLR_ERROR, "cannot allocate seat");
 		exit(EXIT_FAILURE);
 	}
@@ -641,7 +641,7 @@ seat_init(void)
 	wl_list_init(&seat->inputs);
 
 	CONNECT_SIGNAL(server.backend, seat, new_input);
-	CONNECT_SIGNAL(&seat->seat->keyboard_state, seat, focus_change);
+	CONNECT_SIGNAL(&seat->wlr_seat->keyboard_state, seat, focus_change);
 
 	seat->virtual_pointer = wlr_virtual_pointer_manager_v1_create(
 		server.wl_display);
@@ -706,7 +706,7 @@ configure_keyboard(struct seat *seat, struct input *input)
 void
 seat_pointer_end_grab(struct seat *seat, struct wlr_surface *surface)
 {
-	if (!surface || !wlr_seat_pointer_has_grab(seat->seat)) {
+	if (!surface || !wlr_seat_pointer_has_grab(seat->wlr_seat)) {
 		return;
 	}
 
@@ -721,7 +721,7 @@ seat_pointer_end_grab(struct seat *seat, struct wlr_surface *surface)
 		 * on button notifications in another client (observed in GTK4),
 		 * so end the grab manually.
 		 */
-		wlr_seat_pointer_end_grab(seat->seat);
+		wlr_seat_pointer_end_grab(seat->wlr_seat);
 	}
 }
 
@@ -767,7 +767,7 @@ seat_force_focus_surface(struct seat *seat, struct wlr_surface *surface)
 	int nr_pressed_sent_keycodes = key_state_nr_pressed_sent_keycodes();
 	struct wlr_keyboard *kb = &seat->keyboard_group->keyboard;
 
-	wlr_seat_keyboard_enter(seat->seat, surface,
+	wlr_seat_keyboard_enter(seat->wlr_seat, surface,
 		pressed_sent_keycodes, nr_pressed_sent_keycodes, &kb->modifiers);
 }
 
@@ -792,18 +792,18 @@ seat_focus(struct seat *seat, struct wlr_surface *surface,
 	}
 
 	if (!surface) {
-		wlr_seat_keyboard_notify_clear_focus(seat->seat);
+		wlr_seat_keyboard_notify_clear_focus(seat->wlr_seat);
 		input_method_relay_set_focus(seat->input_method_relay, NULL);
 		return;
 	}
 
-	if (!wlr_seat_get_keyboard(seat->seat)) {
+	if (!wlr_seat_get_keyboard(seat->wlr_seat)) {
 		/*
 		 * wlr_seat_keyboard_notify_enter() sends wl_keyboard.modifiers,
 		 * but it may crash some apps (e.g. Chromium) if
 		 * wl_keyboard.keymap is not sent beforehand.
 		 */
-		wlr_seat_set_keyboard(seat->seat, &seat->keyboard_group->keyboard);
+		wlr_seat_set_keyboard(seat->wlr_seat, &seat->keyboard_group->keyboard);
 	}
 
 	/*
@@ -817,14 +817,14 @@ seat_focus(struct seat *seat, struct wlr_surface *surface,
 	int nr_pressed_sent_keycodes = key_state_nr_pressed_sent_keycodes();
 
 	struct wlr_keyboard *kb = &seat->keyboard_group->keyboard;
-	wlr_seat_keyboard_notify_enter(seat->seat, surface,
+	wlr_seat_keyboard_notify_enter(seat->wlr_seat, surface,
 		pressed_sent_keycodes, nr_pressed_sent_keycodes, &kb->modifiers);
 
 	input_method_relay_set_focus(seat->input_method_relay, surface);
 
 	struct wlr_pointer_constraint_v1 *constraint =
 		wlr_pointer_constraints_v1_constraint_for_surface(server.constraints,
-			surface, seat->seat);
+			surface, seat->wlr_seat);
 	constrain_cursor(constraint);
 }
 
@@ -898,7 +898,7 @@ seat_focus_override_begin(struct seat *seat, enum input_mode input_mode,
 
 	server.input_mode = input_mode;
 
-	seat->focus_override.surface = seat->seat->keyboard_state.focused_surface;
+	seat->focus_override.surface = seat->wlr_seat->keyboard_state.focused_surface;
 	if (seat->focus_override.surface) {
 		seat->focus_override.surface_destroy.notify =
 			handle_focus_override_surface_destroy;
@@ -908,7 +908,7 @@ seat_focus_override_begin(struct seat *seat, enum input_mode input_mode,
 
 	seat_focus(seat, NULL, /*replace_exclusive_layer*/ false,
 		/*is_lock_surface*/ false);
-	wlr_seat_pointer_clear_focus(seat->seat);
+	wlr_seat_pointer_clear_focus(seat->wlr_seat);
 	cursor_set(seat, cursor_shape);
 }
 

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -140,7 +140,7 @@ handle_unmap(struct wl_listener *listener, void *data)
 
 	cursor_update_focus();
 
-	if (seat->seat->keyboard_state.focused_surface == xsurface->surface) {
+	if (seat->wlr_seat->keyboard_state.focused_surface == xsurface->surface) {
 		focus_next_surface(xsurface);
 	}
 }

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -678,7 +678,7 @@ handle_focus_in(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	if (view->surface != seat->seat->keyboard_state.focused_surface) {
+	if (view->surface != seat->wlr_seat->keyboard_state.focused_surface) {
 		seat_focus_surface(seat, view->surface);
 	}
 }
@@ -1220,7 +1220,7 @@ handle_server_ready(struct wl_listener *listener, void *data)
 static void
 handle_xwm_ready(struct wl_listener *listener, void *data)
 {
-	wlr_xwayland_set_seat(server.xwayland, server.seat.seat);
+	wlr_xwayland_set_seat(server.xwayland, server.seat.wlr_seat);
 	xwayland_update_workarea();
 }
 


### PR DESCRIPTION
"Paper cut" type improvement. Also for after 0.9.4.

As we use "seat" to refer to the labwc struct, this makes it clearer at a quick glance which code is using the wlr struct instead.