### PR TITLE
[v0.9] view: save view->last_placement on initial positioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,9 +92,15 @@ jobs:
           sed -i '/^Types/ s/deb/& deb-src/' /etc/apt/sources.list.d/debian.sources
           apt-get update
           apt-get upgrade -y
-          apt-get install -y git gcc clang gdb xwayland
-          apt-get build-dep -y labwc
-          apt-get build-dep -y libwlroots-0.19-dev
+          apt-get install -y git gcc clang gdb xwayland meson pkgconf
+          apt-get build-dep -y libwlroots-0.20-dev
+          # Debian Testing temporarily removed labwc due to wlroots 0.20 transition
+          # apt-get build-dep -y labwc
+          # Thus install the deps manually
+          apt-get install -y libxml2-dev liblzma-dev libglib2.0-dev \
+            libcairo2-dev libpango1.0-dev libinput-dev libpng-dev \
+            librsvg2-dev wayland-protocols libxkbcommon-dev libdrm-dev \
+            scdoc gettext libsfdo-dev
 
       - name: Install FreeBSD dependencies
         if: matrix.name == 'FreeBSD'

--- a/include/view.h
+++ b/include/view.h
@@ -546,7 +546,15 @@ bool view_titlebar_visible(struct view *view);
 void view_set_ssd_mode(struct view *view, enum lab_ssd_mode mode);
 void view_set_decorations(struct view *view, enum lab_ssd_mode mode, bool force_ssd);
 void view_toggle_fullscreen(struct view *view);
+
+/*
+ * Saves the window position in view->last_placement. This should be called
+ * when a view is first mapped or manually moved by the user.
+ */
+void view_save_last_placement(struct view *view);
+/* Restores and adjusts the view's position from the view->last_placement */
 void view_adjust_for_layout_change(struct view *view);
+
 void view_move_to_edge(struct view *view, enum lab_edge direction, bool snap_to_windows);
 void view_grow_to_edge(struct view *view, enum lab_edge direction);
 void view_shrink_to_edge(struct view *view, enum lab_edge direction);

--- a/src/common/buf.c
+++ b/src/common/buf.c
@@ -53,15 +53,14 @@ buf_expand_shell_variables(struct buf *s)
 		if (s->data[i] == '$' && isvalid(s->data[i+1])) {
 			/* expand environment variable */
 			buf_clear(&environment_variable);
-			buf_add(&environment_variable, s->data + i + 1);
-			char *p = environment_variable.data;
-			while (isvalid(*p)) {
-				++p;
+			int len = 0;
+			while (isvalid(s->data[i + 1 + len])) {
+				buf_add_char(&environment_variable, s->data[i + 1 + len]);
+				++len;
 			}
-			*p = '\0';
-			i += strlen(environment_variable.data);
+			i += len;
 			strip_curly_braces(environment_variable.data);
-			p = getenv(environment_variable.data);
+			char *p = getenv(environment_variable.data);
 			if (p) {
 				buf_add(&tmp, p);
 			}

--- a/src/img/img-xpm.c
+++ b/src/img/img-xpm.c
@@ -351,7 +351,7 @@ xpm_load_to_surface(struct file_handle *handle)
 			goto out;
 		}
 
-		for (int n = 0, xcnt = 0; n < wbytes; n += cpp, xcnt++) {
+		for (int n = 0; n < wbytes; n += cpp) {
 			g_strlcpy(pixel_str, &buffer[n], cpp + 1);
 
 			struct xpm_color *color =

--- a/src/view.c
+++ b/src/view.c
@@ -568,8 +568,6 @@ view_moved(struct view *view)
 	}
 }
 
-static void save_last_placement(struct view *view);
-
 void
 view_move_resize(struct view *view, struct wlr_box geo)
 {
@@ -589,7 +587,7 @@ view_move_resize(struct view *view, struct wlr_box geo)
 	 * Not sure if it might have other side-effects though.
 	 */
 	if (!view->adjusting_for_layout_change) {
-		save_last_placement(view);
+		view_save_last_placement(view);
 	}
 }
 
@@ -1721,8 +1719,8 @@ view_set_fullscreen(struct view *view, bool fullscreen)
 	cursor_update_focus(view->server);
 }
 
-static void
-save_last_placement(struct view *view)
+void
+view_save_last_placement(struct view *view)
 {
 	assert(view);
 	struct output *output = view->output;

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -128,6 +128,8 @@ do_late_positioning(struct view *view)
 			view->pending.width, view->pending.height,
 			&view->pending.x, &view->pending.y);
 	}
+
+	view_save_last_placement(view);
 }
 
 static void

--- a/src/xwayland.c
+++ b/src/xwayland.c
@@ -789,6 +789,9 @@ set_initial_position(struct view *view,
 		}
 	}
 
+	/* view->last_placement is still unset if has_position=true */
+	view_save_last_placement(view);
+
 	/*
 	 * Always make sure the view is onscreen and adjusted for any
 	 * layout changes that could have occurred between map_request


### PR DESCRIPTION
Backport of #3433 to fix #3616.

Not personally tested at all but confirmed fixing the issue in #3616.

----
Also some assorted compile fix backports to keep the CI happy.