### PR TITLE
config: migrate from amixer to pactl

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ If you have not created an rc.xml config file, default bindings will be:
 | `super`-`mouse-right`    | resize window
 | `super`-`arrow`          | resize window to fill half the output
 | `alt`-`space`            | show the window menu
-| `XF86AudioLowerVolume`   | amixer sset Master 5%-
-| `XF86AudioRaiseVolume`   | amixer sset Master 5%+
-| `XF86AudioMute`          | amixer sset Master toggle
+| `XF86AudioLowerVolume`   | pactl set-sink-volume @DEFAULT_SINK@ -5%
+| `XF86AudioRaiseVolume`   | pactl set-sink-volume @DEFAULT_SINK@ +5%
+| `XF86AudioMute`          | pactl set-sink-mute @DEFAULT_SINK@ toggle
 | `XF86MonBrightnessUp`    | brightnessctl set +10%
 | `XF86MonBrightnessDown`  | brightnessctl set 10%-
 

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -845,7 +845,7 @@ References:
   A-Space - show window menu
 ```
 
-	Audio and MonBrightness keys are also bound to amixer and
+	Audio and MonBrightness keys are also bound to pactl and
 	brightnessctl, respectively.
 
 *<keyboard><repeatRate>*

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -292,13 +292,13 @@
       <action name="ShowMenu" menu="client-menu" atCursor="no" />
     </keybind>
     <keybind key="XF86AudioLowerVolume">
-      <action name="Execute" command="amixer sset Master 5%-" />
+      <action name="Execute" command="pactl set-sink-volume @DEFAULT_SINK@ -5%" />
     </keybind>
     <keybind key="XF86AudioRaiseVolume">
-      <action name="Execute" command="amixer sset Master 5%+" />
+      <action name="Execute" command="pactl set-sink-volume @DEFAULT_SINK@ +5%" />
     </keybind>
     <keybind key="XF86AudioMute">
-      <action name="Execute" command="amixer sset Master toggle" />
+      <action name="Execute" command="pactl set-sink-mute @DEFAULT_SINK@ toggle" />
     </keybind>
     <keybind key="XF86MonBrightnessUp">
       <action name="Execute" command="brightnessctl set +10%" />

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -88,21 +88,21 @@ static struct key_combos {
 		.action = "Execute",
 		.attributes[0] = {
 			.name = "command",
-			.value = "amixer sset Master 5%-",
+			.value = "pactl set-sink-volume @DEFAULT_SINK@ -5%",
 		},
 	}, {
 		.binding = "XF86AudioRaiseVolume",
 		.action = "Execute",
 		.attributes[0] = {
 			.name = "command",
-			.value = "amixer sset Master 5%+",
+			.value = "pactl set-sink-volume @DEFAULT_SINK@ +5%",
 		},
 	}, {
 		.binding = "XF86AudioMute",
 		.action = "Execute",
 		.attributes[0] = {
 			.name = "command",
-			.value = "amixer sset Master toggle",
+			.value = "pactl set-sink-mute @DEFAULT_SINK@ toggle",
 		},
 	}, {
 		.binding = "XF86MonBrightnessUp",


### PR DESCRIPTION
As suggested in https://github.com/labwc/labwc/discussions/3478. Another alternative to `amixer`/`pactl` would be `wpctl`, from WirePlumber, but `pactl` probably covers a wider range of users.
