### PR TITLE
docs: point the gettext tutorial at an archived copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -446,7 +446,7 @@ generate their `MY_LOCALE.po` file in a few steps:
 contact and locale details in the header of the file. Then, add the
 translation strings under each English string.
 
-[See this tutorial for further guidance](https://www.labri.fr/perso/fleury/posts/programming/a-quick-gettext-tutorial.html)
+[See this tutorial for further guidance](https://web.archive.org/web/20260325002553/https://www.labri.fr/perso/fleury/posts/programming/a-quick-gettext-tutorial.html)
 
 ## Coders
 


### PR DESCRIPTION
The translations section of `CONTRIBUTING.md` ends with:

> [See this tutorial for further guidance](https://www.labri.fr/perso/fleury/posts/programming/a-quick-gettext-tutorial.html)

That URL returns 404. The page is gone rather than moved: the author's site root still resolves, but the post is absent from his blog index, so there is nothing live to repoint to. This uses the Wayback snapshot from 2026-03-25, which preserves the tutorial the sentence promises.

If you would rather not link an archive, the natural live substitute is the [GNU gettext manual](https://www.gnu.org/software/gettext/manual/gettext.html) — authoritative and stable, but a reference manual rather than a quick tutorial, so it changes what a translator gets. Happy to switch to that instead; I went with the archive because it keeps the original intent.

One other dead link I left alone: `NEWS.md` line 2893 has `[#270]: .../pull/270`, and neither PR nor issue 270 exists any more. That is the historical changelog, so rewriting entries would falsify the record.

AI disclosure: found and prepared with Claude Opus 5 in Claude Code, which swept every link in the repo markdown; I verified the dead URL, the author's blog index and the archive snapshot myself. The commit carries the `Assisted-by:` tag your contributing guide asks for. The change is a single URL, so there is no licensing question about generated code.