### PR TITLE
output: destroy scene output before scene cleanup

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -291,6 +291,21 @@ handle_output_destroy(struct wl_listener *listener, void *data)
 	if (seat->overlay.active.output == output) {
 		overlay_finish(seat);
 	}
+
+	/*
+	 * Destroy the scene output before changing the scene graph below.
+	 * Otherwise those changes can send a surface-enter for this output while
+	 * its destroy signal is already being emitted. The new listener then
+	 * misses that signal and makes wlr_output_finish() abort because
+	 * output->events.bind is not empty.
+	 *
+	 * See https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/4096
+	 */
+	if (output->scene_output) {
+		wlr_scene_output_destroy(output->scene_output);
+		output->scene_output = NULL;
+	}
+
 	wl_list_remove(&output->link);
 	wl_list_remove(&output->frame.link);
 	wl_list_remove(&output->destroy.link);
@@ -338,10 +353,6 @@ handle_output_destroy(struct wl_listener *listener, void *data)
 		wl_display_terminate(server.wl_display);
 	}
 
-	/*
-	 * output->scene_output (if still around at this point) is
-	 * destroyed automatically when the wlr_output is destroyed
-	 */
 	free(output);
 }
 


### PR DESCRIPTION
## Problem

When an output is destroyed, existing `wlr_surface_output` bind listeners are removed while wlroots emits the output destroy signal. Labwc then destroys per-output scene nodes while the corresponding `wlr_scene_output` is still active.

Those scene changes can send a new surface-enter for the output being destroyed. The newly created bind listener misses the destroy signal already in progress, leaving `output->events.bind` non-empty and making `wlr_output_finish()` abort.

This is the failure mode described in [wlroots#4096](https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/4096).

## Change

Destroy the associated scene output before changing the per-output scene graph, and clear the pointer to prevent the later automatic cleanup from being relied upon.

## Testing

- `./scripts/check`
- Built with `-Dtest=enabled -Dwerror=true`
- `meson test --verbose`: 3/3 passed
- Reproduced the assertion with Labwc 0.20.1 and wlroots 0.20.2 on Arch Linux during suspend/resume with swaylock active. With this change applied, the DRM output was destroyed and recreated, the same Labwc process survived resume, and no assertion or Labwc core dump was produced.

Fixes #3689.
Related to #3643.
