### PR TITLE
config: remove the underline from the XF86 keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ If you have not created an rc.xml config file, default bindings will be:
 | `XF86_AudioLowerVolume`  | amixer sset Master 5%-
 | `XF86_AudioRaiseVolume`  | amixer sset Master 5%+
 | `XF86_AudioMute`         | amixer sset Master toggle
-| `XF86_MonBrightnessUp`   | brightnessctl set +10%
-| `XF86_MonBrightnessDown` | brightnessctl set 10%-
+| `XF86MonBrightnessUp`    | brightnessctl set +10%
+| `XF86MonBrightnessDown`  | brightnessctl set 10%-
 
 A root-menu can be opened by clicking on the desktop.
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -300,10 +300,10 @@
     <keybind key="XF86_AudioMute">
       <action name="Execute" command="amixer sset Master toggle" />
     </keybind>
-    <keybind key="XF86_MonBrightnessUp">
+    <keybind key="XF86MonBrightnessUp">
       <action name="Execute" command="brightnessctl set +10%" />
     </keybind>
-    <keybind key="XF86_MonBrightnessDown">
+    <keybind key="XF86MonBrightnessDown">
       <action name="Execute" command="brightnessctl set 10%-" />
     </keybind>
   <!-- SnapToRegion via W-Numpad -->

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -105,14 +105,14 @@ static struct key_combos {
 			.value = "amixer sset Master toggle",
 		},
 	}, {
-		.binding = "XF86_MonBrightnessUp",
+		.binding = "XF86MonBrightnessUp",
 		.action = "Execute",
 		.attributes[0] = {
 			.name = "command",
 			.value = "brightnessctl set +10%",
 		},
 	}, {
-		.binding = "XF86_MonBrightnessDown",
+		.binding = "XF86MonBrightnessDown",
 		.action = "Execute",
 		.attributes[0] = {
 			.name = "command",


### PR DESCRIPTION
...to match the actual key names in https://github.com/xkbcommon/libxkbcommon/blob/48500df7160d0ec6278dfcec0665a7907cfdf302/include/xkbcommon/xkbcommon-keysyms.h#L2583
