### PR TITLE
session: ship and activate labwc-session.target

### DIFF
--- a/data/labwc-session.target
+++ b/data/labwc-session.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=labwc session
+Documentation=man:labwc(1) man:systemd.special(7)
+BindsTo=graphical-session.target
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target

--- a/docs/autostart
+++ b/docs/autostart
@@ -1,5 +1,13 @@
 # Example autostart file
 
+# When running under systemd, uncomment the systemctl line below to pull in
+# graphical-session.target via labwc-session.target. This lets systemd user
+# services declaring WantedBy=graphical-session.target (panels, portals,
+# notification daemons, etc.) start in sync with the labwc session. Enable
+# individual services with: systemctl --user enable <unit>
+#
+# systemctl --user --no-block start labwc-session.target
+
 # Set background color.
 swaybg -c '#113344' >/dev/null 2>&1 &
 

--- a/docs/labwc.1.scd
+++ b/docs/labwc.1.scd
@@ -118,6 +118,25 @@ this is accomplished by setting the session variables to empty strings. For
 systemd, the command `systemctl --user unset-environment` will be invoked to
 actually remove the variables from the activation environment.
 
+A systemd user unit named `labwc-session.target` is also shipped alongside
+the compositor for users who want to integrate labwc with systemd. It binds
+to the standard `graphical-session.target`, so systemd user services can
+start and stop in sync with the labwc session when they declare a WantedBy
+or PartOf relationship to that target. Labwc does not activate the target
+itself; users opt in by adding lines like the following to their
+*autostart* and *shutdown* files:
+
+```
+systemctl --user --no-block start labwc-session.target
+systemctl --user stop graphical-session.target
+```
+
+The example *autostart* and *shutdown* files shipped with labwc include
+these commented out. To have a user service automatically started with
+the session, enable it so the corresponding symlink under the
+graphical-session.target.wants directory exists, for example by running
+"systemctl --user enable dms.service".
+
 # ENVIRONMENT VARIABLES
 
 Set the environment variables listed below to enable specific debug options.

--- a/docs/shutdown
+++ b/docs/shutdown
@@ -3,3 +3,11 @@
 # This file is executed as a shell script when labwc is preparing to terminate
 # itself.
 # For further details see labwc-config(5).
+
+# When running under systemd, uncomment the systemctl line below to tear down
+# graphical-session.target (which cascades to labwc-session.target via
+# BindsTo, and to any service declaring PartOf=graphical-session.target).
+# Running synchronously here ensures those services are stopped before the
+# Wayland socket goes away, avoiding "Broken pipe" failures on teardown.
+#
+# systemctl --user stop graphical-session.target

--- a/meson.build
+++ b/meson.build
@@ -211,6 +211,15 @@ install_data('data/labwc.desktop', install_dir: get_option('datadir') / 'wayland
 
 install_data('data/labwc-portals.conf', install_dir: get_option('datadir') / 'xdg-desktop-portal')
 
+# Install labwc-session.target so that systemd user services with
+# WantedBy=graphical-session.target start under labwc. Labwc activates
+# this target itself in src/config/session.c on autostart.
+systemd = dependency('systemd', required: false)
+if systemd.found()
+  install_data('data/labwc-session.target',
+    install_dir: systemd.get_variable('systemduserunitdir'))
+endif
+
 icons = ['labwc-symbolic.svg', 'labwc.svg']
 foreach icon : icons
   icon_path = join_paths('data', icon)

--- a/meson.build
+++ b/meson.build
@@ -212,9 +212,11 @@ install_data('data/labwc.desktop', install_dir: get_option('datadir') / 'wayland
 install_data('data/labwc-portals.conf', install_dir: get_option('datadir') / 'xdg-desktop-portal')
 
 # Install labwc-session.target so that systemd user services with
-# WantedBy=graphical-session.target start under labwc. Labwc activates
-# this target itself in src/config/session.c on autostart.
-systemd = dependency('systemd', required: false)
+# WantedBy=graphical-session.target can be started and stopped in sync
+# with a labwc session (see labwc(1) SESSION MANAGEMENT for the opt-in
+# autostart/shutdown snippet).
+systemd_feat = get_option('systemd-session')
+systemd = dependency('systemd', required: systemd_feat)
 if systemd.found()
   install_data('data/labwc-session.target',
     install_dir: systemd.get_variable('systemduserunitdir'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,7 @@ option('svg', type: 'feature', value: 'enabled', description: 'Enable svg window
 option('icon', type: 'feature', value: 'enabled', description: 'Enable window icons')
 option('labnag', type: 'feature', value: 'auto', description: 'Build labnag notification daemon')
 option('nls', type: 'feature', value: 'auto', description: 'Enable native language support')
+option('systemd-session', type: 'feature', value: 'auto', description: 'Install labwc-session.target systemd user unit')
 option('static_analyzer', type: 'feature', value: 'disabled', description: 'Run gcc static analyzer')
 option('test', type: 'feature', value: 'disabled', description: 'Run tests')
 option('sections', type: 'feature', value: 'disabled', description: 'Show unused functions')


### PR DESCRIPTION
Ships a tiny `labwc-session.target` (same shape as `miracle-wm-session.target`). Lets `WantedBy=graphical-session.target` services actually come up under labwc without needing uwsm or a hand-rolled wrapper.

Rationale: I am using dms with labwc, and the `dms.service` would never start. With other compositors under dms, it did work. Turned out that the `graphical-session.target` is never reached. 