### PR TITLE
src/buffer.c: prevent creating invalid buffers

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -95,6 +95,7 @@ buffer_adopt_cairo_surface(cairo_surface_t *surface)
 
 	buffer->surface = surface;
 	buffer->data = cairo_image_surface_get_data(buffer->surface);
+	assert(buffer->data);
 	buffer->format = DRM_FORMAT_ARGB8888;
 	buffer->stride = cairo_image_surface_get_stride(buffer->surface);
 	buffer->logical_width = width;
@@ -107,6 +108,12 @@ buffer_adopt_cairo_surface(cairo_surface_t *surface)
 struct lab_data_buffer *
 buffer_create_cairo(uint32_t logical_width, uint32_t logical_height, float scale)
 {
+	if (!logical_width || !logical_height) {
+		wlr_log(WLR_ERROR, "Failed to create cairo buffer of %ux%u: dimensions must be > 0",
+			logical_width, logical_height);
+		return NULL;
+	}
+
 	/* Create an image surface with the scaled size */
 	cairo_surface_t *surface =
 		cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
@@ -142,6 +149,7 @@ buffer_create_from_data(void *pixel_data, uint32_t width, uint32_t height,
 	buffer->logical_width = width;
 	buffer->logical_height = height;
 	buffer->data = pixel_data;
+	assert(buffer->data);
 	buffer->format = DRM_FORMAT_ARGB8888;
 	buffer->stride = stride;
 	buffer->surface = cairo_image_surface_create_for_data(
@@ -188,6 +196,10 @@ buffer_resize(struct lab_data_buffer *src_buffer, int width, int height,
 
 	struct lab_data_buffer *buffer =
 		buffer_create_cairo(width, height, scale);
+	if (!buffer) {
+		wlr_log(WLR_INFO, "Failed to resize buffer to %dx%d", width, height);
+		return NULL;
+	}
 	cairo_t *cairo = cairo_create(buffer->surface);
 
 	struct wlr_box container = {

--- a/src/common/font.c
+++ b/src/common/font.c
@@ -82,6 +82,7 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	cairo_pattern_t *bg_pattern, double scale, bool use_markup)
 {
 	if (string_null_or_empty(text)) {
+		*buffer = NULL;
 		return;
 	}
 
@@ -89,6 +90,13 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	font_get_buffer_size(max_width, text, font, &width, &computed_height);
 	if (height <= 0) {
 		height = computed_height;
+	}
+
+	if (height <= 0 || width <= 0) {
+		wlr_log(WLR_INFO, "Refusing to create invisible font buffer of %dx%d",
+			width, height);
+		*buffer = NULL;
+		return;
 	}
 
 	*buffer = buffer_create_cairo(width, height, scale);

--- a/src/scaled-buffer/scaled-font-buffer.c
+++ b/src/scaled-buffer/scaled-font-buffer.c
@@ -29,7 +29,7 @@ _create_buffer(struct scaled_buffer *scaled_buffer, double scale)
 		&self->font, self->color, bg_pattern, scale, self->use_markup);
 
 	if (!buffer) {
-		wlr_log(WLR_ERROR, "font_buffer_create() failed");
+		wlr_log(WLR_INFO, "font_buffer_create() failed");
 	}
 
 	zfree_pattern(solid_bg_pattern);


### PR DESCRIPTION
Testcase: set title of foot to an invisible string (here LTR)

First one works and correctly sets the title, 2nd one crashes
- `printf "\x1b]0;\xe2\x80\x8e%s\x07" "some title"`
- `printf "\x1b]0;\xe2\x80\x8e%s\x07" ""`

Reported-by: Domo via IRC