### PR TITLE
Round menu corners using rc.corner_radius

### DIFF
--- a/include/common/graphic-helpers.h
+++ b/include/common/graphic-helpers.h
@@ -7,6 +7,9 @@
 #include <cairo.h>
 
 struct wlr_fbox;
+struct wlr_scene_buffer;
+struct wlr_scene_node;
+struct wlr_scene_tree;
 
 /**
  * Sets the cairo color.
@@ -32,5 +35,22 @@ void draw_cairo_border(cairo_t *cairo, struct wlr_fbox fbox, double line_width);
 
 /* Converts X11 color name to ARGB32 (with alpha = 255) */
 bool lookup_named_color(const char *name, uint32_t *argb);
+
+/**
+ * create_rounded_rect_bg - Draw a filled rounded rectangle background.
+ *
+ * All four corners are rounded by @corner_radius. Falls back to a
+ * plain rectangular scene rect if Cairo buffer creation fails.
+ *
+ * @parent: parent scene tree node
+ * @width: width in layout pixels
+ * @height: height in layout pixels
+ * @color: premultiplied RGBA fill color (float[4])
+ * @corner_radius: corner radius in layout pixels
+ * @lower_to_bottom: if true, background is lowered to bottom
+ */
+void create_rounded_rect_bg(struct wlr_scene_tree *parent, int width,
+	int height, const float color[4], int corner_radius,
+	bool lower_to_bottom);
 
 #endif /* LABWC_GRAPHIC_HELPERS_H */

--- a/src/common/graphic-helpers.c
+++ b/src/common/graphic-helpers.c
@@ -3,7 +3,10 @@
 #include "common/graphic-helpers.h"
 #include <cairo.h>
 #include <glib.h> /* g_ascii_strcasecmp */
+#include <wlr/types/wlr_scene.h>
 #include <wlr/util/box.h>
+#include "buffer.h"
+#include "common/scene-helpers.h"
 #include "common/macros.h"
 #include "xcolor-table.h"
 
@@ -112,4 +115,62 @@ lookup_named_color(const char *name, uint32_t *argb)
 	*argb = 0xFF000000u | ((uint32_t)found->red << 16)
 		| ((uint32_t)found->green << 8) | found->blue;
 	return true;
+}
+
+/* 1 degree in radians (=2π/360) */
+static const double deg = 0.017453292519943295;
+
+void
+create_rounded_rect_bg(struct wlr_scene_tree *parent, int width,
+	int height, const float color[4], int corner_radius,
+	bool lower_to_bottom)
+{
+	if (width <= 0 || height <= 0) {
+		return;
+	}
+
+	double r = MIN(corner_radius, MIN(width, height) / 2.0);
+	if (r < 0) {
+		r = 0;
+	}
+
+	struct lab_data_buffer *buf = buffer_create_cairo(width, height, 1);
+	if (!buf) {
+		/* Fallback to plain rectangular scene rect */
+		lab_wlr_scene_rect_create(parent, width, height, color);
+		return;
+	}
+
+	cairo_surface_t *surface = buf->surface;
+	cairo_t *cairo = cairo_create(surface);
+
+	/* Clear to transparent */
+	cairo_set_operator(cairo, CAIRO_OPERATOR_CLEAR);
+	cairo_paint(cairo);
+	cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
+
+	if (r > 0) {
+		cairo_new_sub_path(cairo);
+		cairo_arc(cairo, r, r, r, 180 * deg, 270 * deg);
+		cairo_arc(cairo, width - r, r, r, -90 * deg, 0);
+		cairo_arc(cairo, width - r, height - r, r, 0,
+			90 * deg);
+		cairo_arc(cairo, r, height - r, r, 90 * deg,
+			180 * deg);
+		cairo_close_path(cairo);
+	} else {
+		cairo_rectangle(cairo, 0, 0, width, height);
+	}
+
+	set_cairo_color(cairo, color);
+	cairo_fill(cairo);
+
+	cairo_surface_flush(surface);
+	cairo_destroy(cairo);
+
+	struct wlr_scene_buffer *scene_buf =
+		lab_wlr_scene_buffer_create(parent, &buf->base);
+	if (lower_to_bottom) {
+		wlr_scene_node_lower_to_bottom(&scene_buf->node);
+	}
 }

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -14,7 +14,9 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include "action.h"
+#include "buffer.h"
 #include "common/buf.h"
+#include "common/graphic-helpers.h"
 #include "common/dir.h"
 #include "common/font.h"
 #include "common/lab-scene-rect.h"
@@ -277,8 +279,9 @@ item_create_scene_for_state(struct menuitem *item, float *text_color,
 		return tree;
 	}
 
-	/* Create background */
-	lab_wlr_scene_rect_create(tree, bg_width, theme->menu_item_height, bg_color);
+	/* Create background with rounded corners */
+	create_rounded_rect_bg(tree, bg_width,
+		theme->menu_item_height, bg_color, rc.corner_radius, false);
 
 	/* Create icon */
 	bool show_app_icon = !strcmp(item->parent->id, "client-list-combined-menu")
@@ -446,9 +449,9 @@ title_create_scene(struct menuitem *menuitem, int *item_y)
 		goto error;
 	}
 
-	/* Background */
-	lab_wlr_scene_rect_create(menuitem->normal_tree,
-		bg_width, theme->menu_header_height, bg_color);
+	/* Background with rounded corners */
+	create_rounded_rect_bg(menuitem->normal_tree, bg_width,
+		theme->menu_header_height, bg_color, rc.corner_radius, false);
 
 	/* Draw separator title */
 	struct scaled_font_buffer *title_font_buffer =
@@ -540,16 +543,51 @@ menu_create_scene(struct menu *menu)
 	}
 	menu->size.height = item_y + theme->menu_border_width;
 
-	struct lab_scene_rect_options opts = {
-		.border_colors = (float *[1]) {theme->menu_border_color},
-		.nr_borders = 1,
-		.border_width = theme->menu_border_width,
-		.width = menu->size.width,
-		.height = menu->size.height,
-	};
-	struct lab_scene_rect *bg_rect =
-		lab_scene_rect_create(menu->scene_tree, &opts);
-	wlr_scene_node_lower_to_bottom(&bg_rect->tree->node);
+	/* Draw rounded menu background (border + fill) as single buffer */
+	static const double deg2 = 0.017453292519943295;
+	int bw = theme->menu_border_width;
+	int w = menu->size.width;
+	int h = menu->size.height;
+	double r = MIN(rc.corner_radius, MIN(w, h) / 2.0);
+	double ir = MAX(r - bw, 0);
+
+	struct lab_data_buffer *bg_buf = buffer_create_cairo(w, h, 1);
+	cairo_surface_t *surface = bg_buf->surface;
+	cairo_t *cr = cairo_create(surface);
+
+	cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
+	cairo_paint(cr);
+
+	/* Outer rounded rect — border color */
+	cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+	cairo_new_sub_path(cr);
+	cairo_arc(cr, r, r, r, 180 * deg2, 270 * deg2);
+	cairo_arc(cr, w - r, r, r, -90 * deg2, 0);
+	cairo_arc(cr, w - r, h - r, r, 0, 90 * deg2);
+	cairo_arc(cr, r, h - r, r, 90 * deg2, 180 * deg2);
+	cairo_close_path(cr);
+	set_cairo_color(cr, theme->menu_border_color);
+	cairo_fill(cr);
+
+	/* Inner rounded rect — background fill */
+	cairo_new_sub_path(cr);
+	cairo_arc(cr, bw + ir, bw + ir, ir, 180 * deg2,
+		270 * deg2);
+	cairo_arc(cr, w - bw - ir, bw + ir, ir, -90 * deg2, 0);
+	cairo_arc(cr, w - bw - ir, h - bw - ir, ir, 0,
+		90 * deg2);
+	cairo_arc(cr, bw + ir, h - bw - ir, ir, 90 * deg2,
+		180 * deg2);
+	cairo_close_path(cr);
+	set_cairo_color(cr, theme->menu_items_bg_color);
+	cairo_fill(cr);
+
+	cairo_surface_flush(surface);
+	cairo_destroy(cr);
+
+	struct wlr_scene_buffer *bg_node =
+		lab_wlr_scene_buffer_create(menu->scene_tree, &bg_buf->base);
+	wlr_scene_node_lower_to_bottom(&bg_node->node);
 }
 
 /*

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -281,7 +281,7 @@ item_create_scene_for_state(struct menuitem *item, float *text_color,
 
 	/* Create background with rounded corners */
 	create_rounded_rect_bg(tree, bg_width,
-		theme->menu_item_height, bg_color, rc.corner_radius, false);
+		theme->menu_item_height, bg_color, rc.corner_radius - 1, false);
 
 	/* Create icon */
 	bool show_app_icon = !strcmp(item->parent->id, "client-list-combined-menu")
@@ -451,7 +451,7 @@ title_create_scene(struct menuitem *menuitem, int *item_y)
 
 	/* Background with rounded corners */
 	create_rounded_rect_bg(menuitem->normal_tree, bg_width,
-		theme->menu_header_height, bg_color, rc.corner_radius, false);
+		theme->menu_header_height, bg_color, rc.corner_radius - 1, false);
 
 	/* Draw separator title */
 	struct scaled_font_buffer *title_font_buffer =


### PR DESCRIPTION
Add a shared helper, create_rounded_rect_bg(), that renders a filled rounded rectangle via Cairo into a lab_data_buffer. Uses rc.corner_radius from the theme config (no new config options added).

- include/common/graphic-helpers.h: forward-declare wlr_scene types, declare create_rounded_rect_bg()
- src/common/graphic-helpers.c: implement create_rounded_rect_bg() with fallback to plain scene rect on buffer creation failure
- src/menu/menu.c: use create_rounded_rect_bg() for item and title backgrounds; rewrite menu container background to draw rounded border + fill in a single Cairo buffer
- Separators remain rectangular

All of this pr is created with AI I need a review for that because I'm not familiar with codebase but it does have now rouned corners on the menu.
<img width="244" height="244" alt="image" src="https://github.com/user-attachments/assets/8068a9c4-5263-4e37-873e-ccd6663a48ed" />

I don't have any problem with not accepting this because readme clearly said that no rounded corner.