### PR TITLE
main: update --version string

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,7 @@ static void
 print_version(void)
 {
 	#define FEATURE_ENABLED(feature) (HAVE_##feature ? "+" : "-")
-	printf("labwc %s (%sxwayland %snls %srsvg %slibsfdo) running on wlroots %d.%d.%d\n",
+	printf("labwc %s (%sxwayland %snls %srsvg %slibsfdo) wlroots-%d.%d.%d\n",
 		LABWC_VERSION,
 		FEATURE_ENABLED(XWAYLAND),
 		FEATURE_ENABLED(NLS),


### PR DESCRIPTION
--
change easy, commit msg hard, so I chose "minimalism" this time (`-C 2189b2be1e` then edit)

This format matches gnu version strings style where stuff in (parens) is not considered
when parsing version string, and `bsdtar`  where subcomponent versions are in 
`name version` pairs after main version and ` - `. 

This format is now "languange agnostic" (i.e. one does not need to think translations ;)) 
also, one might get confused which version is currently "running" vs. which executable
printed the version string.