### PR TITLE
output: keep the working render format when every candidate fails

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -85,7 +85,8 @@ uint32_t output_formats_10bit[] = {
 };
 
 static bool
-output_set_render_format(struct output *output, uint32_t candidates[], size_t count)
+output_set_render_format(struct output *output, uint32_t candidates[],
+		size_t count, bool silent)
 {
 	for (size_t i = 0; i < count; i++) {
 		wlr_output_state_set_render_format(&output->pending, candidates[i]);
@@ -93,6 +94,16 @@ output_set_render_format(struct output *output, uint32_t candidates[], size_t co
 			return true;
 		}
 	}
+	if (!silent) {
+		wlr_log(WLR_DEBUG, "output %s supports none of the %zu candidate"
+			" render formats", output->wlr_output->name, count);
+	}
+	/*
+	 * Leaving the last candidate tried on the pending state means no
+	 * swapchain can be created for this output at all, so clear the flag
+	 * and leave the format alone instead.
+	 */
+	output->pending.committed &= ~WLR_OUTPUT_STATE_RENDER_FORMAT;
 	return false;
 }
 
@@ -174,14 +185,14 @@ output_state_setup_hdr(struct output *output, bool silent)
 		hdr_succeeded = true;
 	} else if (render_bit_depth == LAB_RENDER_BIT_DEPTH_10) {
 		hdr_succeeded = output_set_render_format(output, output_formats_10bit,
-			ARRAY_SIZE(output_formats_10bit));
+			ARRAY_SIZE(output_formats_10bit), silent);
 		if (!hdr_succeeded) {
 			if (!silent) {
 				wlr_log(WLR_INFO, "No 10 bit color formats"
 					" supported, HDR disabled.");
 			}
 			if (!output_set_render_format(output, output_formats_8bit,
-					ARRAY_SIZE(output_formats_8bit))) {
+					ARRAY_SIZE(output_formats_8bit), silent)) {
 				if (!silent) {
 					wlr_log(WLR_ERROR, "No 8 bit color formats"
 						" supported either!");
@@ -190,7 +201,7 @@ output_state_setup_hdr(struct output *output, bool silent)
 		}
 	} else {
 		if (!output_set_render_format(output, output_formats_8bit,
-				ARRAY_SIZE(output_formats_8bit)) && !silent) {
+				ARRAY_SIZE(output_formats_8bit), silent) && !silent) {
 			wlr_log(WLR_ERROR, "No 8 bit color formats supported!");
 		}
 	}


### PR DESCRIPTION
### What

output_set_render_format() tries each candidate format on output->pending and
returns false if none of them passes. The last one it tried stays on the state
and nothing takes it off, so from then on no swapchain can be created for that
output: every frame fails with "Failed to pick primary buffer format" and
nothing is drawn.

### How

Clear the WLR_OUTPUT_STATE_RENDER_FORMAT bit when every candidate fails, so the
state doesn't change the format at all. Plus a debug line, since a probe that
rejects every candidate is otherwise invisible. It's gated on the existing
`silent` flag, because output_state_setup_hdr() runs twice per output on a
config apply and the second pass is meant to be quiet.

### Testing

Raspberry Pi 5 (vc4 + v3d), labwc 0.20.0 on wlroots 0.20.2.

I ran into this with a locally patched wlroots that hands the surface above a
fullscreen video to the backend as a wlr_output_layer. That made a render format
probe fail on a box where one never had before, and the screen went black:
"Failed to pick primary buffer format" into "Failed to create swapchain" into
"Failed to build output state", hundreds a second.

The bug isn't layer specific though. Anything that makes a probe fail ends up
there, layers are just how I got to it.

With the fix, same box: a 4K film plays with the app UI over it, both on their
own hardware planes, 0 dropped and 0 delayed frames, no format errors.

An earlier version of this PR also added layer bookkeeping to labwc's own output
states. That turned out to be papering over something my own wlroots patch did,
so it's gone. The branch name is left over from it.
