### PR TITLE
xwayland: handle client close request

### DIFF
--- a/include/xwayland.h
+++ b/include/xwayland.h
@@ -46,6 +46,7 @@ struct xwayland_view {
 	struct wl_listener dissociate;
 	struct wl_listener request_above;
 	struct wl_listener request_activate;
+	struct wl_listener request_close;
 	struct wl_listener request_configure;
 	struct wl_listener set_class;
 	struct wl_listener set_decorations;

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -357,6 +357,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&xwayland_view->dissociate.link);
 	wl_list_remove(&xwayland_view->request_above.link);
 	wl_list_remove(&xwayland_view->request_activate.link);
+	wl_list_remove(&xwayland_view->request_close.link);
 	wl_list_remove(&xwayland_view->request_configure.link);
 	wl_list_remove(&xwayland_view->set_class.link);
 	wl_list_remove(&xwayland_view->set_decorations.link);
@@ -447,6 +448,15 @@ handle_request_activate(struct wl_listener *listener, void *data)
 	}
 
 	desktop_focus_view(view, /*raise*/ true);
+}
+
+static void
+handle_request_close(struct wl_listener *listener, void *data)
+{
+	struct xwayland_view *xwayland_view =
+		wl_container_of(listener, xwayland_view, request_close);
+
+	view_close(&xwayland_view->base);
 }
 
 static void
@@ -1050,6 +1060,7 @@ xwayland_view_create(struct server *server,
 	CONNECT_SIGNAL(xsurface, xwayland_view, dissociate);
 	CONNECT_SIGNAL(xsurface, xwayland_view, request_above);
 	CONNECT_SIGNAL(xsurface, xwayland_view, request_activate);
+	CONNECT_SIGNAL(xsurface, xwayland_view, request_close);
 	CONNECT_SIGNAL(xsurface, xwayland_view, request_configure);
 	CONNECT_SIGNAL(xsurface, xwayland_view, set_class);
 	CONNECT_SIGNAL(xsurface, xwayland_view, set_decorations);


### PR DESCRIPTION
Tested with `QT_QPA_PLATFORM=xcb qmpanel` (middle-click on a taskbar button now closes the associated xwayland window).