### PR TITLE
server: allow external renderer and allocator on Android

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -502,7 +502,17 @@ server_init(void)
 	 * The renderer is responsible for defining the various pixel formats it
 	 * supports for shared memory, this configures that for clients.
 	 */
-	server.renderer = wlr_renderer_autocreate(server.backend);
+#ifdef __ANDROID__
+	/* Android: accept externally created renderer (e.g. GLES2 via
+	 * eglGetDisplay + wlr_egl_create_with_context) */
+	extern struct wlr_renderer *android_renderer;
+	if (android_renderer) {
+		server.renderer = android_renderer;
+	} else
+#endif
+	{
+		server.renderer = wlr_renderer_autocreate(server.backend);
+	}
 	if (!server.renderer) {
 		wlr_log(WLR_ERROR, "unable to create renderer");
 		exit(EXIT_FAILURE);
@@ -541,8 +551,16 @@ server_init(void)
 	 * the renderer and the backend. It handles the buffer creation,
 	 * allowing wlroots to render onto the screen
 	 */
-	server.allocator = wlr_allocator_autocreate(
-		server.backend, server.renderer);
+#ifdef __ANDROID__
+	extern struct wlr_allocator *android_allocator;
+	if (android_allocator) {
+		server.allocator = android_allocator;
+	} else
+#endif
+	{
+		server.allocator = wlr_allocator_autocreate(
+			server.backend, server.renderer);
+	}
 	if (!server.allocator) {
 		wlr_log(WLR_ERROR, "unable to create allocator");
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
On Android, `wlr_renderer_autocreate()` and `wlr_allocator_autocreate()` fail because there is no DRM subsystem. Android apps create EGL contexts via `eglGetDisplay(EGL_DEFAULT_DISPLAY)` and provide GPU buffers via `AHardwareBuffer`.

This adds hooks guarded by `#ifdef __ANDROID__` that check for externally provided renderer/allocator globals before falling back to autocreate. The JNI bridge can then:

1. Create an EGL context via Android's native EGL
2. Wrap it via `wlr_egl_create_with_context()`
3. Create a GLES2 renderer via `wlr_gles2_renderer_create()`
4. Provide a custom allocator (e.g. AHardwareBuffer-based)

The globals (`android_renderer`, `android_allocator`) are declared `extern` and only referenced when `__ANDROID__` is defined — no impact on non-Android builds.

Tested on Pixel 8 Pro: EGL 1.5, Mali-G715, OpenGL ES 3.2. The GLES2 renderer creates successfully through this path.

Context: https://github.com/GlassOnTin/Haven/issues/47

Follows on from #3473 and #3474 (both merged).