### PR TITLE
src/server.c: increase max client buffer size to 1 MiB

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,7 @@ wlroots = dependency(
 wlroots_has_xwayland = wlroots.get_variable('have_xwayland') == 'true'
 have_libsfdo = not get_option('icon').disabled()
 
-wayland_server = dependency('wayland-server', version: '>=1.19.0')
+wayland_server = dependency('wayland-server', version: '>=1.22.90')
 wayland_protos = dependency('wayland-protocols', version: '>=1.39')
 xkbcommon = dependency('xkbcommon')
 xcb = dependency('xcb', required: get_option('xwayland'))

--- a/src/server.c
+++ b/src/server.c
@@ -431,9 +431,10 @@ server_init(struct server *server)
 		wlr_log(WLR_ERROR, "cannot allocate a wayland display");
 		exit(EXIT_FAILURE);
 	}
+	/* Increase max client buffer size to make slow clients less likely to terminate  */
+	wl_display_set_default_max_buffer_size(server->wl_display, 1024 * 1024);
 
 	wl_display_set_global_filter(server->wl_display, server_global_filter, server);
-
 	server->wl_event_loop = wl_display_get_event_loop(server->wl_display);
 
 	/* Catch signals */


### PR DESCRIPTION
Allows slow clients to better deal with large amounts of events coming in from labwc like from high refresh rate mice. Without this patch, the client is likely to get disconnected because the labwc side client write buffer is full.

----

Only compile time tested + single startup nested.

Fixes:
- #3399