### PR TITLE
window-title: add command line argument --title

### DIFF
--- a/docs/labwc.1.scd
+++ b/docs/labwc.1.scd
@@ -70,13 +70,13 @@ the `--exit` and `--reconfigure` options use.
 	session clients support both X11 and Wayland, this command line option
 	avoids re-writes and fragmentation.
 
-*-t, --window-title* <fmtstr>
-	Set the window title for labwc to use when nested in a compositor.
-	<fmtstr> is a format string to be used as the window title, replacing
-	`%o` with the name of the output region. This is useful when simulating
-	multiple screens, such as with running labwc with the enviornment
-	variable `WLR_WL_OUTPUTS=2`. In this case, `%o` will be unique per
-	simulated screen.
+*-t, --title* <fmtstr>
+	Set the window title for labwc to use when it is running in a window
+	(i.e. nested in a compositor). <fmtstr> is a format string to be used as
+	the window title, replacing `%o` with the name of the output
+	region. This is useful when simulating multiple screens, such as with
+	running labwc with the enviornment variable `WLR_WL_OUTPUTS=2`. In this
+	case, `%o` will be unique per simulated screen.
 
 *-v, --version*
 	Show the version number and quit

--- a/docs/labwc.1.scd
+++ b/docs/labwc.1.scd
@@ -70,6 +70,14 @@ the `--exit` and `--reconfigure` options use.
 	session clients support both X11 and Wayland, this command line option
 	avoids re-writes and fragmentation.
 
+*-t, --window-title* <fmtstr>
+	Set the window title for labwc to use when nested in a compositor.
+	<fmtstr> is a format string to be used as the window title, replacing
+	`%o` with the name of the output region. This is useful when simulating
+	multiple screens, such as with running labwc with the enviornment
+	variable `WLR_WL_OUTPUTS=2`. In this case, `%o` will be unique per
+	simulated screen.
+
 *-v, --version*
 	Show the version number and quit
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -316,7 +316,7 @@ struct server {
 
 	pid_t primary_client_pid;
 
-	char *window_title_fmt;
+	char *title_fmt;
 };
 
 /* defined in main.c */

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -315,6 +315,8 @@ struct server {
 	struct sfdo *sfdo;
 
 	pid_t primary_client_pid;
+
+	char *window_title_fmt;
 };
 
 /* defined in main.c */

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include "common/font.h"
 #include "common/macros.h"
 #include "common/spawn.h"
+#include "common/string-helpers.h"
 #include "config/rcxml.h"
 #include "config/session.h"
 #include "labwc.h"
@@ -37,6 +38,7 @@ static const struct option long_options[] = {
 	{"reconfigure", no_argument, NULL, 'r'},
 	{"startup", required_argument, NULL, 's'},
 	{"session", required_argument, NULL, 'S'},
+	{"window-title", required_argument, NULL, 't'},
 	{"version", no_argument, NULL, 'v'},
 	{"verbose", no_argument, NULL, 'V'},
 	{0, 0, 0, 0}
@@ -178,7 +180,7 @@ main(int argc, char *argv[])
 	int c;
 	while (1) {
 		int index = 0;
-		c = getopt_long(argc, argv, "c:C:dehmrs:S:vV", long_options, &index);
+		c = getopt_long(argc, argv, "c:C:dehmrs:S:t:vV", long_options, &index);
 		if (c == -1) {
 			break;
 		}
@@ -206,6 +208,9 @@ main(int argc, char *argv[])
 			break;
 		case 'S':
 			primary_client = optarg;
+			break;
+		case 't':
+			server.window_title_fmt = optarg;
 			break;
 		case 'v':
 			print_version();
@@ -264,6 +269,10 @@ main(int argc, char *argv[])
 	}
 
 	increase_nofile_limit();
+
+	if (string_null_or_empty(server.window_title_fmt)) {
+		server.window_title_fmt = "labwc - %o";
+	}
 
 	server_init();
 	server_start();

--- a/src/main.c
+++ b/src/main.c
@@ -38,7 +38,7 @@ static const struct option long_options[] = {
 	{"reconfigure", no_argument, NULL, 'r'},
 	{"startup", required_argument, NULL, 's'},
 	{"session", required_argument, NULL, 'S'},
-	{"window-title", required_argument, NULL, 't'},
+	{"title", required_argument, NULL, 't'},
 	{"version", no_argument, NULL, 'v'},
 	{"verbose", no_argument, NULL, 'V'},
 	{0, 0, 0, 0}
@@ -46,18 +46,18 @@ static const struct option long_options[] = {
 
 static const char labwc_usage[] =
 "Usage: labwc [options...]\n"
-"  -c, --config <file>         Specify config file (with path)\n"
-"  -C, --config-dir <dir>      Specify config directory\n"
-"  -d, --debug                 Enable full logging, including debug information\n"
-"  -e, --exit                  Exit the compositor\n"
-"  -h, --help                  Show help message and quit\n"
-"  -m, --merge-config          Merge user config files/theme in all XDG Base Dirs\n"
-"  -r, --reconfigure           Reload the compositor configuration\n"
-"  -s, --startup <command>     Run command on startup\n"
-"  -S, --session <command>     Run command on startup and terminate on exit\n"
-"  -t, --window-title <fmtstr> Specify title to use when the compositor is nested\n"
-"  -v, --version               Show version number and quit\n"
-"  -V, --verbose               Enable more verbose logging\n";
+"  -c, --config <file>      Specify config file (with path)\n"
+"  -C, --config-dir <dir>   Specify config directory\n"
+"  -d, --debug              Enable full logging, including debug information\n"
+"  -e, --exit               Exit the compositor\n"
+"  -h, --help               Show help message and quit\n"
+"  -m, --merge-config       Merge user config files/theme in all XDG Base Dirs\n"
+"  -r, --reconfigure        Reload the compositor configuration\n"
+"  -s, --startup <command>  Run command on startup\n"
+"  -S, --session <command>  Run command on startup and terminate on exit\n"
+"  -t, --title <fmtstr>     Specify title to use when running in a window\n"
+"  -v, --version            Show version number and quit\n"
+"  -V, --verbose            Enable more verbose logging\n";
 
 static void
 usage(void)
@@ -211,7 +211,7 @@ main(int argc, char *argv[])
 			primary_client = optarg;
 			break;
 		case 't':
-			server.window_title_fmt = optarg;
+			server.title_fmt = optarg;
 			break;
 		case 'v':
 			print_version();
@@ -271,8 +271,8 @@ main(int argc, char *argv[])
 
 	increase_nofile_limit();
 
-	if (string_null_or_empty(server.window_title_fmt)) {
-		server.window_title_fmt = "labwc - %o";
+	if (string_null_or_empty(server.title_fmt)) {
+		server.title_fmt = "labwc - %o";
 	}
 
 	server_init();

--- a/src/main.c
+++ b/src/main.c
@@ -46,17 +46,18 @@ static const struct option long_options[] = {
 
 static const char labwc_usage[] =
 "Usage: labwc [options...]\n"
-"  -c, --config <file>      Specify config file (with path)\n"
-"  -C, --config-dir <dir>   Specify config directory\n"
-"  -d, --debug              Enable full logging, including debug information\n"
-"  -e, --exit               Exit the compositor\n"
-"  -h, --help               Show help message and quit\n"
-"  -m, --merge-config       Merge user config files/theme in all XDG Base Dirs\n"
-"  -r, --reconfigure        Reload the compositor configuration\n"
-"  -s, --startup <command>  Run command on startup\n"
-"  -S, --session <command>  Run command on startup and terminate on exit\n"
-"  -v, --version            Show version number and quit\n"
-"  -V, --verbose            Enable more verbose logging\n";
+"  -c, --config <file>         Specify config file (with path)\n"
+"  -C, --config-dir <dir>      Specify config directory\n"
+"  -d, --debug                 Enable full logging, including debug information\n"
+"  -e, --exit                  Exit the compositor\n"
+"  -h, --help                  Show help message and quit\n"
+"  -m, --merge-config          Merge user config files/theme in all XDG Base Dirs\n"
+"  -r, --reconfigure           Reload the compositor configuration\n"
+"  -s, --startup <command>     Run command on startup\n"
+"  -S, --session <command>     Run command on startup and terminate on exit\n"
+"  -t, --window-title <fmtstr> Specify title to use when the compositor is nested\n"
+"  -v, --version               Show version number and quit\n"
+"  -V, --verbose               Enable more verbose logging\n";
 
 static void
 usage(void)

--- a/src/output.c
+++ b/src/output.c
@@ -607,8 +607,8 @@ handle_new_output(struct wl_listener *listener, void *data)
 	}
 
 	if (wlr_output_is_wl(wlr_output)) {
-		gchar** parts = g_strsplit(server.window_title_fmt, "%o", -1);
-		gchar* formatted_title = g_strjoinv(wlr_output->name, parts);
+		gchar **parts = g_strsplit(server.title_fmt, "%o", -1);
+		gchar *formatted_title = g_strjoinv(wlr_output->name, parts);
 		g_strfreev(parts);
 		wlr_wl_output_set_title(wlr_output, formatted_title);
 		g_free(formatted_title);

--- a/src/output.c
+++ b/src/output.c
@@ -607,11 +607,10 @@ handle_new_output(struct wl_listener *listener, void *data)
 	}
 
 	if (wlr_output_is_wl(wlr_output)) {
-		gchar **parts = g_strsplit(server.title_fmt, "%o", -1);
-		gchar *formatted_title = g_strjoinv(wlr_output->name, parts);
-		g_strfreev(parts);
-		wlr_wl_output_set_title(wlr_output, formatted_title);
-		g_free(formatted_title);
+		GString *title = g_string_new(server.title_fmt);
+		g_string_replace(title, "%o", wlr_output->name, 0);
+		wlr_wl_output_set_title(wlr_output, title->str);
+		g_string_free(title, TRUE);
 		wlr_wl_output_set_app_id(wlr_output, "labwc");
 	}
 

--- a/src/output.c
+++ b/src/output.c
@@ -606,7 +606,11 @@ handle_new_output(struct wl_listener *listener, void *data)
 
 	if (wlr_output_is_wl(wlr_output)) {
 		char title[64];
-		snprintf(title, sizeof(title), "%s - %s", "labwc", wlr_output->name);
+		if (getenv("LABWC_TITLE")) {
+			snprintf(title, sizeof(title), "%s", getenv("LABWC_TITLE"));
+		} else {
+			snprintf(title, sizeof(title), "%s - %s", "labwc", wlr_output->name);
+		}
 		wlr_wl_output_set_title(wlr_output, title);
 		wlr_wl_output_set_app_id(wlr_output, "labwc");
 	}

--- a/src/output.c
+++ b/src/output.c
@@ -10,6 +10,7 @@
 #include "output.h"
 #include <assert.h>
 #include <drm_fourcc.h>
+#include <glib.h>
 #include <strings.h>
 #include <wlr/backend/wayland.h>
 #include <wlr/config.h>
@@ -26,6 +27,7 @@
 #include "common/macros.h"
 #include "common/mem.h"
 #include "common/scene-helpers.h"
+#include "common/string-helpers.h"
 #include "config/rcxml.h"
 #include "labwc.h"
 #include "layers.h"
@@ -605,13 +607,11 @@ handle_new_output(struct wl_listener *listener, void *data)
 	}
 
 	if (wlr_output_is_wl(wlr_output)) {
-		char title[64];
-		if (getenv("LABWC_TITLE")) {
-			snprintf(title, sizeof(title), "%s", getenv("LABWC_TITLE"));
-		} else {
-			snprintf(title, sizeof(title), "%s - %s", "labwc", wlr_output->name);
-		}
-		wlr_wl_output_set_title(wlr_output, title);
+		gchar** parts = g_strsplit(server.window_title_fmt, "%o", -1);
+		gchar* formatted_title = g_strjoinv(wlr_output->name, parts);
+		g_strfreev(parts);
+		wlr_wl_output_set_title(wlr_output, formatted_title);
+		g_free(formatted_title);
 		wlr_wl_output_set_app_id(wlr_output, "labwc");
 	}
 


### PR DESCRIPTION
Introduces a new command line argument, `-t`/`--title`, that can be used to set the title of nested instances of labwc via a format string. `%o` is replaced by the output name wayland gives us.

Fixes #1850