### PR TITLE
tree-wide: use rc.theme instead of server.theme

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -302,8 +302,6 @@ struct server {
 	/* Set when in cycle (alt-tab) mode */
 	struct cycle_state cycle;
 
-	struct theme *theme;
-
 	struct menu *menu_current;
 	struct wl_list menus;
 

--- a/include/theme.h
+++ b/include/theme.h
@@ -213,12 +213,9 @@ struct theme {
 	int mag_border_width;
 };
 
-struct server;
-
 /**
  * theme_init - read openbox theme and generate button textures
  * @theme: theme data
- * @server: server
  * @theme_name: theme-name in <theme-dir>/<theme-name>/labwc/themerc
  * Note <theme-dir> is obtained in theme-dir.c
  */

--- a/src/action.c
+++ b/src/action.c
@@ -776,7 +776,7 @@ show_menu(struct view *view, struct cursor_context *ctx,
 			int lx, ly;
 			wlr_scene_node_coords(ctx->node, &lx, &ly);
 			/* MAX() prevents negative x when the window is maximized */
-			x = MAX(x, lx - server.theme->menu_border_width);
+			x = MAX(x, lx - rc.theme->menu_border_width);
 		}
 	}
 

--- a/src/cycle/cycle.c
+++ b/src/cycle/cycle.c
@@ -26,7 +26,7 @@ static void
 update_preview_outlines(struct view *view)
 {
 	/* Create / Update preview outline tree */
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	struct lab_scene_rect *rect = server.cycle.preview_outline;
 	if (!rect) {
 		struct lab_scene_rect_options opts = {

--- a/src/cycle/osd-classic.c
+++ b/src/cycle/osd-classic.c
@@ -32,7 +32,7 @@ create_fields_scene(struct view *view,
 		struct wlr_scene_tree *parent, const float *text_color,
 		const float *bg_color, int field_widths_sum, int x, int y)
 {
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	struct window_switcher_classic_theme *switcher_theme =
 		&theme->osd_window_switcher_classic;
 
@@ -80,7 +80,7 @@ static void
 cycle_osd_classic_init(struct cycle_osd_output *osd_output)
 {
 	struct output *output = osd_output->output;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	struct window_switcher_classic_theme *switcher_theme =
 		&theme->osd_window_switcher_classic;
 	int padding = theme->osd_border_width + switcher_theme->padding;

--- a/src/cycle/osd-thumbnail.c
+++ b/src/cycle/osd-thumbnail.c
@@ -119,7 +119,7 @@ static struct cycle_osd_thumbnail_item *
 create_item_scene(struct wlr_scene_tree *parent, struct view *view,
 		struct cycle_osd_output *osd_output)
 {
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	struct window_switcher_thumbnail_theme *switcher_theme =
 		&theme->osd_window_switcher_thumbnail;
 	int padding = theme->border_width + switcher_theme->item_padding;
@@ -196,7 +196,7 @@ static void
 get_items_geometry(struct output *output, int nr_thumbs,
 		int *nr_cols, int *nr_rows, int *nr_visible_rows)
 {
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	struct window_switcher_thumbnail_theme *switcher_theme =
 		&theme->osd_window_switcher_thumbnail;
 	int output_width, output_height;
@@ -232,7 +232,7 @@ static void
 cycle_osd_thumbnail_init(struct cycle_osd_output *osd_output)
 {
 	struct output *output = osd_output->output;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	struct window_switcher_thumbnail_theme *switcher_theme =
 		&theme->osd_window_switcher_thumbnail;
 	int padding = theme->osd_border_width + switcher_theme->padding;

--- a/src/magnifier.c
+++ b/src/magnifier.c
@@ -41,7 +41,7 @@ box_logical_to_physical(struct wlr_box *box, struct wlr_output *output)
 void
 magnifier_draw(struct output *output, struct wlr_buffer *output_buffer, struct wlr_box *damage)
 {
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	bool fullscreen = (rc.mag_width == -1 || rc.mag_height == -1);
 
 	struct wlr_box output_box = {

--- a/src/main.c
+++ b/src/main.c
@@ -260,7 +260,6 @@ main(int argc, char *argv[])
 	struct theme theme = { 0 };
 	theme_init(&theme, rc.theme_name);
 	rc.theme = &theme;
-	server.theme = &theme;
 
 	menu_init();
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -135,7 +135,7 @@ item_create(struct menu *menu, const char *text, const char *icon_name, bool sho
 	assert(menu);
 	assert(text);
 
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	struct menuitem *menuitem = znew(*menuitem);
 	menuitem->parent = menu;
 	menuitem->selectable = true;
@@ -166,7 +166,7 @@ item_create_scene_for_state(struct menuitem *item, float *text_color,
 	float *bg_color)
 {
 	struct menu *menu = item->parent;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	/* Tree to hold background and label buffers */
 	struct wlr_scene_tree *tree = lab_wlr_scene_tree_create(item->tree);
@@ -242,7 +242,7 @@ item_create_scene(struct menuitem *menuitem, int *item_y)
 	assert(menuitem);
 	assert(menuitem->type == LAB_MENU_ITEM);
 	struct menu *menu = menuitem->parent;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	/* Menu item root node */
 	menuitem->tree = lab_wlr_scene_tree_create(menu->scene_tree);
@@ -291,7 +291,7 @@ separator_create_scene(struct menuitem *menuitem, int *item_y)
 	assert(menuitem);
 	assert(menuitem->type == LAB_MENU_SEPARATOR_LINE);
 	struct menu *menu = menuitem->parent;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	/* Menu item root node */
 	menuitem->tree = lab_wlr_scene_tree_create(menu->scene_tree);
@@ -337,7 +337,7 @@ title_create_scene(struct menuitem *menuitem, int *item_y)
 	assert(menuitem);
 	assert(menuitem->type == LAB_MENU_TITLE);
 	struct menu *menu = menuitem->parent;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	float *bg_color = theme->menu_title_bg_color;
 	float *text_color = theme->menu_title_text_color;
 
@@ -411,7 +411,7 @@ static void
 menu_create_scene(struct menu *menu)
 {
 	struct menuitem *item;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	assert(!menu->scene_tree);
 
@@ -1351,7 +1351,7 @@ menu_process_item_selection(struct menuitem *item)
 		item->submenu->parent = item->parent;
 		/* And open the new submenu tree */
 		struct wlr_box anchor_rect =
-			get_item_anchor_rect(server.theme, item);
+			get_item_anchor_rect(rc.theme, item);
 		if (item->submenu->execute && !item->submenu->scene_tree) {
 			open_pipemenu_async(item->submenu, anchor_rect);
 		} else {

--- a/src/resize-outlines.c
+++ b/src/resize-outlines.c
@@ -4,7 +4,7 @@
 #include <wlr/types/wlr_scene.h>
 #include "common/border.h"
 #include "common/lab-scene-rect.h"
-#include "labwc.h"
+#include "config/rcxml.h"
 #include "resize-indicator.h"
 #include "ssd.h"
 #include "theme.h"
@@ -25,9 +25,9 @@ resize_outlines_update(struct view *view, struct wlr_box new_geo)
 	if (!outlines->rect) {
 		struct lab_scene_rect_options opts = {
 			.border_colors = (float *[3]) {
-				server.theme->osd_bg_color,
-				server.theme->osd_label_text_color,
-				server.theme->osd_bg_color,
+				rc.theme->osd_bg_color,
+				rc.theme->osd_label_text_color,
+				rc.theme->osd_bg_color,
 			},
 			.nr_borders = 3,
 			.border_width = 1,

--- a/src/server.c
+++ b/src/server.c
@@ -86,8 +86,8 @@ reload_config_and_theme(void)
 	scaled_buffer_invalidate_sharing();
 	rcxml_finish();
 	rcxml_read(rc.config_file);
-	theme_finish(server.theme);
-	theme_init(server.theme, rc.theme_name);
+	theme_finish(rc.theme);
+	theme_init(rc.theme, rc.theme_name);
 
 #if HAVE_LIBSFDO
 	desktop_entry_finish();

--- a/src/ssd/ssd-border.c
+++ b/src/ssd/ssd-border.c
@@ -4,7 +4,7 @@
 #include <wlr/types/wlr_scene.h>
 #include "common/macros.h"
 #include "common/scene-helpers.h"
-#include "labwc.h"
+#include "config/rcxml.h"
 #include "ssd.h"
 #include "ssd-internal.h"
 #include "theme.h"
@@ -17,7 +17,7 @@ ssd_border_create(struct ssd *ssd)
 	assert(!ssd->border.tree);
 
 	struct view *view = ssd->view;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	int width = view->current.width;
 	int height = view_effective_height(view, /* use_pending */ false);
 	int full_width = width + 2 * theme->border_width;
@@ -90,7 +90,7 @@ ssd_border_update(struct ssd *ssd)
 		ssd->margin = ssd_thickness(ssd->view);
 	}
 
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	int width = view->current.width;
 	int height = view_effective_height(view, /* use_pending */ false);

--- a/src/ssd/ssd-extents.c
+++ b/src/ssd/ssd-extents.c
@@ -14,7 +14,7 @@ void
 ssd_extents_create(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	int border_width = MAX(0, MAX(rc.resize_minimum_area, theme->border_width));
 
@@ -100,7 +100,7 @@ ssd_extents_update(struct ssd *ssd)
 		return;
 	}
 
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	int width = view->current.width;
 	int height = view_effective_height(view, /* use_pending */ false);

--- a/src/ssd/ssd-shadow.c
+++ b/src/ssd/ssd-shadow.c
@@ -145,7 +145,7 @@ static void
 set_shadow_geometry(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	int titlebar_height = ssd->titlebar.height;
 	int width = view->current.width;
 	int height = view_effective_height(view, false) + titlebar_height;
@@ -203,7 +203,7 @@ ssd_shadow_create(struct ssd *ssd)
 
 	ssd->shadow.tree = lab_wlr_scene_tree_create(ssd->tree);
 
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	struct view *view = ssd->view;
 
 	enum ssd_active_state active;
@@ -256,7 +256,7 @@ ssd_shadow_update(struct ssd *ssd)
 	assert(ssd->shadow.tree);
 
 	struct view *view = ssd->view;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	bool maximized = view->maximized == VIEW_AXIS_BOTH;
 	bool tiled_shadows = false;
 	if (rc.shadows_on_tiled) {

--- a/src/ssd/ssd-titlebar.c
+++ b/src/ssd/ssd-titlebar.c
@@ -27,7 +27,7 @@ void
 ssd_titlebar_create(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	int width = view->current.width;
 	int corner_width = ssd_get_corner_width();
 
@@ -160,7 +160,7 @@ set_squared_corners(struct ssd *ssd, bool enable)
 	struct view *view = ssd->view;
 	int width = view->current.width;
 	int corner_width = ssd_get_corner_width();
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	int x = enable ? 0 : corner_width;
 
@@ -220,7 +220,7 @@ static void
 update_visible_buttons(struct ssd *ssd)
 {
 	struct view *view = ssd->view;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	int width = MAX(view->current.width - 2 * theme->window_titlebar_padding_width, 0);
 	int button_width = theme->window_button_width;
 	int button_spacing = theme->window_button_spacing;
@@ -273,7 +273,7 @@ ssd_titlebar_update(struct ssd *ssd)
 	struct view *view = ssd->view;
 	int width = view->current.width;
 	int corner_width = ssd_get_corner_width();
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	bool maximized = view->maximized == VIEW_AXIS_BOTH;
 	bool squared = ssd_should_be_squared(ssd);
@@ -365,7 +365,7 @@ static void
 ssd_update_title_positions(struct ssd *ssd, int offset_left, int offset_right)
 {
 	struct view *view = ssd->view;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	int width = view->current.width;
 	int title_bg_width = width - offset_left - offset_right;
 
@@ -413,9 +413,9 @@ static void
 get_title_offsets(struct ssd *ssd, int *offset_left, int *offset_right)
 {
 	struct ssd_titlebar_subtree *subtree = &ssd->titlebar.subtrees[SSD_ACTIVE];
-	int button_width = server.theme->window_button_width;
-	int button_spacing = server.theme->window_button_spacing;
-	int padding_width = server.theme->window_titlebar_padding_width;
+	int button_width = rc.theme->window_button_width;
+	int button_spacing = rc.theme->window_button_spacing;
+	int padding_width = rc.theme->window_titlebar_padding_width;
 	*offset_left = padding_width;
 	*offset_right = padding_width;
 
@@ -443,7 +443,7 @@ ssd_update_title(struct ssd *ssd)
 	/* view->title is never NULL (instead it can be an empty string) */
 	assert(view->title);
 
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	struct ssd_state_title *state = &ssd->state.title;
 	bool title_unchanged = state->text && !strcmp(view->title, state->text);
 

--- a/src/ssd/ssd.c
+++ b/src/ssd/ssd.c
@@ -39,7 +39,7 @@ ssd_thickness(struct view *view)
 		return (struct border){ 0 };
 	}
 
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	if (view->maximized == VIEW_AXIS_BOTH) {
 		struct border thickness = { 0 };
@@ -101,7 +101,7 @@ ssd_get_resizing_type(const struct ssd *ssd, struct wlr_cursor *cursor)
 
 	if (view_titlebar_visible(view)) {
 		/* If the titlebar is visible, consider it part of the view */
-		int titlebar_height = server.theme->titlebar_height;
+		int titlebar_height = rc.theme->titlebar_height;
 		view_box.y -= titlebar_height;
 		view_box.height += titlebar_height;
 	}
@@ -156,7 +156,7 @@ ssd_create(struct view *view, bool active)
 		LAB_NODE_SSD_ROOT, view, /*data*/ NULL);
 
 	wlr_scene_node_lower_to_bottom(&ssd->tree->node);
-	ssd->titlebar.height = server.theme->titlebar_height;
+	ssd->titlebar.height = rc.theme->titlebar_height;
 	ssd_shadow_create(ssd);
 	ssd_extents_create(ssd);
 	/*
@@ -257,7 +257,7 @@ ssd_set_titlebar(struct ssd *ssd, bool enabled)
 		return;
 	}
 	wlr_scene_node_set_enabled(&ssd->titlebar.tree->node, enabled);
-	ssd->titlebar.height = enabled ? server.theme->titlebar_height : 0;
+	ssd->titlebar.height = enabled ? rc.theme->titlebar_height : 0;
 	ssd_border_update(ssd);
 	ssd_extents_update(ssd);
 	ssd_shadow_update(ssd);

--- a/src/view.c
+++ b/src/view.c
@@ -994,7 +994,7 @@ view_compute_cascaded_position(struct view *view, struct wlr_box *geom)
 	/* TODO: move this logic to rcxml.c */
 	int offset_x = rc.placement_cascade_offset_x;
 	int offset_y = rc.placement_cascade_offset_y;
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 	int default_offset = theme->titlebar_height + theme->border_width + 5;
 	if (offset_x <= 0) {
 		offset_x = default_offset;

--- a/src/workspaces.c
+++ b/src/workspaces.c
@@ -64,7 +64,7 @@ parse_workspace_index(const char *name)
 static void
 _osd_update(void)
 {
-	struct theme *theme = server.theme;
+	struct theme *theme = rc.theme;
 
 	/* Settings */
 	uint16_t margin = 10;
@@ -117,7 +117,7 @@ _osd_update(void)
 			x = (width - marker_width) / 2;
 			wl_list_for_each(workspace, &server.workspaces.all, link) {
 				bool active =  workspace == server.workspaces.current;
-				set_cairo_color(cairo, server.theme->osd_label_text_color);
+				set_cairo_color(cairo, rc.theme->osd_label_text_color);
 				struct wlr_fbox fbox = {
 					.x = x,
 					.y = margin,
@@ -136,7 +136,7 @@ _osd_update(void)
 		}
 
 		/* Text */
-		set_cairo_color(cairo, server.theme->osd_label_text_color);
+		set_cairo_color(cairo, rc.theme->osd_label_text_color);
 		PangoLayout *layout = pango_cairo_create_layout(cairo);
 		pango_context_set_round_glyph_positions(pango_layout_get_context(layout), false);
 		pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);


### PR DESCRIPTION
Having two global pointers to the same struct is redundant.