### PR TITLE
NEWS.md: fix 0.9.6 release notes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -146,8 +146,7 @@ refactoring and new features.
 
 - Disable outputs where all modes fail [#3428] [#3429] @Consolatis @kode54
 - Fix regression in `0.9.4` that causes `NextWindow` action to segfault when
-  no outputs are connected. This fixes a window-switcher crash with some
-  Nvidia GPUs/drivers after suspend [#3425] [#3430] @Consolatis
+  no outputs are connected. [#3425] [#3430] @Consolatis
 - Fix typo to allow `xdg-dialog-v1` global [#3426] @xi
 
 ### Changed


### PR DESCRIPTION
...by removing the comment about crashes after suspend on some Nvidia GPUs because this only happens after #3387 has is not yet in any release.

Ref:
- https://github.com/labwc/labwc/pull/3430#discussion_r2911781637
- https://github.com/labwc/labwc/pull/3448#discussion_r2948247530

Helped-by: @tokyo4j