### PR TITLE
src/img/img-xpm.c: fix unused variable warning

### DIFF
--- a/src/img/img-xpm.c
+++ b/src/img/img-xpm.c
@@ -351,7 +351,7 @@ xpm_load_to_surface(struct file_handle *handle)
 			goto out;
 		}
 
-		for (int n = 0, xcnt = 0; n < wbytes; n += cpp, xcnt++) {
+		for (int n = 0; n < wbytes; n += cpp) {
 			g_strlcpy(pixel_str, &buffer[n], cpp + 1);
 
 			struct xpm_color *color =


### PR DESCRIPTION
This fixes a warning in gcc16 below:

```
../src/img/img-xpm.c: In function ‘xpm_load_to_surface’: ../src/img/img-xpm.c:354:33: warning: variable ‘xcnt’ set but not used [-Wunused-but-set-variable=]
  354 |                 for (int n = 0, xcnt = 0; n < wbytes; n += cpp, xcnt++) {
      |                                 ^~~~
```