### PR TITLE
Typo/style fixes in docs and code comments

### DIFF
--- a/docs/autostart
+++ b/docs/autostart
@@ -12,7 +12,7 @@
 swaybg -c '#113344' >/dev/null 2>&1 &
 
 # Configure output directives such as mode, position, scale and transform.
-# Use wlr-randr to get your output names
+# Use wlr-randr to get your output names.
 # Example ~/.config/kanshi/config below:
 #   profile {
 #     output HDMI-A-1 position 1366,0

--- a/docs/labwc-actions.5.scd
+++ b/docs/labwc-actions.5.scd
@@ -16,7 +16,7 @@ Actions are used in menus and keyboard/mouse bindings.
 	SIGTERM signal.
 
 *<action name="Execute" command="value" />*
-	Execute command.  Note that in the interest of backward compatibility,
+	Execute command. Note that in the interest of backward compatibility,
 	labwc supports <execute> as an alternative to <command> even though
 	openbox documentation states that it is deprecated.
 	Note: Tilde (~) is expanded in the command before passing to execvp().
@@ -139,22 +139,21 @@ Actions are used in menus and keyboard/mouse bindings.
 	and OSD, useful for binding to keys without modifiers.
 
 	*workspace* [all|current]
-	This determines whether to cycle through windows on all workspaces or the
-	current workspace. Default is "current".
+	This determines whether to cycle through windows on all workspaces or
+	the current workspace. Default is "current".
 
 	*output* [all|focused|cursor]
-	This determines whether to cycle through windows on all outputs, the focused
-	output, or the output under the cursor. Default is "all".
+	This determines whether to cycle through windows on all outputs, the
+	focused output, or the output under the cursor. Default is "all".
 
 	*identifier* [all|current]
-	This determines whether to cycle through all windows or only windows of the
-	same application as the currently focused window. Default is "all".
+	This determines whether to cycle through all windows or only windows of
+	the same application as the currently focused window. Default is "all".
 
 *<action name="Reconfigure" />*
 	Re-load configuration and theme files.
 
-*<action name="ShowMenu" menu="root-menu"/>*
-
+*<action name="ShowMenu" menu="root-menu" />*
 	Show a menu.
 
 ```
@@ -300,7 +299,7 @@ Actions are used in menus and keyboard/mouse bindings.
 	(if one exists).
 
 	*wrap* [yes|no] When using the direction attribute, wrap around from
-	right-to-left or top-to-bottom, and vice versa. Default no.
+	right-to-left or top-to-bottom, and vice versa. Default is no.
 
 *<action name="FitToOutput" />*
 	Resizes active window size to width and height of the output when the
@@ -314,10 +313,10 @@ Actions are used in menus and keyboard/mouse bindings.
 	workspace or its index (starting at 1) as configured in rc.xml.
 
 	*wrap* [yes|no] Wrap around from last desktop to first, and vice
-	versa. Default yes.
+	versa. Default is yes.
 
 	*toggle* [yes|no] Toggle to “last” if already on the workspace that
-	would be the actual destination. Default no.
+	would be the actual destination. Default is no.
 
 *<action name="SendToDesktop" to="value" follow="yes" wrap="yes" />*
 	Send active window to workspace.
@@ -325,10 +324,11 @@ Actions are used in menus and keyboard/mouse bindings.
 	*to* The workspace to send the window to. Supported values are the same
 	as for GoToDesktop.
 
-	*follow* [yes|no] Also switch to the specified workspace. Default yes.
+	*follow* [yes|no] Also switch to the specified workspace.
+	Default is yes.
 
 	*wrap* [yes|no] Wrap around from last desktop to first, and vice
-	versa. Default yes.
+	versa. Default is yes.
 
 *<action name="VirtualOutputAdd" output_name="value" />*
 	Add virtual output (headless backend).
@@ -346,11 +346,11 @@ Actions are used in menus and keyboard/mouse bindings.
 
 ```
 <keybind key="W-v">
-  <action name="VirtualOutputAdd" output_name="ScreenCasting"/>
-  <action name="Execute" command='sh -c "wlr-randr --output ScreenCasting --pos 0,0 --scale 2 --custom-mode 3840x2110; wlr-randr --output eDP-1 --pos 0,0 --scale 2 --mode 3840x2160"'/>
+  <action name="VirtualOutputAdd" output_name="ScreenCasting" />
+  <action name="Execute" command='sh -c "wlr-randr --output ScreenCasting --pos 0,0 --scale 2 --custom-mode 3840x2110; wlr-randr --output eDP-1 --pos 0,0 --scale 2 --mode 3840x2160"' />
 </keybind>
 <keybind key="W-c">
-  <action name="VirtualOutputRemove"/>
+  <action name="VirtualOutputRemove" />
 </keybind>
 ```
 
@@ -371,7 +371,7 @@ Actions are used in menus and keyboard/mouse bindings.
 	*output_name* The name of virtual output. If not supplied, will remove
 	the last virtual output added.
 
-*<action name="AutoPlace" policy="value"/>*
+*<action name="AutoPlace" policy="value" />*
 	Reposition the window according to the desired placement policy.
 
 	*policy* [automatic|cursor|center|cascade] Use the specified policy,
@@ -430,11 +430,11 @@ Actions are used in menus and keyboard/mouse bindings.
 	used.
 
 *<action name="ToggleShowDesktop" />*
-	Minimize all windows in the current workspace so that the desktop becomes
-	visible. On calling the action again the hidden windows are unminimized,
-	provided that - since the initial `ShowDesktop` - (a) no windows have been
-	unminimized; (b) workspaces have not been switched; and (c) no new
-	applications have been started.
+	Minimize all windows in the current workspace so that the desktop
+	becomes visible. On calling the action again the hidden windows are
+	unminimized, provided that - since the initial `ShowDesktop` - (a) no
+	windows have been unminimized; (b) workspaces have not been switched;
+	and (c) no new applications have been started.
 
 *<action name="ZoomIn">*++
 *<action name="ZoomOut">*
@@ -449,8 +449,8 @@ Actions are used in menus and keyboard/mouse bindings.
 	binding.
 
 *<action name="DebugToggleKeyStateIndicator" />*
-	Toggle visibility of key-state on-screen display (OSD). Note: This is for
-	debugging purposes only.
+	Toggle visibility of key-state on-screen display (OSD). Note: This is
+	for debugging purposes only.
 
 # CONDITIONAL ACTIONS
 
@@ -464,10 +464,10 @@ Actions that execute other actions. Used in keyboard/mouse bindings.
 
 	```
 	<action name="If">
-	  <query/>
-	  <prompt message=""/>
-	  <then><action/></then>
-	  <else><action/></else>
+	  <query />
+	  <prompt message="" />
+	  <then><action /></then>
+	  <else><action /></else>
 	</action>
 	```
 
@@ -549,9 +549,9 @@ Actions that execute other actions. Used in keyboard/mouse bindings.
 		```
 		<keybind key="W-q">
 		  <action name="If">
-		    <prompt message="Quit?"/>
+		    <prompt message="Quit?" />
 		    <then>
-		      <action name="Exit"/>
+		      <action name="Exit" />
 		    </then>
 		  </action>
 		</keybind>

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -25,7 +25,7 @@ The XDG Base Directory Specification does not specify whether or not programs
 should (a) allow the first-identified configuration file to supersede any
 others, or (b) define rules for merging the information from more than one file.
 
-By default, labwc uses option (a), reading only the first file identified.  With
+By default, labwc uses option (a), reading only the first file identified. With
 the --merge-config option, the search order is reversed, but every configuration
 file encountered is processed in turn. Thus, user-specific files will augment
 system-wide configurations, with conflicts favoring the user-specific
@@ -526,7 +526,8 @@ extending outward from the snapped edge.
 	*<range><inner>* and *<range><outer>*, and 50 for *<cornerRange>*.
 
 *<snapping><overlay><enabled>* [yes|no]
-	Show an overlay when snapping a window to an output edge. Default is yes.
+	Show an overlay when snapping a window to an output edge.
+	Default is yes.
 
 *<snapping><overlay><delay><inner>*++
 *<snapping><overlay><delay><outer>*
@@ -595,7 +596,7 @@ extending outward from the snapped edge.
 	A setting of 0 disables the OSD. Default is 1000 ms.
 
 *<desktops><prefix>*
-	Set the prefix to use when using "number" above. Default is "Workspace"
+	Set the prefix to use when using "number" above. Default is "Workspace".
 
 ## THEME
 
@@ -749,7 +750,7 @@ generate gesture events, like swipe and pinch. There are some related settings
 (e.g. *threeFingerDrag* and *twoFingerScroll*) in the *<libinput>* section.
 
 In the Wayland Compositor domain, events associated with touchscreens are
-sometimes simply referred to as *touch* events.  Touchscreens can be configured
+sometimes simply referred to as *touch* events. Touchscreens can be configured
 in both the *<touch>* and *<libinput>* sections. Note that touchscreen gestures
 are not interpreted by libinput, nor labwc. Any touch point is passed to the
 client (application) for any interpretation of gestures.
@@ -824,9 +825,10 @@ overrideInhibition="">*
 	Make this keybind work even if the screen is locked. Default is no.
 
 	*overrideInhibition* [yes|no]
-	Make this keybind work even if the view inhibits keybinds. Default is no.
+	Make this keybind work even if the view inhibits keybinds.
 	This can be used to prevent W-Tab and similar keybinds from being
 	delivered to Virtual Machines, VNC clients or nested compositors.
+	Default is no.
 
 	*onRelease* [yes|no]
 	When yes, fires the keybind action when the key or key
@@ -840,7 +842,7 @@ overrideInhibition="">*
 
 	```
 	<keybind key="Super_L" onRelease="yes">
-	  <action name="Execute" command="rofi -show drun"/>
+	  <action name="Execute" command="rofi -show drun" />
 	</keybind>
 	```
 
@@ -900,7 +902,7 @@ input-devices by the Wayland protocol.
 	- Shade: A button that, by default, toggles window shading.
 	- AllDesktops: A button that, by default, toggles omnipresence of a
 	  window.
-	- Close: A button that, by default, closses a window.
+	- Close: A button that, by default, closes a window.
 	- Border: The window's border including Top...BRCorner below.
 	- Top: The top edge of the window's border.
 	- Bottom: The bottom edge of the window's border.
@@ -974,10 +976,10 @@ input-devices by the Wayland protocol.
 
 ```
 <mouse>
-  <default/>
+  <default />
   <context name="Frame">
-    <mousebind button="W-Left" action="Press"/>
-    <mousebind button="W-Left" action="Drag"/>
+    <mousebind button="W-Left" action="Press" />
+    <mousebind button="W-Left" action="Drag" />
   </context>
 </mouse>
 ```
@@ -985,7 +987,7 @@ input-devices by the Wayland protocol.
 *<mouse><default />*
 	Load default mousebinds. This is an addition to the openbox
 	specification and provides a way to keep config files simpler whilst
-	allowing user specific binds.  Note that if no rc.xml is found, or if no
+	allowing user specific binds. Note that if no rc.xml is found, or if no
 	<mouse><mousebind> entries exist, the same default mousebinds will be
 	loaded even if the <default /> element is not provided.
 
@@ -997,7 +999,7 @@ Note: To rotate touch events with output rotation, use the libinput
 *calibrationMatrix* setting.
 
 ```
-<touch deviceName="" mapToOutput="" mouseEmulation="no"/>
+<touch deviceName="" mapToOutput="" mouseEmulation="no" />
 ```
 
 *<touch deviceName="" />*
@@ -1260,7 +1262,8 @@ Note: To rotate touch events with output rotation, use the libinput
 	The default method depends on the touchpad hardware.
 
 *<libinput><device><scrollMethod>* [none|twofinger|edge|onbutton]
-	Configure the method by which physical movements are mapped to scroll events.
+	Configure the method by which physical movements are mapped to scroll
+	events.
 
 	The scroll methods available are:
 	- *twofinger* - Scroll by two fingers being placed on the surface of the
@@ -1275,7 +1278,8 @@ Note: To rotate touch events with output rotation, use the libinput
 *<libinput><device><scrollButton>* [button]
 	Set the button used for the *onbutton* scroll method.
 
-	*button* is the decimal form of a value from `linux/input-event-codes.h`.
+	*button* is the decimal form of a value
+	from `linux/input-event-codes.h`.
 
 *<libinput><device><sendEventsMode>* [yes|no|disabledOnExternalMouse]
 	Optionally enable or disable sending any device events.
@@ -1324,7 +1328,7 @@ defined as shown below.
 
   <!-- Action -->
   <windowRule identifier="" title="" type="">
-    <action name=""/>
+    <action name="" />
   </windowRule>
 
   <!-- Property -->
@@ -1521,7 +1525,7 @@ This is the full list of interfaces that can be controlled with this mechanism:
 
 *XCURSOR_PATH*
 	Specify a colon-separated list of paths to look for mouse cursors in.
-	Default
+	Default is
 	~/.local/share/icons:
 	~/.icons:
 	/usr/share/icons:
@@ -1532,7 +1536,7 @@ This is the full list of interfaces that can be controlled with this mechanism:
 
 *XCURSOR_SIZE*
 	Specify an alternative mouse cursor size in pixels. Requires
-	XCURSOR_THEME to be set also. Default 24.
+	XCURSOR_THEME to be set also. Default is 24.
 
 *XCURSOR_THEME*
 	Specify a mouse cursor theme within XCURSOR_PATH.

--- a/docs/labwc-menu.5.scd
+++ b/docs/labwc-menu.5.scd
@@ -12,7 +12,7 @@ Static menus are built based on the menu.xml file located at
 # SYNTAX
 
 The menu file must be entirely enclosed within <openbox_menu> and
-</openbox_menu> tags.  Inside these tags, menus are specified as follows:
+</openbox_menu> tags. Inside these tags, menus are specified as follows:
 
 ```
 <!-- A toplevel menu -->
@@ -111,7 +111,7 @@ Pipe menus are menus generated dynamically based on output of scripts or
 binaries. They are so-called because the output of the executable is piped to
 the labwc menu.
 
-For any *<menu id="" label="" execute="COMMAND"/>* entry in menu.xml, the
+For any *<menu id="" label="" execute="COMMAND" />* entry in menu.xml, the
 COMMAND will be executed the first time the item is selected (for example by
 cursor or keyboard input). The XML output of the command will be parsed and
 shown as a submenu. The content of pipemenus is cached until the whole menu
@@ -124,7 +124,7 @@ menus, for example:
 ```
 <openbox_pipe_menu>
   <item label="Terminal">
-    <action name="Execute" command="xterm"/>
+    <action name="Execute" command="xterm" />
   </item>
 </openbox_pipe_menu>
 ```
@@ -144,7 +144,7 @@ obmenu-generator with the menu generator of your choice):
 ```
 <?xml version="1.0"?>
 <openbox_menu>
-  <menu id="root-menu" label="" execute="obmenu-generator"/>
+  <menu id="root-menu" label="" execute="obmenu-generator" />
 </openbox_menu>
 ```
 

--- a/docs/labwc-theme.5.scd
+++ b/docs/labwc-theme.5.scd
@@ -135,7 +135,7 @@ window.*.title.bg.colorTo.splitTo: #557485
 
 *window.active.title.bg*
 	Texture for the focused window's titlebar. See texture section above.
-	Default is *Solid*
+	Default is *Solid*.
 
 *window.active.title.bg.color*
 	Background color for the focused window's titlebar. See texture section
@@ -144,7 +144,7 @@ window.*.title.bg.colorTo.splitTo: #557485
 
 *window.inactive.title.bg*
 	Texture for non-focused windows' titlebars. See texture section above.
-	Default is *Solid*
+	Default is *Solid*.
 
 *window.inactive.title.bg.color*
 	Background color for non-focused windows' titlebars. See texture section
@@ -470,7 +470,7 @@ all are supported.
 	Width of magnifier window border in pixels. Default is 1.
 
 *magnifier.border.color*
-	Color of the magnfier window border. Default is #ff0000 (red).
+	Color of the magnifier window border. Default is #ff0000 (red).
 
 # BUTTONS
 

--- a/docs/labwc.1.scd
+++ b/docs/labwc.1.scd
@@ -66,7 +66,7 @@ the `--exit` and `--reconfigure` options use.
 	Manager, or the Window Manager can be launched independently first. On
 	Wayland, the Compositor is both Display Server and Window Manager, so
 	the described session management mechanisms do not work because the
-	Compositor needs to be running before the session can function.  As some
+	Compositor needs to be running before the session can function. As some
 	session clients support both X11 and Wayland, this command line option
 	avoids re-writes and fragmentation.
 
@@ -75,7 +75,7 @@ the `--exit` and `--reconfigure` options use.
 	(i.e. nested in a compositor). <fmtstr> is a format string to be used as
 	the window title, replacing `%o` with the name of the output
 	region. This is useful when simulating multiple screens, such as with
-	running labwc with the enviornment variable `WLR_WL_OUTPUTS=2`. In this
+	running labwc with the environment variable `WLR_WL_OUTPUTS=2`. In this
 	case, `%o` will be unique per simulated screen.
 
 *-v, --version*

--- a/docs/menu.xml
+++ b/docs/menu.xml
@@ -23,7 +23,7 @@
     Any menu with the id "workspaces" will be hidden
     if there is only a single workspace available.
   -->
-  <menu id="client-send-to-menu"/>
+  <menu id="client-send-to-menu" />
   <!--
     openbox default workspace selector
     to use replace above workspace menu with the example below
@@ -56,9 +56,9 @@
   # A prompt can be used as follows:
   <item label="Exit">
     <action name="If">
-      <prompt message="Do you really want to exit the compositor?"/>
+      <prompt message="Do you really want to exit the compositor?" />
       <then>
-        <action name="Exit"/>
+        <action name="Exit" />
       </then>
     </action>
   </item>

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -642,10 +642,10 @@
     #     string and '?' matches any single character.
 
     <windowRules>
-      <windowRule identifier="*"><action name="Maximize"/></windowRule>
-      <windowRule identifier="foo" serverDecoration="yes"/>
-      <windowRule title="bar" serverDecoration="yes"/>
-      <windowRule identifier="baz" title="quax" serverDecoration="yes"/>
+      <windowRule identifier="*"><action name="Maximize" /></windowRule>
+      <windowRule identifier="foo" serverDecoration="yes" />
+      <windowRule title="bar" serverDecoration="yes" />
+      <windowRule identifier="baz" title="quax" serverDecoration="yes" />
     </windowRules>
 
     # Example below for `lxqt-panel` and `pcmanfm-qt \-\-desktop`
@@ -656,18 +656,18 @@
       <windowRule identifier="lxqt-panel" matchOnce="true">
         <skipTaskbar>yes</skipTaskbar>
         <action name="MoveTo" x="0" y="0" />
-        <action name="ToggleAlwaysOnTop"/>
+        <action name="ToggleAlwaysOnTop" />
       </windowRule>
       <windowRule title="pcmanfm-desktop*">
         <skipTaskbar>yes</skipTaskbar>
         <skipWindowSwitcher>yes</skipWindowSwitcher>
         <fixedPosition>yes</fixedPosition>
         <action name="MoveTo" x="0" y="0" />
-        <action name="ToggleAlwaysOnBottom"/>
+        <action name="ToggleAlwaysOnBottom" />
       </windowRule>
       <windowRule identifier="org.qutebrowser.qutebrowser">
         <action name="ResizeTo" width="1024" height="800" />
-        <action name="AutoPlace"/>
+        <action name="AutoPlace" />
       </windowRule>
     </windowRules>
   -->

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -141,14 +141,14 @@ static struct key_combos {
  * <mouse>
  *   <context name="Maximize">
  *     <mousebind button="Left" action="Click">
- *       <action name="Focus"/>
- *       <action name="Raise"/>
- *       <action name="ToggleMaximize"/>
+ *       <action name="Focus" />
+ *       <action name="Raise" />
+ *       <action name="ToggleMaximize" />
  *     </mousebind>
  *   </context>
  *   <context name="Root">
  *     <mousebind direction="Up" action="Scroll">
- *       <action name="GoToDesktop" to="left" wrap="yes"/>
+ *       <action name="GoToDesktop" to="left" wrap="yes" />
  *     </mousebind>
  *   </context>
  * </mouse>

--- a/include/scaled-buffer/scaled-buffer.h
+++ b/include/scaled-buffer/scaled-buffer.h
@@ -130,7 +130,7 @@ void scaled_buffer_request_update(struct scaled_buffer *self,
 
 /**
  * scaled_buffer_invalidate_sharing - clear the list of entire cached
- * scaled_buffers used to share visually dupliated buffers. This should
+ * scaled_buffers used to share visually duplicated buffers. This should
  * be called on Reconfigure to force updates of newly created
  * scaled_buffers rather than reusing ones created before Reconfigure.
  */

--- a/src/action.c
+++ b/src/action.c
@@ -145,7 +145,7 @@ struct action_arg_list {
  * Will expand to:
  *
  * enum action_type {
- *	ACTION_TYPE_INVALID,
+ *	ACTION_TYPE_INVALID = 0,
  *	ACTION_TYPE_NONE,
  *	ACTION_TYPE_CLOSE,
  *	ACTION_TYPE_KILL,
@@ -1312,7 +1312,7 @@ run_action(struct view *view, struct action *action,
 
 			/*
 			 * To support only setting one of width/height
-			 * in <action name="ResizeTo" width="" height=""/>
+			 * in <action name="ResizeTo" width="" height="" />
 			 * we fall back to current dimension when unset.
 			 */
 			struct wlr_box box = {

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -613,9 +613,9 @@ fill_mousebind(xmlNode *node, const char *context)
 	/*
 	 * Example of what we are parsing:
 	 * <mousebind button="Left" action="DoubleClick">
-	 *   <action name="Focus"/>
-	 *   <action name="Raise"/>
-	 *   <action name="ToggleMaximize"/>
+	 *   <action name="Focus" />
+	 *   <action name="Raise" />
+	 *   <action name="ToggleMaximize" />
 	 * </mousebind>
 	 */
 

--- a/src/img/img-xbm.c
+++ b/src/img/img-xbm.c
@@ -226,7 +226,7 @@ out:
 
 /*
  * Openbox built-in icons are not bigger than 8x8, so have only written this
- * function to cope wit that max size
+ * function to cope with that max size
  */
 #define LABWC_BUILTIN_ICON_MAX_SIZE (8)
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -172,7 +172,7 @@ item_parse_accelerator(struct menuitem *item, const char *text)
 			accel_ptr = underscore + 1;
 			break;
 		} else {
-			/* Ignore empty accelertor */
+			/* Ignore empty accelerator */
 			break;
 		}
 	}
@@ -627,7 +627,7 @@ fill_menu(struct menu *parent, xmlNode *n)
 			 *
 			 * <?xml version="1.0" encoding="UTF-8"?>
 			 * <openbox_menu>
-			 *   <menu id="root-menu" label="foo" execute="bar"/>
+			 *   <menu id="root-menu" label="foo" execute="bar" />
 			 * </openbox_menu>
 			 */
 		} else {

--- a/src/theme.c
+++ b/src/theme.c
@@ -788,7 +788,7 @@ entry(struct theme *theme, const char *key, const char *value)
 			value, "window.button.spacing");
 	}
 
-	/* botton hover overlay */
+	/* button hover overlay */
 	if (match_glob(key, "window.button.hover.bg.color")) {
 		parse_color(value, theme->window_button_hover_bg_color);
 	}

--- a/src/window-rules.c
+++ b/src/window-rules.c
@@ -69,8 +69,8 @@ window_rules_get_property(struct view *view, const char *property)
 	 * for foot's "serverDecoration" property to be "default".
 	 *
 	 *     <windowRules>
-	 *       <windowRule identifier="*" serverDecoration="no"/>
-	 *       <windowRule identifier="foot" serverDecoration="default"/>
+	 *       <windowRule identifier="*" serverDecoration="no" />
+	 *       <windowRule identifier="foot" serverDecoration="default" />
 	 *     </windowRules>
 	 */
 	struct window_rule *rule;


### PR DESCRIPTION
Codespell(1)-pointed typos in files listed by `git ls-files` (sans checkpatch.pl and possibly some others). Removed some extra spaces. Added a few missing trailing periods. `Default is ...`.  Added spaces in ' />' where missing (sans e.g. wayland protocol and t/* files).
Fit some lines in docs/*.scd to 80 colums.

Used git grep commands (to find similar cases):
$ git grep -n '\S/>'
$ git grep -nF '.  '
$ git grep -n '[^\t*'\'',{#]\t'
$ git grep -ni 'default '

No functional change. No change in *.[ch] line numbers.

--

I hope no new typos before release (last seen: enviornment 2026-05-16) :D