### PR TITLE
tree-wide: use die_if_null() for wlr_scene alloc failures

### DIFF
--- a/include/common/scene-helpers.h
+++ b/include/common/scene-helpers.h
@@ -4,12 +4,20 @@
 
 #include <stdbool.h>
 
+struct wlr_buffer;
 struct wlr_scene_node;
 struct wlr_surface;
 struct wlr_scene_output;
 struct wlr_output_state;
 
 struct wlr_surface *lab_wlr_surface_from_node(struct wlr_scene_node *node);
+
+/* variants of wlr_scene_*_create() functions that don't return NULL */
+struct wlr_scene_tree *lab_wlr_scene_tree_create(struct wlr_scene_tree *parent);
+struct wlr_scene_rect *lab_wlr_scene_rect_create(struct wlr_scene_tree *parent,
+	int width, int height, const float color[static 4]);
+struct wlr_scene_buffer *lab_wlr_scene_buffer_create(
+	struct wlr_scene_tree *parent, struct wlr_buffer *buffer);
 
 /**
  * lab_get_prev_node - return previous (sibling) node

--- a/src/common/lab-scene-rect.c
+++ b/src/common/lab-scene-rect.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 
 struct border_scene {
 	struct wlr_scene_tree *tree;
@@ -26,20 +27,20 @@ lab_scene_rect_create(struct wlr_scene_tree *parent,
 	rect->border_width = opts->border_width;
 	rect->nr_borders = opts->nr_borders;
 	rect->borders = znew_n(rect->borders[0], opts->nr_borders);
-	rect->tree = wlr_scene_tree_create(parent);
+	rect->tree = lab_wlr_scene_tree_create(parent);
 
 	if (opts->bg_color) {
-		rect->fill = wlr_scene_rect_create(rect->tree, 0, 0, opts->bg_color);
+		rect->fill = lab_wlr_scene_rect_create(rect->tree, 0, 0, opts->bg_color);
 	}
 
 	for (int i = 0; i < rect->nr_borders; i++) {
 		struct border_scene *border = &rect->borders[i];
 		float *color = opts->border_colors[i];
-		border->tree = wlr_scene_tree_create(rect->tree);
-		border->top = wlr_scene_rect_create(border->tree, 0, 0, color);
-		border->right = wlr_scene_rect_create(border->tree, 0, 0, color);
-		border->bottom = wlr_scene_rect_create(border->tree, 0, 0, color);
-		border->left = wlr_scene_rect_create(border->tree, 0, 0, color);
+		border->tree = lab_wlr_scene_tree_create(rect->tree);
+		border->top = lab_wlr_scene_rect_create(border->tree, 0, 0, color);
+		border->right = lab_wlr_scene_rect_create(border->tree, 0, 0, color);
+		border->bottom = lab_wlr_scene_rect_create(border->tree, 0, 0, color);
+		border->left = lab_wlr_scene_rect_create(border->tree, 0, 0, color);
 	}
 
 	rect->node_destroy.notify = handle_node_destroy;

--- a/src/common/scene-helpers.c
+++ b/src/common/scene-helpers.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/log.h>
+#include "common/mem.h"
 #include "magnifier.h"
 #include "output.h"
 
@@ -22,6 +23,34 @@ lab_wlr_surface_from_node(struct wlr_scene_node *node)
 		}
 	}
 	return NULL;
+}
+
+struct wlr_scene_tree *
+lab_wlr_scene_tree_create(struct wlr_scene_tree *parent)
+{
+	struct wlr_scene_tree *tree = wlr_scene_tree_create(parent);
+	die_if_null(tree);
+	return tree;
+}
+
+struct wlr_scene_rect *
+lab_wlr_scene_rect_create(struct wlr_scene_tree *parent,
+		int width, int height, const float color[static 4])
+{
+	struct wlr_scene_rect *rect =
+		wlr_scene_rect_create(parent, width, height, color);
+	die_if_null(rect);
+	return rect;
+}
+
+struct wlr_scene_buffer *
+lab_wlr_scene_buffer_create(struct wlr_scene_tree *parent,
+		struct wlr_buffer *buffer)
+{
+	struct wlr_scene_buffer *scene_buffer =
+		wlr_scene_buffer_create(parent, buffer);
+	die_if_null(scene_buffer);
+	return scene_buffer;
 }
 
 struct wlr_scene_node *

--- a/src/cycle/cycle.c
+++ b/src/cycle/cycle.c
@@ -231,7 +231,7 @@ preview_selected_view(struct view *view)
 	cycle->preview_node = &view->scene_tree->node;
 
 	/* Create a dummy node at the original place of the previewed window */
-	struct wlr_scene_rect *dummy_rect = wlr_scene_rect_create(
+	struct wlr_scene_rect *dummy_rect = lab_wlr_scene_rect_create(
 		cycle->preview_node->parent, 0, 0, (float [4]) {0});
 	wlr_scene_node_place_below(&dummy_rect->node, cycle->preview_node);
 	wlr_scene_node_set_enabled(&dummy_rect->node, false);

--- a/src/cycle/osd-classic.c
+++ b/src/cycle/osd-classic.c
@@ -9,6 +9,7 @@
 #include "common/lab-scene-rect.h"
 #include "common/list.h"
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "common/string-helpers.h"
 #include "config/rcxml.h"
 #include "cycle.h"
@@ -108,7 +109,7 @@ cycle_osd_classic_init(struct cycle_osd_output *osd_output)
 	int h = workspace_name_h + nr_visible_views * switcher_theme->item_height
 		+ 2 * padding;
 
-	osd_output->tree = wlr_scene_tree_create(output->cycle_osd_tree);
+	osd_output->tree = lab_wlr_scene_tree_create(output->cycle_osd_tree);
 
 	float *text_color = theme->osd_label_text_color;
 	float *bg_color = theme->osd_bg_color;
@@ -161,7 +162,7 @@ cycle_osd_classic_init(struct cycle_osd_output *osd_output)
 
 	float *active_bg_color = switcher_theme->item_active_bg_color;
 	float *active_border_color = switcher_theme->item_active_border_color;
-	osd_output->items_tree = wlr_scene_tree_create(osd_output->tree);
+	osd_output->items_tree = lab_wlr_scene_tree_create(osd_output->tree);
 
 	/* Draw text for each node */
 	struct view *view;
@@ -169,7 +170,7 @@ cycle_osd_classic_init(struct cycle_osd_output *osd_output)
 		struct cycle_osd_classic_item *item = znew(*item);
 		wl_list_append(&osd_output->items, &item->base.link);
 		item->base.view = view;
-		item->base.tree = wlr_scene_tree_create(osd_output->items_tree);
+		item->base.tree = lab_wlr_scene_tree_create(osd_output->items_tree);
 		node_descriptor_create(&item->base.tree->node,
 			LAB_NODE_CYCLE_OSD_ITEM, NULL, item);
 		/*
@@ -191,8 +192,8 @@ cycle_osd_classic_init(struct cycle_osd_output *osd_output)
 		int x = padding
 			+ switcher_theme->item_active_border_width
 			+ switcher_theme->item_padding_x;
-		item->normal_tree = wlr_scene_tree_create(item->base.tree);
-		item->active_tree = wlr_scene_tree_create(item->base.tree);
+		item->normal_tree = lab_wlr_scene_tree_create(item->base.tree);
+		item->active_tree = lab_wlr_scene_tree_create(item->base.tree);
 		wlr_scene_node_set_enabled(&item->active_tree->node, false);
 
 		/* Highlight around selected window's item */
@@ -209,7 +210,7 @@ cycle_osd_classic_init(struct cycle_osd_output *osd_output)
 		wlr_scene_node_set_position(&highlight_rect->tree->node, padding, y);
 
 		/* hitbox for mouse clicks */
-		struct wlr_scene_rect *hitbox = wlr_scene_rect_create(item->base.tree,
+		struct wlr_scene_rect *hitbox = lab_wlr_scene_rect_create(item->base.tree,
 			w - 2 * padding, switcher_theme->item_height, (float[4]) {0});
 		wlr_scene_node_set_position(&hitbox->node, padding, y);
 

--- a/src/cycle/osd-scroll.c
+++ b/src/cycle/osd-scroll.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/lab-scene-rect.h"
+#include "common/scene-helpers.h"
 #include "labwc.h"
 #include "cycle.h"
 #include "output.h"
@@ -23,7 +24,7 @@ cycle_osd_scroll_init(struct cycle_osd_output *osd_output, struct wlr_box bar_ar
 	scroll->top_row_idx = 0;
 	scroll->bar_area = bar_area;
 	scroll->delta_y = delta_y;
-	scroll->bar_tree = wlr_scene_tree_create(osd_output->tree);
+	scroll->bar_tree = lab_wlr_scene_tree_create(osd_output->tree);
 	wlr_scene_node_set_position(&scroll->bar_tree->node,
 		bar_area.x, bar_area.y);
 

--- a/src/cycle/osd-thumbnail.c
+++ b/src/cycle/osd-thumbnail.c
@@ -10,6 +10,7 @@
 #include "common/lab-scene-rect.h"
 #include "common/list.h"
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "cycle.h"
 #include "labwc.h"
 #include "node.h"
@@ -138,7 +139,7 @@ create_item_scene(struct wlr_scene_tree *parent, struct view *view,
 
 	struct cycle_osd_thumbnail_item *item = znew(*item);
 	wl_list_append(&osd_output->items, &item->base.link);
-	struct wlr_scene_tree *tree = wlr_scene_tree_create(parent);
+	struct wlr_scene_tree *tree = lab_wlr_scene_tree_create(parent);
 	node_descriptor_create(&tree->node, LAB_NODE_CYCLE_OSD_ITEM, NULL, item);
 	item->base.tree = tree;
 	item->base.view = view;
@@ -155,14 +156,14 @@ create_item_scene(struct wlr_scene_tree *parent, struct view *view,
 	item->active_bg = lab_scene_rect_create(tree, &opts);
 
 	/* hitbox for mouse clicks */
-	wlr_scene_rect_create(tree, switcher_theme->item_width,
+	lab_wlr_scene_rect_create(tree, switcher_theme->item_width,
 		switcher_theme->item_height, (float[4]) {0});
 
 	/* thumbnail */
 	struct wlr_buffer *thumb_buffer = render_thumb(osd_output->output, view);
 	if (thumb_buffer) {
 		struct wlr_scene_buffer *thumb_scene_buffer =
-			wlr_scene_buffer_create(tree, thumb_buffer);
+			lab_wlr_scene_buffer_create(tree, thumb_buffer);
 		wlr_buffer_drop(thumb_buffer);
 		struct wlr_box thumb_box = box_fit_within(
 			thumb_buffer->width, thumb_buffer->height,
@@ -239,8 +240,8 @@ cycle_osd_thumbnail_init(struct cycle_osd_output *osd_output)
 		&theme->osd_window_switcher_thumbnail;
 	int padding = theme->osd_border_width + switcher_theme->padding;
 
-	osd_output->tree = wlr_scene_tree_create(output->cycle_osd_tree);
-	osd_output->items_tree = wlr_scene_tree_create(osd_output->tree);
+	osd_output->tree = lab_wlr_scene_tree_create(output->cycle_osd_tree);
+	osd_output->items_tree = lab_wlr_scene_tree_create(osd_output->tree);
 
 	int nr_views = wl_list_length(&server->cycle.views);
 	assert(nr_views > 0);

--- a/src/dnd.c
+++ b/src/dnd.c
@@ -4,6 +4,7 @@
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/log.h>
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "input/cursor.h"
 #include "labwc.h"  /* for struct seat */
@@ -83,7 +84,7 @@ handle_drag_destroy(struct wl_listener *listener, void *data)
 void
 dnd_init(struct seat *seat)
 {
-	seat->drag.icons = wlr_scene_tree_create(&seat->server->scene->tree);
+	seat->drag.icons = lab_wlr_scene_tree_create(&seat->server->scene->tree);
 	wlr_scene_node_set_enabled(&seat->drag.icons->node, false);
 
 	seat->drag.events.request.notify = handle_drag_request;

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -12,6 +12,7 @@
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "input/keyboard.h"
 #include "labwc.h"
 #include "node.h"
@@ -398,6 +399,8 @@ handle_input_method_new_popup_surface(struct wl_listener *listener, void *data)
 
 	popup->tree = wlr_scene_subsurface_tree_create(
 		relay->popup_tree, popup->popup_surface->surface);
+	die_if_null(popup->tree);
+
 	node_descriptor_create(&popup->tree->node, LAB_NODE_IME_POPUP,
 		/*view*/ NULL, /*data*/ NULL);
 
@@ -580,7 +583,7 @@ input_method_relay_create(struct seat *seat)
 	relay->seat = seat;
 	wl_list_init(&relay->text_inputs);
 	wl_list_init(&relay->popups);
-	relay->popup_tree = wlr_scene_tree_create(&seat->server->scene->tree);
+	relay->popup_tree = lab_wlr_scene_tree_create(&seat->server->scene->tree);
 
 	relay->new_text_input.notify = handle_new_text_input;
 	wl_signal_add(&seat->server->text_input_manager->events.text_input,

--- a/src/layers.c
+++ b/src/layers.c
@@ -561,10 +561,7 @@ create_popup(struct server *server, struct wlr_xdg_popup *wlr_popup,
 	popup->wlr_popup = wlr_popup;
 	popup->scene_tree =
 		wlr_scene_xdg_surface_create(parent, wlr_popup->base);
-	if (!popup->scene_tree) {
-		free(popup);
-		return NULL;
-	}
+	die_if_null(popup->scene_tree);
 
 	/* In support of IME popup */
 	wlr_popup->base->surface->data = popup->scene_tree;
@@ -597,12 +594,6 @@ handle_popup_new_popup(struct wl_listener *listener, void *data)
 	struct lab_layer_popup *new_popup = create_popup(
 		lab_layer_popup->server, wlr_popup,
 		lab_layer_popup->scene_tree);
-
-	if (!new_popup) {
-		wl_resource_post_no_memory(wlr_popup->resource);
-		wlr_xdg_popup_destroy(wlr_popup);
-		return;
-	}
 
 	new_popup->output_toplevel_sx_box =
 		lab_layer_popup->output_toplevel_sx_box;
@@ -664,12 +655,6 @@ handle_new_popup(struct wl_listener *listener, void *data)
 	};
 	struct lab_layer_popup *popup =
 		create_popup(server, wlr_popup, surface->tree);
-	if (!popup) {
-		wl_resource_post_no_memory(wlr_popup->resource);
-		wlr_xdg_popup_destroy(wlr_popup);
-		return;
-	}
-
 	popup->output_toplevel_sx_box = output_toplevel_sx_box;
 
 	if (surface->layer_surface->current.layer
@@ -716,11 +701,7 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 
 	surface->scene_layer_surface = wlr_scene_layer_surface_v1_create(
 		selected_layer, layer_surface);
-	if (!surface->scene_layer_surface) {
-		wlr_layer_surface_v1_destroy(layer_surface);
-		wlr_log(WLR_ERROR, "could not create layer surface");
-		return;
-	}
+	die_if_null(surface->scene_layer_surface);
 
 	/* In support of IME popup */
 	layer_surface->surface->data = surface->scene_layer_surface->tree;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -4,7 +4,6 @@
 #include <assert.h>
 #include <libxml/parser.h>
 #include <signal.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
@@ -19,6 +18,7 @@
 #include "common/lab-scene-rect.h"
 #include "common/list.h"
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"
 #include "common/xml.h"
@@ -170,7 +170,7 @@ item_create_scene_for_state(struct menuitem *item, float *text_color,
 	struct theme *theme = menu->server->theme;
 
 	/* Tree to hold background and label buffers */
-	struct wlr_scene_tree *tree = wlr_scene_tree_create(item->tree);
+	struct wlr_scene_tree *tree = lab_wlr_scene_tree_create(item->tree);
 
 	int icon_width = 0;
 	int icon_size = ICON_SIZE;
@@ -190,7 +190,7 @@ item_create_scene_for_state(struct menuitem *item, float *text_color,
 	}
 
 	/* Create background */
-	wlr_scene_rect_create(tree, bg_width, theme->menu_item_height, bg_color);
+	lab_wlr_scene_rect_create(tree, bg_width, theme->menu_item_height, bg_color);
 
 	/* Create icon */
 	bool show_app_icon = !strcmp(item->parent->id, "client-list-combined-menu")
@@ -246,7 +246,7 @@ item_create_scene(struct menuitem *menuitem, int *item_y)
 	struct theme *theme = menu->server->theme;
 
 	/* Menu item root node */
-	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
+	menuitem->tree = lab_wlr_scene_tree_create(menu->scene_tree);
 	node_descriptor_create(&menuitem->tree->node, LAB_NODE_MENUITEM,
 		/*view*/ NULL, menuitem);
 
@@ -295,12 +295,12 @@ separator_create_scene(struct menuitem *menuitem, int *item_y)
 	struct theme *theme = menu->server->theme;
 
 	/* Menu item root node */
-	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
+	menuitem->tree = lab_wlr_scene_tree_create(menu->scene_tree);
 	node_descriptor_create(&menuitem->tree->node, LAB_NODE_MENUITEM,
 		/*view*/ NULL, menuitem);
 
 	/* Tree to hold background and line buffer */
-	menuitem->normal_tree = wlr_scene_tree_create(menuitem->tree);
+	menuitem->normal_tree = lab_wlr_scene_tree_create(menuitem->tree);
 
 	int bg_height = theme->menu_separator_line_thickness
 		+ 2 * theme->menu_separator_padding_height;
@@ -313,11 +313,11 @@ separator_create_scene(struct menuitem *menuitem, int *item_y)
 	}
 
 	/* Item background nodes */
-	wlr_scene_rect_create(menuitem->normal_tree, bg_width, bg_height,
+	lab_wlr_scene_rect_create(menuitem->normal_tree, bg_width, bg_height,
 		theme->menu_items_bg_color);
 
 	/* Draw separator line */
-	struct wlr_scene_rect *line_rect = wlr_scene_rect_create(
+	struct wlr_scene_rect *line_rect = lab_wlr_scene_rect_create(
 		menuitem->normal_tree, line_width,
 		theme->menu_separator_line_thickness,
 		theme->menu_separator_color);
@@ -343,12 +343,12 @@ title_create_scene(struct menuitem *menuitem, int *item_y)
 	float *text_color = theme->menu_title_text_color;
 
 	/* Menu item root node */
-	menuitem->tree = wlr_scene_tree_create(menu->scene_tree);
+	menuitem->tree = lab_wlr_scene_tree_create(menu->scene_tree);
 	node_descriptor_create(&menuitem->tree->node, LAB_NODE_MENUITEM,
 		/*view*/ NULL, menuitem);
 
 	/* Tree to hold background and text buffer */
-	menuitem->normal_tree = wlr_scene_tree_create(menuitem->tree);
+	menuitem->normal_tree = lab_wlr_scene_tree_create(menuitem->tree);
 
 	int bg_width = menu->size.width - 2 * theme->menu_border_width;
 	int text_width = bg_width - 2 * theme->menu_items_padding_x;
@@ -359,7 +359,7 @@ title_create_scene(struct menuitem *menuitem, int *item_y)
 	}
 
 	/* Background */
-	wlr_scene_rect_create(menuitem->normal_tree,
+	lab_wlr_scene_rect_create(menuitem->normal_tree,
 		bg_width, theme->menu_header_height, bg_color);
 
 	/* Draw separator title */
@@ -416,7 +416,7 @@ menu_create_scene(struct menu *menu)
 
 	assert(!menu->scene_tree);
 
-	menu->scene_tree = wlr_scene_tree_create(menu->server->menu_tree);
+	menu->scene_tree = lab_wlr_scene_tree_create(menu->server->menu_tree);
 	wlr_scene_node_set_enabled(&menu->scene_tree->node, false);
 
 	/* Menu width is the maximum item width, capped by menu.width.{min,max} */

--- a/src/output.c
+++ b/src/output.c
@@ -557,11 +557,11 @@ handle_new_output(struct wl_listener *listener, void *data)
 	 */
 	for (size_t i = 0; i < ARRAY_SIZE(output->layer_tree); i++) {
 		output->layer_tree[i] =
-			wlr_scene_tree_create(&server->scene->tree);
+			lab_wlr_scene_tree_create(&server->scene->tree);
 	}
-	output->layer_popup_tree = wlr_scene_tree_create(&server->scene->tree);
-	output->cycle_osd_tree = wlr_scene_tree_create(&server->scene->tree);
-	output->session_lock_tree = wlr_scene_tree_create(&server->scene->tree);
+	output->layer_popup_tree = lab_wlr_scene_tree_create(&server->scene->tree);
+	output->cycle_osd_tree = lab_wlr_scene_tree_create(&server->scene->tree);
+	output->session_lock_tree = lab_wlr_scene_tree_create(&server->scene->tree);
 
 	/*
 	 * Set the z-positions to achieve the following order (from top to

--- a/src/scaled-buffer/scaled-buffer.c
+++ b/src/scaled-buffer/scaled-buffer.c
@@ -12,6 +12,7 @@
 #include "common/list.h"
 #include "common/macros.h"
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "node.h"
 
 /*
@@ -191,12 +192,7 @@ scaled_buffer_create(struct wlr_scene_tree *parent,
 	assert(impl->create_buffer);
 
 	struct scaled_buffer *self = znew(*self);
-	self->scene_buffer = wlr_scene_buffer_create(parent, NULL);
-	if (!self->scene_buffer) {
-		wlr_log(WLR_ERROR, "Failed to create scene buffer");
-		free(self);
-		return NULL;
-	}
+	self->scene_buffer = lab_wlr_scene_buffer_create(parent, NULL);
 
 	self->impl = impl;
 	/*

--- a/src/server.c
+++ b/src/server.c
@@ -46,6 +46,8 @@
 
 #include "action.h"
 #include "common/macros.h"
+#include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "config/session.h"
 #include "decorations.h"
@@ -555,10 +557,8 @@ server_init(struct server *server)
 	wl_list_init(&server->cycle.osd_outputs);
 
 	server->scene = wlr_scene_create();
-	if (!server->scene) {
-		wlr_log(WLR_ERROR, "unable to create scene");
-		exit(EXIT_FAILURE);
-	}
+	die_if_null(server->scene);
+
 	server->direct_scanout_enabled = server->scene->WLR_PRIVATE.direct_scanout;
 
 	/*
@@ -586,13 +586,13 @@ server_init(struct server *server)
 	 * | output->layer_tree[0]              | background layer surfaces (e.g. swaybg)
 	 */
 
-	server->workspace_tree = wlr_scene_tree_create(&server->scene->tree);
-	server->xdg_popup_tree = wlr_scene_tree_create(&server->scene->tree);
+	server->workspace_tree = lab_wlr_scene_tree_create(&server->scene->tree);
+	server->xdg_popup_tree = lab_wlr_scene_tree_create(&server->scene->tree);
 #if HAVE_XWAYLAND
-	server->unmanaged_tree = wlr_scene_tree_create(&server->scene->tree);
+	server->unmanaged_tree = lab_wlr_scene_tree_create(&server->scene->tree);
 #endif
-	server->menu_tree = wlr_scene_tree_create(&server->scene->tree);
-	server->cycle_preview_tree = wlr_scene_tree_create(&server->scene->tree);
+	server->menu_tree = lab_wlr_scene_tree_create(&server->scene->tree);
+	server->cycle_preview_tree = lab_wlr_scene_tree_create(&server->scene->tree);
 
 	workspaces_init(server);
 

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_session_lock_v1.h>
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "labwc.h"
 #include "node.h"
 #include "output.h"
@@ -135,8 +136,11 @@ handle_new_surface(struct wl_listener *listener, void *data)
 	}
 
 	lock_output->surface = lock_surface;
+
 	struct wlr_scene_tree *surface_tree =
 		wlr_scene_subsurface_tree_create(lock_output->tree, lock_surface->surface);
+	die_if_null(surface_tree);
+
 	node_descriptor_create(&surface_tree->node,
 		LAB_NODE_SESSION_LOCK_SURFACE, /*view*/ NULL, /*data*/ NULL);
 
@@ -209,12 +213,7 @@ session_lock_output_create(struct session_lock_manager *manager, struct output *
 
 	struct session_lock_output *lock_output = znew(*lock_output);
 
-	struct wlr_scene_tree *tree = wlr_scene_tree_create(output->session_lock_tree);
-	if (!tree) {
-		wlr_log(WLR_ERROR, "session-lock: wlr_scene_tree_create()");
-		free(lock_output);
-		goto exit_session;
-	}
+	struct wlr_scene_tree *tree = lab_wlr_scene_tree_create(output->session_lock_tree);
 
 	/*
 	 * The ext-session-lock protocol says that the compositor should blank
@@ -222,13 +221,7 @@ session_lock_output_create(struct session_lock_manager *manager, struct output *
 	 * fully hidden
 	 */
 	float black[4] = { 0.f, 0.f, 0.f, 1.f };
-	struct wlr_scene_rect *background = wlr_scene_rect_create(tree, 0, 0, black);
-	if (!background) {
-		wlr_log(WLR_ERROR, "session-lock: wlr_scene_rect_create()");
-		wlr_scene_node_destroy(&tree->node);
-		free(lock_output);
-		goto exit_session;
-	}
+	struct wlr_scene_rect *background = lab_wlr_scene_rect_create(tree, 0, 0, black);
 
 	/*
 	 * Delay blanking output by 100ms to prevent flicker. If the session is
@@ -258,12 +251,6 @@ session_lock_output_create(struct session_lock_manager *manager, struct output *
 	lock_output_reconfigure(lock_output);
 
 	wl_list_insert(&manager->lock_outputs, &lock_output->link);
-	return;
-
-exit_session:
-	/* TODO: Consider a better - but secure - way to deal with this */
-	wlr_log(WLR_ERROR, "out of memory");
-	exit(EXIT_FAILURE);
 }
 
 static void

--- a/src/ssd/resize-indicator.c
+++ b/src/ssd/resize-indicator.c
@@ -3,6 +3,7 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
 #include <wlr/util/log.h>
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "resize-indicator.h"
@@ -44,10 +45,10 @@ resize_indicator_init(struct view *view)
 	struct resize_indicator *indicator = &view->resize_indicator;
 	assert(!indicator->tree);
 
-	indicator->tree = wlr_scene_tree_create(view->scene_tree);
-	indicator->border = wlr_scene_rect_create(
+	indicator->tree = lab_wlr_scene_tree_create(view->scene_tree);
+	indicator->border = lab_wlr_scene_rect_create(
 		indicator->tree, 0, 0, rc.theme->osd_border_color);
-	indicator->background = wlr_scene_rect_create(
+	indicator->background = lab_wlr_scene_rect_create(
 		indicator->tree, 0, 0, rc.theme->osd_bg_color);
 	indicator->text = scaled_font_buffer_create(indicator->tree);
 

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/macros.h"
+#include "common/scene-helpers.h"
 #include "labwc.h"
 #include "ssd.h"
 #include "ssd-internal.h"
@@ -22,32 +23,32 @@ ssd_border_create(struct ssd *ssd)
 	int full_width = width + 2 * theme->border_width;
 	int corner_width = ssd_get_corner_width();
 
-	ssd->border.tree = wlr_scene_tree_create(ssd->tree);
+	ssd->border.tree = lab_wlr_scene_tree_create(ssd->tree);
 	wlr_scene_node_set_position(&ssd->border.tree->node, -theme->border_width, 0);
 
 	enum ssd_active_state active;
 	FOR_EACH_ACTIVE_STATE(active) {
 		struct ssd_border_subtree *subtree = &ssd->border.subtrees[active];
-		subtree->tree = wlr_scene_tree_create(ssd->border.tree);
+		subtree->tree = lab_wlr_scene_tree_create(ssd->border.tree);
 		struct wlr_scene_tree *parent = subtree->tree;
 		wlr_scene_node_set_enabled(&parent->node, active);
 		float *color = theme->window[active].border_color;
 
-		subtree->left = wlr_scene_rect_create(parent,
+		subtree->left = lab_wlr_scene_rect_create(parent,
 			theme->border_width, height, color);
 		wlr_scene_node_set_position(&subtree->left->node, 0, 0);
 
-		subtree->right = wlr_scene_rect_create(parent,
+		subtree->right = lab_wlr_scene_rect_create(parent,
 			theme->border_width, height, color);
 		wlr_scene_node_set_position(&subtree->right->node,
 			theme->border_width + width, 0);
 
-		subtree->bottom = wlr_scene_rect_create(parent,
+		subtree->bottom = lab_wlr_scene_rect_create(parent,
 			full_width, theme->border_width, color);
 		wlr_scene_node_set_position(&subtree->bottom->node,
 			0, height);
 
-		subtree->top = wlr_scene_rect_create(parent,
+		subtree->top = lab_wlr_scene_rect_create(parent,
 			MAX(width - 2 * corner_width, 0), theme->border_width, color);
 		wlr_scene_node_set_position(&subtree->top->node,
 			theme->border_width + corner_width,

--- a/src/ssd/ssd-button.c
+++ b/src/ssd/ssd-button.c
@@ -5,6 +5,7 @@
 #include "config/rcxml.h"
 #include "common/list.h"
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "node.h"
 #include "scaled-buffer/scaled-icon-buffer.h"
 #include "scaled-buffer/scaled-img-buffer.h"
@@ -19,7 +20,7 @@ attach_ssd_button(struct wl_list *button_parts, enum lab_node_type type,
 		struct lab_img *imgs[LAB_BS_ALL + 1],
 		int x, int y, struct view *view)
 {
-	struct wlr_scene_tree *root = wlr_scene_tree_create(parent);
+	struct wlr_scene_tree *root = lab_wlr_scene_tree_create(parent);
 	wlr_scene_node_set_position(&root->node, x, y);
 
 	assert(node_type_contains(LAB_NODE_BUTTON, type));
@@ -31,7 +32,7 @@ attach_ssd_button(struct wl_list *button_parts, enum lab_node_type type,
 
 	/* Hitbox */
 	float invisible[4] = { 0, 0, 0, 0 };
-	wlr_scene_rect_create(root, rc.theme->window_button_width,
+	lab_wlr_scene_rect_create(root, rc.theme->window_button_width,
 		rc.theme->window_button_height, invisible);
 
 	/* Icons */

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -2,6 +2,7 @@
 
 #include <pixman.h>
 #include <wlr/types/wlr_scene.h>
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "output.h"
@@ -17,7 +18,7 @@ ssd_extents_create(struct ssd *ssd)
 
 	int border_width = MAX(0, MAX(rc.resize_minimum_area, theme->border_width));
 
-	ssd->extents.tree = wlr_scene_tree_create(ssd->tree);
+	ssd->extents.tree = lab_wlr_scene_tree_create(ssd->tree);
 	struct wlr_scene_tree *parent = ssd->extents.tree;
 	if (view->fullscreen || view->maximized == VIEW_AXIS_BOTH) {
 		wlr_scene_node_set_enabled(&parent->node, false);
@@ -26,10 +27,10 @@ ssd_extents_create(struct ssd *ssd)
 		-border_width, -(ssd->titlebar.height + border_width));
 
 	float invisible[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-	ssd->extents.top = wlr_scene_rect_create(parent, 0, 0, invisible);
-	ssd->extents.left = wlr_scene_rect_create(parent, 0, 0, invisible);
-	ssd->extents.right = wlr_scene_rect_create(parent, 0, 0, invisible);
-	ssd->extents.bottom = wlr_scene_rect_create(parent, 0, 0, invisible);
+	ssd->extents.top = lab_wlr_scene_rect_create(parent, 0, 0, invisible);
+	ssd->extents.left = lab_wlr_scene_rect_create(parent, 0, 0, invisible);
+	ssd->extents.right = lab_wlr_scene_rect_create(parent, 0, 0, invisible);
+	ssd->extents.bottom = lab_wlr_scene_rect_create(parent, 0, 0, invisible);
 
 	/* Initial manual update to keep X11 applications happy */
 	ssd_extents_update(ssd);

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <wlr/types/wlr_scene.h>
 #include "buffer.h"
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "ssd.h"
@@ -183,7 +184,7 @@ make_shadow(struct view *view,
 	enum wl_output_transform tx)
 {
 	struct wlr_scene_buffer *scene_buf =
-		wlr_scene_buffer_create(parent, buf);
+		lab_wlr_scene_buffer_create(parent, buf);
 	wlr_scene_buffer_set_transform(scene_buf, tx);
 	scene_buf->point_accepts_input = never_accepts_input;
 	/*
@@ -200,7 +201,7 @@ ssd_shadow_create(struct ssd *ssd)
 	assert(ssd);
 	assert(!ssd->shadow.tree);
 
-	ssd->shadow.tree = wlr_scene_tree_create(ssd->tree);
+	ssd->shadow.tree = lab_wlr_scene_tree_create(ssd->tree);
 
 	struct theme *theme = ssd->view->server->theme;
 	struct view *view = ssd->view;
@@ -218,7 +219,7 @@ ssd_shadow_create(struct ssd *ssd)
 			continue;
 		}
 
-		subtree->tree = wlr_scene_tree_create(ssd->shadow.tree);
+		subtree->tree = lab_wlr_scene_tree_create(ssd->shadow.tree);
 		struct wlr_scene_tree *parent = subtree->tree;
 		struct wlr_buffer *corner_top_buffer =
 			&theme->window[active].shadow_corner_top->base;

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -7,7 +7,7 @@
 #include <wlr/types/wlr_scene.h>
 #include "buffer.h"
 #include "common/mem.h"
-#include "common/string-helpers.h"
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "node.h"
@@ -31,14 +31,14 @@ ssd_titlebar_create(struct ssd *ssd)
 	int width = view->current.width;
 	int corner_width = ssd_get_corner_width();
 
-	ssd->titlebar.tree = wlr_scene_tree_create(ssd->tree);
+	ssd->titlebar.tree = lab_wlr_scene_tree_create(ssd->tree);
 	node_descriptor_create(&ssd->titlebar.tree->node,
 		LAB_NODE_TITLEBAR, view, /*data*/ NULL);
 
 	enum ssd_active_state active;
 	FOR_EACH_ACTIVE_STATE(active) {
 		struct ssd_titlebar_subtree *subtree = &ssd->titlebar.subtrees[active];
-		subtree->tree = wlr_scene_tree_create(ssd->titlebar.tree);
+		subtree->tree = lab_wlr_scene_tree_create(ssd->titlebar.tree);
 		struct wlr_scene_tree *parent = subtree->tree;
 		wlr_scene_node_set_enabled(&parent->node, active);
 		wlr_scene_node_set_position(&parent->node, 0, -theme->titlebar_height);
@@ -51,7 +51,7 @@ ssd_titlebar_create(struct ssd *ssd)
 			&theme->window[active].corner_top_right_normal->base;
 
 		/* Background */
-		subtree->bar = wlr_scene_buffer_create(parent, titlebar_fill);
+		subtree->bar = lab_wlr_scene_buffer_create(parent, titlebar_fill);
 		/*
 		 * Work around the wlroots/pixman bug that widened 1px buffer
 		 * becomes translucent when bilinear filtering is used.
@@ -64,11 +64,11 @@ ssd_titlebar_create(struct ssd *ssd)
 		}
 		wlr_scene_node_set_position(&subtree->bar->node, corner_width, 0);
 
-		subtree->corner_left = wlr_scene_buffer_create(parent, corner_top_left);
+		subtree->corner_left = lab_wlr_scene_buffer_create(parent, corner_top_left);
 		wlr_scene_node_set_position(&subtree->corner_left->node,
 			-rc.theme->border_width, -rc.theme->border_width);
 
-		subtree->corner_right = wlr_scene_buffer_create(parent, corner_top_right);
+		subtree->corner_right = lab_wlr_scene_buffer_create(parent, corner_top_right);
 		wlr_scene_node_set_position(&subtree->corner_right->node,
 			width - corner_width, -rc.theme->border_width);
 

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -12,6 +12,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_scene.h>
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "node.h"
@@ -145,7 +146,7 @@ ssd_create(struct view *view, bool active)
 	struct ssd *ssd = znew(*ssd);
 
 	ssd->view = view;
-	ssd->tree = wlr_scene_tree_create(view->scene_tree);
+	ssd->tree = lab_wlr_scene_tree_create(view->scene_tree);
 
 	/*
 	 * Attach node_descriptor to the root node so that get_cursor_context()

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -15,6 +15,7 @@
 #include "common/graphic-helpers.h"
 #include "common/list.h"
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "input/keyboard.h"
 #include "labwc.h"
@@ -163,7 +164,7 @@ _osd_update(struct server *server)
 		cairo_destroy(cairo);
 
 		if (!output->workspace_osd) {
-			output->workspace_osd = wlr_scene_buffer_create(
+			output->workspace_osd = lab_wlr_scene_buffer_create(
 				&server->scene->tree, NULL);
 		}
 		/* Position the whole thing */
@@ -234,13 +235,13 @@ add_workspace(struct server *server, const char *name)
 	struct workspace *workspace = znew(*workspace);
 	workspace->server = server;
 	workspace->name = xstrdup(name);
-	workspace->tree = wlr_scene_tree_create(server->workspace_tree);
+	workspace->tree = lab_wlr_scene_tree_create(server->workspace_tree);
 	workspace->view_trees[VIEW_LAYER_ALWAYS_ON_BOTTOM] =
-		wlr_scene_tree_create(workspace->tree);
+		lab_wlr_scene_tree_create(workspace->tree);
 	workspace->view_trees[VIEW_LAYER_NORMAL] =
-		wlr_scene_tree_create(workspace->tree);
+		lab_wlr_scene_tree_create(workspace->tree);
 	workspace->view_trees[VIEW_LAYER_ALWAYS_ON_TOP] =
-		wlr_scene_tree_create(workspace->tree);
+		lab_wlr_scene_tree_create(workspace->tree);
 	wl_list_append(&server->workspaces.all, &workspace->link);
 	wlr_scene_node_set_enabled(&workspace->tree->node, false);
 

--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -164,6 +164,8 @@ xdg_popup_create(struct view *view, struct wlr_xdg_popup *wlr_popup)
 	}
 	wlr_popup->base->surface->data =
 		wlr_scene_xdg_surface_create(parent_tree, wlr_popup->base);
+	die_if_null(wlr_popup->base->surface->data);
+
 	node_descriptor_create(wlr_popup->base->surface->data,
 		LAB_NODE_XDG_POPUP, view, /*data*/ NULL);
 }

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -13,6 +13,7 @@
 #include "common/box.h"
 #include "common/macros.h"
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "decorations.h"
 #include "foreign-toplevel/foreign.h"
@@ -193,7 +194,7 @@ center_fullscreen_if_needed(struct view *view)
 	if (!xdg_view->fullscreen_bg) {
 		const float black[4] = {0, 0, 0, 1};
 		xdg_view->fullscreen_bg =
-			wlr_scene_rect_create(view->scene_tree, 0, 0, black);
+			lab_wlr_scene_rect_create(view->scene_tree, 0, 0, black);
 		wlr_scene_node_lower_to_bottom(&xdg_view->fullscreen_bg->node);
 	}
 
@@ -984,18 +985,14 @@ handle_new_xdg_toplevel(struct wl_listener *listener, void *data)
 	}
 
 	view->workspace = server->workspaces.current;
-	view->scene_tree = wlr_scene_tree_create(
+	view->scene_tree = lab_wlr_scene_tree_create(
 		view->workspace->view_trees[VIEW_LAYER_NORMAL]);
 	wlr_scene_node_set_enabled(&view->scene_tree->node, false);
 
 	struct wlr_scene_tree *tree = wlr_scene_xdg_surface_create(
 		view->scene_tree, xdg_surface);
-	if (!tree) {
-		/* TODO: might need further clean up */
-		wl_resource_post_no_memory(xdg_surface->resource);
-		free(xdg_toplevel_view);
-		return;
-	}
+	die_if_null(tree);
+
 	view->content_tree = tree;
 	node_descriptor_create(&view->scene_tree->node,
 		LAB_NODE_VIEW, view, /*data*/ NULL);

--- a/src/xwayland-unmanaged.c
+++ b/src/xwayland-unmanaged.c
@@ -68,9 +68,11 @@ handle_map(struct wl_listener *listener, void *data)
 		seat_focus_surface(&unmanaged->server->seat, xsurface->surface);
 	}
 
-	unmanaged->node = &wlr_scene_surface_create(
-			unmanaged->server->unmanaged_tree,
-			xsurface->surface)->buffer->node;
+	struct wlr_scene_surface *scene_surface = wlr_scene_surface_create(
+		unmanaged->server->unmanaged_tree, xsurface->surface);
+	die_if_null(scene_surface);
+	unmanaged->node = &scene_surface->buffer->node;
+
 	wlr_scene_node_set_position(unmanaged->node, xsurface->x, xsurface->y);
 	cursor_update_focus(unmanaged->server);
 }

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -13,6 +13,7 @@
 #include "common/array.h"
 #include "common/macros.h"
 #include "common/mem.h"
+#include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "config/session.h"
 #include "foreign-toplevel/foreign.h"
@@ -842,11 +843,7 @@ handle_map(struct wl_listener *listener, void *data)
 	if (!view->content_tree) {
 		view->content_tree = wlr_scene_subsurface_tree_create(
 			view->scene_tree, view->surface);
-		if (!view->content_tree) {
-			/* TODO: might need further clean up */
-			wl_resource_post_no_memory(view->surface->resource);
-			return;
-		}
+		die_if_null(view->content_tree);
 	}
 
 	wlr_scene_node_set_enabled(&view->content_tree->node, !view->shaded);
@@ -1050,7 +1047,7 @@ xwayland_view_create(struct server *server,
 	xsurface->data = view;
 
 	view->workspace = server->workspaces.current;
-	view->scene_tree = wlr_scene_tree_create(
+	view->scene_tree = lab_wlr_scene_tree_create(
 		view->workspace->view_trees[VIEW_LAYER_NORMAL]);
 	node_descriptor_create(&view->scene_tree->node,
 		LAB_NODE_VIEW, view, /*data*/ NULL);


### PR DESCRIPTION
wlr_scene_*_create() functions all allocate memory via calloc() and return NULL if the allocation fails. Previously, the failures were handled in any of 3 different ways:

 - sending a wayland protocol error
 - exiting labwc with an error
 - segfault (no NULL check at all)

Since labwc does not attempt to survive heap exhaustion in other allocation paths (such as `znew`), it seems more consistent to use the same die_if_null() check used in those paths to exit with an error.

For the three most common create() functions (tree, rect, buffer), add small lab_wlr_ wrappers to common/scene-helpers.