### PR TITLE
labwc-config.5: document mouse cursor variables

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -1429,9 +1429,25 @@ situation.
 
 ## ENVIRONMENT VARIABLES
 
-*XCURSOR_THEME* and *XCURSOR_SIZE* are supported to set cursor theme
-and size respectively. The default size is 24. System cursor themes can
-typically be found with a command such as:
+*XCURSOR_PATH*
+	Specify a colon-separated list of paths to look for mouse cursors in.
+	Default
+	~/.local/share/icons:
+	~/.icons:
+	/usr/share/icons:
+	/usr/share/pixmaps:
+	~/.cursors:
+	/usr/share/cursors/xorg-x11:
+	/usr/X11R6/lib/X11/icons:
+
+*XCURSOR_SIZE*
+	Specify an alternative mouse cursor size in pixels. Requires
+	XCURSOR_THEME to be set also. Default 24.
+
+*XCURSOR_THEME*
+	Specify a mouse cursor theme within XCURSOR_PATH.
+
+System cursor themes can typically be found with a command such as:
 
 ```
 find /usr/share/icons/ -type d -name "cursors"

--- a/docs/labwc.1.scd
+++ b/docs/labwc.1.scd
@@ -141,7 +141,7 @@ example: *LABWC_DEBUG_FOO=1 labwc*.
 
 *LABWC_DEBUG_KEY_STATE*
 	Enable logging of press and release events for bound keys (generally
-	key-combinations like *Ctrl-Alt-t*)
+	key-combinations like *Ctrl-Alt-t*).
 
 # SEE ALSO
 


### PR DESCRIPTION
Everyone knows that mouse cursors can be configured with XCURSOR_SIZE. What was not obvious is that XCURSOR_THEME is also required. Which, is not obvious how to use without XCURSOR_PATH. Rewrite the manual to make these things explicit. I accidentally fixed a missing period too while here, before I noticed that the project wants these in labwc-config(5) instead of labwc(1).

Thanks @jbeich for teaching me how to fix my tiny mouse cursor!