### PR TITLE
nag_log: add line numbers from xml to error message

### DIFF
--- a/include/common/nag.h
+++ b/include/common/nag.h
@@ -6,6 +6,7 @@
 #include <sys/wait.h>
 #include <wlr/util/log.h>
 #include "common/buf.h"
+#include "common/xml.h"
 
 /* May return NULL if the buffer is currently written to a client */
 struct buf *nag_get_buf(void);
@@ -21,7 +22,7 @@ do { \
 	wlr_log(verbosity, fmt, ##__VA_ARGS__); \
 	nag_set_error(verbosity); \
 	if (nag_get_buf()) { \
-		buf_add_fmt(nag_get_buf(), fmt "\n", ##__VA_ARGS__); \
+		buf_add_fmt(nag_get_buf(), "%s" fmt "\n", lab_xml_line_string(), ##__VA_ARGS__); \
 	} \
 } while (0)
 

--- a/include/common/xml.h
+++ b/include/common/xml.h
@@ -34,6 +34,9 @@ bool lab_xml_get_string(xmlNode *node, const char *key, char *s, size_t len);
 bool lab_xml_get_int(xmlNode *node, const char *key, int *i);
 bool lab_xml_get_bool(xmlNode *node, const char *key, bool *b);
 
+void lab_xml_update_line(xmlNode *node);
+const char *lab_xml_line_string(void);
+
 /* also skips other unusual nodes like comments */
 static inline xmlNode *
 lab_xml_skip_text(xmlNode *child)
@@ -48,6 +51,7 @@ static inline void
 lab_xml_get_key_and_content(xmlNode *node, char **name, char **content)
 {
 	if (node) {
+		lab_xml_update_line(node);
 		*name = (char *)node->name;
 		*content = (char *)xmlNodeGetContent(node);
 	}

--- a/src/common/xml.c
+++ b/src/common/xml.c
@@ -7,7 +7,7 @@
 #include "common/parse-bool.h"
 
 static long line_number = 0;
-static char line_string[20];
+static char line_string[40];
 
 /*
  * Converts an attribute A.B.C="X" into <C><B><A>X</A></B></C>

--- a/src/common/xml.c
+++ b/src/common/xml.c
@@ -6,6 +6,9 @@
 #include "common/xml.h"
 #include "common/parse-bool.h"
 
+static long line_number = 0;
+static char line_string[20];
+
 /*
  * Converts an attribute A.B.C="X" into <C><B><A>X</A></B></C>
  */
@@ -192,4 +195,30 @@ lab_xml_get_bool(xmlNode *node, const char *key, bool *b)
 		}
 	}
 	return false;
+}
+
+void lab_xml_update_line(xmlNode *node)
+{
+	if (!node) {
+		line_number = 0;
+		return;
+	}
+	long line = xmlGetLineNo(node);
+
+	/* When parsing attributes, xmlGetLineNo() returns 0,
+	 * so we keep the previous value if valid.
+	 */
+	if (line == 0) {
+		return;
+	}
+	line_number = line;
+}
+
+const char *lab_xml_line_string(void)
+{
+	if (line_number > 0) {
+		snprintf(line_string, sizeof(line_string), "Line: %ld - ", line_number);
+		return line_string;
+	}
+	return "";
 }

--- a/src/common/xml.c
+++ b/src/common/xml.c
@@ -206,7 +206,7 @@ void lab_xml_update_line(xmlNode *node)
 	long line = xmlGetLineNo(node);
 
 	/* When parsing attributes, xmlGetLineNo() returns 0,
-	 * so we keep the previous value if valid.
+	 * so we keep the previous value when this happens.
 	 */
 	if (line == 0) {
 		return;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -1476,7 +1476,7 @@ traverse(xmlNode *node)
 static void
 rcxml_parse_xml(struct buf *b)
 {
-	int options = 0;
+	int options = XML_PARSE_BIG_LINES;
 	xmlDoc *d = xmlReadMemory(b->data, b->len, NULL, NULL, options);
 	if (!d) {
 		nag_log(WLR_ERROR, "error parsing config file");
@@ -2041,7 +2041,7 @@ rcxml_read(const char *filename)
 		if (!b.len) {
 			continue;
 		}
-
+		lab_xml_update_line(NULL); /* reset line to 0 on reconfigure */
 		nag_log(WLR_INFO, "read config file %s", path->string);
 
 		rcxml_parse_xml(&b);


### PR DESCRIPTION
adds line numbers from the xml file to the error message in labnag:
<img width="1304" height="275" alt="nagline" src="https://github.com/user-attachments/assets/b63977c1-b074-47ec-8062-785df52e92c4" />

it seems to work fine here, but the line number reported is the one with the closing tag as shown in the picture, and all attributes get the same line number as the tag, `xmlGetLineNo()` returns 0 on attributes, maybe due to `lab_xml_expand_dotted_attributes(xmlNode *parent)` or `merge_two_trees(xmlNode *dst, xmlNode *src)`, so i kept the same value.

I also added `XML_PARSE_BIG_LINES` according to docs, but would probably need to have a very big config file for it to be needed.
https://gnome.pages.gitlab.gnome.org/libxml2/html/tree_8h.html#a44b0a9b87c1ac0ee5f9393e18faded91