### PR TITLE
nag_log: log xml syntax errors

### DIFF
--- a/include/common/buf.h
+++ b/include/common/buf.h
@@ -8,6 +8,8 @@
 #ifndef LABWC_BUF_H
 #define LABWC_BUF_H
 
+#include <stdarg.h>
+
 struct buf {
 	/**
 	 * Pointer to underlying string buffer. If alloc != 0, then
@@ -49,6 +51,16 @@ void buf_expand_shell_variables(struct buf *s);
  * @fmt: format string to be added
  */
 void buf_add_fmt(struct buf *s, const char *fmt, ...);
+
+/**
+ * buf_add_vfmt - add format string to C string buffer
+ * @s: buffer
+ * @fmt: format string to be added
+ * @args: variable arguments created by va_start() by the caller
+ *
+ * The caller is responsible to match its va_start() with a va_end()
+ */
+void buf_add_vfmt(struct buf *s, const char *fmt, va_list args);
 
 /**
  * buf_add_hex_color - add rgb color as hex string to C string buffer

--- a/include/common/nag.h
+++ b/include/common/nag.h
@@ -10,6 +10,7 @@
 /* May return NULL if the buffer is currently written to a client */
 struct buf *nag_get_buf(void);
 
+void nag_init(void);
 void nag_set_error(enum wlr_log_importance importance);
 bool nag_check_pid(pid_t exited_pid);
 void nag_reset(void);

--- a/src/common/buf.c
+++ b/src/common/buf.c
@@ -98,16 +98,16 @@ buf_expand(struct buf *s, int new_alloc)
 }
 
 void
-buf_add_fmt(struct buf *s, const char *fmt, ...)
+buf_add_vfmt(struct buf *s, const char *fmt, va_list args)
 {
 	if (string_null_or_empty(fmt)) {
 		return;
 	}
-	va_list ap;
 
-	va_start(ap, fmt);
-	int n = vsnprintf(NULL, 0, fmt, ap);
-	va_end(ap);
+	va_list start;
+	va_copy(start, args);
+	int n = vsnprintf(NULL, 0, fmt, start);
+	va_end(start);
 
 	if (n < 0) {
 		return;
@@ -115,10 +115,7 @@ buf_add_fmt(struct buf *s, const char *fmt, ...)
 
 	size_t size = (size_t)n + 1;
 	buf_expand(s, s->len + size);
-
-	va_start(ap, fmt);
-	n = vsnprintf(s->data + s->len, size, fmt, ap);
-	va_end(ap);
+	n = vsnprintf(s->data + s->len, size, fmt, args);
 
 	if (n < 0) {
 		return;
@@ -126,6 +123,15 @@ buf_add_fmt(struct buf *s, const char *fmt, ...)
 
 	s->len += n;
 	s->data[s->len] = 0;
+}
+
+void
+buf_add_fmt(struct buf *s, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	buf_add_vfmt(s, fmt, ap);
+	va_end(ap);
 }
 
 void

--- a/src/common/nag.c
+++ b/src/common/nag.c
@@ -17,6 +17,43 @@ static int pipe_w = -1;
 static struct wl_event_source *write_notifier = NULL;
 static size_t remaining = 0;
 
+static void
+xml_error_log_cb(void *data, const char *fmt, ...)
+{
+	/*
+	 * libxml2 will call this functions for small parts
+	 * of a line so we can't use the usual logging as it
+	 * adds various line breaks within the message.
+	 *
+	 * Instead we rely on vfprintf() and buf_add_vfmt()
+	 * directly.
+	 */
+
+	va_list args;
+
+	/* Write to stderr as usual */
+	va_start(args, fmt);
+	vfprintf(stderr, fmt, args);
+	va_end(args);
+
+	/* But also to the nag log buffer */
+	if (write_notifier) {
+		wlr_log(WLR_ERROR, "Not writing to log buffer while sending to client");
+		return;
+	}
+
+	has_error = true;
+	va_start(args, fmt);
+	buf_add_vfmt(&log_buf, fmt, args);
+	va_end(args);
+}
+
+void
+nag_init(void)
+{
+	xmlSetGenericErrorFunc(NULL, xml_error_log_cb);
+}
+
 struct buf *
 nag_get_buf(void)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include "common/fd-util.h"
 #include "common/font.h"
 #include "common/macros.h"
+#include "common/nag.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"
 #include "config/rcxml.h"
@@ -229,6 +230,7 @@ main(int argc, char *argv[])
 	}
 
 	wlr_log_init(verbosity, NULL);
+	nag_init();
 
 	die_on_detecting_suid();
 	die_on_no_fonts();
@@ -301,6 +303,8 @@ main(int argc, char *argv[])
 	font_finish();
 
 	server_finish();
+
+	nag_finish();
 
 	return 0;
 }

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -20,6 +20,7 @@
 #include "common/lab-scene-rect.h"
 #include "common/list.h"
 #include "common/mem.h"
+#include "common/nag.h"
 #include "common/scene-helpers.h"
 #include "common/spawn.h"
 #include "common/string-helpers.h"
@@ -755,7 +756,7 @@ parse_buf(struct menu *parent, struct buf *buf)
 	int options = 0;
 	xmlDoc *d = xmlReadMemory(buf->data, buf->len, NULL, NULL, options);
 	if (!d) {
-		wlr_log(WLR_ERROR, "xmlParseMemory()");
+		nag_log(WLR_ERROR, "error parsing menu file");
 		return false;
 	}
 
@@ -783,7 +784,7 @@ parse_xml(const char *filename)
 		if (!buf.len) {
 			continue;
 		}
-		wlr_log(WLR_INFO, "read menu file %s", path->string);
+		nag_log(WLR_INFO, "read menu file %s", path->string);
 		parse_buf(/*parent*/ NULL, &buf);
 		buf_reset(&buf);
 		if (!should_merge_config) {

--- a/src/server.c
+++ b/src/server.c
@@ -175,7 +175,7 @@ handle_sigchld(int signal, void *data)
 			 * into an endless loop without giving the wlroots internal
 			 * xwayland startup handler a chance to use its own waitid().
 			 *
-			 * Further queued up child process terminatations will be
+			 * Further queued up child process terminations will be
 			 * dealt with on the next SIGCHLD handler invocation and
 			 * float around as zombies until that point.
 			 */

--- a/src/server.c
+++ b/src/server.c
@@ -889,7 +889,6 @@ server_finish(void)
 
 	wl_display_destroy_clients(server.wl_display);
 
-	nag_finish();
 	seat_finish();
 	output_finish();
 	xdg_shell_finish();


### PR DESCRIPTION
<img width="1280" height="720" alt="20260811_15h13m54s_grim" src="https://github.com/user-attachments/assets/affb1298-441c-4ee0-85d5-4a60c8fe79ee" />

A slight annoyance is that this will also log pipe menu syntax errors. However, they won't show up because we don't set up a `nag_show()` idle callback and when reconfiguring we clear the buffer first. I am also not sure if we really want to show pipe menu syntax errors via labnag.

Another potential issue I didn't test yet is if we now also get errors from the SVG importers as libxml2 seems to only have a generic callback without referring to some parser instance.