### PR TITLE
[Feature] Override view inhibition for individual keybinds

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -760,7 +760,8 @@ References:
 	Stores the keyboard layout either globally or per window and restores
 	it when switching back to the window. Default is global.
 
-*<keyboard><keybind key="" layoutDependent="" onRelease="" allowWhenLocked="">*
+*<keyboard><keybind key="" layoutDependent="" onRelease="" allowWhenLocked=""
+overrideInhibition="">*
 	Define a *key* binding in the format *modifier-key*, where supported
 	modifiers are:
 	- S (shift)
@@ -807,6 +808,11 @@ References:
 
 	*allowWhenLocked* [yes|no]
 	Make this keybind work even if the screen is locked. Default is no.
+
+	*overrideInhibition* [yes|no]
+	Make this keybind work even if the view inhibits keybinds. Default is no.
+	This can be used to prevent W-Tab and similar keybinds from being
+	delivered to Virtual Machines, VNC clients or nested compositors.
 
 	*onRelease* [yes|no]
 	When yes, fires the keybind action when the key or key

--- a/include/config/keybind.h
+++ b/include/config/keybind.h
@@ -23,6 +23,7 @@ struct keybind {
 	struct wl_list actions;  /* struct action.link */
 	struct wl_list link;     /* struct rcxml.keybinds */
 	bool on_release;
+	bool override_inhibition;
 };
 
 /**

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -602,6 +602,7 @@ fill_keybind(xmlNode *node)
 	lab_xml_get_bool(node, "onRelease", &keybind->on_release);
 	lab_xml_get_bool(node, "layoutDependent", &keybind->use_syms_only);
 	lab_xml_get_bool(node, "allowWhenLocked", &keybind->allow_when_locked);
+	lab_xml_get_bool(node, "overrideInhibition", &keybind->override_inhibition);
 
 	append_parsed_actions(node, &keybind->actions);
 }
@@ -1706,6 +1707,8 @@ deduplicate_key_bindings(void)
 			wl_list_remove(&current->link);
 			keybind_destroy(current);
 			cleared++;
+		} else if (actions_contain_toggle_keybinds(&current->actions)) {
+			current->override_inhibition = true;
 		}
 	}
 	if (replaced) {

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -203,8 +203,10 @@ match_keybinding_for_sym(uint32_t modifiers,
 		if (modifiers ^ keybind->modifiers) {
 			continue;
 		}
-		if (view_inhibits_actions(server.active_view, &keybind->actions)) {
-			continue;
+		if (!(keybind->override_inhibition)) {
+			if (view_inhibits_actions(server.active_view, &keybind->actions)) {
+				continue;
+			}
 		}
 		if (sym == XKB_KEY_NoSymbol) {
 			/* Use keycodes */


### PR DESCRIPTION
When working with virtual machines, VNC clients, etc, all keybinds are delivered to the view (for obvious reasons). For certain keybinds, (i.e. `XF86AudioMute`, or even `W-Tab`) that might not make sense. Currently, the solution is to bind the `ToggleKeybinds` action and then use that to switch all keybinds between labwc and the view (VNC / VM / other).

This adds a new `overrideInhibition` flag to `keyboard.keybinds` to make the above scenario easier for certain keybinds: When set, the keybind is always delivered to the compositor, not the view.