### PR TITLE
add logger for config errors and <core><errorCommand> to display it.

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -180,6 +180,7 @@ this is for compatibility with Openbox.
   <xwaylandPersistence>no</xwaylandPersistence>
   <primarySelection>yes</primarySelection>
   <promptCommand>[see details below]</promptCommand>
+  <errorCommand>[see details below]</errorCommand>
 </core>
 ```
 
@@ -314,6 +315,29 @@ this is for compatibility with Openbox.
 		--text="%m" \\
 		--ok-label="%y" \\
 		--cancel-label="%n"
+	```
+
+*<core><errorCommand>*
+	Set command to be invoked for displaying errors in the config files,
+	it is executed when errors are detected on startup and reconfigure.
+	The errors are sent to STDIN of the program, and a SIGTERM is sent to
+	it if the process is still running when a reconfigure is triggered.
+
+	The default error command is:
+	```
+	labnag \\
+		--message 'Config Error' \\
+		--button-dismiss 'Close' \\
+		--layer overlay \\
+		--timeout 0 \\
+		--detailed-message
+	```
+
+	Example using `zenity`:
+	```
+	<core>
+	  <errorCommand>zenity --title='Config Error' --text-info</errorCommand>
+	</core>
 	```
 
 ## PLACEMENT

--- a/include/common/nag.h
+++ b/include/common/nag.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_NAG_H
+#define LABWC_NAG_H
+
+#include <wlr/util/log.h>
+#include "common/buf.h"
+
+struct buf *nag_get_buf(void);
+void nag_set_error(enum wlr_log_importance importance);
+void nag_reset(void);
+void nag_show_callback(void *data);
+
+#define nag_log(verb, fmt, ...) \
+do { \
+	wlr_log(verb, fmt, ##__VA_ARGS__); \
+	nag_set_error(verb); \
+	buf_add_fmt(nag_get_buf(), fmt "\n", ##__VA_ARGS__); \
+} while (0)
+
+#endif /* LABWC_NAG_H */

--- a/include/common/nag.h
+++ b/include/common/nag.h
@@ -10,10 +10,10 @@ void nag_set_error(enum wlr_log_importance importance);
 void nag_reset(void);
 void nag_show_callback(void *data);
 
-#define nag_log(verb, fmt, ...) \
+#define nag_log(verbosity, fmt, ...) \
 do { \
-	wlr_log(verb, fmt, ##__VA_ARGS__); \
-	nag_set_error(verb); \
+	wlr_log(verbosity, fmt, ##__VA_ARGS__); \
+	nag_set_error(verbosity); \
 	buf_add_fmt(nag_get_buf(), fmt "\n", ##__VA_ARGS__); \
 } while (0)
 

--- a/include/common/nag.h
+++ b/include/common/nag.h
@@ -2,11 +2,13 @@
 #ifndef LABWC_NAG_H
 #define LABWC_NAG_H
 
+#include <sys/wait.h>
 #include <wlr/util/log.h>
 #include "common/buf.h"
 
 struct buf *nag_get_buf(void);
 void nag_set_error(enum wlr_log_importance importance);
+void nag_check_pid(pid_t exited_pid);
 void nag_reset(void);
 void nag_show_callback(void *data);
 

--- a/include/common/spawn.h
+++ b/include/common/spawn.h
@@ -23,6 +23,19 @@ void spawn_async_no_shell(char const *command);
 void spawn_sync_no_shell(char const *command);
 
 /**
+ * spawn_piped_async_no_shell - execute asynchronously
+ * @command: command to be executed
+ * @pipe_fd_w: set to the write end of a pipe
+ *             connected to stdin of the command
+ * Notes:
+ * The returned pid_t has to be waited for to
+ * not produce zombies and the pipe_fd_w has to
+ * be closed. spawn_piped_close() can be used
+ * to ensure both.
+ */
+pid_t spawn_piped_async_no_shell(const char *command, int *pipe_fd_w);
+
+/**
  * spawn_piped - execute asynchronously
  * @command: command to be executed
  * @pipe_fd: set to the read end of a pipe

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -87,6 +87,7 @@ struct rcxml {
 	bool xwayland_persistence;
 	bool primary_selection;
 	char *prompt_command;
+	char *error_command;
 
 	/* placement */
 	enum lab_placement_policy placement_policy;

--- a/src/action.c
+++ b/src/action.c
@@ -14,6 +14,7 @@
 #include "common/macros.h"
 #include "common/list.h"
 #include "common/mem.h"
+#include "common/nag.h"
 #include "common/parse-bool.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"
@@ -347,7 +348,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			} else if (!strcasecmp(content, "current")) {
 				action_arg_add_int(action, argument, CYCLE_WORKSPACE_CURRENT);
 			} else {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			}
 			goto cleanup;
@@ -360,7 +361,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			} else if (!strcasecmp(content, "focused")) {
 				action_arg_add_int(action, argument, CYCLE_OUTPUT_FOCUSED);
 			} else {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			}
 			goto cleanup;
@@ -371,7 +372,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			} else if (!strcasecmp(content, "current")) {
 				action_arg_add_int(action, argument, CYCLE_APP_ID_CURRENT);
 			} else {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			}
 			goto cleanup;
@@ -401,7 +402,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 		if (!strcmp(argument, "direction")) {
 			enum view_axis axis = view_axis_parse(content);
 			if (axis == VIEW_AXIS_NONE || axis == VIEW_AXIS_INVALID) {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {
 				action_arg_add_int(action, argument, axis);
@@ -415,7 +416,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			if (mode != LAB_SSD_MODE_INVALID) {
 				action_arg_add_int(action, argument, mode);
 			} else {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			}
 			goto cleanup;
@@ -430,7 +431,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			enum lab_edge edge = lab_edge_parse(content,
 				/*tiled*/ true, /*any*/ false);
 			if (edge == LAB_EDGE_NONE || edge == LAB_EDGE_CENTER) {
-				wlr_log(WLR_ERROR,
+				nag_log(WLR_ERROR,
 					"Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {
@@ -497,7 +498,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			enum lab_edge edge = lab_edge_parse(content,
 				/*tiled*/ false, /*any*/ false);
 			if (edge == LAB_EDGE_NONE) {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {
 				action_arg_add_int(action, argument, edge);
@@ -521,7 +522,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			enum lab_placement_policy policy =
 				view_placement_parse(content);
 			if (policy == LAB_PLACE_INVALID) {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 						action_names[action->type], argument, content);
 			} else {
 				action_arg_add_int(action, argument, policy);
@@ -542,7 +543,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 		goto cleanup;
 	}
 
-	wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s'",
+	nag_log(WLR_ERROR, "Invalid argument for action %s: '%s'",
 		action_names[action->type], argument);
 
 cleanup:

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -10,6 +10,7 @@ labwc_sources += files(
   'lab-scene-rect.c',
   'match.c',
   'mem.c',
+  'nag.c',
   'nodename.c',
   'node-type.c',
   'parse-bool.c',

--- a/src/common/nag.c
+++ b/src/common/nag.c
@@ -2,7 +2,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "common/nag.h"
 #include <stdarg.h>
-#include <sys/wait.h>
 #include <unistd.h>
 #include "common/buf.h"
 #include "config/rcxml.h"
@@ -27,15 +26,21 @@ nag_set_error(enum wlr_log_importance importance)
 }
 
 void
+nag_check_pid(pid_t exited_pid)
+{
+	if (pid && pid == exited_pid) {
+		pid = 0;
+	}
+}
+
+void
 nag_reset(void)
 {
 	has_error = false;
 	buf_reset(&log_buf);
 	if (pid > 0) {
-		if (!waitpid(pid, NULL, WNOHANG)) {
-			kill(pid, SIGTERM);
-			/* waitpid() is done in a generic SIGCHLD handler in src/server.c */
-		}
+		kill(pid, SIGTERM);
+		/* waitpid() is done in a generic SIGCHLD handler in src/server.c */
 	}
 	pid = 0;
 }

--- a/src/common/nag.c
+++ b/src/common/nag.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include "common/nag.h"
+#include <stdarg.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "common/buf.h"
+#include "config/rcxml.h"
+#include "common/spawn.h"
+
+static struct buf log_buf = BUF_INIT;
+static bool has_error = false;
+static pid_t pid = 0;
+
+struct buf *
+nag_get_buf(void)
+{
+	return &log_buf;
+}
+
+void
+nag_set_error(enum wlr_log_importance importance)
+{
+	if (!has_error && importance == WLR_ERROR) {
+		has_error = true;
+	}
+}
+
+void
+nag_reset(void)
+{
+	has_error = false;
+	buf_reset(&log_buf);
+	if (pid > 0) {
+		if (!waitpid(pid, NULL, WNOHANG)) {
+			kill(pid, SIGTERM);
+			/* waitpid() is done in a generic SIGCHLD handler in src/server.c */
+		}
+	}
+	pid = 0;
+}
+
+static void
+nag_show(void)
+{
+	if (!has_error) {
+		return;
+	}
+	int pipe_w;
+	pid = spawn_piped_async_no_shell(rc.error_command, &pipe_w);
+	if (pid > 0) {
+		ssize_t bytes = write(pipe_w, log_buf.data, log_buf.len);
+		if (bytes < 0) {
+			wlr_log(WLR_ERROR, "Failed to write errors to process: %s",
+				rc.error_command);
+		}
+		spawn_piped_close(pid, pipe_w);
+	} else if (pid < 0) {
+		wlr_log(WLR_ERROR, "Failed to launch process: %s", rc.error_command);
+	}
+}
+
+void
+nag_show_callback(void *data)
+{
+	nag_show();
+}

--- a/src/common/nag.c
+++ b/src/common/nag.c
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #define _POSIX_C_SOURCE 200809L
 #include "common/nag.h"
+#include <assert.h>
 #include <stdarg.h>
 #include <unistd.h>
 #include "common/buf.h"
 #include "config/rcxml.h"
 #include "common/spawn.h"
+#include "labwc.h"
 
 static struct buf log_buf = BUF_INIT;
 static bool has_error = false;
 static pid_t pid = 0;
+static int pipe_w;
+static struct wl_event_source *write_notifier = NULL;
+static size_t remaining = 0;
 
 struct buf *
 nag_get_buf(void)
@@ -45,21 +50,41 @@ nag_reset(void)
 	pid = 0;
 }
 
+static int
+handle_writable(int fd, uint32_t mask, void *data)
+{
+	assert(remaining > 0);
+	wlr_log(WLR_ERROR, "Writable");
+	ssize_t bytes = write(pipe_w, log_buf.data + (log_buf.len - remaining), remaining);
+	if (bytes < 0) {
+		wlr_log(WLR_ERROR, "Failed to write errors to process: %s", rc.error_command);
+	} else {
+		remaining -= bytes;
+		if (remaining > 0) {
+			goto keep_waiting;
+		}
+	}
+
+	wl_event_source_remove(write_notifier);
+	write_notifier = NULL;
+	spawn_piped_close(pid, pipe_w);
+
+keep_waiting:
+	return 0;
+}
+
 static void
 nag_show(void)
 {
 	if (!has_error) {
 		return;
 	}
-	int pipe_w;
 	pid = spawn_piped_async_no_shell(rc.error_command, &pipe_w);
 	if (pid > 0) {
-		ssize_t bytes = write(pipe_w, log_buf.data, log_buf.len);
-		if (bytes < 0) {
-			wlr_log(WLR_ERROR, "Failed to write errors to process: %s",
-				rc.error_command);
-		}
-		spawn_piped_close(pid, pipe_w);
+		assert(!write_notifier);
+		remaining = log_buf.len;
+		write_notifier = wl_event_loop_add_fd(server.wl_event_loop,
+			pipe_w, WL_EVENT_WRITABLE, handle_writable, NULL);
 	} else if (pid < 0) {
 		wlr_log(WLR_ERROR, "Failed to launch process: %s", rc.error_command);
 	}

--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -156,6 +156,82 @@ spawn_primary_client(const char *command)
 }
 
 pid_t
+spawn_piped_async_no_shell(const char *command, int *pipe_fd_w)
+{
+	assert(command);
+
+	GError *err = NULL;
+	gchar **argv = NULL;
+
+	/* Use glib's shell-parse to mimic Openbox's behaviour */
+	g_shell_parse_argv((gchar *)command, NULL, &argv, &err);
+	if (err) {
+		g_message("%s", err->message);
+		g_error_free(err);
+		return -1;
+	}
+
+	int pipe_rw[2];
+	if (pipe(pipe_rw) != 0) {
+		wlr_log(WLR_ERROR, "unable to pipe()");
+		g_strfreev(argv);
+		return -1;
+	}
+
+	pid_t child = 0;
+	child = fork();
+	if (child < 0) {
+		wlr_log(WLR_ERROR, "unable to fork() child");
+		close(pipe_rw[0]);
+		close(pipe_rw[1]);
+		g_strfreev(argv);
+		return child;
+	}
+
+	if (child == 0) {
+		/* Child */
+		reset_signals_and_limits();
+
+		/*
+		 * replace stdout and stderr with /dev/null
+		 * and stdin with the read end of the pipe
+		 */
+		close(pipe_rw[1]);
+		dup2(pipe_rw[0], STDIN_FILENO);
+		close(pipe_rw[0]);
+
+		int dev_null = open("/dev/null", O_WRONLY);
+		if (dev_null < 0) {
+			wlr_log_errno(WLR_ERROR, "opening /dev/null failed");
+			/*
+			 * Just close stdout and stderr and
+			 * hope $command can deal with that.
+			 */
+			close(STDOUT_FILENO);
+			close(STDERR_FILENO);
+		} else {
+			dup2(dev_null, STDOUT_FILENO);
+			dup2(dev_null, STDERR_FILENO);
+			close(dev_null);
+		}
+		execvp(argv[0], argv);
+		_exit(1);
+	}
+	/* labwc */
+	close(pipe_rw[0]);
+	g_strfreev(argv);
+
+	/*
+	 * Prevent leaking the write end of the pipe to further
+	 * children forked during the lifetime of the descriptor.
+	 */
+	set_cloexec(pipe_rw[1]);
+	*pipe_fd_w = pipe_rw[1];
+
+	return child;
+}
+
+pid_t
 spawn_piped(const char *command, int *pipe_fd)
 {
 	assert(command);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -17,6 +17,7 @@
 #include "common/list.h"
 #include "common/macros.h"
 #include "common/mem.h"
+#include "common/nag.h"
 #include "common/nodename.h"
 #include "common/parse-bool.h"
 #include "common/parse-double.h"
@@ -1167,6 +1168,8 @@ entry(xmlNode *node, char *nodename, char *content)
 
 	} else if (!strcasecmp(nodename, "promptCommand.core")) {
 		xstrdup_replace(rc.prompt_command, content);
+	} else if (!strcasecmp(nodename, "errorCommand.core")) {
+		xstrdup_replace(rc.error_command, content);
 
 	} else if (!strcmp(nodename, "policy.placement")) {
 		enum lab_placement_policy policy = view_placement_parse(content);
@@ -1476,7 +1479,7 @@ rcxml_parse_xml(struct buf *b)
 	int options = 0;
 	xmlDoc *d = xmlReadMemory(b->data, b->len, NULL, NULL, options);
 	if (!d) {
-		wlr_log(WLR_ERROR, "error parsing config file");
+		nag_log(WLR_ERROR, "error parsing config file");
 		return;
 	}
 	xmlNode *root = xmlDocGetRootElement(d);
@@ -1802,6 +1805,15 @@ post_processing(void)
 				"--layer overlay "
 				"--timeout 0");
 	}
+	if (!rc.error_command) {
+		rc.error_command =
+			xstrdup("labnag "
+				"--message 'Config Error' "
+				"--button-dismiss 'Close' "
+				"--layer overlay "
+				"--timeout 0 "
+				"--detailed-message");
+	}
 	if (!rc.fallback_app_icon_name) {
 		rc.fallback_app_icon_name = xstrdup("labwc");
 	}
@@ -2030,7 +2042,7 @@ rcxml_read(const char *filename)
 			continue;
 		}
 
-		wlr_log(WLR_INFO, "read config file %s", path->string);
+		nag_log(WLR_INFO, "read config file %s", path->string);
 
 		rcxml_parse_xml(&b);
 		buf_reset(&b);
@@ -2052,6 +2064,7 @@ rcxml_finish(void)
 	zfree(rc.font_menuitem.name);
 	zfree(rc.font_osd.name);
 	zfree(rc.prompt_command);
+	zfree(rc.error_command);
 	zfree(rc.theme_name);
 	zfree(rc.icon_theme_name);
 	zfree(rc.fallback_app_icon_name);

--- a/src/server.c
+++ b/src/server.c
@@ -54,6 +54,7 @@
 #include "action.h"
 #include "common/macros.h"
 #include "common/mem.h"
+#include "common/nag.h"
 #include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "config/session.h"
@@ -98,6 +99,7 @@ reload_config_and_theme(void)
 
 	scaled_buffer_invalidate_sharing();
 	rcxml_finish();
+	nag_reset();
 	rcxml_read(rc.config_file);
 	theme_finish(rc.theme);
 	theme_init(rc.theme, rc.theme_name);
@@ -119,6 +121,8 @@ reload_config_and_theme(void)
 	resize_indicator_reconfigure();
 	kde_server_decoration_update_default();
 	workspaces_reconfigure();
+
+	wl_event_loop_add_idle(server.wl_event_loop, nag_show_callback, NULL);
 }
 
 static int
@@ -809,6 +813,7 @@ server_init(void)
 #if HAVE_XWAYLAND
 	xwayland_server_init(server.compositor);
 #endif
+	wl_event_loop_add_idle(server.wl_event_loop, nag_show_callback, NULL);
 }
 
 void

--- a/src/server.c
+++ b/src/server.c
@@ -184,6 +184,7 @@ handle_sigchld(int signal, void *data)
 				"spawned child %ld exited with %d",
 				(long)info.si_pid, info.si_status);
 		}
+		nag_check_pid(info.si_pid);
 		break;
 	case CLD_KILLED:
 	case CLD_DUMPED:
@@ -194,6 +195,7 @@ handle_sigchld(int signal, void *data)
 				signame ? signame : "unknown");
 		/* Allow cleanup of killed prompt */
 		action_check_prompt_result(info.si_pid, -info.si_status);
+		nag_check_pid(info.si_pid);
 		break;
 	default:
 		wlr_log(WLR_ERROR,


### PR DESCRIPTION
supersedes #3575
closes #1250 and #1686

Added `nag_log` macro to replace `wlr_log` when the error message should be saved for displaying later in addition to printing it.
Added `<core><errorCommand>` to display errors on startup and reconfigure.
Added `spawn_piped_async_no_shell` function to launch `errorCommand` program, get the pid and pipe fd to write to it.
When a reconfigure is triggered, sends a SIGTERM signal to the program so we don't get multiple "nags".

Default errorCommand is : `labnag --message 'Config Error' --button-dismiss 'Close' --layer overlay --timeout 0 --detailed-message` (no timeout)

video:

https://github.com/user-attachments/assets/efbe9fb6-a6b4-4a43-9938-36928ebd606a

@johanmalm @Consolatis ~~Still missing docs and more logging (currently onliy `actions.c` and filename/parse error in `rcxml.c`)~~ Added logging in `rcxml.c` in another branch since it's a lot of changes and might be annoying to review, i'll add later, wanted someone to check it first, especially the `spawn_piped_async_no_shell` function as i had no idea how to work with forks and pipes before this, i referenced the other functions in the `spawn.c` file and i think it should be ok.

Note: While searching, i found some mentions of a problem of using `##__VA_ARGS__` twice as i did in the `nag_log` macro because it will be evaluated twice, so if `i++` is passed in the args, it would increase it twice, but i don't see this issue anywhere `wlr_log` is used, should we worry about this?
I think to "fix" it it would need a function receiving `(verbosity, _WLR_FILENAME, __LINE__, fmt, ...)` use `va_start` and `va_copy` then calling `_wlr_vlog` and a variant of `buf_add_fmt` that accepts `va_list` (needs to be created).

