### PR TITLE
When ending cycle, restore focus when not switching focus.

### DIFF
--- a/src/cycle/cycle.c
+++ b/src/cycle/cycle.c
@@ -204,7 +204,7 @@ cycle_finish(bool switch_focus)
 	struct view *selected_view = server.cycle.selected_view;
 	destroy_cycle();
 
-	seat_focus_override_end(&server.seat, /*restore_focus*/ false);
+	seat_focus_override_end(&server.seat, /*restore_focus*/ !switch_focus);
 
 	/* Hiding OSD may need a cursor change */
 	cursor_update_focus();


### PR DESCRIPTION
fixes #3650

found 3 places where `cycle_finish(false)` is called with `grep -rn "cycle_finish("` (where this PR would cause any change):

```
void
cycle_reinitialize(void)
...
src/cycle/cycle.c:118:		cycle_finish(/*switch_focus*/ false);
```

this is the one from the issue:
```
static bool
handle_cycle_view_key(struct keyinfo *keyinfo)
...
if (keyinfo->translated.syms[i] == XKB_KEY_Escape) {
...
src/input/keyboard.c:481:			cycle_finish(/*switch_focus*/ false);
```

```
static void
reload_config_and_theme(void)
...
src/server.c:115:	cycle_finish(/*switch_focus*/ false);
```

Tested a bit and it fixes the problem, i don't think these other calls will cause any problems, and IMO it makes sense that you restore focus when not switching it, is there a reason it wasn't like that?