### PR TITLE
Add onbutton scrollMethod, scrollButton

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -1140,6 +1140,7 @@ Note: To rotate touch events with output rotation, use the libinput
     <disableWhileTyping></disableWhileTyping>
     <clickMethod></clickMethod>
     <scrollMethod></scrollMethod>
+    <scrollButton></scrollButton>
     <sendEventsMode></sendEventsMode>
     <calibrationMatrix></calibrationMatrix>
     <scrollFactor>1.0</scrollFactor>
@@ -1244,18 +1245,23 @@ Note: To rotate touch events with output rotation, use the libinput
 
 	The default method depends on the touchpad hardware.
 
-*<libinput><device><scrollMethod>* [none|twofinger|edge]
-	Configure the method by which physical movements on a touchpad are
-	mapped to scroll events.
+*<libinput><device><scrollMethod>* [none|twofinger|edge|onbutton]
+	Configure the method by which physical movements are mapped to scroll events.
 
 	The scroll methods available are:
 	- *twofinger* - Scroll by two fingers being placed on the surface of the
 	  touchpad, then moving those fingers vertically or horizontally.
 	- *edge* - Scroll by moving a single finger along the right edge
 	  (vertical scroll) or bottom edge (horizontal scroll).
+	- *onbutton* - Scroll by pressing a button.
 	- *none* - No scroll events will be produced.
 
 	The default method depends on the touchpad hardware.
+
+*<libinput><device><scrollButton>* [button]
+	Set the button used for the *onbutton* scroll method.
+
+	*button* is the decimal form of a value from `linux/input-event-codes.h`.
 
 *<libinput><device><sendEventsMode>* [yes|no|disabledOnExternalMouse]
 	Optionally enable or disable sending any device events.

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -592,7 +592,7 @@
       - accelProfile [flat|adaptive]
       - tapButtonMap [lrm|lmr]
       - clickMethod [none|buttonAreas|clickfinger]
-      - scrollMethod [twoFinger|edge|none]
+      - scrollMethod [twoFinger|edge|onbutton|none]
       - sendEventsMode [yes|no|disabledOnExternalMouse]
       - calibrationMatrix [six float values split by space]
       - scrollFactor [float]
@@ -618,6 +618,7 @@
       <!-- <disableWhileTyping>yes</disableWhileTyping> -->
       <!-- <clickMethod>buttonAreas</clickMethod> -->
       <!-- <scrollMethod>twofinger</scrollMethod> -->
+      <!-- <scrollButton>274</scrollButton> -->
       <!-- <sendEventsMode>yes</sendEventsMode> -->
       <!-- <calibrationMatrix>1 0 0 0 1 0</calibrationMatrix> -->
       <scrollFactor>1.0</scrollFactor>

--- a/include/config/libinput.h
+++ b/include/config/libinput.h
@@ -31,6 +31,7 @@ struct libinput_category {
 	int dwt;                        /* -1 or libinput_config_dwt_state */
 	int click_method;               /* -1 or libinput_config_click_method */
 	int scroll_method;              /* -1 or libinput_config_scroll_method */
+	int scroll_button;              /* -1 or a button from linux/input_event_codes.h */
 	int send_events_mode;           /* -1 or libinput_config_send_events_mode */
 	bool have_calibration_matrix;
 	double scroll_factor;

--- a/src/config/libinput.c
+++ b/src/config/libinput.c
@@ -25,6 +25,7 @@ libinput_category_init(struct libinput_category *l)
 	l->dwt = -1;
 	l->click_method = -1;
 	l->scroll_method = -1;
+	l->scroll_button = -1;
 	l->send_events_mode = -1;
 	l->have_calibration_matrix = false;
 	l->scroll_factor = 1.0;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -891,8 +891,18 @@ fill_libinput_category(xmlNode *node)
 			} else if (!strcasecmp(content, "twofinger")) {
 				category->scroll_method =
 					LIBINPUT_CONFIG_SCROLL_2FG;
+			} else if (!strcasecmp(content, "onbutton")) {
+				category->scroll_method =
+					LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN;
 			} else {
 				wlr_log(WLR_ERROR, "invalid scrollMethod");
+			}
+		} else if (!strcasecmp(key, "scrollButton")) {
+			int button = atoi(content);
+			if (button != 0) {
+				category->scroll_button = button;
+			} else {
+				wlr_log(WLR_ERROR, "invalid scrollButton");
 			}
 		} else if (!strcasecmp(key, "sendEventsMode")) {
 			category->send_events_mode =

--- a/src/seat.c
+++ b/src/seat.c
@@ -328,6 +328,16 @@ configure_libinput(struct wlr_input_device *wlr_input_device)
 		libinput_device_config_scroll_set_method(libinput_dev, dc->scroll_method);
 	}
 
+	libinput_device_config_scroll_set_button(libinput_dev,
+		libinput_device_config_scroll_get_default_button(libinput_dev));
+	if (dc->scroll_button < 0) {
+		wlr_log(WLR_INFO, "scroll button not configured");
+	} else {
+		wlr_log(WLR_INFO, "scroll button configured (%d)",
+			dc->scroll_button);
+		libinput_device_config_scroll_set_button(libinput_dev, dc->scroll_button);
+	}
+
 	libinput_device_config_send_events_set_mode(libinput_dev,
 		libinput_device_config_send_events_get_default_mode(libinput_dev));
 	if ((dc->send_events_mode != LIBINPUT_CONFIG_SEND_EVENTS_ENABLED


### PR DESCRIPTION
Adds the missing on-button(-down) scroll method (https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#button-scrolling).

The scrollButton option currently takes a decimal equivalent to a button in `linux/input-event-codes.h`, which is far from ideal, but I couldn't find a function in the labwc codebase that is a universal string-to-button conversion, and I'm not sure what the best way would be to implement it, because of the massive scope. The closest ones are `mouse_button_from_str` and `tablet_button_from_str`, but using them would
1. require a branch on the device type when setting device-unspecific options (not a big deal)
2. not cover all cases, because there might be other device types that support this scroll method

Related:
#2767 (pull request adding scrollMethod)
#1079 (related tracking issue)
#3404 (feature request discussion)
