### PR TITLE
fix name of xdg-dialog-v1 global

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -277,7 +277,7 @@ allow_for_sandbox(const struct wlr_security_context_v1_state *security_state,
 		"zxdg_importer_v1",
 		"zxdg_importer_v2",
 		"xdg_toplevel_icon_manager_v1",
-		"xdg_dialog_v1",
+		"xdg_wm_dialog_v1",
 		/* plus */
 		"wp_alpha_modifier_v1",
 		"wp_linux_drm_syncobj_manager_v1",


### PR DESCRIPTION
I noticed the following line in the log:

```
[ERROR] [../src/server.c:345] Blocking unknown protocol xdg_wm_dialog_v1
```

If I understand correctly,  `allow_for_sandbox()` has a list of globals. The xdg-dialog-v1 defines a global called `xdg_wm_dialog_v1`, so I think this needs to be changed.