### PR TITLE
Use labnag for config error display

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -180,6 +180,7 @@ this is for compatibility with Openbox.
   <xwaylandPersistence>no</xwaylandPersistence>
   <primarySelection>yes</primarySelection>
   <promptCommand>[see details below]</promptCommand>
+  <errorCommand>[see details below]</errorCommand>
 </core>
 ```
 
@@ -314,6 +315,29 @@ this is for compatibility with Openbox.
 		--text="%m" \\
 		--ok-label="%y" \\
 		--cancel-label="%n"
+	```
+
+*<core><errorCommand>*
+	Set command to be invoked for displaying errors in the config files,
+	it is executed when errors are detected on startup and reconfigure.
+	The errors are sent to STDIN of the program, and a SIGTERM is sent to
+	it if the process is still running when a reconfigure is triggered.
+
+	The default error command is:
+	```
+	labnag \\
+		--message 'Config Error' \\
+		--button-dismiss 'Close' \\
+		--layer overlay \\
+		--timeout 0 \\
+		--detailed-message
+	```
+
+	Example using `zenity`:
+	```
+	<core>
+	  <errorCommand>zenity --title='Config Error' --text-info</errorCommand>
+	</core>
 	```
 
 ## PLACEMENT

--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -326,7 +326,7 @@ this is for compatibility with Openbox.
 	The default error command is:
 	```
 	labnag \\
-		--message 'Config Error' \\
+		--message 'Config errors detected' \\
 		--button-dismiss 'Close' \\
 		--layer overlay \\
 		--timeout 0 \\

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -20,6 +20,8 @@
     <!--
       # See labwc-config(5) for details
       <promptCommand></promptCommand>
+      # See labwc-config(5) for details
+      <errorCommand></errorCommand>
     -->
   </core>
 

--- a/include/common/nag.h
+++ b/include/common/nag.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef LABWC_NAG_H
+#define LABWC_NAG_H
+
+#include <sys/wait.h>
+#include <wlr/util/log.h>
+#include "common/buf.h"
+
+struct buf *nag_get_buf(void);
+void nag_set_error(enum wlr_log_importance importance);
+void nag_check_pid(pid_t exited_pid);
+void nag_reset(void);
+void nag_show_callback(void *data);
+
+#define nag_log(verbosity, fmt, ...) \
+do { \
+	wlr_log(verbosity, fmt, ##__VA_ARGS__); \
+	nag_set_error(verbosity); \
+	buf_add_fmt(nag_get_buf(), fmt "\n", ##__VA_ARGS__); \
+} while (0)
+
+#endif /* LABWC_NAG_H */

--- a/include/common/nag.h
+++ b/include/common/nag.h
@@ -2,13 +2,14 @@
 #ifndef LABWC_NAG_H
 #define LABWC_NAG_H
 
+#include <stdbool.h>
 #include <sys/wait.h>
 #include <wlr/util/log.h>
 #include "common/buf.h"
 
 struct buf *nag_get_buf(void);
 void nag_set_error(enum wlr_log_importance importance);
-void nag_check_pid(pid_t exited_pid);
+bool nag_check_pid(pid_t exited_pid);
 void nag_reset(void);
 void nag_show_callback(void *data);
 

--- a/include/common/nag.h
+++ b/include/common/nag.h
@@ -7,7 +7,9 @@
 #include <wlr/util/log.h>
 #include "common/buf.h"
 
+/* May return NULL if the buffer is currently written to a client */
 struct buf *nag_get_buf(void);
+
 void nag_set_error(enum wlr_log_importance importance);
 bool nag_check_pid(pid_t exited_pid);
 void nag_reset(void);
@@ -17,7 +19,9 @@ void nag_show_callback(void *data);
 do { \
 	wlr_log(verbosity, fmt, ##__VA_ARGS__); \
 	nag_set_error(verbosity); \
-	buf_add_fmt(nag_get_buf(), fmt "\n", ##__VA_ARGS__); \
+	if (nag_get_buf()) { \
+		buf_add_fmt(nag_get_buf(), fmt "\n", ##__VA_ARGS__); \
+	} \
 } while (0)
 
 #endif /* LABWC_NAG_H */

--- a/include/common/nag.h
+++ b/include/common/nag.h
@@ -14,6 +14,7 @@ void nag_set_error(enum wlr_log_importance importance);
 bool nag_check_pid(pid_t exited_pid);
 void nag_reset(void);
 void nag_show_callback(void *data);
+void nag_finish(void);
 
 #define nag_log(verbosity, fmt, ...) \
 do { \

--- a/include/common/spawn.h
+++ b/include/common/spawn.h
@@ -23,6 +23,19 @@ void spawn_async_no_shell(char const *command);
 void spawn_sync_no_shell(char const *command);
 
 /**
+ * spawn_piped_async_no_shell - execute asynchronously
+ * @command: command to be executed
+ * @pipe_fd_w: set to the write end of a pipe
+ *             connected to stdin of the command
+ * Notes:
+ * The returned pid_t has to be waited for to
+ * not produce zombies and the pipe_fd_w has to
+ * be closed. spawn_piped_close() can be used
+ * to ensure both.
+ */
+pid_t spawn_piped_async_no_shell(const char *command, int *pipe_fd_w);
+
+/**
  * spawn_piped - execute asynchronously
  * @command: command to be executed
  * @pipe_fd: set to the read end of a pipe

--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -87,6 +87,7 @@ struct rcxml {
 	bool xwayland_persistence;
 	bool primary_selection;
 	char *prompt_command;
+	char *error_command;
 
 	/* placement */
 	enum lab_placement_policy placement_policy;

--- a/src/action.c
+++ b/src/action.c
@@ -14,6 +14,7 @@
 #include "common/macros.h"
 #include "common/list.h"
 #include "common/mem.h"
+#include "common/nag.h"
 #include "common/parse-bool.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"
@@ -347,7 +348,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			} else if (!strcasecmp(content, "current")) {
 				action_arg_add_int(action, argument, CYCLE_WORKSPACE_CURRENT);
 			} else {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			}
 			goto cleanup;
@@ -360,7 +361,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			} else if (!strcasecmp(content, "focused")) {
 				action_arg_add_int(action, argument, CYCLE_OUTPUT_FOCUSED);
 			} else {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			}
 			goto cleanup;
@@ -371,7 +372,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			} else if (!strcasecmp(content, "current")) {
 				action_arg_add_int(action, argument, CYCLE_APP_ID_CURRENT);
 			} else {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			}
 			goto cleanup;
@@ -401,7 +402,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 		if (!strcmp(argument, "direction")) {
 			enum view_axis axis = view_axis_parse(content);
 			if (axis == VIEW_AXIS_NONE || axis == VIEW_AXIS_INVALID) {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {
 				action_arg_add_int(action, argument, axis);
@@ -415,7 +416,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			if (mode != LAB_SSD_MODE_INVALID) {
 				action_arg_add_int(action, argument, mode);
 			} else {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			}
 			goto cleanup;
@@ -430,7 +431,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			enum lab_edge edge = lab_edge_parse(content,
 				/*tiled*/ true, /*any*/ false);
 			if (edge == LAB_EDGE_NONE || edge == LAB_EDGE_CENTER) {
-				wlr_log(WLR_ERROR,
+				nag_log(WLR_ERROR,
 					"Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {
@@ -497,7 +498,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			enum lab_edge edge = lab_edge_parse(content,
 				/*tiled*/ false, /*any*/ false);
 			if (edge == LAB_EDGE_NONE) {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 					action_names[action->type], argument, content);
 			} else {
 				action_arg_add_int(action, argument, edge);
@@ -521,7 +522,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 			enum lab_placement_policy policy =
 				view_placement_parse(content);
 			if (policy == LAB_PLACE_INVALID) {
-				wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
+				nag_log(WLR_ERROR, "Invalid argument for action %s: '%s' (%s)",
 						action_names[action->type], argument, content);
 			} else {
 				action_arg_add_int(action, argument, policy);
@@ -542,7 +543,7 @@ action_arg_from_xml_node(struct action *action, const char *nodename, const char
 		goto cleanup;
 	}
 
-	wlr_log(WLR_ERROR, "Invalid argument for action %s: '%s'",
+	nag_log(WLR_ERROR, "Invalid argument for action %s: '%s'",
 		action_names[action->type], argument);
 
 cleanup:

--- a/src/action.c
+++ b/src/action.c
@@ -558,7 +558,7 @@ action_type_from_str(const char *action_name)
 			return i;
 		}
 	}
-	wlr_log(WLR_ERROR, "Invalid action: %s", action_name);
+	nag_log(WLR_ERROR, "Invalid action: %s", action_name);
 	return ACTION_TYPE_INVALID;
 }
 
@@ -566,7 +566,7 @@ struct action *
 action_create(const char *action_name)
 {
 	if (!action_name) {
-		wlr_log(WLR_ERROR, "action name not specified");
+		nag_log(WLR_ERROR, "action name not specified");
 		return NULL;
 	}
 

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -10,6 +10,7 @@ labwc_sources += files(
   'lab-scene-rect.c',
   'match.c',
   'mem.c',
+  'nag.c',
   'nodename.c',
   'node-type.c',
   'parse-bool.c',

--- a/src/common/nag.c
+++ b/src/common/nag.c
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#define _POSIX_C_SOURCE 200809L
+#include "common/nag.h"
+#include <assert.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include "common/buf.h"
+#include "config/rcxml.h"
+#include "common/spawn.h"
+#include "labwc.h"
+
+static struct buf log_buf = BUF_INIT;
+static bool has_error = false;
+static pid_t pid = 0;
+static int pipe_w;
+static struct wl_event_source *write_notifier = NULL;
+static size_t remaining = 0;
+
+struct buf *
+nag_get_buf(void)
+{
+	return &log_buf;
+}
+
+void
+nag_set_error(enum wlr_log_importance importance)
+{
+	if (!has_error && importance == WLR_ERROR) {
+		has_error = true;
+	}
+}
+
+void
+nag_check_pid(pid_t exited_pid)
+{
+	if (pid && pid == exited_pid) {
+		pid = 0;
+	}
+}
+
+void
+nag_reset(void)
+{
+	has_error = false;
+	buf_reset(&log_buf);
+	if (pid > 0) {
+		kill(pid, SIGTERM);
+		/* waitpid() is done in a generic SIGCHLD handler in src/server.c */
+	}
+	pid = 0;
+}
+
+static int
+handle_writable(int fd, uint32_t mask, void *data)
+{
+	assert(remaining > 0);
+	wlr_log(WLR_ERROR, "Writable");
+	ssize_t bytes = write(pipe_w, log_buf.data + (log_buf.len - remaining), remaining);
+	if (bytes < 0) {
+		wlr_log(WLR_ERROR, "Failed to write errors to process: %s", rc.error_command);
+	} else {
+		remaining -= bytes;
+		if (remaining > 0) {
+			goto keep_waiting;
+		}
+	}
+
+	wl_event_source_remove(write_notifier);
+	write_notifier = NULL;
+	spawn_piped_close(pid, pipe_w);
+
+keep_waiting:
+	return 0;
+}
+
+static void
+nag_show(void)
+{
+	if (!has_error) {
+		return;
+	}
+	pid = spawn_piped_async_no_shell(rc.error_command, &pipe_w);
+	if (pid > 0) {
+		assert(!write_notifier);
+		remaining = log_buf.len;
+		write_notifier = wl_event_loop_add_fd(server.wl_event_loop,
+			pipe_w, WL_EVENT_WRITABLE, handle_writable, NULL);
+	} else if (pid < 0) {
+		wlr_log(WLR_ERROR, "Failed to launch process: %s", rc.error_command);
+	}
+}
+
+void
+nag_show_callback(void *data)
+{
+	nag_show();
+}

--- a/src/common/nag.c
+++ b/src/common/nag.c
@@ -123,3 +123,10 @@ nag_show_callback(void *data)
 {
 	nag_show();
 }
+
+void
+nag_finish(void)
+{
+	nag_reset();
+	buf_reset(&log_buf);
+}

--- a/src/common/nag.c
+++ b/src/common/nag.c
@@ -2,8 +2,9 @@
 #define _POSIX_C_SOURCE 200809L
 #include "common/nag.h"
 #include <assert.h>
-#include <stdarg.h>
 #include <unistd.h>
+#include <wlr/util/log.h>
+#include <wayland-server-core.h>
 #include "common/buf.h"
 #include "config/rcxml.h"
 #include "common/spawn.h"
@@ -12,13 +13,24 @@
 static struct buf log_buf = BUF_INIT;
 static bool has_error = false;
 static pid_t pid = 0;
-static int pipe_w;
+static int pipe_w = -1;
 static struct wl_event_source *write_notifier = NULL;
 static size_t remaining = 0;
 
 struct buf *
 nag_get_buf(void)
 {
+	if (write_notifier) {
+		/*
+		 * Ensure we are not accidentally modifying
+		 * the buffer while writing it to a client.
+		 *
+		 * This may happend when using nag_log() after
+		 * nag_show() without a nag_reset() in between.
+		 */
+		wlr_log(WLR_ERROR, "Not writing to log buffer while sending to client");
+		return NULL;
+	}
 	return &log_buf;
 }
 
@@ -43,53 +55,67 @@ nag_check_pid(pid_t exited_pid)
 void
 nag_reset(void)
 {
-	has_error = false;
-	buf_reset(&log_buf);
 	if (pid > 0) {
 		kill(pid, SIGTERM);
 		/* waitpid() is done in a generic SIGCHLD handler in src/server.c */
+		pid = 0;
 	}
-	pid = 0;
+	if (write_notifier) {
+		wl_event_source_remove(write_notifier);
+		write_notifier = NULL;
+	}
+	if (pipe_w != -1) {
+		close(pipe_w);
+		pipe_w = -1;
+	}
+	has_error = false;
+	buf_clear(&log_buf);
 }
 
 static int
 handle_writable(int fd, uint32_t mask, void *data)
 {
+	assert(write_notifier);
+	assert(fd == pipe_w);
 	assert(remaining > 0);
-	wlr_log(WLR_ERROR, "Writable");
-	ssize_t bytes = write(pipe_w, log_buf.data + (log_buf.len - remaining), remaining);
+	assert(remaining <= (size_t)log_buf.len);
+
+	ssize_t bytes = write(fd, log_buf.data + (log_buf.len - remaining), remaining);
 	if (bytes < 0) {
-		wlr_log(WLR_ERROR, "Failed to write errors to process: %s", rc.error_command);
+		wlr_log_errno(WLR_ERROR, "Failed to write errors to process %s", rc.error_command);
 	} else {
 		remaining -= bytes;
 		if (remaining > 0) {
-			goto keep_waiting;
+			/* Keep waiting */
+			return 0;
 		}
 	}
 
 	wl_event_source_remove(write_notifier);
 	write_notifier = NULL;
-	spawn_piped_close(pid, pipe_w);
 
-keep_waiting:
+	close(pipe_w);
+	pipe_w = -1;
 	return 0;
 }
 
 static void
 nag_show(void)
 {
-	if (!has_error) {
+	if (!has_error || log_buf.len == 0) {
 		return;
 	}
+
 	pid = spawn_piped_async_no_shell(rc.error_command, &pipe_w);
-	if (pid > 0) {
-		assert(!write_notifier);
-		remaining = log_buf.len;
-		write_notifier = wl_event_loop_add_fd(server.wl_event_loop,
-			pipe_w, WL_EVENT_WRITABLE, handle_writable, NULL);
-	} else if (pid < 0) {
-		wlr_log(WLR_ERROR, "Failed to launch process: %s", rc.error_command);
+	if (pid < 0) {
+		wlr_log_errno(WLR_ERROR, "Failed to launch process: %s", rc.error_command);
+		return;
 	}
+
+	assert(!write_notifier);
+	remaining = log_buf.len;
+	write_notifier = wl_event_loop_add_fd(server.wl_event_loop,
+		pipe_w, WL_EVENT_WRITABLE, handle_writable, NULL);
 }
 
 void

--- a/src/common/nag.c
+++ b/src/common/nag.c
@@ -30,12 +30,14 @@ nag_set_error(enum wlr_log_importance importance)
 	}
 }
 
-void
+bool
 nag_check_pid(pid_t exited_pid)
 {
 	if (pid && pid == exited_pid) {
 		pid = 0;
+		return true;
 	}
+	return false;
 }
 
 void

--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -156,6 +156,82 @@ spawn_primary_client(const char *command)
 }
 
 pid_t
+spawn_piped_async_no_shell(const char *command, int *pipe_fd_w)
+{
+	assert(command);
+
+	GError *err = NULL;
+	gchar **argv = NULL;
+
+	/* Use glib's shell-parse to mimic Openbox's behaviour */
+	g_shell_parse_argv((gchar *)command, NULL, &argv, &err);
+	if (err) {
+		g_message("%s", err->message);
+		g_error_free(err);
+		return -1;
+	}
+
+	int pipe_rw[2];
+	if (pipe(pipe_rw) != 0) {
+		wlr_log(WLR_ERROR, "unable to pipe()");
+		g_strfreev(argv);
+		return -1;
+	}
+
+	pid_t child = 0;
+	child = fork();
+	if (child < 0) {
+		wlr_log(WLR_ERROR, "unable to fork() child");
+		close(pipe_rw[0]);
+		close(pipe_rw[1]);
+		g_strfreev(argv);
+		return child;
+	}
+
+	if (child == 0) {
+		/* Child */
+		reset_signals_and_limits();
+
+		/*
+		 * replace stdout and stderr with /dev/null
+		 * and stdin with the read end of the pipe
+		 */
+		close(pipe_rw[1]);
+		dup2(pipe_rw[0], STDIN_FILENO);
+		close(pipe_rw[0]);
+
+		int dev_null = open("/dev/null", O_WRONLY);
+		if (dev_null < 0) {
+			wlr_log_errno(WLR_ERROR, "opening /dev/null failed");
+			/*
+			 * Just close stdout and stderr and
+			 * hope $command can deal with that.
+			 */
+			close(STDOUT_FILENO);
+			close(STDERR_FILENO);
+		} else {
+			dup2(dev_null, STDOUT_FILENO);
+			dup2(dev_null, STDERR_FILENO);
+			close(dev_null);
+		}
+		execvp(argv[0], argv);
+		_exit(1);
+	}
+	/* labwc */
+	close(pipe_rw[0]);
+	g_strfreev(argv);
+
+	/*
+	 * Prevent leaking the write end of the pipe to further
+	 * children forked during the lifetime of the descriptor.
+	 */
+	set_cloexec(pipe_rw[1]);
+	*pipe_fd_w = pipe_rw[1];
+
+	return child;
+}
+
+pid_t
 spawn_piped(const char *command, int *pipe_fd)
 {
 	assert(command);

--- a/src/common/spawn.c
+++ b/src/common/spawn.c
@@ -30,13 +30,30 @@ set_cloexec(int fd)
 	int flags = fcntl(fd, F_GETFD);
 	if (flags == -1) {
 		wlr_log_errno(WLR_ERROR,
-			"Unable to set the CLOEXEC flag: fnctl failed");
+			"Unable to get the CLOEXEC flag: fcntl failed");
 		return false;
 	}
 	flags = flags | FD_CLOEXEC;
 	if (fcntl(fd, F_SETFD, flags) == -1) {
 		wlr_log_errno(WLR_ERROR,
-			"Unable to set the CLOEXEC flag: fnctl failed");
+			"Unable to set the CLOEXEC flag: fcntl failed");
+		return false;
+	}
+	return true;
+}
+
+static bool
+set_nonblock(int fd)
+{
+	int flags = fcntl(fd, F_GETFL);
+	if (flags == -1) {
+		wlr_log_errno(WLR_ERROR,
+			"Unable to get the O_NONBLOCK flag: fcntl failed");
+		return false;
+	}
+	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+		wlr_log_errno(WLR_ERROR,
+			"Unable to set the O_NONBLOCK flag: fcntl failed");
 		return false;
 	}
 	return true;
@@ -217,9 +234,16 @@ spawn_piped_async_no_shell(const char *command, int *pipe_fd_w)
 		execvp(argv[0], argv);
 		_exit(1);
 	}
+
 	/* labwc */
 	close(pipe_rw[0]);
 	g_strfreev(argv);
+
+	/*
+	 * Prevent blocking of the labwc process when
+	 * writing more than the pipe buffer can hold.
+	 */
+	set_nonblock(pipe_rw[1]);
 
 	/*
 	 * Prevent leaking the write end of the pipe to further

--- a/src/common/string-helpers.c
+++ b/src/common/string-helpers.c
@@ -57,6 +57,8 @@ string_truncate_at_pattern(char *buf, const char *pattern)
 char *
 strdup_printf(const char *fmt, ...)
 {
+	assert(fmt);
+
 	size_t size = 0;
 	char *p = NULL;
 	va_list ap;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -17,6 +17,7 @@
 #include "common/list.h"
 #include "common/macros.h"
 #include "common/mem.h"
+#include "common/nag.h"
 #include "common/nodename.h"
 #include "common/parse-bool.h"
 #include "common/parse-double.h"
@@ -1167,6 +1168,8 @@ entry(xmlNode *node, char *nodename, char *content)
 
 	} else if (!strcasecmp(nodename, "promptCommand.core")) {
 		xstrdup_replace(rc.prompt_command, content);
+	} else if (!strcasecmp(nodename, "errorCommand.core")) {
+		xstrdup_replace(rc.error_command, content);
 
 	} else if (!strcmp(nodename, "policy.placement")) {
 		enum lab_placement_policy policy = view_placement_parse(content);
@@ -1476,7 +1479,7 @@ rcxml_parse_xml(struct buf *b)
 	int options = 0;
 	xmlDoc *d = xmlReadMemory(b->data, b->len, NULL, NULL, options);
 	if (!d) {
-		wlr_log(WLR_ERROR, "error parsing config file");
+		nag_log(WLR_ERROR, "error parsing config file");
 		return;
 	}
 	xmlNode *root = xmlDocGetRootElement(d);
@@ -1802,6 +1805,15 @@ post_processing(void)
 				"--layer overlay "
 				"--timeout 0");
 	}
+	if (!rc.error_command) {
+		rc.error_command =
+			xstrdup("labnag "
+				"--message 'Config Error' "
+				"--button-dismiss 'Close' "
+				"--layer overlay "
+				"--timeout 0 "
+				"--detailed-message");
+	}
 	if (!rc.fallback_app_icon_name) {
 		rc.fallback_app_icon_name = xstrdup("labwc");
 	}
@@ -2030,7 +2042,7 @@ rcxml_read(const char *filename)
 			continue;
 		}
 
-		wlr_log(WLR_INFO, "read config file %s", path->string);
+		nag_log(WLR_INFO, "read config file %s", path->string);
 
 		rcxml_parse_xml(&b);
 		buf_reset(&b);
@@ -2052,6 +2064,7 @@ rcxml_finish(void)
 	zfree(rc.font_menuitem.name);
 	zfree(rc.font_osd.name);
 	zfree(rc.prompt_command);
+	zfree(rc.error_command);
 	zfree(rc.theme_name);
 	zfree(rc.icon_theme_name);
 	zfree(rc.fallback_app_icon_name);

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1808,7 +1808,7 @@ post_processing(void)
 	if (!rc.error_command) {
 		rc.error_command =
 			xstrdup("labnag "
-				"--message 'Config Error' "
+				"--message 'Config errors detected' "
 				"--button-dismiss 'Close' "
 				"--layer overlay "
 				"--timeout 0 "

--- a/src/server.c
+++ b/src/server.c
@@ -54,6 +54,7 @@
 #include "action.h"
 #include "common/macros.h"
 #include "common/mem.h"
+#include "common/nag.h"
 #include "common/scene-helpers.h"
 #include "config/rcxml.h"
 #include "config/session.h"
@@ -98,6 +99,7 @@ reload_config_and_theme(void)
 
 	scaled_buffer_invalidate_sharing();
 	rcxml_finish();
+	nag_reset();
 	rcxml_read(rc.config_file);
 	theme_finish(rc.theme);
 	theme_init(rc.theme, rc.theme_name);
@@ -119,6 +121,8 @@ reload_config_and_theme(void)
 	resize_indicator_reconfigure();
 	kde_server_decoration_update_default();
 	workspaces_reconfigure();
+
+	wl_event_loop_add_idle(server.wl_event_loop, nag_show_callback, NULL);
 }
 
 static int
@@ -180,6 +184,7 @@ handle_sigchld(int signal, void *data)
 				"spawned child %ld exited with %d",
 				(long)info.si_pid, info.si_status);
 		}
+		nag_check_pid(info.si_pid);
 		break;
 	case CLD_KILLED:
 	case CLD_DUMPED:
@@ -190,6 +195,7 @@ handle_sigchld(int signal, void *data)
 				signame ? signame : "unknown");
 		/* Allow cleanup of killed prompt */
 		action_check_prompt_result(info.si_pid, -info.si_status);
+		nag_check_pid(info.si_pid);
 		break;
 	default:
 		wlr_log(WLR_ERROR,
@@ -809,6 +815,7 @@ server_init(void)
 #if HAVE_XWAYLAND
 	xwayland_server_init(server.compositor);
 #endif
+	wl_event_loop_add_idle(server.wl_event_loop, nag_show_callback, NULL);
 }
 
 void

--- a/src/server.c
+++ b/src/server.c
@@ -863,6 +863,7 @@ server_finish(void)
 
 	wl_display_destroy_clients(server.wl_display);
 
+	nag_finish();
 	seat_finish();
 	output_finish();
 	xdg_shell_finish();

--- a/src/server.c
+++ b/src/server.c
@@ -179,12 +179,12 @@ handle_sigchld(int signal, void *data)
 	const char *signame;
 	switch (info.si_code) {
 	case CLD_EXITED:
-		if (!action_check_prompt_result(info.si_pid, info.si_status)) {
+		if (!action_check_prompt_result(info.si_pid, info.si_status)
+				&& !nag_check_pid(info.si_pid)) {
 			wlr_log(info.si_status == 0 ? WLR_DEBUG : WLR_ERROR,
 				"spawned child %ld exited with %d",
 				(long)info.si_pid, info.si_status);
 		}
-		nag_check_pid(info.si_pid);
 		break;
 	case CLD_KILLED:
 	case CLD_DUMPED:

--- a/src/server.c
+++ b/src/server.c
@@ -150,64 +150,90 @@ handle_sigchld(int signal, void *data)
 	siginfo_t info;
 	info.si_pid = 0;
 
-	/* First call waitid() with NOWAIT which doesn't consume the zombie */
-	if (waitid(P_ALL, /*id*/ 0, &info, WEXITED | WNOHANG | WNOWAIT) == -1) {
-		return 0;
-	}
+	/*
+	 * We may get a single SIGCHILD event although there are
+	 * multiple childs terminating so we loop through them.
+	 *
+	 * A 'while true; labwc --reconfigure; done' loop along
+	 * with some config error which causes labnag to re-spawn
+	 * constantly is a good test for this handler.
+	 */
 
-	if (info.si_pid == 0) {
-		/* No children in waitable state */
-		return 0;
-	}
-
-#if HAVE_XWAYLAND
-	/* Ensure that we do not break xwayland lazy initialization */
-	if (server.xwayland && server.xwayland->server
-			&& info.si_pid == server.xwayland->server->pid) {
-		return 0;
-	}
-#endif
-
-	/* And then do the actual (consuming) lookup again */
-	int ret = waitid(P_PID, info.si_pid, &info, WEXITED);
-	if (ret == -1) {
-		wlr_log(WLR_ERROR, "blocking waitid() for %ld failed: %d",
-			(long)info.si_pid, ret);
-		return 0;
-	}
-
-	const char *signame;
-	switch (info.si_code) {
-	case CLD_EXITED:
-		if (!action_check_prompt_result(info.si_pid, info.si_status)
-				&& !nag_check_pid(info.si_pid)) {
-			wlr_log(info.si_status == 0 ? WLR_DEBUG : WLR_ERROR,
-				"spawned child %ld exited with %d",
-				(long)info.si_pid, info.si_status);
+	/* First call waitid() with NOWAIT which doesn't consume the zombie. */
+	while (waitid(P_ALL, /*id*/ 0, &info, WEXITED | WNOHANG | WNOWAIT) != -1) {
+		if (info.si_pid == 0) {
+			/* No children in waitable state */
+			return 0;
 		}
-		break;
-	case CLD_KILLED:
-	case CLD_DUMPED:
-		signame = strsignal(info.si_status);
-		wlr_log(WLR_ERROR,
-			"spawned child %ld terminated with signal %d (%s)",
-				(long)info.si_pid, info.si_status,
-				signame ? signame : "unknown");
-		/* Allow cleanup of killed prompt */
-		action_check_prompt_result(info.si_pid, -info.si_status);
-		nag_check_pid(info.si_pid);
-		break;
-	default:
-		wlr_log(WLR_ERROR,
-			"spawned child %ld terminated unexpectedly: %d"
-			" please report", (long)info.si_pid, info.si_code);
-	}
 
-	if (info.si_pid == server.primary_client_pid) {
-		wlr_log(WLR_INFO, "primary client %ld exited", (long)info.si_pid);
-		wl_display_terminate(server.wl_display);
-	}
+	#if HAVE_XWAYLAND
+		/* Ensure that we do not break xwayland lazy initialization */
+		if (server.xwayland && server.xwayland->server
+				&& info.si_pid == server.xwayland->server->pid) {
+			/*
+			 * We need to completely return here to prevent running
+			 * into an endless loop without giving the wlroots internal
+			 * xwayland startup handler a chance to use its own waitid().
+			 *
+			 * Further queued up child process terminatations will be
+			 * dealt with on the next SIGCHLD handler invocation and
+			 * float around as zombies until that point.
+			 */
+			return 0;
+		}
+	#endif
 
+		/* And then do the actual (consuming) lookup again */
+		int ret = waitid(P_PID, info.si_pid, &info, WEXITED);
+		if (ret == -1) {
+			wlr_log(WLR_ERROR, "blocking waitid() for %ld failed: %d",
+				(long)info.si_pid, ret);
+			goto check_next;
+		}
+
+		const char *signame;
+		switch (info.si_code) {
+		case CLD_EXITED:
+			if (!action_check_prompt_result(info.si_pid, info.si_status)
+					&& !nag_check_pid(info.si_pid)) {
+				wlr_log(info.si_status == 0 ? WLR_DEBUG : WLR_ERROR,
+					"spawned child %ld exited with %d",
+					(long)info.si_pid, info.si_status);
+			}
+			break;
+		case CLD_KILLED:
+		case CLD_DUMPED:
+			signame = strsignal(info.si_status);
+			wlr_log(WLR_ERROR,
+				"spawned child %ld terminated with signal %d (%s)",
+					(long)info.si_pid, info.si_status,
+					signame ? signame : "unknown");
+			/* Allow cleanup of killed prompt */
+			action_check_prompt_result(info.si_pid, -info.si_status);
+			nag_check_pid(info.si_pid);
+			break;
+		default:
+			wlr_log(WLR_ERROR,
+				"spawned child %ld terminated unexpectedly: %d"
+				" please report", (long)info.si_pid, info.si_code);
+		}
+
+		if (info.si_pid == server.primary_client_pid) {
+			wlr_log(WLR_INFO, "primary client %ld exited", (long)info.si_pid);
+			wl_display_terminate(server.wl_display);
+		}
+check_next:
+		/*
+		 * We need each initial WNOHANG | WNOWAIT call to clearly identify
+		 * if there are no more children to wait for so we reset si_pid
+		 * as recommended for portability in the waitid man page.
+		 *
+		 * Note that at least on one of the devs linux system the call
+		 * actually returns with -1 in that case, contrary to what is
+		 * written in the man page. We do handle both cases.
+		 */
+		info.si_pid = 0;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Based on
- #3578

<img width="1280" height="720" alt="20260810_15h06m13s_grim" src="https://github.com/user-attachments/assets/880e003b-a62c-4b5a-b04d-3e996c9ec7f8" />

Changes:
- the write fd is now non-blocking so we don't ever end up in a situation where a log client may block the compositor
- our generic SIGCHLD handler now loops through all terminated child processes instead of only handling the first one found
- the logic in `nag.c` is now (hopefully) more robust against future API usage errors by only allowing to modify the buffer when we are not currently writing to a client
- the log buffer doesn't free its heap allocations  between invocations and on labwc shutdown we reset the buffer and thus free everything. Mysteriously, ASAN doesn't detect the leak but we fix it anyway
- Original commits squashed into one
- Default title for labnag changed from `Config Error` to `Config errors detected`
- Unrelated random fix when compiling with `-Doptimization=1` on an older gcc / libc version

Thanks @elviosak for the initial work!

Testing with something like this seems to work fine and I didn't detect fd leaks nor was triggering any asserts but more testing appreciated:
```sh
#!/bin/bash
while true; do labwc --reconfigure; done
```