### PR TITLE
keybind.c: fix minor coding style

### DIFF
--- a/src/config/keybind.c
+++ b/src/config/keybind.c
@@ -161,7 +161,7 @@ keybind_create(const char *keybind)
 			 * "-". In order to avoid such duplications, we perform
 			 * a lookahead on the tokens to treat that edge-case.
 			 */
-			if (symnames[i+1] && !symnames[i+1][0]) {
+			if (symnames[i + 1] && !symnames[i + 1][0]) {
 				continue;
 			}
 			symname = "-";


### PR DESCRIPTION
...adding spaces around binary operators in accordance with https://github.com/labwc/labwc/blob/master/CONTRIBUTING.md#linux-kernel-style-basics

I used https://github.com/johanmalm/c-fmt to find these.

