### PR TITLE
Skip switcher state when osd.show=no

### DIFF
--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -145,6 +145,10 @@ Actions are used in menus and keyboard/mouse bindings.
 	This determines whether to cycle through all windows or only windows of the
 	same application as the currently focused window. Default is "all".
 
+	*immediate* [yes|no]
+	This determines whether the switch happens immediately, useful when bound to
+	a key without modifier. Default is "no".
+
 *<action name="Reconfigure" />*
 	Re-load configuration and theme files.
 

--- a/src/action.c
+++ b/src/action.c
@@ -1150,6 +1150,15 @@ run_action(struct view *view, struct action *action,
 			if (action_get_bool(action, "immediate", false)) {
 				cycle_finish(true);
 				if (view && dir == LAB_CYCLE_DIR_FORWARD) {
+					/*
+					 * With immediate=no, running NextWindow just
+					 * once places the previously selected view
+					 * second from the top, causing the next call
+					 * to select it again. For immediate=yes, to
+					 * prevent getting stuck between the topmost
+					 * two views, we move the previously selected
+					 * view to the bottom.
+					 */
 					view_move_to_back(view);
 				}
 			}

--- a/src/action.c
+++ b/src/action.c
@@ -372,6 +372,10 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			}
 			goto cleanup;
 		}
+		if (!strcasecmp(argument, "immediate")) {
+			action_arg_add_bool(action, argument, parse_bool(content, false));
+			goto cleanup;
+		}
 		break;
 	case ACTION_TYPE_SHOW_MENU:
 		if (!strcmp(argument, "menu")) {
@@ -1143,7 +1147,7 @@ run_action(struct view *view, struct action *action,
 			cycle_step(dir);
 		} else {
 			cycle_begin(dir, filter);
-			if (!rc.window_switcher.osd.show) {
+			if (action_get_bool(action, "immediate", false)) {
 				cycle_finish(true);
 				if (view && dir == LAB_CYCLE_DIR_FORWARD) {
 					view_move_to_back(view);

--- a/src/action.c
+++ b/src/action.c
@@ -1143,6 +1143,12 @@ run_action(struct view *view, struct action *action,
 			cycle_step(dir);
 		} else {
 			cycle_begin(dir, filter);
+			if (!rc.window_switcher.osd.show) {
+				cycle_finish(true);
+				if (view && dir == LAB_CYCLE_DIR_FORWARD) {
+					view_move_to_back(view);
+				}
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
fixes #3535 
Should we just skip the state (the border around the selected window, waiting for the modifier release) when `osd.show = no`?
I think this is closer to what is expected when turning osd off, i don't use it, but i makes sense to me.
When switching forward i had to send the current view to back so it doesn't get stuck cycling the same 2 windows.

If this is to be merged, does it need an update to docs too?
currently:
`show [yes|no] Draw the OnScreenDisplay when switching between windows. Default is yes.`
