### PR TITLE
input: fix tablet tool tilt motion

### DIFF
--- a/src/input/tablet.c
+++ b/src/input/tablet.c
@@ -431,8 +431,6 @@ handle_tablet_tool_axis(struct wl_listener *listener, void *data)
 	 */
 	tool->dx = 0;
 	tool->dy = 0;
-	tool->tilt_x = 0;
-	tool->tilt_y = 0;
 
 	if (ev->updated_axes & WLR_TABLET_TOOL_AXIS_X) {
 		tool->x = ev->x;


### PR DESCRIPTION
Tilt axis are not relative.

~Stilt draft because awaiting confirmation about tilt i.c.w. rotation.~ This should be good, including setups that use rotation.

Closes #3492 