### PR TITLE
keyboard: use XKB_CONTEXT_NO_SECURE_GETENV on Android

### DIFF
--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -745,7 +745,18 @@ set_layout(struct wlr_keyboard *kb)
 	static bool fallback_mode;
 
 	struct xkb_rule_names rules = { 0 };
-	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	enum xkb_context_flags ctx_flags = XKB_CONTEXT_NO_FLAGS;
+#ifdef __ANDROID__
+	/*
+	 * Android's bionic libc implements secure_getenv() as a function
+	 * that always returns NULL (the app process has no AT_SECURE).
+	 * This prevents xkbcommon from reading XKB_DEFAULT_LAYOUT and
+	 * friends via secure_getenv(). Use the flag to fall back to
+	 * regular getenv() which works fine on Android.
+	 */
+	ctx_flags |= XKB_CONTEXT_NO_SECURE_GETENV;
+#endif
+	struct xkb_context *context = xkb_context_new(ctx_flags);
 	struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
 		XKB_KEYMAP_COMPILE_NO_FLAGS);
 


### PR DESCRIPTION
On Android (bionic libc), `secure_getenv()` always returns NULL because app processes don't have `AT_SECURE` set. This prevents xkbcommon from reading `XKB_DEFAULT_LAYOUT` and other environment variables when resolving keyboard layouts via `set_layout()`.

Use `XKB_CONTEXT_NO_SECURE_GETENV` on Android so xkbcommon falls back to regular `getenv()`, which works correctly.

Guarded with `#ifdef __ANDROID__` so non-Android builds are unaffected.

Ref: #3468