### PR TITLE
Make labnag a meson feature flag

### DIFF
--- a/clients/meson.build
+++ b/clients/meson.build
@@ -1,59 +1,61 @@
-wayland_client = dependency('wayland-client')
-wayland_cursor = dependency('wayland-cursor')
+if get_option('labnag').allowed()
+  wayland_client = dependency('wayland-client')
+  wayland_cursor = dependency('wayland-cursor')
 
-nag_sources = files(
-  'labnag.c',
-  'pool-buffer.c',
-)
-
-wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
-
-protocols = [
-  wl_protocol_dir / 'stable/tablet/tablet-v2.xml',
-  wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
-  wl_protocol_dir / 'staging/cursor-shape/cursor-shape-v1.xml',
-  '../protocols/wlr-layer-shell-unstable-v1.xml',
-]
-
-foreach xml : protocols
-  nag_sources += custom_target(
-    xml.underscorify() + '_c',
-    input: xml,
-    output: '@BASENAME@-protocol.c',
-    command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+  nag_sources = files(
+    'labnag.c',
+    'pool-buffer.c',
   )
-  nag_sources += custom_target(
-    xml.underscorify() + '_client_h',
-    input: xml,
-    output: '@BASENAME@-client-protocol.h',
-    command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
-  )
-endforeach
 
-if host_machine.system() in ['freebsd', 'openbsd']
-  # For signalfd()
-  epoll_dep = dependency('epoll-shim')
-else
-  epoll_dep = []
+  wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
+
+  protocols = [
+    wl_protocol_dir / 'stable/tablet/tablet-v2.xml',
+    wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
+    wl_protocol_dir / 'staging/cursor-shape/cursor-shape-v1.xml',
+    '../protocols/wlr-layer-shell-unstable-v1.xml',
+  ]
+
+  foreach xml : protocols
+    nag_sources += custom_target(
+      xml.underscorify() + '_c',
+      input: xml,
+      output: '@BASENAME@-protocol.c',
+      command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+    )
+    nag_sources += custom_target(
+      xml.underscorify() + '_client_h',
+      input: xml,
+      output: '@BASENAME@-client-protocol.h',
+      command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+    )
+  endforeach
+
+  if host_machine.system() in ['freebsd', 'openbsd']
+    # For signalfd()
+    epoll_dep = dependency('epoll-shim')
+  else
+    epoll_dep = []
+  endif
+
+  executable(
+    'labnag',
+    nag_sources,
+    dependencies: [
+      cairo,
+      pangocairo,
+      glib,
+      wayland_client,
+      wayland_cursor,
+      wlroots,
+      server_protos,
+      epoll_dep,
+      xkbcommon,
+    ],
+    include_directories: [labwc_inc],
+    install: true,
+  )
 endif
-
-executable(
-  'labnag',
-  nag_sources,
-  dependencies: [
-    cairo,
-    pangocairo,
-    glib,
-    wayland_client,
-    wayland_cursor,
-    wlroots,
-    server_protos,
-    epoll_dep,
-    xkbcommon,
-  ],
-  include_directories: [labwc_inc],
-  install: true,
-)
 
 clients = files('lab-sensible-terminal')
 install_data(clients, install_dir: get_option('bindir'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,6 +2,7 @@ option('man-pages', type: 'feature', value: 'auto', description: 'Generate and i
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('svg', type: 'feature', value: 'enabled', description: 'Enable svg window buttons')
 option('icon', type: 'feature', value: 'enabled', description: 'Enable window icons')
+option('labnag', type: 'feature', value: 'auto', description: 'Build labnag notification daemon')
 option('nls', type: 'feature', value: 'auto', description: 'Enable native language support')
 option('static_analyzer', type: 'feature', value: 'disabled', description: 'Run gcc static analyzer')
 option('test', type: 'feature', value: 'disabled', description: 'Run tests')


### PR DESCRIPTION
Add a `labnag` meson option (type: feature, default: auto) to allow disabling the labnag notification daemon at build time.

### Motivation

As discussed in #3468, labnag uses `shm_open()` in `pool-buffer.c` which isn't available on Android (bionic). Rather than patching the shm implementation, making labnag optional is cleaner — embedded/headless deployments don't need it.

This also benefits other use cases like wayvnc-only hosts or nested-only settings where labnag isn't relevant.

### Usage

```sh
meson setup build -Dlabnag=disabled
```

Default is `auto` so existing builds are unaffected.

### Changes

- `meson_options.txt`: add `labnag` feature option
- `clients/meson.build`: wrap labnag build in `if get_option('labnag').allowed()`

Ref: #3468