### PR TITLE
Fix for chromium popup on maximized window

### DIFF
--- a/src/xdg-popup.c
+++ b/src/xdg-popup.c
@@ -43,10 +43,13 @@ popup_unconstrain(struct xdg_popup *popup)
 	 * than zero, typically with Qt apps. We therefore clamp it to avoid for
 	 * example the 'File' menu of a maximized window to end up on an another
 	 * output.
+	 * Also some apps open the menu exactly at the right border when maximized,
+	 * causing popup_box->x (or y?) to be in the next output. We subtract one
+	 * inside MAX to avoid the problem mentioned above.
 	 */
 	struct wlr_box *popup_box = &popup->wlr_popup->scheduled.geometry;
-	struct output *output = output_nearest_to(parent_lx + MAX(popup_box->x, 0),
-		parent_ly + MAX(popup_box->y, 0));
+	struct output *output = output_nearest_to(parent_lx + MAX(popup_box->x - 1, 0),
+		parent_ly + MAX(popup_box->y - 1, 0));
 	struct wlr_box usable = output_usable_area_in_layout_coords(output);
 
 	/* Get offset of toplevel window from its surface */


### PR DESCRIPTION
closes #3544

the issue is the popup x + parent x coordinates have the exact value as the output width + output x, so the popups ends up with a coordinate x equal to 0 of the next monitor.

can be solved in a few different ways, this one made sense to me.

for easy checking the bug and fix: `WLR_WL_OUTPUTS=2 ./build/labwc -s chromium` move the chromium window to WL-1 and maximize it, then open the menu and some submenu. Use other chromium-based browser if u don't have chromium.

Edit: Just thought of something else, couldn't we just remove the MAX(...) part? just keep `output_nearest_to(parent_lx, parent_ly)` shouldn't it always be the same output as the parent?