### PR TITLE
xwayland: fix missing title and icon with override-redirect toggle

### DIFF
--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -1083,6 +1083,16 @@ xwayland_view_create(struct server *server,
 
 	if (xsurface->surface) {
 		handle_associate(&xwayland_view->associate, NULL);
+		/*
+		 * If a surface is already associated, then we've
+		 * missed the various initial set_* events as well.
+		 *
+		 * TODO: update_icon() -> handle_set_icon() after
+		 * https://github.com/labwc/labwc/pull/2760
+		 */
+		handle_set_title(&view->set_title, NULL);
+		handle_set_class(&xwayland_view->set_class, NULL);
+		update_icon(xwayland_view);
 	}
 	if (mapped) {
 		handle_map(&xwayland_view->base.mappable.map, NULL);


### PR DESCRIPTION
When an X11 client clears override-redirect on a window (i.e. it becomes "managed") without an unmap/map cycle, wlroots doesn't re-emit the set_title/class/icon events. We need to synthesize them to re-read the values from the surface.

From what I can tell, only older/misbehaving X11 clients would actually do this (toggle override-redirect without unmap/map), so this is perhaps a bit pedantic, but an easy fix anyway.

Test case (AI-assisted): https://gist.github.com/jlindgren90/712931190aaa027c8a7d60a5f65ce60a