### PR TITLE
decorations: fix accidental rename

### DIFF
--- a/include/decorations.h
+++ b/include/decorations.h
@@ -7,12 +7,12 @@ struct view;
 struct wlr_surface;
 
 void kde_server_decoration_init(void);
-void xdserver_decoration_init(void);
+void xdg_server_decoration_init(void);
 
 void kde_server_decoration_update_default(void);
 void kde_server_decoration_set_view(struct view *view, struct wlr_surface *surface);
 
 void kde_server_decoration_finish(void);
-void xdserver_decoration_finish(void);
+void xdg_server_decoration_finish(void);
 
 #endif /* LABWC_DECORATIONS_H */

--- a/src/decorations/xdg-deco.c
+++ b/src/decorations/xdg-deco.c
@@ -115,7 +115,7 @@ xdg_toplevel_decoration(struct wl_listener *listener, void *data)
 }
 
 void
-xdserver_decoration_init(void)
+xdg_server_decoration_init(void)
 {
 	struct wlr_xdg_decoration_manager_v1 *xdg_deco_mgr = NULL;
 	xdg_deco_mgr = wlr_xdg_decoration_manager_v1_create(server.wl_display);
@@ -130,7 +130,7 @@ xdserver_decoration_init(void)
 }
 
 void
-xdserver_decoration_finish(void)
+xdg_server_decoration_finish(void)
 {
 	wl_list_remove(&server.xdg_toplevel_decoration.link);
 }

--- a/src/server.c
+++ b/src/server.c
@@ -635,7 +635,7 @@ server_init(void)
 	seat_init();
 	xdg_shell_init();
 	kde_server_decoration_init();
-	xdserver_decoration_init();
+	xdg_server_decoration_init();
 
 	struct wlr_presentation *presentation = wlr_presentation_create(
 		server.wl_display, server.backend,
@@ -775,7 +775,7 @@ server_finish(void)
 	xdg_shell_finish();
 	layers_finish();
 	kde_server_decoration_finish();
-	xdserver_decoration_finish();
+	xdg_server_decoration_finish();
 	wl_list_remove(&server.new_constraint.link);
 	wl_list_remove(&server.output_power_manager_set_mode.link);
 	wl_list_remove(&server.tearing_new_object.link);


### PR DESCRIPTION
Mea culpa.

Fixes: 4f72e6775ea671cd07330a7a0b3039bd7d9e99aa
("tree-wide: rename g_server to just server")