### PR TITLE
Add default keybind super-d for ToggleShowDesktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ If you have not created an rc.xml config file, default bindings will be:
 | `super`-`return`         | lab-sensible-terminal
 | `alt`-`F4`               | close window
 | `super`-`a`              | toggle maximize
+| `super`-`d`              | toggle show-desktop
 | `super`-`mouse-left`     | move window
 | `super`-`mouse-right`    | resize window
 | `super`-`arrow`          | resize window to fill half the output

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -863,6 +863,7 @@ overrideInhibition="">*
   W-Return - lab-sensible-terminal
   A-F4 - close window
   W-a - toggle maximize
+  W-d - toggle show-desktop
   W-<arrow> - resize window to fill half or quarter of the output
   A-Space - show window menu
 ```

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -279,6 +279,9 @@
     <keybind key="W-a">
       <action name="ToggleMaximize" />
     </keybind>
+    <keybind key="W-d">
+      <action name="ToggleShowDesktop" />
+    </keybind>
     <keybind key="W-Left">
       <action name="SnapToEdge" direction="left" combine="yes" />
     </keybind>

--- a/include/config/default-bindings.h
+++ b/include/config/default-bindings.h
@@ -29,6 +29,9 @@ static struct key_combos {
 		.binding = "W-a",
 		.action = "ToggleMaximize",
 	}, {
+		.binding = "W-d",
+		.action = "ToggleShowDesktop",
+	}, {
 		.binding = "W-Left",
 		.action = "SnapToEdge",
 		.attributes[0] = {


### PR DESCRIPTION
@Consolatis You suggested this when we first introduced `ToggleShowDesktop` and I think it's a good idea.

Suggest we do it before pressing the button on the `0.20.0` release.