### PR TITLE
menu: wait for pipemenus to render before entering via accelerator

### DIFF
--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -70,7 +70,7 @@ void menu_item_select_next(void);
 void menu_item_select_previous(void);
 
 /**
- * menu_item_select_by_accelerator - selects the next menu item with
+ * menu_process_accelerator - selects the next menu item with
  * a matching accelerator, starting after the current selection
  *
  * @accelerator a shortcut to quickly select/open an item, defined in menu.xml
@@ -79,7 +79,7 @@ void menu_item_select_previous(void);
  * Return: a boolean value that represents whether the newly selected item
  * needs to be executed.
  */
-bool menu_item_select_by_accelerator(uint32_t accelerator);
+void menu_process_accelerator(uint32_t accelerator);
 
 void menu_submenu_enter(void);
 void menu_submenu_leave(void);

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -56,6 +56,7 @@ struct menu {
 		struct menuitem *item;
 	} selection;
 	struct wlr_scene_tree *scene_tree;
+	bool pending_auto_enter;
 	bool is_pipemenu_child;
 	bool align_left;
 	bool has_icons;

--- a/include/menu/menu.h
+++ b/include/menu/menu.h
@@ -71,14 +71,11 @@ void menu_item_select_next(void);
 void menu_item_select_previous(void);
 
 /**
- * menu_process_accelerator - selects the next menu item with
+ * menu_process_accelerator - executes the next menu item with
  * a matching accelerator, starting after the current selection
  *
  * @accelerator a shortcut to quickly select/open an item, defined in menu.xml
  * with an underscore in the item label before the target letter.
- *
- * Return: a boolean value that represents whether the newly selected item
- * needs to be executed.
  */
 void menu_process_accelerator(uint32_t accelerator);
 

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -457,9 +457,7 @@ handle_menu_keys(struct keysyms *syms)
 			if (accelerator == 0) {
 				continue;
 			}
-			if (menu_item_select_by_accelerator(accelerator)) {
-				menu_call_selected_actions();
-			}
+			menu_process_accelerator(accelerator);
 			break;
 		}}
 		break;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1336,6 +1336,9 @@ handle_pipemenu_readable(int fd, uint32_t mask, void *_ctx)
 	char data[8193];
 	ssize_t size;
 
+	/* Track if creation succeded */
+	bool create_success = false;
+
 	do {
 		/* leave space for terminating NULL byte */
 		size = read(fd, data, sizeof(data) - 1);
@@ -1370,27 +1373,28 @@ handle_pipemenu_readable(int fd, uint32_t mask, void *_ctx)
 	}
 
 	create_pipe_menu(ctx);
+	create_success = true;
 
+clean_up:
 	struct menu *menu = ctx->pipemenu;
-	bool pending_auto_enter = menu->pending_auto_enter;
-	menu->pending_auto_enter = false;
 
+	/*
+	 * This unsets the waiting_for_pipemenu flag
+	 * so that menu_submenu_enter() won't be blocked
+	 */
 	pipemenu_ctx_destroy(ctx);
 
-	if (pending_auto_enter) {
-		struct menu *active_leaf = get_selection_leaf();
-		if (active_leaf && active_leaf->selection.menu == menu) {
-			menu_submenu_enter();
+	if (menu && menu->pending_auto_enter) {
+		menu->pending_auto_enter = false;
+
+		if (create_success) {
+			struct menu *active_leaf = get_selection_leaf();
+			if (active_leaf && active_leaf->selection.menu == menu) {
+				menu_submenu_enter();
+			}
 		}
 	}
 
-	return 0;
-
-clean_up:
-	if (ctx->pipemenu) {
-		ctx->pipemenu->pending_auto_enter = false;
-	}
-	pipemenu_ctx_destroy(ctx);
 	return 0;
 }
 
@@ -1615,6 +1619,7 @@ menu_process_accelerator(uint32_t accelerator)
 	}
 
 	menu_process_item_selection(next_selection);
+
 	if (needs_exec && next_selection->submenu) {
 		/* Since we can't execute a submenu, enter it */
 		needs_exec = false;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1332,6 +1332,7 @@ static int
 handle_pipemenu_readable(int fd, uint32_t mask, void *_ctx)
 {
 	struct menu_pipe_context *ctx = _ctx;
+	struct menu *menu = ctx->pipemenu;
 	/* two 4k pages + 1 NULL byte */
 	char data[8193];
 	ssize_t size;
@@ -1376,8 +1377,6 @@ handle_pipemenu_readable(int fd, uint32_t mask, void *_ctx)
 	create_success = true;
 
 clean_up:
-	struct menu *menu = ctx->pipemenu;
-
 	/*
 	 * This unsets the waiting_for_pipemenu flag
 	 * so that menu_submenu_enter() won't be blocked

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -1549,12 +1549,12 @@ menu_item_select_previous(void)
 	menu_item_select(/* forward */ false);
 }
 
-bool
-menu_item_select_by_accelerator(uint32_t accelerator)
+void
+menu_process_accelerator(uint32_t accelerator)
 {
 	struct menu *menu = get_selection_leaf();
 	if (!menu || wl_list_empty(&menu->menuitems)) {
-		return false;
+		return;
 	}
 
 	bool needs_exec = false;
@@ -1590,7 +1590,7 @@ menu_item_select_by_accelerator(uint32_t accelerator)
 	} while (current != start);
 
 	if (!next_selection) {
-		return false;
+		return;
 	}
 
 	menu_process_item_selection(next_selection);
@@ -1598,9 +1598,12 @@ menu_item_select_by_accelerator(uint32_t accelerator)
 		/* Since we can't execute a submenu, enter it */
 		needs_exec = false;
 		menu_submenu_enter();
+		return;
 	}
 
-	return needs_exec;
+	if (needs_exec) {
+		menu_call_selected_actions();
+	}
 }
 
 bool

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -83,6 +83,7 @@ menu_create(struct menu *parent, const char *id,
 	menu->label = xstrdup(label ? label : id);
 	menu->parent = parent;
 	menu->is_pipemenu_child = waiting_for_pipe_menu;
+	menu->pending_auto_enter = false;
 	return menu;
 }
 
@@ -1325,6 +1326,8 @@ handle_pipemenu_timeout(void *_ctx)
 	return 0;
 }
 
+static struct menu *get_selection_leaf(void);
+
 static int
 handle_pipemenu_readable(int fd, uint32_t mask, void *_ctx)
 {
@@ -1368,7 +1371,25 @@ handle_pipemenu_readable(int fd, uint32_t mask, void *_ctx)
 
 	create_pipe_menu(ctx);
 
+	struct menu *menu = ctx->pipemenu;
+	bool pending_auto_enter = menu->pending_auto_enter;
+	menu->pending_auto_enter = false;
+
+	pipemenu_ctx_destroy(ctx);
+
+	if (pending_auto_enter) {
+		struct menu *active_leaf = get_selection_leaf();
+		if (active_leaf && active_leaf->selection.menu == menu) {
+			menu_submenu_enter();
+		}
+	}
+
+	return 0;
+
 clean_up:
+	if (ctx->pipemenu) {
+		ctx->pipemenu->pending_auto_enter = false;
+	}
 	pipemenu_ctx_destroy(ctx);
 	return 0;
 }
@@ -1623,6 +1644,11 @@ menu_submenu_enter(void)
 {
 	struct menu *menu = get_selection_leaf();
 	if (!menu || !menu->selection.menu) {
+		return;
+	}
+
+	if (waiting_for_pipe_menu) {
+		menu->selection.menu->pending_auto_enter = true;
 		return;
 	}
 


### PR DESCRIPTION
This fix allows to enter pipemenus with accelerators (previously they only got selected because of the race condition).

Fixes #3696.

---

While figuring out the fix, I noticed that the creation of a pipemenu is blocking, i.e. `menu_process_item_selection()` immediately returns if a pipemenu is getting created. I tried to follow this rule, making `menu_submenu_enter()` return in the same case. But generally, as mentioned by @Consolatis in the related issue, it would be nice to allow to cancel pipemenu creation by moving the selection, for example.