### PR TITLE
focus: add raiseOnFocusDelay option

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -493,6 +493,13 @@ this is for compatibility with Openbox.
 *<focus><raiseOnFocus>* [yes|no]
 	Raise window to top when focused. Default is no.
 
+*<focus><raiseOnFocusDelay>* [milliseconds]
+	When raiseOnFocus is enabled, delay the actual raise by this many
+	milliseconds. Default is 0 (raise immediately). A subsequent focus
+	change before the timer elapses restarts or cancels the pending raise.
+	Useful together with followMouse to avoid brief passes of the cursor
+	stacking up z-order changes.
+
 ## WINDOW SNAPPING
 
 Windows may be "snapped" to an edge or user-defined region of an output when

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -158,6 +158,8 @@
     <followMouse>no</followMouse>
     <followMouseRequiresMovement>yes</followMouseRequiresMovement>
     <raiseOnFocus>no</raiseOnFocus>
+    <!-- Delay (ms) before applying raise-on-focus. 0 = immediate. -->
+    <raiseOnFocusDelay>0</raiseOnFocusDelay>
   </focus>
 
   <snapping>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -90,6 +90,7 @@ struct rcxml {
 	bool focus_follow_mouse;
 	bool focus_follow_mouse_requires_movement;
 	bool raise_on_focus;
+	uint32_t raise_on_focus_delay_ms;
 
 	/* theme */
 	char *theme_name;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -150,6 +150,11 @@ struct seat {
 struct server {
 	struct wl_display *wl_display;
 	struct wl_event_loop *wl_event_loop;  /* Can be used for timer events */
+
+	/* Pending auto-raise timer (used when rc.raise_on_focus_delay_ms > 0) */
+	struct view *pending_auto_raise_view;
+	struct wl_event_source *pending_auto_raise_timer;
+
 	struct wlr_renderer *renderer;
 	struct wlr_allocator *allocator;
 	struct wlr_backend *backend;
@@ -342,6 +347,13 @@ void xdg_shell_finish(void);
  * session is locked; it will simply do nothing.
  */
 void desktop_focus_view(struct view *view, bool raise);
+
+/**
+ * desktop_cancel_pending_auto_raise() - cancel any pending delayed auto-raise
+ * (from raiseOnFocusDelay). Called when a view is being destroyed, on config
+ * reload, or when a new focus change with raise=false supersedes the pending.
+ */
+void desktop_cancel_pending_auto_raise(void);
 
 /**
  * desktop_focus_view_or_surface() - like desktop_focus_view() but can

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1185,6 +1185,9 @@ entry(xmlNode *node, char *nodename, char *content)
 		set_bool(content, &rc.focus_follow_mouse_requires_movement);
 	} else if (!strcasecmp(nodename, "raiseOnFocus.focus")) {
 		set_bool(content, &rc.raise_on_focus);
+	} else if (!strcasecmp(nodename, "raiseOnFocusDelay.focus")) {
+		long val = strtol(content, NULL, 10);
+		rc.raise_on_focus_delay_ms = val > 0 ? (uint32_t)val : 0;
 	} else if (!strcasecmp(nodename, "doubleClickTime.mouse")) {
 		long doubleclick_time_parsed = strtol(content, NULL, 10);
 		if (doubleclick_time_parsed > 0) {
@@ -1520,6 +1523,7 @@ rcxml_init(void)
 	rc.focus_follow_mouse = false;
 	rc.focus_follow_mouse_requires_movement = true;
 	rc.raise_on_focus = false;
+	rc.raise_on_focus_delay_ms = 0;
 
 	rc.doubleclick_time = 500;
 

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include "common/scene-helpers.h"
+#include "config/rcxml.h"
 #include "dnd.h"
 #include "labwc.h"
 #include "layers.h"
@@ -65,6 +66,49 @@ set_or_offer_focus(struct view *view)
 	}
 }
 
+static int
+handle_auto_raise_timer(void *data)
+{
+	(void)data;
+	struct view *view = server.pending_auto_raise_view;
+	server.pending_auto_raise_view = NULL;
+
+	if (view && view->mapped) {
+		view_move_to_front(view);
+	}
+	return 0; /* ignored per wl_event_loop docs */
+}
+
+void
+desktop_cancel_pending_auto_raise(void)
+{
+	server.pending_auto_raise_view = NULL;
+	if (server.pending_auto_raise_timer) {
+		/* Disarm by setting to 0 ms */
+		wl_event_source_timer_update(server.pending_auto_raise_timer, 0);
+	}
+}
+
+static void
+schedule_auto_raise(struct view *view)
+{
+	if (rc.raise_on_focus_delay_ms == 0) {
+		/* Immediate raise — preserves original behavior */
+		desktop_cancel_pending_auto_raise();
+		view_move_to_front(view);
+		return;
+	}
+
+	server.pending_auto_raise_view = view;
+	if (!server.pending_auto_raise_timer) {
+		server.pending_auto_raise_timer =
+			wl_event_loop_add_timer(server.wl_event_loop,
+				handle_auto_raise_timer, NULL);
+	}
+	wl_event_source_timer_update(server.pending_auto_raise_timer,
+		rc.raise_on_focus_delay_ms);
+}
+
 void
 desktop_focus_view(struct view *view, bool raise)
 {
@@ -104,7 +148,13 @@ desktop_focus_view(struct view *view, bool raise)
 	}
 
 	if (raise) {
-		view_move_to_front(view);
+		schedule_auto_raise(view);
+	} else {
+		/*
+		 * A new focus change without a raise supersedes any
+		 * pending auto-raise from a previous focus event.
+		 */
+		desktop_cancel_pending_auto_raise();
 	}
 
 	/*

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -90,15 +90,8 @@ desktop_cancel_pending_auto_raise(void)
 }
 
 static void
-schedule_auto_raise(struct view *view)
+schedule_delayed_auto_raise(struct view *view)
 {
-	if (rc.raise_on_focus_delay_ms == 0) {
-		/* Immediate raise — preserves original behavior */
-		desktop_cancel_pending_auto_raise();
-		view_move_to_front(view);
-		return;
-	}
-
 	server.pending_auto_raise_view = view;
 	if (!server.pending_auto_raise_timer) {
 		server.pending_auto_raise_timer =
@@ -109,8 +102,15 @@ schedule_auto_raise(struct view *view)
 		rc.raise_on_focus_delay_ms);
 }
 
-void
-desktop_focus_view(struct view *view, bool raise)
+/*
+ * The raise_on_focus_delay is only meant to dampen z-order churn from
+ * focus-follows-mouse cursor passes. Explicit focus changes (alt-tab,
+ * Focus action, xdg/xwayland activation, etc.) should raise immediately.
+ * allow_delay is therefore only set when the caller is the sloppy-focus
+ * path in desktop_focus_view_or_surface().
+ */
+static void
+desktop_focus_view_internal(struct view *view, bool raise, bool allow_delay)
 {
 	assert(view);
 	/*
@@ -147,14 +147,17 @@ desktop_focus_view(struct view *view, bool raise)
 		workspaces_switch_to(view->workspace, /*update_focus*/ false);
 	}
 
+	/*
+	 * A new focus change supersedes any pending auto-raise from a
+	 * previous focus event, regardless of whether we raise now.
+	 */
+	desktop_cancel_pending_auto_raise();
 	if (raise) {
-		schedule_auto_raise(view);
-	} else {
-		/*
-		 * A new focus change without a raise supersedes any
-		 * pending auto-raise from a previous focus event.
-		 */
-		desktop_cancel_pending_auto_raise();
+		if (allow_delay && rc.raise_on_focus_delay_ms > 0) {
+			schedule_delayed_auto_raise(view);
+		} else {
+			view_move_to_front(view);
+		}
 	}
 
 	/*
@@ -168,6 +171,12 @@ desktop_focus_view(struct view *view, bool raise)
 	show_desktop_reset();
 }
 
+void
+desktop_focus_view(struct view *view, bool raise)
+{
+	desktop_focus_view_internal(view, raise, /*allow_delay*/ false);
+}
+
 /* TODO: focus layer-shell surfaces also? */
 void
 desktop_focus_view_or_surface(struct seat *seat, struct view *view,
@@ -175,7 +184,7 @@ desktop_focus_view_or_surface(struct seat *seat, struct view *view,
 {
 	assert(view || surface);
 	if (view) {
-		desktop_focus_view(view, raise);
+		desktop_focus_view_internal(view, raise, /*allow_delay*/ true);
 #if HAVE_XWAYLAND
 	} else {
 		struct wlr_xwayland_surface *xsurface =

--- a/src/server.c
+++ b/src/server.c
@@ -89,6 +89,12 @@ reload_config_and_theme(void)
 	/* Avoid UAF when dialog client is used during reconfigure */
 	action_prompts_destroy();
 
+	/*
+	 * Cancel any pending auto-raise before reloading config in case the
+	 * raiseOnFocusDelay option was disabled or changed.
+	 */
+	desktop_cancel_pending_auto_raise();
+
 	scaled_buffer_invalidate_sharing();
 	rcxml_finish();
 	rcxml_read(rc.config_file);

--- a/src/view.c
+++ b/src/view.c
@@ -2521,6 +2521,10 @@ view_destroy(struct view *view)
 		server.active_view = NULL;
 	}
 
+	if (server.pending_auto_raise_view == view) {
+		desktop_cancel_pending_auto_raise();
+	}
+
 	if (server.session_lock_manager->last_active_view == view) {
 		server.session_lock_manager->last_active_view = NULL;
 	}


### PR DESCRIPTION
Adds `<focus><raiseOnFocusDelay> (ms)`. Every WM I've ever used had this feature, so it was quite surprising to me this feature was missing.

It defers raise-on-focus by that amount; zero or unset keeps the current behaviour. Use case is followMouse=yes + raiseOnFocus=yes, where a brief cursor pass over an intermediate window causes a raise that was never intended — a small delay (I run 500ms) lets the cursor settle on  the target first. 

Related to but not the same as #688, which is about focus delay. This PR is about the auto-raise.

The pending state is a single slot on `struct server` (view pointer + `wl_event_source_timer`). Any new focus change supersedes the previous one: raise=true reschedules, raise=false cancels. View destroy cancels to avoid a dangling pointer at timer fire, and config reload cancels in case the feature was just turned off. Timer is reused across reschedules via `wl_event_source_timer_update`, same pattern as the configure-timeout in `xdg.c`.

Split into six small commits for bisect-ability. Been running on my daily driver (0.9.6 + these patches) for a bit, works as expected.