### PR TITLE
session: run activation env update synchronously

### DIFF
--- a/include/common/spawn.h
+++ b/include/common/spawn.h
@@ -17,6 +17,12 @@ pid_t spawn_primary_client(const char *command);
 void spawn_async_no_shell(char const *command);
 
 /**
+ * spawn_sync_no_shell - execute synchronously
+ * @command: command to be executed
+ */
+void spawn_sync_no_shell(char const *command);
+
+/**
  * spawn_piped - execute asynchronously
  * @command: command to be executed
  * @pipe_fd: set to the read end of a pipe

--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -108,7 +108,7 @@ spawn_sync_no_shell(char const *command)
 	switch (child) {
 	case -1:
 		wlr_log(WLR_ERROR, "unable to fork()");
-		goto out;
+		break;
 	case 0:
 		reset_signals_and_limits();
 		execvp(argv[0], argv);
@@ -117,7 +117,6 @@ spawn_sync_no_shell(char const *command)
 		waitpid(child, NULL, 0);
 		break;
 	}
-out:
 	g_strfreev(argv);
 }
 

--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -89,6 +89,38 @@ out:
 	g_strfreev(argv);
 }
 
+void
+spawn_sync_no_shell(char const *command)
+{
+	GError *err = NULL;
+	gchar **argv = NULL;
+
+	assert(command);
+
+	g_shell_parse_argv((gchar *)command, NULL, &argv, &err);
+	if (err) {
+		g_message("%s", err->message);
+		g_error_free(err);
+		return;
+	}
+
+	pid_t child = fork();
+	switch (child) {
+	case -1:
+		wlr_log(WLR_ERROR, "unable to fork()");
+		goto out;
+	case 0:
+		reset_signals_and_limits();
+		execvp(argv[0], argv);
+		_exit(1);
+	default:
+		waitpid(child, NULL, 0);
+		break;
+	}
+out:
+	g_strfreev(argv);
+}
+
 pid_t
 spawn_primary_client(const char *command)
 {

--- a/src/config/session.c
+++ b/src/config/session.c
@@ -219,12 +219,12 @@ execute_update(const char *env_keys, const char *env_unset_keys, bool initialize
 	char *cmd =
 		strdup_printf("dbus-update-activation-environment %s",
 			initialize ? env_keys : env_unset_keys);
-	spawn_async_no_shell(cmd);
+	spawn_sync_no_shell(cmd);
 	free(cmd);
 
 	cmd = strdup_printf("systemctl --user %s %s",
 		initialize ? "import-environment" : "unset-environment", env_keys);
-	spawn_async_no_shell(cmd);
+	spawn_sync_no_shell(cmd);
 	free(cmd);
 }
 


### PR DESCRIPTION
dbus-update-activation-environment and systemctl --user import-environment were fired asynchronously via spawn_async_no_shell, racing with the autostart script. Any systemd user service started from autostart (e.g. via labwc-session.target #3534) could start before the import completed, leaving WAYLAND_DISPLAY and related variables absent from its environment and those of any apps it launches. This causes DMS shell to fail to launch many apps.

Run both commands synchronously via a new spawn_sync_no_shell helper so the import is guaranteed to complete before the autostart script executes.