### PR TITLE
[v0.9] src/buffer.c: prevent creating invalid buffers

### DIFF
--- a/src/common/font.c
+++ b/src/common/font.c
@@ -82,6 +82,7 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	cairo_pattern_t *bg_pattern, double scale)
 {
 	if (string_null_or_empty(text)) {
+		*buffer = NULL;
 		return;
 	}
 
@@ -89,6 +90,13 @@ font_buffer_create(struct lab_data_buffer **buffer, int max_width,
 	font_get_buffer_size(max_width, text, font, &width, &computed_height);
 	if (height <= 0) {
 		height = computed_height;
+	}
+
+	if (height <= 0 || width <= 0) {
+		wlr_log(WLR_INFO, "Refusing to create invisible font buffer of %dx%d",
+			width, height);
+		*buffer = NULL;
+		return;
 	}
 
 	*buffer = buffer_create_cairo(width, height, scale);

--- a/src/scaled-buffer/scaled-font-buffer.c
+++ b/src/scaled-buffer/scaled-font-buffer.c
@@ -29,7 +29,7 @@ _create_buffer(struct scaled_buffer *scaled_buffer, double scale)
 		&self->font, self->color, bg_pattern, scale);
 
 	if (!buffer) {
-		wlr_log(WLR_ERROR, "font_buffer_create() failed");
+		wlr_log(WLR_INFO, "font_buffer_create() failed");
 	}
 
 	zfree_pattern(solid_bg_pattern);


### PR DESCRIPTION
Testcase: set title of foot to an invisible string (here LTR)

First one works and correctly sets the title, 2nd one crashes
- `printf "\x1b]0;\xe2\x80\x8e%s\x07" "some title"`
- `printf "\x1b]0;\xe2\x80\x8e%s\x07" ""`

Reported-by: Domo via IRC

-----
Simplified version of #3630 to reduce chances of causing side effects.