### PR TITLE
Stop generating some wayland-protocols server headers

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -14,17 +14,6 @@ wayland_scanner_server = generator(
 )
 
 server_protocols = [
-	wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
-	wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
-	wl_protocol_dir / 'stable/tablet/tablet-v2.xml',
-	wl_protocol_dir / 'staging/cursor-shape/cursor-shape-v1.xml',
-	wl_protocol_dir / 'staging/drm-lease/drm-lease-v1.xml',
-	wl_protocol_dir / 'staging/xwayland-shell/xwayland-shell-v1.xml',
-	wl_protocol_dir / 'staging/tearing-control/tearing-control-v1.xml',
-	wl_protocol_dir / 'staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml',
-	wl_protocol_dir / 'staging/ext-workspace/ext-workspace-v1.xml',
-	wl_protocol_dir / 'staging/ext-image-capture-source/ext-image-capture-source-v1.xml',
-	wl_protocol_dir / 'staging/ext-image-copy-capture/ext-image-copy-capture-v1.xml',
 	'wlr-layer-shell-unstable-v1.xml',
 	'wlr-output-power-management-unstable-v1.xml',
 ]

--- a/src/server.c
+++ b/src/server.c
@@ -42,7 +42,6 @@
 
 #if HAVE_XWAYLAND
 #include <wlr/xwayland.h>
-#include "xwayland-shell-v1-protocol.h"
 #endif
 
 #include "action.h"
@@ -308,7 +307,11 @@ server_global_filter(const struct wl_client *client, const struct wl_global *glo
 		? server.xwayland->server->client
 		: NULL;
 
-	if (client != xwayland_client && !strcmp(iface->name, xwayland_shell_v1_interface.name)) {
+	/*
+	 * The interface name `xwayland_shell_v1_interface.name` is hard-coded
+	 * here to avoid generating and including `xwayland-shell-v1-protocol.h`
+	 */
+	if (client != xwayland_client && !strcmp(iface->name, "xwayland_shell_v1")) {
 		/* Filter out the xwayland shell for usual clients */
 		return false;
 	}


### PR DESCRIPTION
We still need to generate wlr-protocols server headers, as well as client headers and code.

References:
- https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5075
- https://github.com/swaywm/sway/pull/8838