### PR TITLE
support on-screen keyboard by allow IME to be on top layer

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -179,6 +179,7 @@ this is for compatibility with Openbox.
   <reuseOutputMode>no</reuseOutputMode>
   <xwaylandPersistence>no</xwaylandPersistence>
   <primarySelection>yes</primarySelection>
+  <allowIMEOnLockScreen>no</allowIMEOnLockScreen>
   <promptCommand>[see details below]</promptCommand>
 </core>
 ```
@@ -266,6 +267,22 @@ this is for compatibility with Openbox.
 	configured at launch. This enables autoscroll (middle-click to scroll
 	up/down) in Chromium and electron based clients without inadvertently
 	pasting the primary clipboard. Default is yes.
+
+*<core><allowIMEOnLockScreen>* [yes|no]
+	Allow the on-screen keyboard (OSK) belonging to the active
+	input-method client (the holder of the zwp_input_method_v2 global) to
+	be shown, and to receive pointer/touch input, above an
+	ext-session-lock-v1 lock screen (e.g. swaylock). This is an opt-in
+	exception to the lock screen normally hiding all other surfaces, and
+	exists so touch-screen users can enter their password with an external
+	OSK. labwc does not show the OSK automatically; bring it up together
+	with the locker, for example:
+
+	```
+	busctl call sm.puri.OSK0 /sm/puri/OSK0 sm.puri.OSK0 SetVisible b true && swaylock
+	```
+
+	Default is no.
 
 *<core><promptCommand>*
 	Set command to be invoked for an action prompt (*<action><prompt>*)

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -17,6 +17,7 @@
     <reuseOutputMode>no</reuseOutputMode>
     <xwaylandPersistence>no</xwaylandPersistence>
     <primarySelection>yes</primarySelection>
+    <allowIMEOnLockScreen>no</allowIMEOnLockScreen>
     <!--
       # See labwc-config(5) for details
       <promptCommand></promptCommand>

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -86,6 +86,12 @@ struct rcxml {
 	uint32_t allowed_interfaces;
 	bool xwayland_persistence;
 	bool primary_selection;
+	/*
+	 * Opt-in exception that lets the on-screen keyboard belonging to the
+	 * active input-method client render (and receive pointer/touch input)
+	 * above an ext-session-lock-v1 lock screen.
+	 */
+	bool allow_ime_on_lock_screen;
 	char *prompt_command;
 
 	/* placement */

--- a/include/layers.h
+++ b/include/layers.h
@@ -13,9 +13,16 @@ struct lab_layer_surface {
 	struct wlr_layer_surface_v1 *layer_surface;
 	struct wlr_scene_layer_surface_v1 *scene_layer_surface;
 
+	struct wl_list link; /* layers.c layer_surfaces */
+
 	bool mapped;
 	/* true only inside handle_unmap() */
 	bool being_unmapped;
+	/*
+	 * true while this surface is temporarily elevated above the
+	 * ext-session-lock-v1 lock screen (see allowIMEOnLockScreen).
+	 */
+	bool on_lock_screen;
 
 	struct wl_listener map;
 	struct wl_listener unmap;
@@ -45,5 +52,12 @@ void layers_finish(void);
 void layers_arrange(struct output *output);
 void layer_try_set_focus(struct seat *seat,
 	struct wlr_layer_surface_v1 *layer_surface);
+
+/*
+ * Re-evaluate which layer-shell surfaces should be elevated above the
+ * session-lock screen. Should be called whenever the session-lock state
+ * changes (lock acquired / released).
+ */
+void layers_update_on_lock_screen(void);
 
 #endif /* LABWC_LAYERS_H */

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1164,6 +1164,8 @@ entry(xmlNode *node, char *nodename, char *content)
 		set_bool(content, &rc.xwayland_persistence);
 	} else if (!strcasecmp(nodename, "primarySelection.core")) {
 		set_bool(content, &rc.primary_selection);
+	} else if (!strcasecmp(nodename, "allowIMEOnLockScreen.core")) {
+		set_bool(content, &rc.allow_ime_on_lock_screen);
 
 	} else if (!strcasecmp(nodename, "promptCommand.core")) {
 		xstrdup_replace(rc.prompt_command, content);
@@ -1536,6 +1538,7 @@ rcxml_init(void)
 	rc.allowed_interfaces = UINT32_MAX;
 	rc.xwayland_persistence = false;
 	rc.primary_selection = true;
+	rc.allow_ime_on_lock_screen = false;
 
 	init_font_defaults(&rc.font_activewindow);
 	init_font_defaults(&rc.font_inactivewindow);

--- a/src/input/ime.c
+++ b/src/input/ime.c
@@ -13,10 +13,13 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include "common/mem.h"
 #include "common/scene-helpers.h"
+#include "config/rcxml.h"
 #include "input/keyboard.h"
 #include "labwc.h"
+#include "layers.h"
 #include "node.h"
 #include "output.h"
+#include "session-lock.h"
 
 #define SAME_CLIENT(wlr_obj1, wlr_obj2) \
 	(wl_resource_get_client((wlr_obj1)->resource) \
@@ -427,6 +430,15 @@ handle_new_input_method(struct wl_listener *listener, void *data)
 	}
 
 	relay->input_method = input_method;
+	wlr_log(WLR_INFO, "IME-on-lock: input-method bound by client %p",
+		(void *)wl_resource_get_client(input_method->resource));
+
+	/*
+	 * If the session is already locked when the input-method binds (e.g.
+	 * the OSK started/registered after the lock screen appeared), this
+	 * gives its layer surface a chance to be elevated above the lock.
+	 */
+	layers_update_on_lock_screen();
 
 	relay->input_method_commit.notify = handle_input_method_commit;
 	wl_signal_add(&relay->input_method->events.commit,

--- a/src/layers.c
+++ b/src/layers.c
@@ -10,21 +10,186 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 #include <strings.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
+#include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_input_method_v2.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_scene.h>
+#include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include "common/macros.h"
 #include "common/mem.h"
 #include "config/rcxml.h"
+#include "input/ime.h"
+#include "input/input.h"
 #include "labwc.h"
 #include "node.h"
 #include "output.h"
+#include "session-lock.h"
 
 #define LAB_LAYERSHELL_VERSION 4
+
+/* All mapped/unmapped layer-shell surfaces (struct lab_layer_surface.link) */
+static struct wl_list layer_surfaces = {0};
+
+/*
+ * Returns the client that owns the active zwp_input_method_v2 global, or NULL
+ * if no input-method is currently bound to the seat.
+ */
+static struct wl_client *
+input_method_client(void)
+{
+	struct input_method_relay *relay = server.seat.input_method_relay;
+	if (!relay || !relay->input_method) {
+		return NULL;
+	}
+	return wl_resource_get_client(relay->input_method->resource);
+}
+
+/*
+ * Whether the given client owns a zwp_virtual_keyboard_v1. On-screen keyboards
+ * inject key events through a virtual keyboard (squeekboard falls back to this
+ * whenever another client, e.g. fcitx, already holds the input-method global),
+ * so a layer-shell client that also owns a virtual keyboard is auto-detected as
+ * an OSK without requiring a hardcoded namespace or any configuration.
+ */
+static bool
+client_has_virtual_keyboard(struct wl_client *client)
+{
+	if (!client) {
+		return false;
+	}
+	struct input *input;
+	wl_list_for_each(input, &server.seat.inputs, link) {
+		struct wlr_input_device *device = input->wlr_input_device;
+		if (!device || device->type != WLR_INPUT_DEVICE_KEYBOARD) {
+			continue;
+		}
+		struct wlr_virtual_keyboard_v1 *vkbd =
+			wlr_input_device_get_virtual_keyboard(device);
+		if (vkbd && wl_resource_get_client(vkbd->resource) == client) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool
+should_be_on_lock_screen(struct lab_layer_surface *layer)
+{
+	if (!rc.allow_ime_on_lock_screen) {
+		return false;
+	}
+	if (!server.session_lock_manager
+			|| !server.session_lock_manager->locked) {
+		return false;
+	}
+	if (!layer->scene_layer_surface) {
+		return false;
+	}
+	struct wlr_layer_surface_v1 *layer_surface =
+		layer->scene_layer_surface->layer_surface;
+	const char *ns = layer_surface->namespace
+		? layer_surface->namespace : "(null)";
+	if (!layer_surface->surface->mapped) {
+		wlr_log(WLR_INFO, "IME-on-lock: '%s' NOT eligible: not mapped", ns);
+		return false;
+	}
+
+	/*
+	 * Eligible if the surface belongs to the active input-method client, or
+	 * if its client also owns a virtual keyboard (auto-detected OSK). The
+	 * latter covers setups where another client (e.g. fcitx) holds the
+	 * input-method global, so the OSK owns its keyboard layer surface and
+	 * virtual keyboard from a separate client.
+	 */
+	struct wl_client *surface_client =
+		wl_resource_get_client(layer_surface->resource);
+	struct wl_client *im_client = input_method_client();
+	bool client_match = im_client && surface_client == im_client;
+	bool vkbd_match = client_has_virtual_keyboard(surface_client);
+	bool eligible = client_match || vkbd_match;
+
+	wlr_log(WLR_INFO, "IME-on-lock: '%s' -> %s (client_match=%d "
+		"vkbd_match=%d)",
+		ns, eligible ? "ELIGIBLE" : "NOT eligible",
+		client_match, vkbd_match);
+	return eligible;
+}
+
+/*
+ * Move an input-method layer-shell surface in or out of the per-output
+ * session-lock tree. The lock tree is rendered (and pointer/touch hit-tested)
+ * above the lock screen. Both the layer-tree and the session-lock tree share
+ * the same output-origin position, so the surface keeps its on-screen
+ * placement across the reparent.
+ */
+static void
+set_layer_on_lock_screen(struct lab_layer_surface *layer, bool enable)
+{
+	if (!layer->scene_layer_surface) {
+		return;
+	}
+	struct wlr_layer_surface_v1 *layer_surface =
+		layer->scene_layer_surface->layer_surface;
+	struct wlr_output *wlr_output = layer_surface->output;
+	if (!wlr_output || !wlr_output->data) {
+		return;
+	}
+	struct output *output = wlr_output->data;
+	struct wlr_scene_node *node = &layer->scene_layer_surface->tree->node;
+
+	if (enable) {
+		/*
+		 * Idempotently (re-)assert the surface above the lock screen.
+		 * This is called from several triggers (lock created, lock
+		 * surface mapped, input-method bound, surface commit) so that
+		 * the OSK reliably ends up on top regardless of the order in
+		 * which the lock surface and the OSK settle.
+		 */
+		if (node->parent != output->session_lock_tree) {
+			wlr_log(WLR_INFO, "IME-on-lock: elevating layer surface "
+				"'%s' above lock screen", layer_surface->namespace);
+			wlr_scene_node_reparent(node, output->session_lock_tree);
+		}
+		wlr_scene_node_raise_to_top(node);
+		layer->on_lock_screen = true;
+	} else if (layer->on_lock_screen) {
+		wlr_log(WLR_INFO, "IME-on-lock: returning layer surface '%s' "
+			"to normal layer", layer_surface->namespace);
+		wlr_scene_node_reparent(node,
+			output->layer_tree[layer_surface->current.layer]);
+		layer->on_lock_screen = false;
+	}
+}
+
+static void
+update_layer_on_lock_screen(struct lab_layer_surface *layer)
+{
+	set_layer_on_lock_screen(layer, should_be_on_lock_screen(layer));
+}
+
+void
+layers_update_on_lock_screen(void)
+{
+	if (!layer_surfaces.next) {
+		return;
+	}
+	wlr_log(WLR_INFO, "IME-on-lock: re-evaluating layer surfaces "
+		"(allowIMEOnLockScreen=%s, locked=%s, n=%d)",
+		rc.allow_ime_on_lock_screen ? "yes" : "no",
+		(server.session_lock_manager
+			&& server.session_lock_manager->locked) ? "yes" : "no",
+		wl_list_length(&layer_surfaces));
+	struct lab_layer_surface *layer;
+	wl_list_for_each(layer, &layer_surfaces, link) {
+		update_layer_on_lock_screen(layer);
+	}
+}
 
 static void
 apply_override(struct output *output, struct wlr_box *usable_area)
@@ -264,8 +429,14 @@ handle_surface_commit(struct wl_listener *listener, void *data)
 	uint32_t committed = layer_surface->current.committed;
 	struct output *output = (struct output *)wlr_output->data;
 
-	/* Process layer change */
-	if (committed & WLR_LAYER_SURFACE_V1_STATE_LAYER) {
+	/*
+	 * Process layer change. Skip the reparent while the surface is
+	 * elevated above the lock screen; it lives in the session-lock tree
+	 * and update_layer_on_lock_screen() (called below) will reparent it
+	 * to the correct layer once it is no longer on the lock screen.
+	 */
+	if ((committed & WLR_LAYER_SURFACE_V1_STATE_LAYER)
+			&& !layer->on_lock_screen) {
 		wlr_scene_node_reparent(&layer->scene_layer_surface->tree->node,
 			output->layer_tree[layer_surface->current.layer]);
 	}
@@ -292,6 +463,13 @@ handle_surface_commit(struct wl_listener *listener, void *data)
 		layer_try_set_focus(seat, layer_surface);
 	}
 out:
+
+	/*
+	 * Keep an input-method on-screen keyboard elevated above the lock
+	 * screen. This also catches the case where the surface changed layer
+	 * above (which reparents it back into the normal layer-tree).
+	 */
+	update_layer_on_lock_screen(layer);
 
 	if (committed || layer->mapped != layer_surface->surface->mapped) {
 		layer->mapped = layer_surface->surface->mapped;
@@ -348,6 +526,7 @@ handle_node_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&layer->new_popup.link);
 	wl_list_remove(&layer->output_destroy.link);
 	wl_list_remove(&layer->node_destroy.link);
+	wl_list_remove(&layer->link);
 	free(layer);
 }
 
@@ -377,6 +556,9 @@ handle_unmap(struct wl_listener *listener, void *data)
 		try_to_focus_next_layer_or_toplevel();
 	}
 	cursor_update_focus();
+
+	/* Return the surface to its normal layer when it is no longer shown */
+	update_layer_on_lock_screen(layer);
 
 	layer->being_unmapped = false;
 }
@@ -424,6 +606,8 @@ handle_map(struct wl_listener *listener, void *data)
 
 	struct seat *seat = &server.seat;
 	layer_try_set_focus(seat, layer->scene_layer_surface->layer_surface);
+
+	update_layer_on_lock_screen(layer);
 }
 
 static bool
@@ -681,6 +865,7 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 
 	struct lab_layer_surface *surface = znew(*surface);
 	surface->layer_surface = layer_surface;
+	wl_list_insert(&layer_surfaces, &surface->link);
 
 	struct output *output = layer_surface->output->data;
 
@@ -727,6 +912,7 @@ handle_new_layer_surface(struct wl_listener *listener, void *data)
 void
 layers_init(void)
 {
+	wl_list_init(&layer_surfaces);
 	server.layer_shell = wlr_layer_shell_v1_create(server.wl_display,
 		LAB_LAYERSHELL_VERSION);
 	server.new_layer_surface.notify = handle_new_layer_surface;

--- a/src/seat.c
+++ b/src/seat.c
@@ -27,6 +27,7 @@
 #include "input/keyboard.h"
 #include "input/key-state.h"
 #include "labwc.h"
+#include "layers.h"
 #include "output.h"
 #include "session-lock.h"
 #include "view.h"
@@ -606,6 +607,13 @@ handle_new_virtual_keyboard(struct wl_listener *listener, void *data)
 	struct input *input = new_keyboard(seat, device, true);
 	device->data = input;
 	seat_add_device(seat, input);
+
+	/*
+	 * A newly bound virtual keyboard may identify a layer-shell client as
+	 * an on-screen keyboard (see should_be_on_lock_screen()); re-evaluate
+	 * elevation in case the OSK surface mapped before its virtual keyboard.
+	 */
+	layers_update_on_lock_screen();
 }
 
 static void

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -8,6 +8,7 @@
 #include "common/mem.h"
 #include "common/scene-helpers.h"
 #include "labwc.h"
+#include "layers.h"
 #include "node.h"
 #include "output.h"
 
@@ -63,6 +64,13 @@ update_focus(void *data)
 	if (!output->manager->focused) {
 		focus_surface(output->manager, output->surface->surface);
 	}
+	/*
+	 * Re-assert any input-method on-screen keyboard above the lock screen
+	 * now that the lock surface has actually mapped. This avoids a race
+	 * where the OSK was elevated before the lock surface existed (or the
+	 * OSK / input-method had not settled yet at lock time).
+	 */
+	layers_update_on_lock_screen();
 }
 
 static void
@@ -283,6 +291,10 @@ handle_lock_unlock(struct wl_listener *listener, void *data)
 	}
 	manager->last_active_view = NULL;
 
+	/* Return any input-method on-screen keyboard to its normal layer */
+	wlr_log(WLR_INFO, "IME-on-lock: ===== session UNLOCKED =====");
+	layers_update_on_lock_screen();
+
 	cursor_update_focus();
 }
 
@@ -343,6 +355,14 @@ handle_new_session_lock(struct wl_listener *listener, void *data)
 	manager->locked = true;
 	manager->lock = lock;
 	wlr_session_lock_v1_send_locked(lock);
+
+	/*
+	 * If an input-method on-screen keyboard is already mapped (for example
+	 * brought up just before locking via SetVisible), elevate it above the
+	 * lock screen.
+	 */
+	wlr_log(WLR_INFO, "IME-on-lock: ===== session LOCKED =====");
+	layers_update_on_lock_screen();
 }
 
 static void


### PR DESCRIPTION
**TL;DR for reviewers:** "show the on-screen keyboard (OSK) above the lock screen" may seem simple but whether it actually works depends on a fragile mix of *three independent stacks* the compositor doesn't control. This PR implement the compositor part (detect the OSK, render it above the lock) and is working. 

## Why do we need this PR

To support touchscreen users. Currently touch screen unlock can be done via a custom locker (e.g. https://codeberg.org/slatian/swaylock-mobile ) or we have make compositor support OSK

This PR is attempting to address https://github.com/labwc/labwc/discussions/3640

See this PR to for more discussion about why this should not be done in swaylock
https://github.com/swaywm/swaylock/pull/462

## what this PR does 

Detect a mapped layer-shell surface whose client owns the active `zwp_input_method_v2` (`client_match`) **or** a `zwp_virtual_keyboard_v1` (`vkbd_match`), then reparent it into the per-output `session_lock_tree` so it renders and takes touch/pointer input above the lock. The compositor **cannot** keep a surface mapped after the client destroys it — that single fact causes every limitation below.

## Why it's fragile (the three stacks)

1. **swaylock speaks only raw keyboard.** It reads `wl_keyboard` and ignores   `zwp_text_input_v3` / input-method. So keys from a **virtual keyboard** reach it , but text via input-method **`commit_string`** does not .

2. **squeekboard's visibility is tied to input-method activation.** It shows  when `activate`d (or forced via DBus `SetVisible`), and hides, which destroys its surface on `deactivate`.

3. **Only one client owns the input-method.** With fcitx present, squeekboard is a pure OSK (virtual keyboard). Without it, squeekboard owns the input-method itself.

And locking *must* clear keyboard focus for security, which sends `deactivate`.

## Compatibility matrix

✅ works · ⚠️ workaround · ❌ unsupported

| IME (fcitx/ibus)? | OSK | Result | Why |
|---|---|---|---|
| Yes | squeekboard | ✅ | `deactivate` hits fcitx, not squeekboard; it stays up and types via virtual keyboard → swaylock. `vkbd_match=1`. **Detection by IME-client alone (`client_match`) fails here — the virtual-keyboard auto-detect is what saves it.** Confirmed on desktop. |
| No | squeekboard (auto-show only) | ❌ | squeekboard owns the IME; lock's focus-clear `deactivate`s it and it destroys its surface right after we elevate it. Confirmed nested. |
| No | squeekboard + DBus `SetVisible` script | ✅ | Forcing visibility keeps it mapped while deactivated, so virtual-keyboard keys reach swaylock and it unlocks. Confirmed in nested (no fcitx). This is the documented workaround. |
| Any | onboard | ❌ | XWayland, not a layer-shell surface, uses XTEST/AT-SPI — never seen by detection. |
| Any | wvkbd / other layer-shell OSK with virtual keyboard | ✅ (expected, untested) | Auto-detected via `vkbd_match` and doesn't self-hide on `deactivate`. |

## Why we are here
Our ecosystem thrives on diversity, but fragmentation is often the cost. Touchscreen users feel that cost the most.

Today, unlocking a touchscreen device requires the compositor, locker, IME, OSK, and visibility/autohide behavior to all align perfectly. A mismatch anywhere can break the experience.

This interoperability issue is long overdue for a fix. Whether the solution belongs in the locker or the compositor, it's time we addressed it.