### PR TITLE
Include wlroots runtime version in --version string

### DIFF
--- a/include/common/macros.h
+++ b/include/common/macros.h
@@ -62,7 +62,11 @@
 #define BOUNDED_INT(a) ((a) < INT_MAX && (a) > INT_MIN)
 #endif
 
-#define LAB_WLR_VERSION_AT_LEAST(major, minor, micro) \
-	(WLR_VERSION_NUM >= (((major) << 16) | ((minor) << 8) | (micro)))
+#define _LAB_CALC_WLR_VERSION_NUM(major, minor, micro) (((major) << 16) | ((minor) << 8) | (micro))
+
+#define LAB_WLR_VERSION_AT_LEAST(major, minor, micro) ( \
+	server.wlr_version >= _LAB_CALC_WLR_VERSION_NUM(major, minor, micro))
+
+#define LAB_WLR_VERSION_LOWER(major, minor, micro) (!LAB_WLR_VERSION_AT_LEAST(major, minor, micro))
 
 #endif /* LABWC_MACROS_H */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -148,6 +148,8 @@ struct seat {
 };
 
 struct server {
+	uint32_t wlr_version;
+
 	struct wl_display *wl_display;
 	struct wl_event_loop *wl_event_loop;  /* Can be used for timer events */
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include "common/fd-util.h"
 #include "common/font.h"
+#include "common/macros.h"
 #include "common/spawn.h"
 #include "config/rcxml.h"
 #include "config/session.h"
@@ -163,6 +164,12 @@ main(int argc, char *argv[])
 	char *startup_cmd = NULL;
 	char *primary_client = NULL;
 	enum wlr_log_importance verbosity = WLR_ERROR;
+
+	server.wlr_version = _LAB_CALC_WLR_VERSION_NUM(
+		wlr_version_get_major(),
+		wlr_version_get_minor(),
+		wlr_version_get_micro()
+	);
 
 	int c;
 	while (1) {

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,7 @@
 #include <pango/pangocairo.h>
 #include <signal.h>
 #include <unistd.h>
+#include <wlr/version.h>
 #include "common/fd-util.h"
 #include "common/font.h"
 #include "common/macros.h"
@@ -66,12 +67,15 @@ static void
 print_version(void)
 {
 	#define FEATURE_ENABLED(feature) (HAVE_##feature ? "+" : "-")
-	printf("labwc %s (%sxwayland %snls %srsvg %slibsfdo)\n",
+	printf("labwc %s (%sxwayland %snls %srsvg %slibsfdo) running on wlroots %d.%d.%d\n",
 		LABWC_VERSION,
 		FEATURE_ENABLED(XWAYLAND),
 		FEATURE_ENABLED(NLS),
 		FEATURE_ENABLED(RSVG),
-		FEATURE_ENABLED(LIBSFDO)
+		FEATURE_ENABLED(LIBSFDO),
+		wlr_version_get_major(),
+		wlr_version_get_minor(),
+		wlr_version_get_micro()
 	);
 	#undef FEATURE_ENABLED
 }


### PR DESCRIPTION
Also change `LAB_WLR_VERSION_AT_LEAST()` macro to use runtime information.