### PR TITLE
Use camelcase also in examples

### DIFF
--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -620,7 +620,7 @@
       <!-- <middleEmulation>no</middleEmulation> -->
       <!-- <disableWhileTyping>yes</disableWhileTyping> -->
       <!-- <clickMethod>buttonAreas</clickMethod> -->
-      <!-- <scrollMethod>twofinger</scrollMethod> -->
+      <!-- <scrollMethod>twoFinger</scrollMethod> -->
       <!-- <scrollButton>274</scrollButton> -->
       <!-- <sendEventsMode>yes</sendEventsMode> -->
       <!-- <calibrationMatrix>1 0 0 0 1 0</calibrationMatrix> -->


### PR DESCRIPTION
Minor nitpick, and wondering about if it's case sensitive at all. Working on 
https://github.com/labwc/labwc-tweaks/compare/master...stefonarch:labwc-tweaks:add_new_settings?expand=1 I wonder if it should be also `onButton`.