### PR TITLE
 view: save view->last_placement on initial positioning

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -564,7 +564,15 @@ bool view_titlebar_visible(struct view *view);
 void view_set_ssd_mode(struct view *view, enum lab_ssd_mode mode);
 void view_set_decorations(struct view *view, enum lab_ssd_mode mode, bool force_ssd);
 void view_toggle_fullscreen(struct view *view);
+
+/*
+ * Saves the window position in view->last_placement. This should be called
+ * when a view is first mapped or manually moved by the user.
+ */
+void view_save_last_placement(struct view *view);
+/* Restores and adjusts the view's position from the view->last_placement */
 void view_adjust_for_layout_change(struct view *view);
+
 void view_move_to_edge(struct view *view, enum lab_edge direction, bool snap_to_windows);
 void view_grow_to_edge(struct view *view, enum lab_edge direction);
 void view_shrink_to_edge(struct view *view, enum lab_edge direction);

--- a/src/view.c
+++ b/src/view.c
@@ -568,8 +568,6 @@ view_moved(struct view *view)
 	}
 }
 
-static void save_last_placement(struct view *view);
-
 void
 view_move_resize(struct view *view, struct wlr_box geo)
 {
@@ -589,7 +587,7 @@ view_move_resize(struct view *view, struct wlr_box geo)
 	 * Not sure if it might have other side-effects though.
 	 */
 	if (!view->adjusting_for_layout_change) {
-		save_last_placement(view);
+		view_save_last_placement(view);
 	}
 }
 
@@ -1722,8 +1720,8 @@ view_set_fullscreen(struct view *view, bool fullscreen)
 	cursor_update_focus(view->server);
 }
 
-static void
-save_last_placement(struct view *view)
+void
+view_save_last_placement(struct view *view)
 {
 	assert(view);
 	struct output *output = view->output;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -148,6 +148,8 @@ set_initial_position(struct view *view)
 				/* allow_cursor */ true, rc.placement_policy);
 		}
 	}
+
+	view_save_last_placement(view);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -786,6 +786,9 @@ set_initial_position(struct view *view,
 		}
 	}
 
+	/* view->last_placement is still unset if has_position=true */
+	view_save_last_placement(view);
+
 	/*
 	 * Always make sure the view is onscreen and adjusted for any
 	 * layout changes that could have occurred between map_request


### PR DESCRIPTION
Fixes #3431.

The 1st commit replaces `view_place_by_policy()` with `view_compute_position_by_policy()` in `set_initial_position()` in `xwayland.c`, just for consistency with `set_initial_position()` in `xdg.c`. CC @jlindgren90

The 2nd commit fixes #3431 by explicitly saving `view->last_placement` on initial positioning. This ensures all the mapped views have `view->last_placement` set when an output layout change occurs. I applied this to both `xdg.c` and `xwayland.c`, as the 1st commit extends #3431 to x11 views too.