### PR TITLE
readme: Use `meson setup` in example to fix meson warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Build dependencies include:
 - meson, ninja, gcc/clang
 - wayland-protocols
 
-Disable xwayland with `meson -Dxwayland=disabled build/`
+Disable xwayland with `meson setup -Dxwayland=disabled build/`
 
 For OS/distribution specific details see [wiki].
 


### PR DESCRIPTION
Using meson without an explicit command emits a warning.