### PR TITLE
output: update comment about wlr_scene_output_layout_add_output()

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -394,9 +394,9 @@ add_output_to_layout(struct output *output)
 			return;
 		}
 		/*
-		 * Note: wlr_scene_output_layout_add_output() is not
-		 * safe to call twice, so we call it only when initially
-		 * creating the scene_output.
+		 * Note: wlr_scene_output_layout_add_output() is safe to
+		 * call multiple times, but we only need to add the output
+		 * when initially creating the scene_output.
 		 */
 		wlr_scene_output_layout_add_output(server.scene_layout,
 			layout_output, output->scene_output);


### PR DESCRIPTION
This reverts commit 447c67df62ea0187162c041736338f8c7f128309.

wlr_scene_output_layout_add_output() is now safe to call twice.

Refs: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/431e8a7fd7d459d740e14f3ad9fd7a6aab62eeb8

---

v2:

wlroots has since made wlr_scene_output_layout_add_output() safe to
call multiple times, so the old warning is outdated.

Refs: 447c67df62ea0187162c041736338f8c7f128309
Refs: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/431e8a7fd7d459d740e14f3ad9fd7a6aab62eeb8