### PR TITLE
Drop wl_drm

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -10,7 +10,6 @@
 #include <wlr/types/wlr_alpha_modifier_v1.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_data_device.h>
-#include <wlr/types/wlr_drm.h>
 #include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_ext_data_control_v1.h>
@@ -516,11 +515,7 @@ server_init(void)
 		exit(EXIT_FAILURE);
 	}
 
-	if (wlr_renderer_get_texture_formats(
-			server.renderer, WLR_BUFFER_CAP_DMABUF)) {
-		if (wlr_renderer_get_drm_fd(server.renderer) >= 0) {
-			wlr_drm_create(server.wl_display, server.renderer);
-		}
+	if (wlr_renderer_get_texture_formats(server.renderer, WLR_BUFFER_CAP_DMABUF)) {
 		server.linux_dmabuf = wlr_linux_dmabuf_v1_create_with_renderer(
 			server.wl_display,
 			LAB_WLR_LINUX_DMABUF_VERSION,


### PR DESCRIPTION
Xwayland + VA-API + amdvlk now all support linux-dmabuf-v1.

Ref:
- https://github.com/swaywm/sway/pull/8247


Note for @Consolatis: Possibly linked to #3470